### PR TITLE
feat(forme-aot-html-doc-emitter): FM00 v0 <!doctype html>...</html> assembly

### DIFF
--- a/code/packages/typescript/forme-aot-html-doc-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-html-doc-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/CHANGELOG.md
@@ -1,0 +1,130 @@
+# Changelog — @coding-adventures/forme-aot-html-doc-emitter
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Eighteenth FM00 v0 stage package — final
+assembly emitter that wraps pre-built `<head>` + `<body>`
+string chunks into a complete `<!doctype html>...</html>`
+document.
+
+Pure transform: `HtmlDocConfig` → HTML string.  Two-pass
+validate-then-emit.  Head/body are passthrough (trusted upstream
+FM00 emitter output); attribute maps and lang/dir get full
+validation.
+
+### Added
+
+- `generateHtmlDocument(config): string` — main entry.
+- `validateLang(value)` — conservative BCP-47-shaped regex
+  (primary alpha subtag + dash-separated alphanumeric
+  subsequent subtags).
+- `validateDir(value)` — `ltr | rtl | auto` allowlist.
+- `validateAttrKey(key, field)` — lowercase ASCII identifier
+  + dashes / colons shape check; rejects reserved (`lang`,
+  `dir`, `xmlns`) AND any `on*` event-handler key.
+- `validateAttrValue(value, field)` — string required, ASCII
+  control bytes rejected.
+- `escapeHtmlAttr` / `stripAsciiControl` — same single-pass
+  character-class pattern as sibling emitters.
+- Types: `HtmlDocConfig`, `DocDirection`.
+
+### Spec adherence
+
+Implements HTML Living Standard `<!doctype html>` + `<html>` /
+`<head>` / `<body>` element semantics.  `lang` validation is a
+conservative subset of BCP-47; `dir` follows the §3.2.6.4
+allowlist.  No divergence.
+
+### Behavioural notes
+
+- **Output layout**: 9 newline-separated lines (doctype, html
+  open, head open, head content, head close, body open, body
+  content, body close, html close).
+- **Attribute order** on `<html>`: `lang → dir → extras`
+  (extras in `Object.keys` insertion order).
+- **Attribute order** on `<body>`: extras in insertion order.
+- **head/body NOT escaped** — passthrough.
+- **Empty head/body** produce empty lines in the output (still
+  valid HTML).
+- **Reproducibility.**  Same input → byte-identical output.
+  No input mutation.
+
+### Security posture
+
+Six concerns explicitly addressed (pre-push review):
+
+- **HTML attribute injection.**  Every interpolated value
+  passes through `escapeHtmlAttr`.
+- **Event-handler injection.**  Entire `on*` namespace
+  rejected at `validateAttrKey` — no way to ship
+  `<body onload="...">` through `bodyAttrs`.  Rejection covers
+  every `on*` prefix (not just the known names) so future-spec
+  event handlers are pre-empted.
+- **Reserved-key shadowing.**  `lang` / `dir` / `xmlns` cannot
+  be supplied via `htmlAttrs` / `bodyAttrs` — they'd shadow the
+  validator-checked dedicated config fields.
+- **Attribute-key injection.**  Key shape regex
+  `^[a-z][a-z0-9\-:]{0,63}$` prevents
+  `x" onclick="alert(1)`-style escapes.  No whitespace, no
+  quote, no `>`, no `=` — all rejected.
+- **Prototype pollution.**  `Object.keys()` (own enumerable
+  only).  Resolved attrs land in a `Map`, not a plain object.
+- **Fail-fast.**  Full validation pass completes before any
+  string concatenation.
+
+### Capabilities
+
+`[]` — pure transform.  No I/O, network, fs, shell, env.
+
+### Tests
+
+116 tests across 2 files:
+
+- `validate.test.ts` (75) — `validateLang` accept (en, en-US,
+  zh-Hant-HK, pt-BR, de-CH-1996, 3-letter, 8-letter cap) +
+  reject (non-string, null, empty, 9-letter over cap,
+  digit-leading, trailing dash, leading dash, double dash,
+  underscore, space, non-ASCII, XSS attempt, attr-injection
+  attempt); `validateDir` (3 accept + case-sensitive +
+  empty + non-string); `validateAttrKey` accept (simple,
+  class, data-*, aria-*, xml:base, alphanumeric, 64-char cap)
+  + reject (non-string, null, empty, uppercase, leading
+  digit / dash, space, quote, `>`, `=`, 65-char over cap,
+  `__proto__` (starts with `_`), reserved `lang`/`dir`/`xmlns`,
+  on* handlers — onload/onclick/onerror/on-thing, error
+  contains field path); `validateAttrValue` (4 accept
+  including embedded quotes / brackets — they get escaped
+  later; reject non-string / null / NUL / tab / newline / DEL
+  / error contains field path); `escapeHtmlAttr` (5 entities +
+  composite + NUL strip + non-string coercion);
+  `stripAsciiControl` (2 cases).  Note: `constructor` is
+  explicitly tested as ACCEPTED — it matches the key shape and
+  isn't reserved / on*; it's a harmless attribute (browsers
+  ignore unknown attrs).  The attack we care about is event
+  handlers / lang shadowing, both of which are rejected.
+- `generate.test.ts` (41) — shape (null / string / missing
+  head / body / non-string head); minimal (empty + populated
+  head + body); lang + dir (each alone, both in order, bad
+  lang, bad dir); htmlAttrs (data-*, multi-attr insertion
+  order, attrs-after-lang-dir, reserved lang/dir/xmlns,
+  onload/onmouseover handlers, attr-injection-attempt key,
+  array/null/string/number rejected as attrs, non-string
+  value, NUL in value, HTML-escapes value); bodyAttrs (class
+  attr, multi-attr, onload/onunload rejected, escape
+  XSS-attempt value); head/body passthrough (full structure
+  preserved, raw HTML in body, multi-line head); purity /
+  determinism (byte-identical, no input mutation); fail-fast
+  (bad attr key, lang checked first); full real-world example
+  with verbatim line check.
+
+Coverage: **100% line / 100% branch** across all source files
+with logic (`types.ts` is type-only).
+
+### v0 simplifications (documented)
+
+- **No XHTML / XML self-closing tags.**  HTML Living Standard
+  syntax only.
+- **No `<head>` / `<body>` content validation** — passthrough.
+- **No `<noscript>` fallback shell** — caller adds via `body`.
+- **No BCP-47 extensions / private-use subtags** in `lang`
+  validation (conservative subset; v1 may extend).

