### PR TITLE
feat(forme-aot-style-tag-emitter): FM00 v0 <link rel=stylesheet> + <style> emitter

### DIFF
--- a/code/packages/typescript/forme-aot-style-tag-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-style-tag-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/CHANGELOG.md
@@ -1,0 +1,143 @@
+# Changelog — @coding-adventures/forme-aot-style-tag-emitter
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Seventeenth FM00 v0 stage package — HTML
+`<link rel="stylesheet">` + inline `<style>` tag emitter with
+SRI integrity validation, media-query passthrough, crossorigin
+allowlist, and `</style>` injection defence on inline CSS.
+
+Pure transform: `StyleConfig` → HTML string.  Two-pass
+validate-then-emit so callers never see partial output.
+
+### Added
+
+- `generateStyleTags(config): string` — main entry.
+- `validateStyleHref(url, field)` — http(s)://-or-root-relative
+  URL accept-list + control-byte rejection.
+- `validateIntegrity(value, field)` — SRI string format
+  validator (algo allowlist, base64 charset, per-algo length +
+  padding).  Same Map-backed algo lookup pattern as
+  `forme-aot-script-tag-emitter`.
+- `validateCrossOrigin(value, field)` — `anonymous |
+  use-credentials` allowlist.
+- `validateInlineCss(css, field)` — non-string + literal
+  `</style>` rejection (case-insensitive, matches HTML parser's
+  close-tag recognition: `</style` followed by `[\s>/]`).
+- `validateOptionalString` — generic optional-string check.
+- `escapeHtmlAttr` / `stripAsciiControl` — single-pass HTML
+  attribute escape + C0 control strip.
+- Types: `StyleConfig`, `StylesheetLink`, `InlineStyle`,
+  `CrossOrigin`.
+
+### Spec adherence
+
+Implements HTML Living Standard `<link rel="stylesheet">` +
+`<style>` semantics + W3C Subresource Integrity.  No
+divergence.
+
+### Behavioural notes
+
+- **Output order**: stylesheets first, then inline.
+- **Attribute order** per `<link>`: `rel → href → media →
+  integrity → crossorigin → disabled`.
+- **`disabled`** is a boolean attribute (bare attribute name).
+- **Inline CSS body is NOT escaped** — browsers parse `<style>`
+  contents as raw text and escaping would corrupt CSS.
+- **`media` query passes through HTML-attr-escaped.**  No
+  CSS-syntax gatekeeping (no usable pure-JS parser).
+- **Empty config** → empty string.
+- **Empty CSS** → empty `<style></style>` block.
+- **Reproducibility.**  Same input → byte-identical output.
+  No input mutation.
+
+### Security posture
+
+Seven concerns explicitly addressed (pre-push review):
+
+- **URL scheme injection.**  Every `href` runs through
+  `validateStyleHref`.  Rejects `javascript:`, `data:`,
+  `file:`, `vbscript:`, protocol-relative `//host`,
+  backslash-variant `/\host`, bare relative, empty, non-string,
+  AND ASCII control bytes anywhere in the URL.
+- **HTML attribute injection.**  Every interpolated value
+  passes through `escapeHtmlAttr`.
+- **SRI integrity format validation** with per-algo length AND
+  padding count checks.  Sha256 with `==` would pass total
+  length but decode to 31 bytes → browsers silently disable
+  SRI → MITM substitution.  Per-algo padding catch is the
+  subtle one.
+- **Object-prototype walk defence.**  Algo table is a `Map`
+  not a plain object — `"__proto__"` / `"toString"` /
+  `"hasOwnProperty"` can't return truthy values from
+  `Object.prototype`.
+- **`</style>` injection in inline CSS.**  This is the
+  canonical XSS sink for `<style>` sinks: any literal
+  `</style` followed by whitespace, `>`, or `/` would close
+  the style block early and let attacker-controlled HTML
+  follow.  We reject it with a clear error.  Case-insensitive
+  match.  Callers who genuinely need `</style>` in a CSS
+  string literal can use the CSS escape `\3C/style>`.
+- **Control bytes in href** rejected at validator (not
+  silently stripped by escape).
+- **Fail-fast.**  Validation completes for every entry BEFORE
+  any tag is emitted.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+122 tests across 2 files:
+
+- `validate.test.ts` (84) — `validateStyleHref` accept (https,
+  http, case-insensitive scheme, root-relative, bare /,
+  multi-segment) + reject matrix (javascript:, data:, file:,
+  vbscript:, protocol-relative, backslash-variant, bare
+  relative, empty, non-string, null, undefined, NUL / tab /
+  newline / DEL control bytes, error contains field path,
+  long-URL truncation); `validateIntegrity` accept (sha256 /
+  sha384 / sha512 single + multi, whitespace collapsing,
+  trimming) + reject (non-string, empty, whitespace-only,
+  md5 / sha1, no dash, dash at start / end, wrong length per
+  algo, invalid base64 chars including URL-safe `_` and triple
+  padding, wrong per-algo padding (sha256 `==`, sha384 padded,
+  sha512 `=`), `__proto__` / `toString` / `hasOwnProperty`
+  algos, second token bad, error contains field path);
+  `validateCrossOrigin` (2 accept + reject true / empty /
+  non-string); `validateInlineCss` (benign CSS, empty,
+  `<`/`>` in selectors, `.style` substring, `</styles>`
+  different tag — all pass; literal `</style>`, `</STYLE>`,
+  mixed-case, with whitespace, with slash — all rejected;
+  non-string + null rejected; field path in error);
+  `validateOptionalString` (5 cases); `escapeHtmlAttr` (5
+  entities + composite + NUL strip + non-string coercion);
+  `stripAsciiControl` (2 cases).
+- `generate.test.ts` (38) — empty / null / non-object configs;
+  external stylesheets (minimal, media, media query, SRI +
+  crossorigin, disabled bool, disabled=false omits,
+  attribute-order, multi-sheet order, bad href, bad integrity,
+  bad crossorigin, non-bool disabled, non-string media, null
+  entry, non-array stylesheets); inline styles (minimal, empty
+  CSS, with media, body NOT escaped (verbatim), multi-block
+  order, `</style>` rejected, case-variant rejected, non-
+  string, null, non-array, media gets escaped); output order
+  (stylesheets → inline); fail-fast (bad mid-stylesheet, bad
+  late inline); HTML escaping (ampersand in href, quote in
+  media); purity / determinism (byte-identical, no input
+  mutation); full real-world example with verbatim line check.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+### v0 simplifications (documented)
+
+- **No CSS minification / autoprefixing** — caller
+  pre-processes.
+- **No CSS-syntax validation** — only the HTML-injection
+  vector (`</style>`) is rejected.
+- **No `<link rel="preload" as="style">`** — that's a resource
+  hint, lives in `forme-aot-meta-link-tags`.
+- **No `title` attribute** on `<link>` (deferred).
+- **No `blocking="render"`** (low adoption).

