### PR TITLE
fix(sql-codegen): RIGHT JOIN + SELECT * preserves FROM-clause column order

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.55.0] - 2026-05-19
+
+### Fixed
+
+- **``SELECT *`` over RIGHT JOIN now emits columns in original FROM
+  order** (via ``sql-codegen 1.32.0``).  Completes the SELECT-star /
+  outer-join saga across the recent PRs:
+
+  - #3600: derived table implicit AS
+  - #3605: SELECT * across cross-join sources
+  - #3612: LEFT JOIN unmatched-row NULL-padding
+  - This PR: RIGHT JOIN column order
+
+  Before::
+
+      SELECT * FROM a RIGHT JOIN b ON a.id = b.id
+      -- mini-sqlite: (b.id, b.y, a.id, a.x)    -- wrong order
+      -- real SQLite: (a.id, a.x, b.id, b.y)
+
+  12 new oracle tests in ``test_tier3_right_join.py`` cover matched,
+  partial-match, no-match, empty-left, explicit-projection sanity,
+  LEFT/FULL/INNER regression guards, and the derived-table /
+  CTE-on-the-left variants.
+
 ## [1.54.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.54.0"
+version = "1.55.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_right_join.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_right_join.py
@@ -1,0 +1,222 @@
+"""Oracle tests for RIGHT [OUTER] JOIN column ordering with SELECT *.
+
+mini-sqlite implements RIGHT JOIN by swapping the left and right sides
+and emitting a LEFT JOIN.  That works correctly for explicit column
+projections (where the Project node above the join controls output
+order by name), but ``SELECT *`` iterates ``ctx.alias_to_cursor`` in
+insertion order — which the swap reverses, putting RIGHT columns
+before LEFT columns and diverging from SQLite.
+
+The fix in ``sql_codegen/compiler.py``'s RIGHT JOIN branch wraps the
+inner ``body`` closure so that ``alias_to_cursor`` is reordered
+(original-left first, original-right second) for the duration of each
+body invocation, restoring left→right column order in SELECT * output.
+
+Coverage:
+- Matched and unmatched-right rows are both correct.
+- LEFT JOIN regression guard — must still work.
+- FULL OUTER JOIN regression guard — must still work.
+- RIGHT JOIN with explicit projection — was already correct, included as
+  a sanity test.
+- RIGHT JOIN with derived right side and CTE left side.
+
+Note: SQLite normalizes column-qualified ORDER BY against ``SELECT *``
+in a way mini-sqlite doesn't fully replicate (latent bug, separate
+from this fix).  Tests therefore either skip ORDER BY or sort the
+result rows in Python before comparing.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both(setup: list[str], query: str):
+    """Apply *setup* on both engines then run *query* and return rows."""
+    conn_m = mini_sqlite.connect(":memory:")
+    conn_r = sqlite3.connect(":memory:")
+    for s in setup:
+        conn_m.execute(s)
+        conn_r.execute(s)
+    m = conn_m.execute(query).fetchall()
+    r = conn_r.execute(query).fetchall()
+    return m, r
+
+
+def _check_unordered(setup: list[str], query: str) -> None:
+    """Compare row multisets — independent of order."""
+    m, r = _both(setup, query)
+    # Use repr-based sort so heterogeneous types and None work.
+    assert sorted(m, key=repr) == sorted(r, key=repr), (
+        f"SQL: {query!r}\n  mini (sorted): {sorted(m, key=repr)}\n"
+        f"  ref  (sorted): {sorted(r, key=repr)}"
+    )
+
+
+def _check_ordered(setup: list[str], query: str) -> None:
+    """Compare row sequences exactly (relies on the query being deterministic)."""
+    m, r = _both(setup, query)
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref: {r}"
+
+
+# ---------------------------------------------------------------------------
+# RIGHT JOIN — SELECT * column ordering
+# ---------------------------------------------------------------------------
+
+
+class TestRightJoinSelectStarColumnOrder:
+    def test_partial_match_right_side(self) -> None:
+        # Right has a row that left doesn't match — must NULL-pad the LEFT
+        # columns and emit them BEFORE the right columns (FROM-order).
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1'), (2, 'a2')",
+                "INSERT INTO b VALUES (2, 'b2'), (3, 'b3')",
+            ],
+            "SELECT * FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+    def test_all_right_matched(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1'), (2, 'a2')",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT * FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+    def test_no_right_match(self) -> None:
+        # b has rows that none of a matches — every result row has left = NULL.
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (10, 'a10')",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT * FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+    def test_empty_left(self) -> None:
+        # a is empty — every b row is null-padded on the left side.
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT * FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RIGHT JOIN — explicit column projection (sanity)
+# ---------------------------------------------------------------------------
+
+
+class TestRightJoinExplicitProjection:
+    def test_named_columns_preserve_order(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1')",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT a.id, b.id, a.x, b.y FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+    def test_only_left_columns(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1')",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT a.x FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+    def test_only_right_columns(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1')",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT b.y FROM a RIGHT JOIN b ON a.id = b.id",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression — LEFT JOIN + FULL OUTER JOIN must still work
+# ---------------------------------------------------------------------------
+
+
+class TestLeftAndFullJoinNoRegression:
+    def test_left_join_select_star(self) -> None:
+        _check_ordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1'), (2, 'a2')",
+                "INSERT INTO b VALUES (2, 'b2')",
+            ],
+            "SELECT * FROM a LEFT JOIN b ON a.id = b.id",
+        )
+
+    def test_full_outer_join_select_star(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1'), (2, 'a2')",
+                "INSERT INTO b VALUES (2, 'b2'), (3, 'b3')",
+            ],
+            "SELECT * FROM a FULL OUTER JOIN b ON a.id = b.id",
+        )
+
+    def test_inner_join_select_star(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE a (id INTEGER, x TEXT)",
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO a VALUES (1, 'a1'), (2, 'a2')",
+                "INSERT INTO b VALUES (2, 'b2')",
+            ],
+            "SELECT * FROM a JOIN b ON a.id = b.id",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RIGHT JOIN with derived tables and CTEs
+# ---------------------------------------------------------------------------
+
+
+class TestRightJoinDerivedAndCte:
+    def test_derived_left_table_right_join(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "SELECT * FROM (SELECT 1 AS id, 'a1' AS x) a "
+            "RIGHT JOIN b ON a.id = b.id",
+        )
+
+    def test_cte_left_table_right_join(self) -> None:
+        _check_unordered(
+            [
+                "CREATE TABLE b (id INTEGER, y TEXT)",
+                "INSERT INTO b VALUES (1, 'b1'), (2, 'b2')",
+            ],
+            "WITH a(id, x) AS (SELECT 1, 'a1') "
+            "SELECT * FROM a RIGHT JOIN b ON a.id = b.id",
+        )

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.32.0] - 2026-05-19
+
+### Fixed
+
+- **RIGHT JOIN + ``SELECT *`` column order**.  The codegen implements
+  RIGHT JOIN by swapping the two sides and emitting a LEFT JOIN
+  (``_compile_join(rgt, lft, JoinKind.LEFT, …)``), which works for
+  explicit column projections (the Project node above the join controls
+  output order by name).  But ``SELECT *`` iterates
+  ``ctx.alias_to_cursor`` in insertion order — and the swap caused the
+  right-side cursor to be allocated first, emitting RIGHT columns
+  before LEFT columns and diverging from SQLite.
+
+  The RIGHT JOIN branch now wraps ``body`` in a closure that reorders
+  ``alias_to_cursor`` (original-left first, original-right second) for
+  the duration of each body invocation, restoring left→right column
+  order in ``SELECT *`` output.
+
+  Example::
+
+      Before: SELECT * FROM a RIGHT JOIN b ON a.id = b.id
+              → (b.id, b.y, a.id, a.x)   -- wrong order
+      Now:    → (a.id, a.x, b.id, b.y)   -- matches sqlite3
+
+- **New helper ``_plan_alias``** — mirrors the alias-extraction logic
+  in ``_compile_source`` for each plan-node type.  Used by the RIGHT
+  JOIN reorder to find the lft/rgt aliases without duplicating the
+  match.
+
 ## [1.31.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.31.0"
+version = "1.32.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -747,6 +747,37 @@ def _primary_cursor(ctx: _Ctx) -> int | None:
     return next(iter(ctx.alias_to_cursor.values()))
 
 
+def _plan_alias(p: LogicalPlan) -> str | None:
+    """Return the alias a plan node would register in ``alias_to_cursor``.
+
+    Used by the RIGHT JOIN compiler to reorder ``alias_to_cursor`` so that
+    ``SELECT *`` emits columns in original FROM-clause order even when the
+    physical scan loops have been swapped (rgt as outer, lft as inner).
+
+    Mirrors the alias-extraction logic inside :func:`_compile_source` for
+    each scan-producing plan node:
+
+    - :class:`Scan` / :class:`IndexScan`: ``alias`` if given, else ``table``.
+    - :class:`DerivedTable`, :class:`RecursiveCTE`, :class:`WorkingSetScan`:
+      the node carries its alias directly.
+    - Any other node type (Filter, Project, Join, etc.) doesn't open a
+      cursor directly — returns ``None`` and the caller skips reordering.
+    """
+    match p:
+        case Scan(table=t, alias=a):
+            return a or t
+        case IndexScan(table=t, alias=a):
+            return a or t
+        case DerivedTable(alias=a):
+            return a
+        case PlanRecursiveCTE(alias=a):
+            return a
+        case WorkingSetScan(alias=a):
+            return a
+        case _:
+            return None
+
+
 # --------------------------------------------------------------------------
 # Data-source compilation — Scan / Join. These emit the loop scaffolding
 # and splice ``body(ctx)`` inside.
@@ -1027,9 +1058,52 @@ def _compile_join(
         # reversing which side is the outer loop is sufficient: the original
         # right table becomes the outer "left" (preserved for every row) and
         # the original left table becomes the inner "right" (null-padded when
-        # no ON match is found).  Output column order is controlled by the
-        # Project node above the join and is not affected by the swap.
-        return _compile_join(rgt, lft, JoinKind.LEFT, cond, body, ctx)
+        # no ON match is found).
+        #
+        # ``SELECT *`` column order
+        # -------------------------
+        # The Project node above the join handles explicit column lists by
+        # name, so swapping doesn't affect output order for those.  But for
+        # ``SELECT *``, the codegen iterates ``ctx.alias_to_cursor.values()``
+        # in insertion order (PR #3605), and the swap below would otherwise
+        # cause the RIGHT side's cursor to be allocated first — making
+        # ``SELECT *`` emit right-table columns before left-table columns,
+        # diverging from SQLite.  We wrap ``body`` so that for the duration
+        # of each invocation, ``alias_to_cursor`` is reordered to put the
+        # original LEFT side's alias first, restoring left→right column
+        # order in the output.
+        lft_alias = _plan_alias(lft)
+        rgt_alias = _plan_alias(rgt)
+
+        def reorder_body(c: _Ctx) -> list[Instruction]:
+            """Reorder alias_to_cursor for ``SELECT *`` then call body."""
+            # Only reorder if both aliases are present in the dict.  Defensive
+            # against unusual cases (e.g. one side without an alias key).
+            if (
+                lft_alias is not None
+                and rgt_alias is not None
+                and lft_alias in c.alias_to_cursor
+                and rgt_alias in c.alias_to_cursor
+            ):
+                original_order = c.alias_to_cursor
+                reordered: dict[str, int] = {
+                    lft_alias: original_order[lft_alias],
+                    rgt_alias: original_order[rgt_alias],
+                }
+                # Preserve any other aliases that happen to be in scope (e.g.
+                # outer-query refs in correlated subqueries) at their original
+                # positions after the two reordered ones.
+                for k, v in original_order.items():
+                    if k not in reordered:
+                        reordered[k] = v
+                c.alias_to_cursor = reordered
+                try:
+                    return body(c)
+                finally:
+                    c.alias_to_cursor = original_order
+            return body(c)
+
+        return _compile_join(rgt, lft, JoinKind.LEFT, cond, reorder_body, ctx)
 
     if kind == JoinKind.FULL:
         # FULL OUTER JOIN — two-pass strategy:


### PR DESCRIPTION
## Summary

Completes the SELECT-star + outer-join saga across four PRs:
- #3600: derived table implicit AS
- #3605: SELECT * across cross-join sources
- #3612: LEFT JOIN unmatched-row NULL-padding
- **This PR**: RIGHT JOIN column order

```sql
SELECT * FROM a RIGHT JOIN b ON a.id = b.id
-- Before: (b.id, b.y, a.id, a.x)   ← wrong order
-- Now:    (a.id, a.x, b.id, b.y)   ← matches sqlite3
```

## Root cause

The codegen implements RIGHT JOIN by swapping the two sides and emitting a LEFT JOIN. That works for explicit projections (the Project node above the join controls output by name), but `SELECT *` iterates `ctx.alias_to_cursor` in **insertion order** (PR #3605) — and the swap caused the right-side cursor to be allocated first.

## Fix

The RIGHT JOIN branch in `_compile_join` now wraps `body` in a closure that reorders `alias_to_cursor` (original-left first, original-right second) for the duration of each invocation. Reordering happens via Python dict insertion-order; the restored mapping is the same set of alias→cursor entries, just iterated in original FROM order.

```python
def reorder_body(c: _Ctx) -> list[Instruction]:
    if lft_alias and rgt_alias and both in alias_to_cursor:
        reordered = {lft_alias: ..., rgt_alias: ...}
        # ... preserve other aliases ...
        c.alias_to_cursor = reordered
        try:
            return body(c)
        finally:
            c.alias_to_cursor = original_order
    return body(c)

return _compile_join(rgt, lft, JoinKind.LEFT, cond, reorder_body, ctx)
```

New helper `_plan_alias(plan)` extracts the alias from a plan node (mirrors the alias resolution inside `_compile_source` for each node type).

## Version bumps

- `sql-codegen`: 1.31.0 → 1.32.0
- `mini-sqlite`: 1.54.0 → 1.55.0

## Test plan

- [x] `pytest code/packages/python/mini-sqlite/tests/` — 1517 pass, no regressions
- [x] 12 new oracle tests in `test_tier3_right_join.py`:
  - partial-match, all-matched, no-match, empty-left
  - explicit-projection sanity (was already correct)
  - LEFT/FULL/INNER regression guards
  - derived-table left side, CTE left side
- [x] Manual security review: closure-based dict reorder with try/finally restore; no new I/O, no external input

## Known deferred

`ORDER BY` on column-qualified names with `SELECT *` has a separate latent bug where the sort key resolves to the first matching unqualified column name. This affects RIGHT JOIN test cases that use `ORDER BY b.id`, but it isn't specific to this fix — the test file uses unordered row-set comparison where needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)