--- a/code/packages/typescript/forme-aot-html-doc-emitter/README.md
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/README.md
@@ -1,0 +1,190 @@
+# @coding-adventures/forme-aot-html-doc-emitter
+
+> FM00 v0 final-assembly emitter — wraps `<head>` + `<body>`
+> string chunks into a complete `<!doctype html>...</html>`
+> document, with `lang` / `dir` / extra-attr support.
+
+Eighteenth FM00 v0 stage package. Pure transform — no I/O, no
+fs, no network, no env, no shell.
+
+## What it does
+
+`generateHtmlDocument(config) → string` takes a `HtmlDocConfig`
+and emits a complete HTML document as a newline-joined string.
+
+| Field       | Required? | Validation                              |
+| ----------- | --------- | --------------------------------------- |
+| `head`      | yes       | string (passthrough — NOT escaped)      |
+| `body`      | yes       | string (passthrough — NOT escaped)      |
+| `lang`      | no        | conservative BCP-47-shaped regex        |
+| `dir`       | no        | `ltr` \| `rtl` \| `auto`                |
+| `htmlAttrs` | no        | extra `<html>` attrs, validated         |
+| `bodyAttrs` | no        | extra `<body>` attrs, validated         |
+
+`head` and `body` are passthrough because they're already
+trusted output from upstream FM00 emitters (`forme-aot-style-tag-emitter`,
+`forme-aot-meta-link-tags`, `forme-aot-script-tag-emitter`,
+`forme-aot-rss-discovery-link`) that did their own validation +
+escaping. The attribute maps **do** get full validation.
+
+## Quick start
+
+```ts
+import { generateHtmlDocument } from "@coding-adventures/forme-aot-html-doc-emitter";
+
+generateHtmlDocument({
+  lang: "en-US",
+  dir: "ltr",
+  head: [
+    `<meta charset="utf-8">`,
+    `<title>Hello</title>`,
+    `<link rel="stylesheet" href="/main.css">`,
+  ].join("\n"),
+  body: [
+    `<header><h1>Hello</h1></header>`,
+    `<main><p>World</p></main>`,
+  ].join("\n"),
+  htmlAttrs: { "data-theme": "dark" },
+  bodyAttrs: { class: "page", id: "home" },
+});
+```
+
+Produces (verbatim, newline-separated):
+
+```html
+<!doctype html>
+<html lang="en-US" dir="ltr" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<title>Hello</title>
+<link rel="stylesheet" href="/main.css">
+</head>
+<body class="page" id="home">
+<header><h1>Hello</h1></header>
+<main><p>World</p></main>
+</body>
+</html>
+```
+
+## Validation
+
+Two-pass fail-fast. The validator walks the entire config
+before emitting any string — an exception means the caller has
+nothing to write.
+
+### `lang`
+
+Conservative BCP-47 subset: one ASCII-alpha primary subtag
+(1–8 chars), optionally followed by dash-separated alphanumeric
+subsequent subtags. Covers `en`, `en-US`, `zh-Hant-HK`, `pt-BR`,
+`de-CH-1996`, etc. Doesn't cover extensions / private-use
+(rare; v1 may add).
+
+### `dir`
+
+Allowlist: `ltr` | `rtl` | `auto`. Case-sensitive.
+
+### `htmlAttrs` / `bodyAttrs` keys
+
+The attribute-key validator is the security-critical piece —
+keys go straight into the rendered tag (`<html ${key}="...">`)
+so they MUST be constrained.
+
+Allowed:
+- Lowercase ASCII letters / digits / dashes / colons only.
+- Must start with a letter.
+- Length 1–64.
+
+Rejected:
+- **Reserved** keys (`lang`, `dir`, `xmlns`) — use the dedicated
+  config fields instead.
+- **Any `on*` key** — event-handler namespace is an
+  attacker-controlled JS execution sink (`onload`, `onclick`,
+  `onerror`, ...). The entire `on*` prefix is rejected, not just
+  the known names — defends against future-spec event handlers
+  and obscure variants.
+
+### `htmlAttrs` / `bodyAttrs` values
+
+- Must be strings.
+- ASCII control bytes rejected (otherwise `escapeHtmlAttr` would
+  silently strip them).
+- Every value passes through `escapeHtmlAttr` at render time.
+
+### `head` / `body`
+
+Required string. **Not escaped** — they're trusted upstream
+output. If you're feeding caller-controlled raw HTML through
+this field, escape it yourself first (or, better, run it
+through a sanitiser).
+
+## Security posture
+
+Six concerns explicitly addressed:
+
+1. **HTML attribute injection.** Every interpolated attribute
+   value passes through `escapeHtmlAttr`. Hard-coded literals
+   (`<html`, `<head>`, `<body`, `<!doctype html>`) are
+   caller-uninfluenced. Attribute names go through the
+   identifier-shape gate before reaching the tag.
+2. **Event-handler injection.** The entire `on*` namespace is
+   rejected outright. No way for a caller to ship
+   `<body onload="...">` through `bodyAttrs`.
+3. **Reserved-key shadowing.** `lang` / `dir` / `xmlns` cannot
+   be supplied via the attribute map — they'd shadow the
+   validator-checked dedicated fields. Caller has to use the
+   typed field.
+4. **Attribute-key injection.** Key shape regex `^[a-z][a-z0-9\-:]{0,63}$`
+   prevents `x" onclick="alert(1)`-style escapes. No space, no
+   quote, no `>`, no `=` — all rejected.
+5. **Prototype pollution.** `Object.keys()` (own enumerable
+   only, no prototype walk). Resolved attrs land in a `Map`,
+   not a plain object.
+6. **Fail-fast.** Full validation pass completes before any
+   string concatenation — no half-formed `<!doctype html>` can
+   reach the output buffer.
+
+## Behavioural notes
+
+- **Output layout** is fixed: 9 lines, newline-separated
+  (`<!doctype html>`, `<html …>`, `<head>`, head, `</head>`,
+  `<body …>`, body, `</body>`, `</html>`).
+- **Attribute order on `<html>`**: `lang → dir → extras`
+  (extras in `Object.keys` insertion order).
+- **Attribute order on `<body>`**: extras in insertion order.
+- **`head` / `body` are emitted verbatim** — caller controls
+  any internal escaping.
+- **Same input → byte-identical output.** No input mutation.
+
+## v0 simplifications (documented)
+
+- **No XHTML / XML self-closing tags.** HTML Living Standard
+  syntax only.
+- **No `<head>` / `<body>` content validation** — passthrough
+  trusted upstream output.
+- **No `<noscript>` fallback shell** — caller can add via
+  `body`.
+- **No BCP-47 extensions / private-use subtags** in `lang`
+  validation (conservative subset).
+
+## Tests
+
+116 tests across two files. **100% line / 100% branch** coverage
+on all source files with logic.
+
+## Capabilities
+
+`[]` — pure transform.
+
+## How it fits in the stack
+
+This is the **final** assembly stage in the FM00 v0 page
+pipeline. Upstream:
+
+- `forme-aot-meta-link-tags` — generic `<meta>` / `<link>` head tags.
+- `forme-aot-style-tag-emitter` — `<link rel="stylesheet">` + `<style>`.
+- `forme-aot-script-tag-emitter` — `<script>` tags.
+- `forme-aot-rss-discovery-link` — feed `<link rel="alternate">` tags.
+
+Caller composes head + body from these, passes both to this
+emitter to get the final HTML document.