--- a/code/packages/typescript/forme-aot-style-tag-emitter/README.md
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/README.md
@@ -1,0 +1,175 @@
+# @coding-adventures/forme-aot-style-tag-emitter
+
+> FM00 v0 emitter — `StyleConfig` → HTML `<link rel="stylesheet">`
+> + inline `<style>` tag strings, with SRI integrity + media-query
+> + `</style>`-injection defence.
+
+Seventeenth FM00 v0 stage package. Pure transform — no I/O, no
+fs, no network, no env, no shell.
+
+## What it does
+
+`generateStyleTags(config) → string` takes a `StyleConfig` and
+emits one tag per line, joined by newlines (no trailing newline).
+Empty config → empty string.
+
+| Section          | Output                                       |
+| ---------------- | -------------------------------------------- |
+| `stylesheets[]`  | `<link rel="stylesheet" href="...">` entries |
+| `inline[]`       | `<style>...css...</style>` blocks            |
+
+External `<link>` first, then `<style>` — external sheets start
+loading earlier and the cascade resolves predictably regardless
+of where in `<head>` this block lands.
+
+## Quick start
+
+```ts
+import { generateStyleTags } from "@coding-adventures/forme-aot-style-tag-emitter";
+
+generateStyleTags({
+  stylesheets: [
+    { href: "/reset.css" },
+    { href: "/main.css",
+      integrity: "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC",
+      crossorigin: "anonymous" },
+    { href: "/print.css", media: "print" },
+  ],
+  inline: [
+    { css: ":root { --c: #0a0a0a; }" },
+    { media: "(prefers-color-scheme: dark)", css: ":root { --c: #fafafa; }" },
+  ],
+});
+```
+
+Produces:
+
+```html
+<link rel="stylesheet" href="/reset.css">
+<link rel="stylesheet" href="/main.css" integrity="sha384-..." crossorigin="anonymous">
+<link rel="stylesheet" href="/print.css" media="print">
+<style>:root { --c: #0a0a0a; }</style>
+<style media="(prefers-color-scheme: dark)">:root { --c: #fafafa; }</style>
+```
+
+## Validation
+
+Two-pass fail-fast. The validator walks every entry before
+emitting any tag — an exception means the caller has nothing to
+write.
+
+### URL accept-list (`href`)
+
+`http://...` or `https://...` (scheme case-insensitive) or
+root-relative `/path` (NOT `//host`, NOT `/\host`). Also rejects
+ASCII control bytes (`\x00-\x1F`, `\x7F`) — otherwise
+`escapeHtmlAttr` would silently strip them and change the URL.
+
+### SRI integrity
+
+Format: `<algo>-<base64>` with algo ∈ `{sha256, sha384, sha512}`
+(or multiple space-separated). Standard base64 only (no URL-safe
+`- _`). Base64 length must match the algo's expected digest
+size **AND** the per-algo padding count must be exact (1 / 0 / 2
+`=` chars respectively).
+
+The per-algo padding check is the subtle one — a sha256 string
+with `==` instead of `=` is the right total length (44 chars) but
+decodes to 31 bytes, and browsers silently disable SRI rather
+than throw. We catch this at the emitter.
+
+The internal algo table is a `Map` (not a plain object) so
+attacker-supplied algo names like `"__proto__"`, `"toString"`,
+`"hasOwnProperty"` can't walk `Object.prototype` and bypass the
+unknown-algo branch.
+
+### `crossorigin` allowlist
+
+`anonymous` | `use-credentials`.
+
+### `media` query
+
+Pure pass-through (HTML-attribute-escaped). We don't gatekeep
+CSS media-query syntax — there's no usable pure-JS parser, and
+locking callers out of valid queries would do more harm than the
+attack surface (caller-controlled `media` attributes can't
+escape attribute context once HTML-attr-escaped).
+
+### Inline CSS body
+
+Emitted verbatim between `<style>` and `</style>` (CSS is
+parsed as raw text by browsers; escaping `<`/`>`/`&` would
+corrupt selectors). The validator rejects any literal
+`</style` sequence followed by whitespace, `>`, or `/`
+(case-insensitive) — that's the only sequence the HTML parser
+treats as a style-block close, and allowing it would let
+attacker-controlled CSS smuggle arbitrary HTML and JS into the
+page. If you genuinely need `</style>` in a CSS string literal,
+use the CSS escape `\3C/style>` which preserves meaning without
+matching this pattern.
+
+### `disabled` boolean
+
+When `true`, emits the bare `disabled` attribute. Browsers
+download the stylesheet but don't apply it until JS toggles the
+`disabled` property.
+
+## Security posture
+
+Seven concerns explicitly addressed:
+
+1. **URL scheme injection.** `validateStyleHref` rejects every
+   non-`http(s)://` / non-root-relative URL.
+2. **HTML attribute injection.** Every interpolated value
+   (including `media`, validated SRI, validated crossorigin,
+   validated `href`) passes through `escapeHtmlAttr`.
+3. **SRI integrity format validation** with **per-algo padding
+   count** — silent-disable defence.
+4. **Object-prototype walk defence.** Algo table is a `Map`.
+5. **`</style>` rejection** in inline CSS — the canonical XSS
+   sink for caller-supplied style blocks. Case-insensitive
+   match against `</style` followed by `[\s>/]` mirrors the
+   HTML parser's actual close-tag recognition.
+6. **Control bytes in `href` rejected** at the validator (not
+   silently stripped by escape).
+7. **Fail-fast.** Validation completes for every entry BEFORE
+   any tag is emitted.
+
+## Behavioural notes
+
+- **Empty config** → empty string.
+- **Output order**: stylesheets first, then inline.
+- **Attribute order** per `<link>`:
+  `rel → href → media → integrity → crossorigin → disabled`.
+- **Reproducibility.** Same input → byte-identical output.
+- **Inline CSS body is NOT escaped.** Browsers parse `<style>`
+  contents as raw text; escaping would corrupt CSS.
+
+## v0 simplifications (documented)
+
+- **No CSS minification / autoprefixing.** Caller pre-processes
+  CSS before passing it in.
+- **No CSS-syntax validation.** We only reject the
+  HTML-injection vector (`</style>`); valid CSS is the caller's
+  responsibility.
+- **No `<link rel="preload" as="style">`.** That's a resource
+  hint and lives in `forme-aot-meta-link-tags`.
+- **No `title` attribute** on `<link>` (rarely used; deferred).
+- **No `blocking="render"`** attribute (low adoption).
+
+## Tests
+
+122 tests across two files. **100% line / 100% branch** coverage
+on all source files with logic.
+
+## Capabilities
+
+`[]` — pure transform.
+
+## How it fits in the stack
+
+Sibling of `forme-aot-script-tag-emitter` (script tags),
+`forme-aot-meta-link-tags` (meta / link tags), and
+`forme-aot-rss-discovery-link` (feed discovery). Higher-level
+FM00 head builders compose all of these to produce the final
+`<head>`.