--- a/code/packages/typescript/forme-aot-html-doc-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-html-doc-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-html-doc-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/package.json
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-html-doc-emitter",
+  "version": "0.1.0",
+  "description": "Wrap pre-built <head> + <body> string chunks into a complete <!doctype html>...</html> document.  Pure transform: lang (BCP-47-shaped), dir allowlist, htmlAttrs/bodyAttrs key validation (lowercase ASCII identifier + dashes, rejects on* event handlers), HTML-attribute-escapes every value.  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-html-doc-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: HtmlDocConfig (head + body strings + html/body attrs) → complete <!doctype html> document string.  No I/O, no network, no env, no shell, no fs."
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/src/escape.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/src/escape.ts
@@ -1,0 +1,26 @@
+/**
+ * escape.ts — HTML attribute escaping.  Same single-pass
+ * character-class pattern as the sibling FM00 emitters.
+ *
+ * @module escape
+ */
+
+const HTML_ATTR_ESCAPE_MAP: Readonly<Record<string, string>> = Object.freeze({
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "\"": "&quot;",
+  "'": "&#39;",
+});
+
+const HTML_ATTR_SPECIAL_RE = /[&<>"']/g;
+// eslint-disable-next-line no-control-regex
+const ASCII_CONTROL_RE = /[\x00-\x1F\x7F]/g;
+
+export function stripAsciiControl(s: string): string {
+  return String(s).replace(ASCII_CONTROL_RE, "");
+}
+
+export function escapeHtmlAttr(s: string): string {
+  return stripAsciiControl(s).replace(HTML_ATTR_SPECIAL_RE, (ch) => HTML_ATTR_ESCAPE_MAP[ch]!);
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/src/generate.ts
@@ -1,0 +1,147 @@
+/**
+ * generate.ts — main `generateHtmlDocument` entry.
+ *
+ * Two-pass fail-fast: validate the entire config (lang, dir,
+ * every htmlAttrs/bodyAttrs key + value), then render the
+ * final document.  An exception means the caller has nothing
+ * to write — no half-formed `<!doctype html>` reaches disk.
+ *
+ * Output layout (newline-joined for readability + deterministic
+ * diffs):
+ *
+ *     <!doctype html>
+ *     <html lang="…" dir="…" …extra>
+ *     <head>
+ *     {head}
+ *     </head>
+ *     <body …extra>
+ *     {body}
+ *     </body>
+ *     </html>
+ *
+ * `head` and `body` are inserted verbatim — they're already
+ * trusted upstream FM00 emitter output.  Attribute order on
+ * `<html>` is fixed: `lang → dir → extras` (extras in
+ * `Object.keys()` insertion order).  Attribute order on
+ * `<body>` is just extras in insertion order.
+ *
+ * @module generate
+ */
+
+import { escapeHtmlAttr } from "./escape.js";
+import type { HtmlDocConfig } from "./types.js";
+import {
+  validateAttrKey,
+  validateAttrValue,
+  validateDir,
+  validateLang,
+} from "./validate.js";
+
+interface ResolvedAttrs {
+  readonly keys: readonly string[];
+  readonly values: ReadonlyMap<string, string>;
+}
+
+/**
+ * Generate a complete HTML document from a `HtmlDocConfig`.
+ *
+ * ```ts
+ * generateHtmlDocument({
+ *   lang: "en",
+ *   dir: "ltr",
+ *   head: "<title>Hello</title>",
+ *   body: "<h1>Hello</h1>",
+ * });
+ * // <!doctype html>
+ * // <html lang="en" dir="ltr">
+ * // <head>
+ * // <title>Hello</title>
+ * // </head>
+ * // <body>
+ * // <h1>Hello</h1>
+ * // </body>
+ * // </html>
+ * ```
+ */
+export function generateHtmlDocument(config: HtmlDocConfig): string {
+  if (config === null || typeof config !== "object") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: config must be a non-null object; got ${typeof config}`,
+    );
+  }
+
+  // `head` and `body` are passthrough but they MUST be strings —
+  // a `null`/`undefined`/array would corrupt the output.
+  if (typeof config.head !== "string") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: head must be a string; got ${typeof config.head}`,
+    );
+  }
+  if (typeof config.body !== "string") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: body must be a string; got ${typeof config.body}`,
+    );
+  }
+
+  const lang = config.lang === undefined ? undefined : validateLang(config.lang);
+  const dir = config.dir === undefined ? undefined : validateDir(config.dir);
+  const htmlAttrs = resolveAttrs(config.htmlAttrs, "htmlAttrs");
+  const bodyAttrs = resolveAttrs(config.bodyAttrs, "bodyAttrs");
+
+  // Render.
+  const htmlOpenParts: string[] = ["<html"];
+  if (lang !== undefined) htmlOpenParts.push(`lang="${escapeHtmlAttr(lang)}"`);
+  if (dir !== undefined)  htmlOpenParts.push(`dir="${escapeHtmlAttr(dir)}"`);
+  for (const key of htmlAttrs.keys) {
+    htmlOpenParts.push(`${key}="${escapeHtmlAttr(htmlAttrs.values.get(key)!)}"`);
+  }
+  const htmlOpen = `${htmlOpenParts.join(" ")}>`;
+
+  const bodyOpenParts: string[] = ["<body"];
+  for (const key of bodyAttrs.keys) {
+    bodyOpenParts.push(`${key}="${escapeHtmlAttr(bodyAttrs.values.get(key)!)}"`);
+  }
+  const bodyOpen = `${bodyOpenParts.join(" ")}>`;
+
+  return [
+    "<!doctype html>",
+    htmlOpen,
+    "<head>",
+    config.head,
+    "</head>",
+    bodyOpen,
+    config.body,
+    "</body>",
+    "</html>",
+  ].join("\n");
+}
+
+function resolveAttrs(
+  attrs: Readonly<Record<string, string>> | undefined,
+  field: string,
+): ResolvedAttrs {
+  if (attrs === undefined) return { keys: [], values: new Map() };
+  if (attrs === null || typeof attrs !== "object" || Array.isArray(attrs)) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} must be an object; got ${
+        attrs === null ? "null" : Array.isArray(attrs) ? "array" : typeof attrs
+      }`,
+    );
+  }
+  // Use `Object.keys` (own enumerable string keys only — won't
+  // walk the prototype chain).  Validate each key + value;
+  // store in a Map (defensive — avoids any later code-path
+  // accidentally exposing prototype-pollution).
+  const keys: string[] = [];
+  const values = new Map<string, string>();
+  for (const key of Object.keys(attrs)) {
+    const validatedKey = validateAttrKey(key, field);
+    const validatedValue = validateAttrValue(
+      (attrs as Record<string, unknown>)[key],
+      `${field}["${key}"]`,
+    );
+    keys.push(validatedKey);
+    values.set(validatedKey, validatedValue);
+  }
+  return { keys, values };
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @coding-adventures/forme-aot-html-doc-emitter
+ *
+ * Final assembly stage of the FM00 v0 head / body pipeline:
+ * wrap pre-built `<head>` + `<body>` string chunks (already
+ * produced by the sibling emitters — meta-link-tags, style-tag,
+ * script-tag, rss-discovery-link, etc.) into a complete
+ * `<!doctype html>...</html>` document with optional `lang`,
+ * `dir`, and extra `<html>` / `<body>` attribute maps.
+ *
+ * Pure transform.  `head` and `body` are passthrough strings
+ * (already trusted FM00 output); attribute maps DO get full
+ * validation — keys constrained to lowercase ASCII identifiers
+ * + dashes, `on*` event-handler namespace rejected outright,
+ * reserved attrs (`lang`, `dir`, `xmlns`) rejected so the
+ * dedicated config fields stay the single source of truth.
+ *
+ * ```ts
+ * import { generateHtmlDocument } from "@coding-adventures/forme-aot-html-doc-emitter";
+ *
+ * generateHtmlDocument({
+ *   lang: "en-US",
+ *   dir: "ltr",
+ *   head: "<title>Hello</title>",
+ *   body: "<h1>Hello, world!</h1>",
+ *   htmlAttrs: { "data-theme": "dark" },
+ *   bodyAttrs: { class: "page" },
+ * });
+ * ```
+ *
+ * Eighteenth FM00 v0 stage package.
+ *
+ * @module index
+ */
+
+export { generateHtmlDocument } from "./generate.js";
+export { escapeHtmlAttr, stripAsciiControl } from "./escape.js";
+export {
+  validateLang,
+  validateDir,
+  validateAttrKey,
+  validateAttrValue,
+} from "./validate.js";
+export type { HtmlDocConfig, DocDirection } from "./types.js";

--- a/code/packages/typescript/forme-aot-html-doc-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * types.ts — public signatures for the HTML document emitter.
+ *
+ * The emitter is the final assembly stage in the FM00 v0 head /
+ * body pipeline.  It takes pre-built `head` and `body` chunks
+ * (already produced by the sibling emitters — meta-link-tags,
+ * style-tag, script-tag, etc.) and wraps them in the canonical
+ * `<!doctype html>...</html>` shell with optional `lang`, `dir`,
+ * and extra `<html>` / `<body>` attribute maps.
+ *
+ * `head` and `body` are passthrough strings — we don't escape
+ * them because they're already trusted output from upstream
+ * FM00 emitters that did their own validation + escaping.  The
+ * attribute maps DO get full validation: keys must be lowercase
+ * ASCII identifier characters (plus dashes) so attacker keys
+ * like `onload`, `__proto__`, or `style; alert(1)` can't sneak
+ * into the tag, and values pass through `escapeHtmlAttr`.
+ *
+ * @module types
+ */
+
+/**
+ * `dir` attribute allowlist.  Per HTML Living Standard §3.2.6.4.
+ */
+export type DocDirection = "ltr" | "rtl" | "auto";
+
+/**
+ * Top-level config consumed by `generateHtmlDocument`.
+ *
+ *   - `head`      — required.  HTML string for the `<head>`
+ *                   interior (e.g. concatenation of
+ *                   `generateStyleTags(...)` +
+ *                   `generateMetaLinkTags(...)` + ...).
+ *                   Passthrough; NOT escaped.
+ *   - `body`      — required.  HTML string for the `<body>`
+ *                   interior.  Passthrough; NOT escaped.
+ *   - `lang`      — optional BCP-47 language tag, e.g. `"en"`,
+ *                   `"en-US"`, `"zh-Hant-HK"`.  Conservative
+ *                   regex (subset of BCP-47): one ASCII alpha
+ *                   primary subtag, optional dash-separated
+ *                   alphanumeric subsequent subtags.  Empty
+ *                   string → throw.
+ *   - `dir`       — optional direction allowlist.
+ *   - `htmlAttrs` — optional extra `<html>` attributes.  Map of
+ *                   attribute name → value.  Names: lowercase
+ *                   ASCII letters/digits/dashes/colons starting
+ *                   with a letter, length ≤ 64.  Reserved names
+ *                   (`lang`, `dir`, `xmlns`) AND any `on*` event
+ *                   handler are rejected.
+ *   - `bodyAttrs` — optional extra `<body>` attributes; same
+ *                   validation rules.
+ */
+export interface HtmlDocConfig {
+  readonly head: string;
+  readonly body: string;
+  readonly lang?: string;
+  readonly dir?: DocDirection;
+  readonly htmlAttrs?: Readonly<Record<string, string>>;
+  readonly bodyAttrs?: Readonly<Record<string, string>>;
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/src/validate.ts
@@ -1,0 +1,155 @@
+/**
+ * validate.ts — lang / dir / attribute-key / attribute-map
+ * validators.
+ *
+ * The attribute-key validator is the security-critical piece.
+ * Keys go straight into the rendered tag (`<html ${key}="...">`)
+ * so they MUST be constrained.  Without the constraint an
+ * attacker-controlled key like `onload`, `style="x:1" onload`,
+ * or `__proto__` would either ship an event handler or land in
+ * the wrong prototype slot.  Our key shape:
+ *
+ *   - Lowercase ASCII letters / digits / dashes / colons only.
+ *   - Must start with a letter.
+ *   - Length 1..64 (cap protects against pathological inputs in
+ *     error messages).
+ *   - Reserved keys (`lang`, `dir`, `xmlns`) rejected so the
+ *     dedicated config fields stay the single source of truth.
+ *   - Any `on*` key rejected (event handlers are
+ *     attacker-controlled JS execution sinks).
+ *
+ * @module validate
+ */
+
+import type { DocDirection } from "./types.js";
+
+const DIR_ALLOWLIST: ReadonlySet<string> = new Set(["ltr", "rtl", "auto"]);
+
+// Conservative BCP-47 subset: primary alpha subtag, optional
+// dash-separated alphanumeric subsequent subtags.  Doesn't
+// cover every legal BCP-47 form (extensions, private-use, etc.)
+// but covers ~all real-world tags people actually write
+// (`en`, `en-US`, `zh-Hant-HK`, `pt-BR`, `de-CH-1996`).
+const BCP47_RE = /^[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*$/;
+
+// Attribute-name shape (lowercase, identifier-ish).  Allows
+// dashes (`data-*`, `aria-*`) and colons (XML-namespaced attrs
+// like `xml:lang`).  Length cap = 64.
+const ATTR_KEY_RE = /^[a-z][a-z0-9\-:]{0,63}$/;
+
+// Reserved attribute names — handled by dedicated config fields
+// so the caller can't supply them via the attribute map and
+// shadow the validator-checked values.
+const RESERVED_ATTRS: ReadonlySet<string> = new Set([
+  "lang",
+  "dir",
+  "xmlns",
+]);
+
+// Reject ASCII control bytes anywhere in an attribute value —
+// `escapeHtmlAttr` would silently strip them and that could
+// change the value's meaning.
+// eslint-disable-next-line no-control-regex
+const ATTR_VALUE_CONTROL_RE = /[\x00-\x1F\x7F]/;
+
+/**
+ * Validate the `lang` field.  Returns the validated tag.
+ * Throws for non-string, empty, or syntactically-invalid tag.
+ */
+export function validateLang(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: lang must be a string; got ${typeof value}`,
+    );
+  }
+  if (value.length === 0) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: lang must be non-empty`,
+    );
+  }
+  if (!BCP47_RE.test(value)) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: lang must be a BCP-47-shaped tag (e.g. "en", "en-US", "zh-Hant-HK"); got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the `dir` field against the allowlist.
+ */
+export function validateDir(value: unknown): DocDirection {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: dir must be a string; got ${typeof value}`,
+    );
+  }
+  if (!DIR_ALLOWLIST.has(value)) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: dir must be one of [${
+        [...DIR_ALLOWLIST].join(", ")
+      }]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as DocDirection;
+}
+
+/**
+ * Validate an attribute key.  Throws for:
+ *   - non-string
+ *   - empty / over-length
+ *   - bad shape (uppercase, leading digit, special chars)
+ *   - reserved (`lang`, `dir`, `xmlns`)
+ *   - any `on*` event handler
+ */
+export function validateAttrKey(key: unknown, field: string): string {
+  if (typeof key !== "string") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute key must be a string; got ${typeof key}`,
+    );
+  }
+  if (key.length === 0) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute key must be non-empty`,
+    );
+  }
+  if (!ATTR_KEY_RE.test(key)) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute key must be lowercase ASCII letter/digit/dash/colon, starting with a letter, length 1..64; got ${JSON.stringify(key)}`,
+    );
+  }
+  if (RESERVED_ATTRS.has(key)) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute key "${key}" is reserved; use the dedicated config field instead`,
+    );
+  }
+  // `onload`, `onclick`, `onerror`, ... — any attribute starting
+  // with "on" followed by alpha is treated as an event handler
+  // by HTML parsers.  Reject the whole `on*` namespace so
+  // callers can't accidentally (or intentionally) ship one.
+  if (key.startsWith("on")) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute key "${key}" is in the on* event-handler namespace; rejected (attacker-controlled JS execution sink)`,
+    );
+  }
+  return key;
+}
+
+/**
+ * Validate an attribute value.  String required, control bytes
+ * rejected (otherwise `escapeHtmlAttr` would silently strip
+ * them).
+ */
+export function validateAttrValue(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute value must be a string; got ${typeof value}`,
+    );
+  }
+  if (ATTR_VALUE_CONTROL_RE.test(value)) {
+    throw new TypeError(
+      `forme-aot-html-doc-emitter: ${field} attribute value must not contain ASCII control bytes (\\x00-\\x1F, \\x7F)`,
+    );
+  }
+  return value;
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/tests/generate.test.ts
@@ -1,0 +1,316 @@
+/**
+ * generate.test.ts — end-to-end generateHtmlDocument.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateHtmlDocument } from "../src/index.js";
+
+describe("generateHtmlDocument — shape", () => {
+  it("null config throws", () => {
+    expect(() => generateHtmlDocument(null as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("string config throws", () => {
+    expect(() => generateHtmlDocument("x" as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("missing head throws", () => {
+    expect(() => generateHtmlDocument({ body: "x" } as unknown as never))
+      .toThrow(/head must be a string/);
+  });
+  it("missing body throws", () => {
+    expect(() => generateHtmlDocument({ head: "x" } as unknown as never))
+      .toThrow(/body must be a string/);
+  });
+  it("non-string head throws", () => {
+    expect(() => generateHtmlDocument({ head: 42 as unknown as string, body: "" }))
+      .toThrow(/head must be a string/);
+  });
+});
+
+describe("generateHtmlDocument — minimal", () => {
+  it("empty head + empty body", () => {
+    expect(generateHtmlDocument({ head: "", body: "" })).toBe([
+      "<!doctype html>",
+      "<html>",
+      "<head>",
+      "",
+      "</head>",
+      "<body>",
+      "",
+      "</body>",
+      "</html>",
+    ].join("\n"));
+  });
+  it("populated head + body", () => {
+    expect(generateHtmlDocument({
+      head: "<title>Hi</title>",
+      body: "<h1>Hi</h1>",
+    })).toBe([
+      "<!doctype html>",
+      "<html>",
+      "<head>",
+      "<title>Hi</title>",
+      "</head>",
+      "<body>",
+      "<h1>Hi</h1>",
+      "</body>",
+      "</html>",
+    ].join("\n"));
+  });
+});
+
+describe("generateHtmlDocument — lang + dir", () => {
+  it("lang only", () => {
+    const out = generateHtmlDocument({ lang: "en", head: "", body: "" });
+    expect(out).toContain(`<html lang="en">`);
+  });
+  it("dir only", () => {
+    const out = generateHtmlDocument({ dir: "rtl", head: "", body: "" });
+    expect(out).toContain(`<html dir="rtl">`);
+  });
+  it("lang + dir, lang first", () => {
+    const out = generateHtmlDocument({ dir: "ltr", lang: "en-US", head: "", body: "" });
+    expect(out).toContain(`<html lang="en-US" dir="ltr">`);
+  });
+  it("bad lang throws", () => {
+    expect(() => generateHtmlDocument({ lang: "123", head: "", body: "" }))
+      .toThrow(/BCP-47/);
+  });
+  it("bad dir throws", () => {
+    expect(() => generateHtmlDocument({ dir: "sideways" as unknown as never, head: "", body: "" }))
+      .toThrow(/one of/);
+  });
+});
+
+describe("generateHtmlDocument — htmlAttrs", () => {
+  it("data-* attribute", () => {
+    const out = generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { "data-theme": "dark" },
+    });
+    expect(out).toContain(`<html data-theme="dark">`);
+  });
+  it("multiple attrs in insertion order", () => {
+    const out = generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { "data-theme": "dark", "data-page": "home" },
+    });
+    expect(out).toContain(`<html data-theme="dark" data-page="home">`);
+  });
+  it("attrs after lang + dir", () => {
+    const out = generateHtmlDocument({
+      lang: "en", dir: "ltr",
+      head: "", body: "",
+      htmlAttrs: { "data-theme": "dark" },
+    });
+    expect(out).toContain(`<html lang="en" dir="ltr" data-theme="dark">`);
+  });
+  it("rejects 'lang' key (reserved)", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { lang: "x" },
+    })).toThrow(/reserved/);
+  });
+  it("rejects 'dir' key (reserved)", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { dir: "ltr" },
+    })).toThrow(/reserved/);
+  });
+  it("rejects 'xmlns' key (reserved)", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { xmlns: "x" },
+    })).toThrow(/reserved/);
+  });
+  it("rejects 'onload' (event handler)", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { onload: "alert(1)" },
+    })).toThrow(/event-handler/);
+  });
+  it("rejects 'onmouseover' (event handler)", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { onmouseover: "alert(1)" },
+    })).toThrow(/event-handler/);
+  });
+  it("rejects attr-injection-attempt as key", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { 'x" onclick="alert(1)': "y" },
+    })).toThrow(/lowercase ASCII/);
+  });
+  it("rejects array as attrs", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: [] as unknown as never,
+    })).toThrow(/htmlAttrs must be an object/);
+  });
+  it("rejects null as attrs", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: null as unknown as never,
+    })).toThrow(/htmlAttrs must be an object/);
+  });
+  it("rejects string as attrs (error reports type)", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: "nope" as unknown as never,
+    })).toThrow(/htmlAttrs must be an object; got string/);
+  });
+  it("rejects number as attrs", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: 42 as unknown as never,
+    })).toThrow(/htmlAttrs must be an object; got number/);
+  });
+  it("rejects non-string value", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { "data-x": 42 as unknown as string },
+    })).toThrow(/attribute value must be a string/);
+  });
+  it("rejects NUL in value", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { "data-x": "a\x00b" },
+    })).toThrow(/control bytes/);
+  });
+  it("HTML-escapes attribute value", () => {
+    const out = generateHtmlDocument({
+      head: "", body: "",
+      htmlAttrs: { "data-x": `she said "hi" & <bye>` },
+    });
+    expect(out).toContain(`data-x="she said &quot;hi&quot; &amp; &lt;bye&gt;"`);
+  });
+});
+
+describe("generateHtmlDocument — bodyAttrs", () => {
+  it("class attr on body", () => {
+    const out = generateHtmlDocument({
+      head: "", body: "",
+      bodyAttrs: { class: "page-home" },
+    });
+    expect(out).toContain(`<body class="page-home">`);
+  });
+  it("multiple body attrs", () => {
+    const out = generateHtmlDocument({
+      head: "", body: "",
+      bodyAttrs: { class: "p", id: "main" },
+    });
+    expect(out).toContain(`<body class="p" id="main">`);
+  });
+  it("rejects onload on body", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      bodyAttrs: { onload: "alert(1)" },
+    })).toThrow(/event-handler/);
+  });
+  it("rejects onunload on body", () => {
+    expect(() => generateHtmlDocument({
+      head: "", body: "",
+      bodyAttrs: { onunload: "x" },
+    })).toThrow(/event-handler/);
+  });
+  it("HTML-escapes bodyAttrs value", () => {
+    const out = generateHtmlDocument({
+      head: "", body: "",
+      bodyAttrs: { class: `"><script>alert(1)</script>` },
+    });
+    expect(out).toContain(`class="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"`);
+    expect(out).not.toContain("<script>alert");
+  });
+});
+
+describe("generateHtmlDocument — head/body passthrough (NOT escaped)", () => {
+  it("head with full HTML structure passes through", () => {
+    const head = `<meta charset="utf-8">\n<title>Test</title>\n<link rel="stylesheet" href="/x.css">`;
+    const out = generateHtmlDocument({ head, body: "" });
+    expect(out).toContain(head);
+  });
+  it("body with raw HTML passes through", () => {
+    const body = `<div class="container">\n<p>Hello & welcome</p>\n</div>`;
+    const out = generateHtmlDocument({ head: "", body });
+    expect(out).toContain(body);
+  });
+  it("multi-line head", () => {
+    const head = "<title>A</title>\n<title>B</title>";
+    const out = generateHtmlDocument({ head, body: "" });
+    expect(out.split("\n").filter((l) => l.includes("title"))).toHaveLength(2);
+  });
+});
+
+describe("generateHtmlDocument — purity / determinism", () => {
+  it("same input → byte-identical output", () => {
+    const cfg = {
+      lang: "en", dir: "ltr" as const,
+      head: "<title>X</title>", body: "<p>x</p>",
+      htmlAttrs: { "data-theme": "dark" },
+      bodyAttrs: { class: "p" },
+    };
+    expect(generateHtmlDocument(cfg)).toBe(generateHtmlDocument(cfg));
+  });
+  it("does not mutate input", () => {
+    const cfg = {
+      lang: "en",
+      head: "<title>X</title>",
+      body: "<p>x</p>",
+      htmlAttrs: { "data-theme": "dark" },
+    };
+    const before = JSON.stringify(cfg);
+    generateHtmlDocument(cfg);
+    expect(JSON.stringify(cfg)).toBe(before);
+  });
+});
+
+describe("generateHtmlDocument — fail-fast", () => {
+  it("bad attr key throws before doc is built", () => {
+    expect(() => generateHtmlDocument({
+      head: "X", body: "Y",
+      htmlAttrs: { onload: "z" },
+    })).toThrow(/event-handler/);
+  });
+  it("bad lang throws before attrs validated", () => {
+    expect(() => generateHtmlDocument({
+      lang: "bad lang",
+      head: "", body: "",
+      htmlAttrs: { onload: "z" }, // would also fail, but lang is checked first
+    })).toThrow(/BCP-47/);
+  });
+});
+
+describe("generateHtmlDocument — full real-world example", () => {
+  it("complete page", () => {
+    const out = generateHtmlDocument({
+      lang: "en-US",
+      dir: "ltr",
+      head: [
+        `<meta charset="utf-8">`,
+        `<title>Hello</title>`,
+        `<link rel="stylesheet" href="/main.css">`,
+      ].join("\n"),
+      body: [
+        `<header><h1>Hello</h1></header>`,
+        `<main><p>World</p></main>`,
+      ].join("\n"),
+      htmlAttrs: { "data-theme": "dark" },
+      bodyAttrs: { class: "page", id: "home" },
+    });
+    expect(out).toBe([
+      "<!doctype html>",
+      `<html lang="en-US" dir="ltr" data-theme="dark">`,
+      "<head>",
+      `<meta charset="utf-8">`,
+      `<title>Hello</title>`,
+      `<link rel="stylesheet" href="/main.css">`,
+      "</head>",
+      `<body class="page" id="home">`,
+      `<header><h1>Hello</h1></header>`,
+      `<main><p>World</p></main>`,
+      "</body>",
+      "</html>",
+    ].join("\n"));
+  });
+});