--- a/code/packages/typescript/forme-aot-style-tag-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-style-tag-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-style-tag-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/package.json
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-style-tag-emitter",
+  "version": "0.1.0",
+  "description": "Emit HTML <link rel=\"stylesheet\"> + inline <style> tag strings.  Pure transform: URL accept-list (http(s):// OR root-relative), SRI integrity sha256/384/512 (Map-backed algo lookup, per-algo padding check), media-query passthrough HTML-attr-escaped, crossorigin allowlist, inline CSS rejects </style> sequence.  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-style-tag-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: StyleConfig → HTML <link rel=stylesheet> + <style> tag string.  No I/O, no network, no env, no shell, no fs."
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/src/escape.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/src/escape.ts
@@ -1,0 +1,34 @@
+/**
+ * escape.ts — HTML attribute escaping.
+ *
+ * Same single-pass character-class replacement pattern as the
+ * sibling FM00 emitters.
+ *
+ * @module escape
+ */
+
+const HTML_ATTR_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",
+});
+
+const HTML_ATTR_SPECIAL_RE = /[&<>"']/g;
+// eslint-disable-next-line no-control-regex
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+/**
+ * Strip ASCII control bytes (`\x00-\x1F`, `\x7F`).
+ */
+export function stripAsciiControl(s: string): string {
+  return String(s).replace(ASCII_CONTROL_RE, "");
+}
+
+/**
+ * Escape HTML attribute special chars + strip control bytes.
+ */
+export function escapeHtmlAttr(s: string): string {
+  return stripAsciiControl(s).replace(HTML_ATTR_SPECIAL_RE, (ch) => HTML_ATTR_ESCAPE_MAP[ch]!);
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/src/generate.ts
@@ -1,0 +1,168 @@
+/**
+ * generate.ts — main `generateStyleTags` entry.
+ *
+ * Two-pass fail-fast: validate every entry into a fresh
+ * resolved array, then render each to its tag string joined by
+ * newlines.  No trailing newline.
+ *
+ * Output order:
+ *   1. external `<link rel="stylesheet">` entries (in caller's
+ *      order)
+ *   2. inline `<style>` entries (in caller's order)
+ *
+ * External-first is the conventional order — external
+ * stylesheets start loading earlier, and the cascade resolves
+ * predictably regardless of where in the head this block lands.
+ *
+ * Attribute order per `<link>`:
+ *   `rel → href → media → integrity → crossorigin → disabled`
+ *
+ * Attribute order per `<style>`:
+ *   `media` (if present), then body.
+ *
+ * @module generate
+ */
+
+import { escapeHtmlAttr } from "./escape.js";
+import type { InlineStyle, StyleConfig, StylesheetLink } from "./types.js";
+import {
+  validateCrossOrigin,
+  validateInlineCss,
+  validateIntegrity,
+  validateOptionalString,
+  validateStyleHref,
+} from "./validate.js";
+
+interface ResolvedLink {
+  readonly kind: "link";
+  readonly href: string;
+  readonly media: string | undefined;
+  readonly integrity: string | undefined;
+  readonly crossorigin: string | undefined;
+  readonly disabled: boolean;
+}
+interface ResolvedInline {
+  readonly kind: "inline";
+  readonly css: string;
+  readonly media: string | undefined;
+}
+type Resolved = ResolvedLink | ResolvedInline;
+
+/**
+ * Generate `<link rel="stylesheet">` + `<style>` tags from a
+ * structured config.  Returns the empty string for an empty
+ * config (no fields set).  Throws `TypeError` synchronously
+ * for any validation failure before emitting anything.
+ *
+ * ```ts
+ * generateStyleTags({
+ *   stylesheets: [
+ *     { href: "/main.css" },
+ *     { href: "https://cdn.example.com/print.css", media: "print",
+ *       integrity: "sha384-...", crossorigin: "anonymous" },
+ *   ],
+ *   inline: [
+ *     { css: ":root { --c: blue; }" },
+ *     { media: "(prefers-color-scheme: dark)", css: ":root { --c: lightblue; }" },
+ *   ],
+ * });
+ * ```
+ */
+export function generateStyleTags(config: StyleConfig): string {
+  if (config === null || typeof config !== "object") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: config must be a non-null object; got ${typeof config}`,
+    );
+  }
+
+  const resolved: Resolved[] = [];
+
+  if (config.stylesheets !== undefined) {
+    if (!Array.isArray(config.stylesheets)) {
+      throw new TypeError(
+        `forme-aot-style-tag-emitter: stylesheets must be an array; got ${typeof config.stylesheets}`,
+      );
+    }
+    for (let i = 0; i < config.stylesheets.length; i++) {
+      resolved.push(validateLink(config.stylesheets[i]!, i));
+    }
+  }
+
+  if (config.inline !== undefined) {
+    if (!Array.isArray(config.inline)) {
+      throw new TypeError(
+        `forme-aot-style-tag-emitter: inline must be an array; got ${typeof config.inline}`,
+      );
+    }
+    for (let i = 0; i < config.inline.length; i++) {
+      resolved.push(validateInline(config.inline[i]!, i));
+    }
+  }
+
+  const lines: string[] = new Array(resolved.length);
+  for (let i = 0; i < resolved.length; i++) {
+    lines[i] = renderResolved(resolved[i]!);
+  }
+  return lines.join("\n");
+}
+
+function validateLink(link: StylesheetLink, i: number): ResolvedLink {
+  if (link === null || typeof link !== "object") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: stylesheets[${i}] must be a non-null object; got ${typeof link}`,
+    );
+  }
+  const href = validateStyleHref(link.href, `stylesheets[${i}].href`);
+  const media = validateOptionalString(link.media, `stylesheets[${i}].media`);
+  const integrity = link.integrity === undefined
+    ? undefined
+    : validateIntegrity(link.integrity, `stylesheets[${i}].integrity`);
+  const crossorigin = link.crossorigin === undefined
+    ? undefined
+    : validateCrossOrigin(link.crossorigin, `stylesheets[${i}].crossorigin`);
+  const disabled = validateBool(link.disabled, `stylesheets[${i}].disabled`);
+  return { kind: "link", href, media, integrity, crossorigin, disabled };
+}
+
+function validateInline(entry: InlineStyle, i: number): ResolvedInline {
+  if (entry === null || typeof entry !== "object") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: inline[${i}] must be a non-null object; got ${typeof entry}`,
+    );
+  }
+  const css = validateInlineCss(entry.css, `inline[${i}].css`);
+  const media = validateOptionalString(entry.media, `inline[${i}].media`);
+  return { kind: "inline", css, media };
+}
+
+function validateBool(value: unknown, field: string): boolean {
+  if (value === undefined || value === false) return false;
+  if (value === true) return true;
+  throw new TypeError(
+    `forme-aot-style-tag-emitter: ${field} must be a boolean; got ${typeof value}`,
+  );
+}
+
+function renderResolved(r: Resolved): string {
+  return r.kind === "link" ? renderLink(r) : renderInline(r);
+}
+
+function renderLink(r: ResolvedLink): string {
+  const parts: string[] = [
+    `<link rel="stylesheet"`,
+    `href="${escapeHtmlAttr(r.href)}"`,
+  ];
+  if (r.media !== undefined)       parts.push(`media="${escapeHtmlAttr(r.media)}"`);
+  if (r.integrity !== undefined)   parts.push(`integrity="${escapeHtmlAttr(r.integrity)}"`);
+  if (r.crossorigin !== undefined) parts.push(`crossorigin="${escapeHtmlAttr(r.crossorigin)}"`);
+  // `disabled` is a boolean attribute — emit bare attribute name.
+  if (r.disabled)                  parts.push("disabled");
+  return `${parts.join(" ")}>`;
+}
+
+function renderInline(r: ResolvedInline): string {
+  const open = r.media !== undefined
+    ? `<style media="${escapeHtmlAttr(r.media)}">`
+    : `<style>`;
+  return `${open}${r.css}</style>`;
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @coding-adventures/forme-aot-style-tag-emitter
+ *
+ * Emit HTML `<link rel="stylesheet">` and inline `<style>` tag
+ * strings from a structured `StyleConfig`.  Pure transform.
+ *
+ * External `<link>` entries support SRI integrity (sha256 /
+ * sha384 / sha512 with per-algo length + padding validation,
+ * Map-backed algo lookup), crossorigin, media query, and the
+ * `disabled` boolean.  Inline `<style>` entries support a media
+ * query and reject any literal `</style>` sequence in the body.
+ *
+ * ```ts
+ * import { generateStyleTags } from "@coding-adventures/forme-aot-style-tag-emitter";
+ *
+ * generateStyleTags({
+ *   stylesheets: [
+ *     { href: "/main.css" },
+ *     { href: "https://cdn.example.com/print.css", media: "print",
+ *       integrity: "sha384-...", crossorigin: "anonymous" },
+ *   ],
+ *   inline: [
+ *     { css: ":root { --c: blue; }" },
+ *     { media: "(prefers-color-scheme: dark)", css: ":root { --c: lightblue; }" },
+ *   ],
+ * });
+ * ```
+ *
+ * Seventeenth FM00 v0 stage package.
+ *
+ * @module index
+ */
+
+export { generateStyleTags } from "./generate.js";
+export { escapeHtmlAttr, stripAsciiControl } from "./escape.js";
+export {
+  validateStyleHref,
+  validateIntegrity,
+  validateCrossOrigin,
+  validateInlineCss,
+  validateOptionalString,
+} from "./validate.js";
+export type {
+  StyleConfig,
+  StylesheetLink,
+  InlineStyle,
+  CrossOrigin,
+} from "./types.js";

--- a/code/packages/typescript/forme-aot-style-tag-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/src/types.ts
@@ -1,0 +1,86 @@
+/**
+ * types.ts — public signatures for the style tag emitter.
+ *
+ * Two complementary tag types:
+ *
+ *   - `<link rel="stylesheet" href="...">` — external stylesheet.
+ *     Supports SRI integrity + crossorigin + media query + the
+ *     `disabled` attribute (which lets JS swap stylesheets
+ *     in/out without re-downloading).
+ *   - `<style>...css...</style>` — inline CSS.  Supports a
+ *     `media` query.  Inline CSS rejects any literal `</style>`
+ *     sequence in its body (case-insensitive) because that
+ *     would close the style block early and let arbitrary HTML
+ *     follow — the canonical XSS vector for inline-style sinks.
+ *
+ * @module types
+ */
+
+/**
+ * `crossorigin` attribute value.  Same allowlist as the sibling
+ * `forme-aot-script-tag-emitter` / `forme-aot-meta-link-tags`.
+ */
+export type CrossOrigin = "anonymous" | "use-credentials";
+
+/**
+ * External stylesheet `<link>` descriptor.
+ *
+ *   - `href`         — required.  http(s):// or root-relative.
+ *   - `media`        — optional CSS media query
+ *                      (e.g. `"screen"`, `"print"`,
+ *                      `"(max-width: 600px)"`).  Passes through
+ *                      HTML-attribute-escaped; CSS validation is
+ *                      explicitly out of scope (no usable
+ *                      pure-JS media-query parser; we'd lock
+ *                      callers out of valid queries by
+ *                      gatekeeping).
+ *   - `integrity`    — optional SRI string.  Same format as
+ *                      `forme-aot-script-tag-emitter`:
+ *                      `<algo>-<base64>` with
+ *                      `algo ∈ {sha256, sha384, sha512}` and
+ *                      the per-algo base64 length + padding
+ *                      enforced.
+ *   - `crossorigin`  — optional `anonymous | use-credentials`.
+ *   - `disabled`     — optional boolean.  When `true`, emits the
+ *                      `disabled` attribute.  Browsers download
+ *                      the stylesheet but don't apply it until
+ *                      JS toggles the property.
+ */
+export interface StylesheetLink {
+  readonly href: string;
+  readonly media?: string;
+  readonly integrity?: string;
+  readonly crossorigin?: CrossOrigin;
+  readonly disabled?: boolean;
+}
+
+/**
+ * Inline `<style>` block descriptor.
+ *
+ *   - `css`   — required CSS source text.  Emitted between
+ *               `<style>` and `</style>` verbatim EXCEPT that
+ *               any literal `</style>` sequence (case-insensitive)
+ *               in the body is rejected at validation time —
+ *               that would close the style block early and let
+ *               arbitrary HTML follow.
+ *   - `media` — optional CSS media query (same passthrough as
+ *               above).
+ */
+export interface InlineStyle {
+  readonly css: string;
+  readonly media?: string;
+}
+
+/**
+ * Top-level config consumed by `generateStyleTags`.
+ *
+ * Output order is fixed: every `stylesheets[]` entry first (in
+ * caller's array order), then every `inline[]` entry (in
+ * caller's order).  External stylesheets first is the
+ * conventional order — they start loading earlier and the
+ * cascade resolves predictably.
+ */
+export interface StyleConfig {
+  readonly stylesheets?: readonly StylesheetLink[];
+  readonly inline?: readonly InlineStyle[];
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/src/validate.ts
@@ -1,0 +1,209 @@
+/**
+ * validate.ts — URL, SRI integrity, crossorigin, inline-CSS
+ * validators.
+ *
+ * The SRI validator is structurally identical to the one in
+ * `forme-aot-script-tag-emitter` — same Map-backed algo
+ * lookup (defends against Object.prototype walks like
+ * `__proto__`), same per-algo padding check (defends against
+ * silent SRI disable in browsers).
+ *
+ * The inline-CSS validator rejects `</style>` because allowing
+ * it would let arbitrary HTML follow inside the `<style>`
+ * block — the canonical XSS sink for caller-supplied CSS.
+ *
+ * @module validate
+ */
+
+import type { CrossOrigin } from "./types.js";
+
+const CROSSORIGIN_ALLOWLIST: ReadonlySet<string> = new Set([
+  "anonymous",
+  "use-credentials",
+]);
+
+// Map-backed so attacker-supplied algo names like `"__proto__"`,
+// `"toString"`, `"hasOwnProperty"` can't walk Object.prototype
+// and return truthy values from inherited properties.
+const SRI_ALGOS: ReadonlyMap<string, number> = new Map([
+  ["sha256", 32],
+  ["sha384", 48],
+  ["sha512", 64],
+]);
+
+// Standard base64 only — SRI does NOT permit URL-safe `- _` variants.
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+// Reject ASCII control bytes anywhere in a URL — otherwise
+// `escapeHtmlAttr` would silently strip them and change the
+// URL's meaning (e.g. `/path\x00.css` → `/path.css`).
+// eslint-disable-next-line no-control-regex
+const URL_CONTROL_RE = /[\x00-\x1F\x7F]/;
+
+// Reject literal `</style>` (case-insensitive) in inline CSS.
+// `<\/style[\s>]` matches the HTML parser's actual close-tag
+// recognition: `</style` followed by whitespace or `>`.  This
+// is the only sequence that can end the style block; matching
+// it exactly avoids false positives on benign CSS like
+// `content: "</style>"` only when that genuinely-attacker-
+// controlled string is naked in source.  We err on the strict
+// side — if you need a literal `</style>` in CSS, use
+// `\3C/style>` (CSS escape) which preserves meaning without
+// matching this pattern.
+const STYLE_CLOSE_RE = /<\/style[\s>\/]/i;
+
+/**
+ * URL accept-list (same logic as the sibling emitters).
+ * `field` is threaded through for clear error messages
+ * (`stylesheets[2].href`).
+ */
+export function validateStyleHref(url: unknown, field: string): string {
+  if (typeof url !== "string" || url.length === 0) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be a non-empty string; got ${
+        url === null ? "null" : typeof url
+      }`,
+    );
+  }
+  if (URL_CONTROL_RE.test(url)) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must not contain ASCII control bytes (\\x00-\\x1F, \\x7F)`,
+    );
+  }
+  if (isHttpUrl(url)) return url;
+  if (isRootRelative(url)) return url;
+  const shown = url.length > 200 ? `${url.slice(0, 200)}…` : url;
+  throw new TypeError(
+    `forme-aot-style-tag-emitter: ${field} must be http(s):// or root-relative /path; got ${JSON.stringify(shown)}`,
+  );
+}
+
+/**
+ * Validate an SRI `integrity` string.  Same format and checks
+ * as `forme-aot-script-tag-emitter`.
+ */
+export function validateIntegrity(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be non-empty`,
+    );
+  }
+  const tokens = trimmed.split(/\s+/);
+  for (const tok of tokens) {
+    validateSriToken(tok, field);
+  }
+  return tokens.join(" ");
+}
+
+function validateSriToken(token: string, field: string): void {
+  const dashIdx = token.indexOf("-");
+  if (dashIdx <= 0 || dashIdx >= token.length - 1) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} token must be "<algo>-<base64>"; got ${JSON.stringify(token)}`,
+    );
+  }
+  const algo = token.slice(0, dashIdx);
+  const b64 = token.slice(dashIdx + 1);
+  const expectedBytes = SRI_ALGOS.get(algo);
+  if (expectedBytes === undefined) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} algo must be one of [${
+        [...SRI_ALGOS.keys()].join(", ")
+      }]; got ${JSON.stringify(algo)}`,
+    );
+  }
+  if (!BASE64_RE.test(b64)) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} base64 has invalid characters; got ${JSON.stringify(b64)}`,
+    );
+  }
+  const expectedB64Len = Math.ceil(expectedBytes / 3) * 4;
+  if (b64.length !== expectedB64Len) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} ${algo} expects ${expectedB64Len}-char base64; got ${b64.length}`,
+    );
+  }
+  // Per-algo padding count check — sha256 needs exactly 1 `=`,
+  // sha384 exactly 0, sha512 exactly 2.  Without this check a
+  // wrong-padded string passes length but decodes to a different
+  // byte length and browsers silently disable SRI.
+  const expectedPad = (3 - (expectedBytes % 3)) % 3;
+  const actualPad = b64.length - b64.replace(/=+$/, "").length;
+  if (actualPad !== expectedPad) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} ${algo} requires ${expectedPad} '=' padding char${expectedPad === 1 ? "" : "s"}; got ${actualPad}`,
+    );
+  }
+}
+
+/**
+ * Validate `crossorigin` value.
+ */
+export function validateCrossOrigin(value: unknown, field: string): CrossOrigin {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  if (!CROSSORIGIN_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be one of [${
+        [...CROSSORIGIN_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as CrossOrigin;
+}
+
+/**
+ * Validate inline CSS body.  Rejects any literal `</style`
+ * (case-insensitive) followed by whitespace, `>`, or `/` —
+ * those are the only sequences the HTML parser recognises as
+ * a style close tag.  Callers who genuinely need `</style>` in
+ * a CSS string literal should use the CSS escape `\3C/style>`
+ * which preserves meaning without matching this pattern.
+ */
+export function validateInlineCss(css: unknown, field: string): string {
+  if (typeof css !== "string") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be a string; got ${typeof css}`,
+    );
+  }
+  if (STYLE_CLOSE_RE.test(css)) {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} contains a literal </style> sequence; this would close the style block early.  Use \\3C/style> as a CSS escape instead.`,
+    );
+  }
+  return css;
+}
+
+/**
+ * Optional string field check — `undefined` passes through,
+ * any other non-string throws.
+ */
+export function validateOptionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-style-tag-emitter: ${field} must be a string; got ${typeof value}`,
+    );
+  }
+  return value;
+}
+
+function isHttpUrl(url: string): boolean {
+  const head = url.slice(0, 8).toLowerCase();
+  return head.startsWith("http://") || head.startsWith("https://");
+}
+
+function isRootRelative(url: string): boolean {
+  if (url === "/") return true;
+  if (url.length < 2 || url[0] !== "/") return false;
+  return url[1] !== "/" && url[1] !== "\\";
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/tests/generate.test.ts
@@ -1,0 +1,245 @@
+/**
+ * generate.test.ts — end-to-end generateStyleTags.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateStyleTags } from "../src/index.js";
+
+const SHA384_B64 = "A".repeat(64);
+
+describe("generateStyleTags — empty / shape", () => {
+  it("empty config → empty string", () => {
+    expect(generateStyleTags({})).toBe("");
+  });
+  it("null config throws", () => {
+    expect(() => generateStyleTags(null as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("string config throws", () => {
+    expect(() => generateStyleTags("x" as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("empty arrays → empty string", () => {
+    expect(generateStyleTags({ stylesheets: [], inline: [] })).toBe("");
+  });
+});
+
+describe("generateStyleTags — external stylesheets", () => {
+  it("minimal href-only", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "/main.css" }] }))
+      .toBe(`<link rel="stylesheet" href="/main.css">`);
+  });
+  it("with media", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "/print.css", media: "print" }] }))
+      .toBe(`<link rel="stylesheet" href="/print.css" media="print">`);
+  });
+  it("with media query", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "/m.css", media: "(max-width: 600px)" }] }))
+      .toBe(`<link rel="stylesheet" href="/m.css" media="(max-width: 600px)">`);
+  });
+  it("with SRI + crossorigin", () => {
+    expect(generateStyleTags({
+      stylesheets: [{ href: "https://cdn.example.com/x.css", integrity: `sha384-${SHA384_B64}`, crossorigin: "anonymous" }],
+    }))
+      .toBe(`<link rel="stylesheet" href="https://cdn.example.com/x.css" integrity="sha384-${SHA384_B64}" crossorigin="anonymous">`);
+  });
+  it("disabled boolean", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "/x.css", disabled: true }] }))
+      .toBe(`<link rel="stylesheet" href="/x.css" disabled>`);
+  });
+  it("disabled=false omits attr", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "/x.css", disabled: false }] }))
+      .toBe(`<link rel="stylesheet" href="/x.css">`);
+  });
+  it("attribute order: rel → href → media → integrity → crossorigin → disabled", () => {
+    expect(generateStyleTags({
+      stylesheets: [{
+        disabled: true,
+        crossorigin: "anonymous",
+        integrity: `sha384-${SHA384_B64}`,
+        media: "screen",
+        href: "https://cdn.example.com/x.css",
+      }],
+    })).toBe(
+      `<link rel="stylesheet" href="https://cdn.example.com/x.css" media="screen" integrity="sha384-${SHA384_B64}" crossorigin="anonymous" disabled>`,
+    );
+  });
+  it("multiple stylesheets in caller's order", () => {
+    expect(generateStyleTags({
+      stylesheets: [{ href: "/a.css" }, { href: "/b.css" }, { href: "/c.css" }],
+    })).toBe([
+      `<link rel="stylesheet" href="/a.css">`,
+      `<link rel="stylesheet" href="/b.css">`,
+      `<link rel="stylesheet" href="/c.css">`,
+    ].join("\n"));
+  });
+  it("rejects bad href", () => {
+    expect(() => generateStyleTags({ stylesheets: [{ href: "javascript:x" }] }))
+      .toThrow(/stylesheets\[0\]\.href must be http\(s\)/);
+  });
+  it("rejects bad integrity", () => {
+    expect(() => generateStyleTags({ stylesheets: [{ href: "/x.css", integrity: "md5-abc" }] }))
+      .toThrow(/stylesheets\[0\]\.integrity algo must be one of/);
+  });
+  it("rejects bad crossorigin", () => {
+    expect(() => generateStyleTags({ stylesheets: [{ href: "/x.css", crossorigin: "true" as unknown as never }] }))
+      .toThrow(/stylesheets\[0\]\.crossorigin must be one of/);
+  });
+  it("rejects non-bool disabled", () => {
+    expect(() => generateStyleTags({ stylesheets: [{ href: "/x.css", disabled: 1 as unknown as boolean }] }))
+      .toThrow(/disabled must be a boolean/);
+  });
+  it("rejects non-string media", () => {
+    expect(() => generateStyleTags({ stylesheets: [{ href: "/x.css", media: 1 as unknown as string }] }))
+      .toThrow(/media must be a string/);
+  });
+  it("rejects null stylesheet entry", () => {
+    expect(() => generateStyleTags({ stylesheets: [null as unknown as never] }))
+      .toThrow(/stylesheets\[0\] must be a non-null object/);
+  });
+  it("rejects non-array stylesheets", () => {
+    expect(() => generateStyleTags({ stylesheets: "x" as unknown as never }))
+      .toThrow(/stylesheets must be an array/);
+  });
+});
+
+describe("generateStyleTags — inline styles", () => {
+  it("minimal inline", () => {
+    expect(generateStyleTags({ inline: [{ css: ":root { --c: blue; }" }] }))
+      .toBe(`<style>:root { --c: blue; }</style>`);
+  });
+  it("empty CSS renders empty <style>", () => {
+    expect(generateStyleTags({ inline: [{ css: "" }] }))
+      .toBe(`<style></style>`);
+  });
+  it("inline with media", () => {
+    expect(generateStyleTags({
+      inline: [{ media: "(prefers-color-scheme: dark)", css: "body{background:#000}" }],
+    })).toBe(
+      `<style media="(prefers-color-scheme: dark)">body{background:#000}</style>`,
+    );
+  });
+  it("CSS body NOT escaped (verbatim between <style> and </style>)", () => {
+    // Browsers parse <style> contents in a special raw-text state;
+    // escaping `<`/`>`/`&` would corrupt CSS selectors.
+    const css = "a > b { color: red; }";
+    expect(generateStyleTags({ inline: [{ css }] }))
+      .toBe(`<style>${css}</style>`);
+  });
+  it("multiple inline blocks in order", () => {
+    expect(generateStyleTags({
+      inline: [
+        { css: ".a {}" },
+        { css: ".b {}" },
+        { css: ".c {}" },
+      ],
+    })).toBe([
+      `<style>.a {}</style>`,
+      `<style>.b {}</style>`,
+      `<style>.c {}</style>`,
+    ].join("\n"));
+  });
+  it("rejects literal </style> in CSS", () => {
+    expect(() => generateStyleTags({
+      inline: [{ css: "body {} </style><script>alert(1)</script>" }],
+    })).toThrow(/literal <\/style> sequence/);
+  });
+  it("rejects </STYLE> case-variant", () => {
+    expect(() => generateStyleTags({ inline: [{ css: "body{} </STYLE> x" }] }))
+      .toThrow(/literal <\/style>/);
+  });
+  it("rejects non-string CSS", () => {
+    expect(() => generateStyleTags({ inline: [{ css: 42 as unknown as string }] }))
+      .toThrow(/inline\[0\]\.css must be a string/);
+  });
+  it("rejects null inline entry", () => {
+    expect(() => generateStyleTags({ inline: [null as unknown as never] }))
+      .toThrow(/inline\[0\] must be a non-null object/);
+  });
+  it("rejects non-array inline", () => {
+    expect(() => generateStyleTags({ inline: "x" as unknown as never }))
+      .toThrow(/inline must be an array/);
+  });
+  it("media gets HTML-escaped (defensive)", () => {
+    const out = generateStyleTags({ inline: [{ media: `screen"x`, css: "" }] });
+    expect(out).toContain(`media="screen&quot;x"`);
+  });
+});
+
+describe("generateStyleTags — output order", () => {
+  it("stylesheets → inline", () => {
+    const out = generateStyleTags({
+      inline: [{ css: ".inline {}" }],
+      stylesheets: [{ href: "/main.css" }],
+    });
+    expect(out).toBe([
+      `<link rel="stylesheet" href="/main.css">`,
+      `<style>.inline {}</style>`,
+    ].join("\n"));
+  });
+});
+
+describe("generateStyleTags — fail-fast", () => {
+  it("bad stylesheet mid-array, no inline emitted", () => {
+    expect(() => generateStyleTags({
+      stylesheets: [{ href: "/a.css" }, { href: "javascript:bad" }],
+      inline: [{ css: ".x {}" }],
+    })).toThrow(/stylesheets\[1\]\.href/);
+  });
+  it("bad inline after good stylesheets, no output", () => {
+    expect(() => generateStyleTags({
+      stylesheets: [{ href: "/a.css" }],
+      inline: [{ css: ".x {}" }, { css: "</style>" }],
+    })).toThrow(/inline\[1\]\.css/);
+  });
+});
+
+describe("generateStyleTags — HTML escaping (security)", () => {
+  it("escapes ampersand in href", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "https://example.com/?a=1&b=2" }] }))
+      .toContain(`href="https://example.com/?a=1&amp;b=2"`);
+  });
+  it("escapes quote in media", () => {
+    expect(generateStyleTags({ stylesheets: [{ href: "/x.css", media: `(max-width:600px) "x"` }] }))
+      .toContain(`media="(max-width:600px) &quot;x&quot;"`);
+  });
+});
+
+describe("generateStyleTags — purity / determinism", () => {
+  it("same input → byte-identical output", () => {
+    const cfg = { stylesheets: [{ href: "/main.css", media: "screen" }] };
+    expect(generateStyleTags(cfg)).toBe(generateStyleTags(cfg));
+  });
+  it("does not mutate input", () => {
+    const cfg = {
+      stylesheets: [{ href: "/x.css", integrity: `sha384-${SHA384_B64}`, disabled: true }],
+      inline: [{ css: ".x {}" }],
+    };
+    const before = JSON.stringify(cfg);
+    generateStyleTags(cfg);
+    expect(JSON.stringify(cfg)).toBe(before);
+  });
+});
+
+describe("generateStyleTags — full real-world example", () => {
+  it("multi-sheet + dark-mode override", () => {
+    const out = generateStyleTags({
+      stylesheets: [
+        { href: "/reset.css" },
+        { href: "/main.css", integrity: `sha384-${SHA384_B64}`, crossorigin: "anonymous" },
+        { href: "/print.css", media: "print" },
+      ],
+      inline: [
+        { css: ":root { --c: #0a0a0a; }" },
+        { media: "(prefers-color-scheme: dark)", css: ":root { --c: #fafafa; }" },
+      ],
+    });
+    expect(out).toBe([
+      `<link rel="stylesheet" href="/reset.css">`,
+      `<link rel="stylesheet" href="/main.css" integrity="sha384-${SHA384_B64}" crossorigin="anonymous">`,
+      `<link rel="stylesheet" href="/print.css" media="print">`,
+      `<style>:root { --c: #0a0a0a; }</style>`,
+      `<style media="(prefers-color-scheme: dark)">:root { --c: #fafafa; }</style>`,
+    ].join("\n"));
+  });
+});