--- a/code/packages/typescript/forme-aot-html-doc-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/tests/validate.test.ts
@@ -1,0 +1,144 @@
+/**
+ * validate.test.ts — lang / dir / attribute-key / attribute-value
+ * validators + escape helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  escapeHtmlAttr,
+  stripAsciiControl,
+  validateAttrKey,
+  validateAttrValue,
+  validateDir,
+  validateLang,
+} from "../src/index.js";
+
+describe("validateLang — accept", () => {
+  it("primary alpha 'en'", () => { expect(validateLang("en")).toBe("en"); });
+  it("'en-US'", () => { expect(validateLang("en-US")).toBe("en-US"); });
+  it("'zh-Hant-HK'", () => { expect(validateLang("zh-Hant-HK")).toBe("zh-Hant-HK"); });
+  it("'pt-BR'", () => { expect(validateLang("pt-BR")).toBe("pt-BR"); });
+  it("'de-CH-1996'", () => { expect(validateLang("de-CH-1996")).toBe("de-CH-1996"); });
+  it("3-letter primary", () => { expect(validateLang("ang")).toBe("ang"); });
+  it("8-letter cap accepted", () => { expect(validateLang("abcdefgh")).toBe("abcdefgh"); });
+});
+
+describe("validateLang — reject", () => {
+  it("non-string", () => { expect(() => validateLang(42 as unknown as string)).toThrow(/must be a string/); });
+  it("null", () => { expect(() => validateLang(null)).toThrow(/must be a string/); });
+  it("empty", () => { expect(() => validateLang("")).toThrow(/non-empty/); });
+  it("9-letter primary (over cap)", () => { expect(() => validateLang("abcdefghi")).toThrow(/BCP-47/); });
+  it("digit-leading subtag", () => { expect(() => validateLang("123")).toThrow(/BCP-47/); });
+  it("trailing dash", () => { expect(() => validateLang("en-")).toThrow(/BCP-47/); });
+  it("leading dash", () => { expect(() => validateLang("-en")).toThrow(/BCP-47/); });
+  it("double dash", () => { expect(() => validateLang("en--US")).toThrow(/BCP-47/); });
+  it("underscore (not dash)", () => { expect(() => validateLang("en_US")).toThrow(/BCP-47/); });
+  it("space", () => { expect(() => validateLang("en US")).toThrow(/BCP-47/); });
+  it("non-ASCII", () => { expect(() => validateLang("enü")).toThrow(/BCP-47/); });
+  it("XSS-attempt", () => { expect(() => validateLang('en"><script>')).toThrow(/BCP-47/); });
+  it("attr-injection-attempt", () => { expect(() => validateLang('en" onclick="')).toThrow(/BCP-47/); });
+});
+
+describe("validateDir", () => {
+  it("ltr", () => { expect(validateDir("ltr")).toBe("ltr"); });
+  it("rtl", () => { expect(validateDir("rtl")).toBe("rtl"); });
+  it("auto", () => { expect(validateDir("auto")).toBe("auto"); });
+  it("rejects LTR (case-sensitive)", () => { expect(() => validateDir("LTR")).toThrow(/one of/); });
+  it("rejects empty", () => { expect(() => validateDir("")).toThrow(/one of/); });
+  it("rejects non-string", () => { expect(() => validateDir(1 as unknown as string)).toThrow(/must be a string/); });
+});
+
+describe("validateAttrKey — accept", () => {
+  it("simple letter", () => { expect(validateAttrKey("a", "f")).toBe("a"); });
+  it("class", () => { expect(validateAttrKey("class", "f")).toBe("class"); });
+  it("data-* attribute", () => { expect(validateAttrKey("data-theme", "f")).toBe("data-theme"); });
+  it("aria-* attribute", () => { expect(validateAttrKey("aria-label", "f")).toBe("aria-label"); });
+  it("colon-namespaced (xml:base)", () => { expect(validateAttrKey("xml:base", "f")).toBe("xml:base"); });
+  it("alphanumeric with dashes", () => { expect(validateAttrKey("data-1-x-2", "f")).toBe("data-1-x-2"); });
+  it("64-char cap accepted", () => {
+    const k = "a" + "1".repeat(63);
+    expect(validateAttrKey(k, "f")).toBe(k);
+  });
+});
+
+describe("validateAttrKey — reject", () => {
+  it("non-string", () => { expect(() => validateAttrKey(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null", () => { expect(() => validateAttrKey(null, "f")).toThrow(/must be a string/); });
+  it("empty", () => { expect(() => validateAttrKey("", "f")).toThrow(/non-empty/); });
+  it("uppercase", () => { expect(() => validateAttrKey("Class", "f")).toThrow(/lowercase ASCII/); });
+  it("starts with digit", () => { expect(() => validateAttrKey("1cls", "f")).toThrow(/lowercase ASCII/); });
+  it("starts with dash", () => { expect(() => validateAttrKey("-data", "f")).toThrow(/lowercase ASCII/); });
+  it("contains space", () => { expect(() => validateAttrKey("class name", "f")).toThrow(/lowercase ASCII/); });
+  it("contains quote (injection attempt)", () => { expect(() => validateAttrKey(`x"y`, "f")).toThrow(/lowercase ASCII/); });
+  it("contains > (injection attempt)", () => { expect(() => validateAttrKey("x>y", "f")).toThrow(/lowercase ASCII/); });
+  it("contains = (injection attempt)", () => { expect(() => validateAttrKey("x=y", "f")).toThrow(/lowercase ASCII/); });
+  it("65-char (over cap)", () => {
+    const k = "a" + "1".repeat(64);
+    expect(() => validateAttrKey(k, "f")).toThrow(/lowercase ASCII/);
+  });
+  it("__proto__ rejected (starts with _)", () => {
+    expect(() => validateAttrKey("__proto__", "f")).toThrow(/lowercase ASCII/);
+  });
+  it("constructor rejected (passes shape — but only if shape matched)", () => {
+    // Wait, "constructor" matches shape.  But it's not reserved AND not on*.
+    // So it actually passes — and that's fine because `constructor` as an
+    // HTML attribute is harmless (browsers ignore unknown attrs).  The
+    // attack we care about is event handlers / lang shadowing.
+    expect(validateAttrKey("constructor", "f")).toBe("constructor");
+  });
+  it("reserved 'lang'", () => { expect(() => validateAttrKey("lang", "f")).toThrow(/reserved/); });
+  it("reserved 'dir'", () => { expect(() => validateAttrKey("dir", "f")).toThrow(/reserved/); });
+  it("reserved 'xmlns'", () => { expect(() => validateAttrKey("xmlns", "f")).toThrow(/reserved/); });
+  it("on* event handler 'onload'", () => { expect(() => validateAttrKey("onload", "f")).toThrow(/event-handler/); });
+  it("on* 'onclick'", () => { expect(() => validateAttrKey("onclick", "f")).toThrow(/event-handler/); });
+  it("on* 'onerror'", () => { expect(() => validateAttrKey("onerror", "f")).toThrow(/event-handler/); });
+  it("on* with dash 'on-thing'", () => { expect(() => validateAttrKey("on-thing", "f")).toThrow(/event-handler/); });
+  it("error contains field path", () => {
+    expect(() => validateAttrKey("onload", "htmlAttrs"))
+      .toThrow(/htmlAttrs attribute key "onload"/);
+  });
+});
+
+describe("validateAttrValue — accept", () => {
+  it("simple string", () => { expect(validateAttrValue("blue", "f")).toBe("blue"); });
+  it("empty allowed", () => { expect(validateAttrValue("", "f")).toBe(""); });
+  it("string with quotes (escaped later by escapeHtmlAttr)", () => {
+    expect(validateAttrValue(`he said "hi"`, "f")).toBe(`he said "hi"`);
+  });
+  it("string with < > & (escaped later)", () => {
+    expect(validateAttrValue("a<b&c>d", "f")).toBe("a<b&c>d");
+  });
+});
+
+describe("validateAttrValue — reject", () => {
+  it("non-string", () => { expect(() => validateAttrValue(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null", () => { expect(() => validateAttrValue(null, "f")).toThrow(/must be a string/); });
+  it("NUL byte", () => { expect(() => validateAttrValue("a\x00b", "f")).toThrow(/control bytes/); });
+  it("tab", () => { expect(() => validateAttrValue("a\tb", "f")).toThrow(/control bytes/); });
+  it("newline", () => { expect(() => validateAttrValue("a\nb", "f")).toThrow(/control bytes/); });
+  it("DEL", () => { expect(() => validateAttrValue("a\x7Fb", "f")).toThrow(/control bytes/); });
+  it("error contains field path", () => {
+    expect(() => validateAttrValue("\x00", "bodyAttrs[\"class\"]"))
+      .toThrow(/bodyAttrs\["class"\]/);
+  });
+});
+
+describe("escapeHtmlAttr", () => {
+  it("ampersand", () => { expect(escapeHtmlAttr("a&b")).toBe("a&amp;b"); });
+  it("less-than", () => { expect(escapeHtmlAttr("a<b")).toBe("a&lt;b"); });
+  it("greater-than", () => { expect(escapeHtmlAttr("a>b")).toBe("a&gt;b"); });
+  it("double quote", () => { expect(escapeHtmlAttr(`"`)).toBe("&quot;"); });
+  it("single quote", () => { expect(escapeHtmlAttr(`'`)).toBe("&#39;"); });
+  it("composite", () => { expect(escapeHtmlAttr(`<&>"'`)).toBe("&lt;&amp;&gt;&quot;&#39;"); });
+  it("strips NUL", () => { expect(escapeHtmlAttr("a\x00b")).toBe("ab"); });
+  it("non-string coerced", () => { expect(escapeHtmlAttr(7 as unknown as string)).toBe("7"); });
+});
+
+describe("stripAsciiControl", () => {
+  it("removes control bytes", () => {
+    expect(stripAsciiControl("a\x00b\x1Bc\x7Fd")).toBe("abcd");
+  });
+  it("preserves printable", () => {
+    expect(stripAsciiControl("Hello, World!")).toBe("Hello, World!");
+  });
+});

--- a/code/packages/typescript/forme-aot-html-doc-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-html-doc-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-html-doc-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Eighteenth FM00 v0 stage package — **final-assembly** emitter for the FM00 v0 page pipeline.
- Wraps pre-built `<head>` + `<body>` string chunks (already produced by upstream FM00 emitters) into a complete `<!doctype html>...</html>` document.
- Supports optional `lang` (BCP-47-shaped regex), `dir` (`ltr`/`rtl`/`auto`), and extra `<html>` / `<body>` attribute maps.
- Two-pass fail-fast: validates lang/dir/every attr key + value before emitting any string.
- 116 tests, **100% line / 100% branch** coverage.
- `required_capabilities.json` → `[]` (pure transform).

## Security posture

Six concerns explicitly addressed. Pre-push security review (general-purpose agent) walked **11 focus areas** and found **no material issues**:

1. **Event-handler injection** — entire `on*` namespace rejected at `validateAttrKey`. Rejection covers every `on*` prefix (not just known names) so future-spec handlers are pre-empted.
2. **Reserved-key shadowing** — `lang`/`dir`/`xmlns` can't be supplied via attribute maps (would shadow the dedicated validated fields).
3. **Attribute-key injection** — shape regex `^[a-z][a-z0-9\-:]{0,63}$` (anchored both ends) prevents `x" onclick="alert(1)`-style escapes.
4. **Attribute-value injection** — every value passes through `escapeHtmlAttr`; control bytes rejected at validate time.
5. **Prototype pollution** — `Object.keys()` (own enumerable only); resolved attrs land in a `Map`.
6. **Fail-fast** — full validation before any string concatenation.

`head` and `body` are intentionally NOT escaped — they're trusted upstream FM00 emitter output. Caller documents this contract.

## Behavioural notes

- Output layout: 9 newline-separated lines (`<!doctype html>`, `<html …>`, `<head>`, head content, `</head>`, `<body …>`, body content, `</body>`, `</html>`).
- Attribute order on `<html>`: `lang → dir → extras` (extras in `Object.keys` insertion order).
- Attribute order on `<body>`: extras in insertion order.
- Same input → byte-identical output. No input mutation.

## How it fits in the stack

This is the **final** assembly stage in the FM00 v0 page pipeline. Upstream:
- `forme-aot-meta-link-tags` — head meta/link tags
- `forme-aot-style-tag-emitter` — stylesheets + inline styles
- `forme-aot-script-tag-emitter` — script tags with SRI
- `forme-aot-rss-discovery-link` — feed discovery

Caller composes head + body from these, passes to this emitter for the final HTML document.

## v0 simplifications (documented)

- No XHTML / XML self-closing tags (HTML Living Standard syntax only).
- No head/body content validation (passthrough).
- No `<noscript>` fallback (caller adds via body).
- No BCP-47 extensions / private-use subtags (conservative subset).

## Test plan

- [x] All 116 vitest tests pass locally
- [x] Coverage 100% line / 100% branch on source files with logic
- [x] Security review via Agent — clean across all 11 focus areas
- [x] CHANGELOG + README with usage examples + security rationale
- [x] `required_capabilities.json` set to `[]` with justification
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)