--- a/code/packages/typescript/forme-aot-style-tag-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/tests/validate.test.ts
@@ -1,0 +1,215 @@
+/**
+ * validate.test.ts — URL, SRI integrity, crossorigin,
+ * inline-CSS, escape helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtmlAttr,
+  stripAsciiControl,
+  validateCrossOrigin,
+  validateInlineCss,
+  validateIntegrity,
+  validateOptionalString,
+  validateStyleHref,
+} from "../src/index.js";
+
+const SHA256_B64 = "A".repeat(43) + "=";
+const SHA384_B64 = "A".repeat(64);
+const SHA512_B64 = "A".repeat(86) + "==";
+
+describe("validateStyleHref — accept", () => {
+  it("https URL", () => {
+    expect(validateStyleHref("https://example.com/x.css", "f")).toBe("https://example.com/x.css");
+  });
+  it("http URL", () => {
+    expect(validateStyleHref("http://example.com/x.css", "f")).toBe("http://example.com/x.css");
+  });
+  it("scheme case-insensitive", () => {
+    expect(validateStyleHref("HTTPS://example.com/x.css", "f")).toBe("HTTPS://example.com/x.css");
+  });
+  it("root-relative", () => { expect(validateStyleHref("/main.css", "f")).toBe("/main.css"); });
+  it("bare /", () => { expect(validateStyleHref("/", "f")).toBe("/"); });
+  it("multi-segment", () => { expect(validateStyleHref("/assets/css/main.css", "f")).toBe("/assets/css/main.css"); });
+});
+
+describe("validateStyleHref — reject", () => {
+  it("javascript:", () => { expect(() => validateStyleHref("javascript:x", "href")).toThrow(/href must be http\(s\)/); });
+  it("data:", () => { expect(() => validateStyleHref("data:text/css,x", "f")).toThrow(/http\(s\)/); });
+  it("file:", () => { expect(() => validateStyleHref("file:///etc", "f")).toThrow(/http\(s\)/); });
+  it("vbscript:", () => { expect(() => validateStyleHref("vbscript:x", "f")).toThrow(/http\(s\)/); });
+  it("protocol-relative //host", () => { expect(() => validateStyleHref("//evil.com/x.css", "f")).toThrow(/http\(s\)/); });
+  it("backslash-variant", () => { expect(() => validateStyleHref("/\\evil.com/x.css", "f")).toThrow(/http\(s\)/); });
+  it("bare relative", () => { expect(() => validateStyleHref("main.css", "f")).toThrow(/http\(s\)/); });
+  it("empty", () => { expect(() => validateStyleHref("", "f")).toThrow(/non-empty/); });
+  it("non-string", () => { expect(() => validateStyleHref(42 as unknown as string, "f")).toThrow(/non-empty/); });
+  it("null", () => { expect(() => validateStyleHref(null, "f")).toThrow(/got null/); });
+  it("undefined", () => { expect(() => validateStyleHref(undefined, "f")).toThrow(/got undefined/); });
+  it("NUL byte rejected", () => { expect(() => validateStyleHref("/x.css\x00", "f")).toThrow(/control bytes/); });
+  it("tab rejected", () => { expect(() => validateStyleHref("/\tevil", "f")).toThrow(/control bytes/); });
+  it("newline rejected", () => { expect(() => validateStyleHref("/x\nevil", "f")).toThrow(/control bytes/); });
+  it("DEL rejected", () => { expect(() => validateStyleHref("/x\x7F", "f")).toThrow(/control bytes/); });
+  it("error contains field name", () => {
+    expect(() => validateStyleHref("javascript:x", "stylesheets[2].href"))
+      .toThrow(/stylesheets\[2\]\.href/);
+  });
+  it("long URL truncated", () => {
+    const long = "bad://" + "a".repeat(500);
+    try {
+      validateStyleHref(long, "f");
+      expect.fail("expected throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("…");
+      expect(msg.length).toBeLessThan(long.length + 100);
+    }
+  });
+});
+
+describe("validateIntegrity — accept", () => {
+  it("sha256", () => { expect(validateIntegrity(`sha256-${SHA256_B64}`, "f")).toBe(`sha256-${SHA256_B64}`); });
+  it("sha384", () => { expect(validateIntegrity(`sha384-${SHA384_B64}`, "f")).toBe(`sha384-${SHA384_B64}`); });
+  it("sha512", () => { expect(validateIntegrity(`sha512-${SHA512_B64}`, "f")).toBe(`sha512-${SHA512_B64}`); });
+  it("two algos joined", () => {
+    const in_ = `sha256-${SHA256_B64} sha384-${SHA384_B64}`;
+    expect(validateIntegrity(in_, "f")).toBe(in_);
+  });
+  it("collapses whitespace", () => {
+    expect(validateIntegrity(`sha256-${SHA256_B64}\t\tsha384-${SHA384_B64}`, "f"))
+      .toBe(`sha256-${SHA256_B64} sha384-${SHA384_B64}`);
+  });
+  it("trims surrounding whitespace", () => {
+    expect(validateIntegrity(`  sha256-${SHA256_B64}  `, "f")).toBe(`sha256-${SHA256_B64}`);
+  });
+});
+
+describe("validateIntegrity — reject", () => {
+  it("non-string", () => { expect(() => validateIntegrity(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("empty", () => { expect(() => validateIntegrity("", "f")).toThrow(/non-empty/); });
+  it("whitespace-only", () => { expect(() => validateIntegrity("   ", "f")).toThrow(/non-empty/); });
+  it("md5 algo", () => { expect(() => validateIntegrity("md5-abc", "f")).toThrow(/algo must be one of/); });
+  it("sha1 algo", () => { expect(() => validateIntegrity("sha1-abc", "f")).toThrow(/algo must be one of/); });
+  it("no dash", () => { expect(() => validateIntegrity("sha256abc", "f")).toThrow(/"<algo>-<base64>"/); });
+  it("dash at start", () => { expect(() => validateIntegrity("-abc", "f")).toThrow(/"<algo>-<base64>"/); });
+  it("dash at end", () => { expect(() => validateIntegrity("sha256-", "f")).toThrow(/"<algo>-<base64>"/); });
+  it("sha256 wrong length", () => { expect(() => validateIntegrity(`sha256-${"A".repeat(20)}=`, "f")).toThrow(/sha256 expects 44/); });
+  it("sha384 wrong length", () => { expect(() => validateIntegrity(`sha384-${"A".repeat(60)}`, "f")).toThrow(/sha384 expects 64/); });
+  it("sha512 wrong length", () => { expect(() => validateIntegrity(`sha512-${"A".repeat(80)}==`, "f")).toThrow(/sha512 expects 88/); });
+  it("invalid base64 char @", () => { expect(() => validateIntegrity(`sha256-${"A".repeat(42)}@=`, "f")).toThrow(/invalid characters/); });
+  it("URL-safe _ rejected", () => { expect(() => validateIntegrity(`sha256-${"A".repeat(42)}_=`, "f")).toThrow(/invalid characters/); });
+  it("triple padding rejected", () => { expect(() => validateIntegrity(`sha256-${"A".repeat(41)}===`, "f")).toThrow(/invalid characters/); });
+  it("sha256 wrong padding (== instead of =)", () => {
+    expect(() => validateIntegrity(`sha256-${"A".repeat(42)}==`, "f"))
+      .toThrow(/sha256 requires 1 '=' padding/);
+  });
+  it("sha384 with padding rejected", () => {
+    expect(() => validateIntegrity(`sha384-${"A".repeat(62)}==`, "f"))
+      .toThrow(/sha384 requires 0 '=' padding chars/);
+  });
+  it("sha512 wrong padding rejected", () => {
+    expect(() => validateIntegrity(`sha512-${"A".repeat(87)}=`, "f"))
+      .toThrow(/sha512 requires 2 '=' padding chars/);
+  });
+  it("__proto__ algo rejected (Object.prototype walk defence)", () => {
+    expect(() => validateIntegrity("__proto__-AAAA", "f")).toThrow(/algo must be one of/);
+  });
+  it("toString algo rejected", () => {
+    expect(() => validateIntegrity("toString-AAAA", "f")).toThrow(/algo must be one of/);
+  });
+  it("hasOwnProperty algo rejected", () => {
+    expect(() => validateIntegrity("hasOwnProperty-AAAA", "f")).toThrow(/algo must be one of/);
+  });
+  it("second token bad", () => {
+    expect(() => validateIntegrity(`sha256-${SHA256_B64} md5-xxx`, "f")).toThrow(/algo must be one of/);
+  });
+  it("error contains field name", () => {
+    expect(() => validateIntegrity("md5-aaaa", "stylesheets[0].integrity"))
+      .toThrow(/stylesheets\[0\]\.integrity/);
+  });
+});
+
+describe("validateCrossOrigin", () => {
+  it("anonymous", () => { expect(validateCrossOrigin("anonymous", "f")).toBe("anonymous"); });
+  it("use-credentials", () => { expect(validateCrossOrigin("use-credentials", "f")).toBe("use-credentials"); });
+  it("rejects 'true'", () => { expect(() => validateCrossOrigin("true", "f")).toThrow(/one of/); });
+  it("rejects empty", () => { expect(() => validateCrossOrigin("", "f")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateCrossOrigin(1 as unknown as string, "f")).toThrow(/must be a string/); });
+});
+
+describe("validateInlineCss", () => {
+  it("benign CSS passes through", () => {
+    expect(validateInlineCss(":root { --c: blue; }", "f")).toBe(":root { --c: blue; }");
+  });
+  it("empty string allowed (renders empty <style>)", () => {
+    expect(validateInlineCss("", "f")).toBe("");
+  });
+  it("CSS with < and > but not </style> passes", () => {
+    expect(validateInlineCss("a > b { color: red; }", "f")).toBe("a > b { color: red; }");
+  });
+  it("CSS with `style` substring but no closing tag passes", () => {
+    expect(validateInlineCss(".style { color: red; }", "f")).toBe(".style { color: red; }");
+  });
+  it("rejects literal </style>", () => {
+    expect(() => validateInlineCss("body{} </style><script>alert(1)</script>", "f"))
+      .toThrow(/literal <\/style> sequence/);
+  });
+  it("rejects case-variant </STYLE>", () => {
+    expect(() => validateInlineCss("</STYLE>", "f")).toThrow(/literal <\/style>/);
+  });
+  it("rejects mixed-case </StYlE>", () => {
+    expect(() => validateInlineCss("</StYlE>", "f")).toThrow(/literal <\/style>/);
+  });
+  it("rejects </style with whitespace", () => {
+    expect(() => validateInlineCss("</style >", "f")).toThrow(/literal <\/style>/);
+  });
+  it("rejects </style with slash", () => {
+    expect(() => validateInlineCss("</style/x", "f")).toThrow(/literal <\/style>/);
+  });
+  it("permits </styles> (different tag name, not a close)", () => {
+    // The regex requires </style followed by whitespace/>//, so </styles
+    // would only match if 's' were in that set.  Actually </styles starts
+    // with </style followed by 's' which is NOT in [\s>/], so it's NOT
+    // matched — passes through.
+    expect(validateInlineCss(".x { content: '</styles'; }", "f"))
+      .toBe(".x { content: '</styles'; }");
+  });
+  it("rejects non-string", () => {
+    expect(() => validateInlineCss(42 as unknown as string, "f"))
+      .toThrow(/must be a string/);
+  });
+  it("rejects null", () => {
+    expect(() => validateInlineCss(null, "f")).toThrow(/must be a string/);
+  });
+  it("error contains field path", () => {
+    expect(() => validateInlineCss("</style>", "inline[2].css"))
+      .toThrow(/inline\[2\]\.css/);
+  });
+});
+
+describe("validateOptionalString", () => {
+  it("undefined → undefined", () => { expect(validateOptionalString(undefined, "f")).toBeUndefined(); });
+  it("string → string", () => { expect(validateOptionalString("x", "f")).toBe("x"); });
+  it("empty string allowed", () => { expect(validateOptionalString("", "f")).toBe(""); });
+  it("non-string rejected", () => { expect(() => validateOptionalString(7 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null rejected", () => { expect(() => validateOptionalString(null, "f")).toThrow(/must be a string/); });
+});
+
+describe("escapeHtmlAttr", () => {
+  it("ampersand", () => { expect(escapeHtmlAttr("a&b")).toBe("a&amp;b"); });
+  it("less-than", () => { expect(escapeHtmlAttr("a<b")).toBe("a&lt;b"); });
+  it("greater-than", () => { expect(escapeHtmlAttr("a>b")).toBe("a&gt;b"); });
+  it("double quote", () => { expect(escapeHtmlAttr(`"`)).toBe("&quot;"); });
+  it("single quote", () => { expect(escapeHtmlAttr(`'`)).toBe("&#39;"); });
+  it("composite", () => { expect(escapeHtmlAttr(`<&>"'`)).toBe("&lt;&amp;&gt;&quot;&#39;"); });
+  it("strips NUL", () => { expect(escapeHtmlAttr("a\x00b")).toBe("ab"); });
+  it("non-string coerced", () => { expect(escapeHtmlAttr(7 as unknown as string)).toBe("7"); });
+});
+
+describe("stripAsciiControl", () => {
+  it("removes control bytes", () => {
+    expect(stripAsciiControl("a\x00b\x1Bc\x7Fd")).toBe("abcd");
+  });
+  it("preserves printable", () => {
+    expect(stripAsciiControl("Hello, World!")).toBe("Hello, World!");
+  });
+});

--- a/code/packages/typescript/forme-aot-style-tag-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-style-tag-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-style-tag-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Seventeenth FM00 v0 stage package — pure-transform emitter for `<link rel="stylesheet">` and inline `<style>` blocks.
- External stylesheets support SRI integrity (with per-algo length + padding validation), crossorigin, media query, and the `disabled` boolean attribute.
- Inline `<style>` blocks support an optional media query; CSS body is emitted **verbatim** between `<style>` and `</style>` (browsers parse style contents as raw text, so HTML-escaping would corrupt CSS) — but the validator **rejects** any literal `</style` sequence followed by whitespace, `>`, or `/` (case-insensitive), which is the only sequence the HTML parser treats as a style-block close.
- Two-pass fail-fast: validates the entire config before emitting any tag.
- 122 tests, **100% line / 100% branch** coverage.
- `required_capabilities.json` → `[]` (pure transform).

## Security posture

Seven concerns explicitly addressed. Pre-push security review (general-purpose agent) found **no material issues**:

1. **URL scheme injection** — every `href` runs through `validateStyleHref` (rejects `javascript:` / `data:` / `file:` / `vbscript:` / protocol-relative / backslash-variant / bare relative / empty / non-string / control bytes).
2. **HTML attribute injection** — every interpolated attribute value passes through `escapeHtmlAttr`.
3. **SRI integrity format validation** with per-algo length AND padding count checks (silent-disable defence — a sha256 string with `==` is the right total length but decodes to 31 bytes).
4. **Object-prototype walk defence** — algo table is a `Map`, not a plain object.
5. **`</style>` injection rejection in inline CSS** — canonical XSS sink for `<style>` sinks. Verified by the review against WHATWG HTML parser spec: matches every spec-recognised style end-tag terminator (TAB/LF/FF/CR/SPACE/`/`/`>`), case-insensitive. Stricter than spec by one char (also catches U+000B vertical tab) but only in the false-positive direction — never a false-negative.
6. **Control bytes in `href` rejected** at the validator (not silently stripped by escape).
7. **Fail-fast** — validation completes before any tag emitted.

## Behavioural notes

- Output order: stylesheets first (start loading earlier; cascade predictable), then inline.
- Attribute order per `<link>`: `rel → href → media → integrity → crossorigin → disabled`.
- `disabled` is a boolean attribute (bare attribute name).
- Inline CSS body is NOT escaped (browsers parse style contents as raw text).
- Same input → byte-identical output. No input mutation.

## v0 simplifications (documented)

- No CSS minification / autoprefixing.
- No CSS-syntax validation (only the HTML-injection vector is rejected).
- No `<link rel="preload" as="style">` (lives in `forme-aot-meta-link-tags`).
- No `title` / `blocking="render"` (deferred).

## Test plan

- [x] All 122 vitest tests pass locally
- [x] Coverage 100% line / 100% branch on source files with logic
- [x] Security review via Agent — clean
- [x] CHANGELOG + README written with usage examples + behavioural notes
- [x] `required_capabilities.json` set to `[]` with justification
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)