### PR TITLE
feat(forme-aot-page-bundle-emitter): FM00 v0 deploy-stage page bundle manifest

### DIFF
--- a/code/packages/typescript/forme-aot-page-bundle-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/CHANGELOG.md
@@ -1,0 +1,137 @@
+# Changelog — @coding-adventures/forme-aot-page-bundle-emitter
+
+## 0.1.0 — 2026-05-19
+
+Initial release.  Nineteenth FM00 v0 stage package — deploy-
+stage page bundle emitter.  Pure transform:
+`PageBundleConfig` → deterministic JSON manifest string.
+
+The manifest is the deploy hand-off format: route → file path
++ content type + size + SHA-256 hash + optional last-modified.
+A downstream deploy tool consumes the manifest and writes the
+actual files.
+
+### Added
+
+- `generatePageBundle(config): string` — main entry.  Returns
+  the manifest as a 2-space-indented JSON string with trailing
+  newline.
+- `validateRoute(value, field)` — strict route validation with
+  path-traversal defence.
+- `validateBaseUrl(value)` — http(s):// accept-list.
+- `validateString(value, field)` — generic string check (for
+  html / lastmod / contentType).
+- `routeToOutputPath(route)` — deterministic route → output
+  file path derivation.  `/` → `index.html`; `/about` →
+  `about/index.html`; `/feed.xml` → `feed.xml` (extension
+  preserved); `/file.tar.gz` → `file.tar.gz`; `/.hidden` →
+  `.hidden/index.html` (dotfile doesn't count as extension).
+- `sha256Base64(s)` — SHA-256 via Node's built-in `node:crypto`,
+  base64-encoded.  Standard alphabet.
+- `utf8ByteLength(s)` — UTF-8 byte count via `TextEncoder`.
+- Types: `PageBundleConfig`, `PageEntry`, `RouteEntry`,
+  `PageBundleManifest`.
+
+### Spec adherence
+
+Internal manifest format (versioned at `version: 1`).  No
+external spec to adhere to.
+
+### Behavioural notes
+
+- **Output is byte-deterministic.**  Same input → byte-identical
+  manifest string.  Reordering input pages doesn't change
+  output (routes sorted alphabetically in the manifest).
+- **Top-level key order**: `version → baseUrl (if present) →
+  routes`.
+- **Route entry key order**: `route → outputPath → contentType
+  → sizeBytes → sha256 → lastmod (if present)`.
+- **HTML body is passthrough** — hashed and measured but never
+  escaped/validated.  Trusted upstream output.
+- **Duplicate routes** (after validation) throw.
+- **Empty `pages: []`** → minimal manifest (`{ version: 1,
+  routes: {} }`).
+- **No input mutation.**
+- **Default contentType** = `text/html; charset=utf-8`.
+- **`sizeBytes`** is UTF-8 byte count, not char count.
+
+### Security posture
+
+Six concerns explicitly addressed (pre-push review):
+
+- **Path traversal.**  Routes validated against strict shape
+  regex + segment-by-segment `..` / `.` / empty-segment
+  checks before becoming file paths.  No `..\..\etc` can
+  escape the deploy root.
+- **Protocol confusion.**  Routes starting with `//` (treated
+  as URL by some servers / CDNs) or `/\` (backslash variant)
+  rejected.
+- **Windows path separators.**  Any `\` in the route rejected
+  — prevents `..\..\etc` on Windows-target deploys.
+- **baseUrl scheme injection.**  `javascript:` / `data:` /
+  `file:` / `ftp:` / scheme-less / non-http(s) rejected.
+- **Hashing**: SHA-256 via Node's built-in `node:crypto`.  No
+  network, no third-party dep, no weak algorithm choice.
+- **Determinism**: same input → byte-identical output.  Two
+  builds diff cleanly; no spurious churn from
+  non-deterministic ordering.
+
+### Capabilities
+
+`[]` — pure transform.  Uses Node's built-in `node:crypto`
+(no network, no fs).  No I/O, network, fs, shell, env.
+
+### Tests
+
+101 tests across 4 files:
+
+- `validate.test.ts` (51) — `validateRoute` accept (bare /,
+  /about, /posts/x, /p/x.html, /feed.xml, dashes/underscores,
+  digits, mixed-case preserved, colon segment) + reject
+  matrix (non-string, null, empty, over-cap 2048, no leading
+  /, protocol-relative //, backslash variant /\, mid-path \,
+  /.., /a/.., /a/../b, /., /a/./b, /a//b, trailing /a/, query
+  /a?b=c, hash /a#b, whitespace, NUL, unicode, error contains
+  field, long-route truncated); `validateBaseUrl` accept
+  (https, http, HTTPS uppercase, with path) + reject
+  (non-string, null, empty, javascript:, data:, file:, ftp:,
+  /relative, over-cap); `validateString` (4 cases).
+- `path.test.ts` (10) — `routeToOutputPath` all 10 documented
+  cases (/, /about, /posts/x, /page.html, /feed.xml,
+  /posts/x.html, /p/x.json, deep no-ext, dotfile, compound
+  extension).
+- `hash.test.ts` (10) — `sha256Base64` empty + known "abc"
+  digest + determinism + different inputs differ + 44-char
+  length; `utf8ByteLength` ASCII + empty + multi-byte é +
+  emoji + mixed.
+- `generate.test.ts` (30) — shape (null config / non-array
+  pages / empty pages → minimal); single page (minimal /,
+  custom contentType, lastmod present-only-when-provided);
+  multiple pages (routes sorted alphabetically regardless
+  of input order, duplicate throws); baseUrl (included,
+  omitted, javascript: throws); route validation (traversal,
+  protocol-relative, backslash, absolute https throws);
+  page field validation (non-string html / contentType /
+  lastmod / null page); output format (2-space indent,
+  trailing newline, top-level key order, entry key order);
+  determinism (byte-identical, reordering invariant, no
+  input mutation); content hashing (different html differs,
+  same html identical, UTF-8 byte count); full real-world
+  example with 4 pages + baseUrl + feed.
+
+Coverage: **100% line / 98.82% branch** across all source
+files with logic (`types.ts` is type-only).  The single
+missing branch is the sort-comparator equality case
+(`a.route === b.route` → returns 0); duplicate routes throw at
+validation time so the equality branch is unreachable in
+practice.
+
+### v0 simplifications (documented)
+
+- **No gzip / brotli precompression metadata** — caller
+  compresses at deploy time.
+- **No per-page redirect / rewrite rules** — 1:1 route to
+  file.
+- **No multi-locale routing logic** — caller pre-flattens.
+- **No content-addressed output paths** (e.g.
+  `page.abc123.html`) — v1 may add as option.

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/README.md
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/README.md
@@ -1,0 +1,191 @@
+# @coding-adventures/forme-aot-page-bundle-emitter
+
+> FM00 v0 deploy-stage emitter — wraps multiple HTML pages
+> into a deterministic JSON manifest describing where each
+> page should be written and its SHA-256 content hash.
+
+Nineteenth FM00 v0 stage package. Pure transform — no I/O, no
+fs, no network, no env, no shell. Uses Node's built-in
+`node:crypto` for hashing.
+
+## What it does
+
+`generatePageBundle(config) → string` takes an array of pages
+and produces a JSON manifest. The downstream deploy tool reads
+the manifest, then writes the actual files.
+
+**Manifest shape:**
+
+```json
+{
+  "version": 1,
+  "baseUrl": "https://example.com",
+  "routes": {
+    "/":           { "route": "/",           "outputPath": "index.html",       "contentType": "text/html; charset=utf-8", "sizeBytes": 15, "sha256": "…=" },
+    "/about":      { "route": "/about",      "outputPath": "about/index.html", "contentType": "text/html; charset=utf-8", "sizeBytes": 32, "sha256": "…=" },
+    "/feed.xml":   { "route": "/feed.xml",   "outputPath": "feed.xml",         "contentType": "application/rss+xml",      "sizeBytes": 28, "sha256": "…=" },
+    "/posts/x":    { "route": "/posts/x",    "outputPath": "posts/x/index.html", … }
+  }
+}
+```
+
+## Quick start
+
+```ts
+import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+
+const manifest = generatePageBundle({
+  baseUrl: "https://example.com",
+  pages: [
+    { route: "/",          html: "<!doctype html><title>Home</title>" },
+    { route: "/about",     html: "<!doctype html><title>About</title>" },
+    { route: "/posts/x",   html: "<!doctype html><title>Post</title>", lastmod: "2026-05-19" },
+    { route: "/feed.xml",  html: "<?xml?><rss/>", contentType: "application/rss+xml" },
+  ],
+});
+
+// `manifest` is a UTF-8 JSON string, 2-space indented,
+// trailing newline.  Hand it to your deploy tool.
+```
+
+## Route → output path
+
+Deterministic derivation. The rule: if the last route segment
+has a `.ext`, write to that filename; otherwise treat the route
+as a directory and write `index.html` inside it.
+
+| Route          | Output path             |
+| -------------- | ----------------------- |
+| `/`            | `index.html`            |
+| `/about`       | `about/index.html`      |
+| `/posts/x`     | `posts/x/index.html`    |
+| `/feed.xml`    | `feed.xml`              |
+| `/page.html`   | `page.html`             |
+| `/file.tar.gz` | `file.tar.gz`           |
+| `/.hidden`     | `.hidden/index.html`    |
+
+The "has extension" check looks at the **last segment** for a
+`.` at index > 0 (so dotfiles like `.hidden` don't count as
+extensions).
+
+## Route validation (path-traversal defence)
+
+The route validator is the security-critical piece. Routes
+become file paths via `routeToOutputPath` — any `..` segment or
+absolute prefix would let an attacker write outside the deploy
+root.
+
+**Accepted:**
+- Must start with `/`.
+- Bare `/` is OK.
+- Segments contain only `[A-Za-z0-9._~!$&'()*+,;=:@-]` (RFC 3986
+  unreserved + sub-delims + `:` `@`).
+- ≤ 2048 chars total.
+
+**Rejected:**
+- Empty / non-string / null.
+- Doesn't start with `/`.
+- Starts with `//` (protocol-relative).
+- Starts with `/\` (backslash variant).
+- Contains `\` anywhere (Windows separator).
+- Contains `..` as a segment (path traversal).
+- Contains `.` as a sole segment.
+- Contains `//` mid-path (empty segment).
+- Trailing `/` (empty trailing segment).
+- Contains `?`, `#`, whitespace, NUL, or any char outside the
+  segment charset.
+
+Duplicate routes (after validation) throw.
+
+## `baseUrl` validation
+
+Optional. When provided: `http://...` or `https://...` only,
+scheme case-insensitive, ≤ 2048 chars. Everything else throws.
+
+## Hashing
+
+SHA-256 via Node's built-in `node:crypto`, base64-encoded
+(standard alphabet, including `+` `/` `=` padding). 44-char
+output. No external dependency, no network.
+
+`sizeBytes` is the UTF-8 byte length of the HTML string (via
+`TextEncoder`), not the character count.
+
+## JSON output format
+
+Byte-deterministic:
+
+- 2-space indent, trailing newline.
+- Top-level key order: `version → baseUrl (if present) → routes`.
+- `routes` keys sorted lexicographically by route string.
+- Each route entry's keys in fixed order: `route → outputPath →
+  contentType → sizeBytes → sha256 → lastmod (if present)`.
+
+Same input → byte-identical output, byte-identical hash.
+Reordering input pages doesn't change output.
+
+## Security posture
+
+Six concerns explicitly addressed:
+
+1. **Path traversal.** Routes are validated against a strict
+   shape regex + segment-by-segment `..` / `.` / empty checks
+   before being converted to file paths. No way to escape the
+   deploy root.
+2. **Protocol confusion.** Routes starting with `//` (treated as
+   URL by some servers) or `/\` (backslash variant) rejected.
+3. **Windows path separators.** Any `\` in the route rejected
+   — prevents `..\..\etc` on Windows-target deploys.
+4. **`baseUrl` scheme injection.** `javascript:` / `data:` /
+   `file:` / `ftp:` / scheme-less / non-http(s) all rejected.
+5. **Hashing.** SHA-256 via Node's built-in `node:crypto`. No
+   network, no third-party dep, no algorithm choice that could
+   collide.
+6. **Determinism.** Same input → byte-identical output. Diff
+   between two builds shows exactly what changed; no spurious
+   churn from non-deterministic ordering.
+
+## Behavioural notes
+
+- **HTML body is passthrough** — the bundle hashes / measures
+  it but never escapes or validates it. It's already trusted
+  upstream FM00 output (from `forme-aot-html-doc-emitter`).
+- **Empty `pages: []`** → minimal manifest (`version + routes:
+  {}`).
+- **Duplicate routes** throw, even if HTML differs (caller bug).
+- **No input mutation.** Pages array is read-only.
+
+## v0 simplifications (documented)
+
+- **No gzip / brotli precompression metadata** in the manifest.
+  Caller compresses at deploy time.
+- **No per-page redirect / rewrite rules.** Routes are 1:1
+  with output files.
+- **No multi-locale (`/en/`, `/de/`) routing logic** — caller
+  pre-flattens.
+- **No content-addressed output paths** (e.g.
+  `page.abc123.html`). v1 may add as an option.
+
+## Capabilities
+
+`[]` — pure transform.
+
+## How it fits in the stack
+
+The **deploy-stage** companion to `forme-aot-html-doc-emitter`
+(which produces individual HTML documents). Upstream:
+
+- `forme-aot-html-doc-emitter` — produces the per-page HTML strings.
+
+Downstream (planned):
+
+- `forme-aot-deploy-manifest-emitter` — combines this page
+  bundle with sitemap + robots + RSS into a single deploy
+  manifest.
+
+## Tests
+
+98 tests across four files (`validate`, `path`, `hash`,
+`generate`). **100% line coverage**, **98.82% branch coverage**
+(the missing branch is a sort-comparator equality case that's
+unreachable because duplicate routes throw).

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-page-bundle-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-page-bundle-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/package.json
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-page-bundle-emitter",
+  "version": "0.1.0",
+  "description": "Wrap multiple HTML pages into a deterministic deploy bundle manifest with route table.  Pure transform: route validation (root-relative, no .., no //, no \\), deterministic file-path derivation (e.g. /about → about/index.html), SHA-256 hash via Node's built-in crypto (no network), canonical JSON output (sorted keys, fixed key order per entry).  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-page-bundle-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: PageBundleConfig → deterministic JSON manifest string.  Uses Node's built-in node:crypto for SHA-256 hashing (no network).  No I/O, no fs, no shell, no env."
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/src/generate.ts
@@ -1,0 +1,140 @@
+/**
+ * generate.ts — main `generatePageBundle` entry.
+ *
+ * Two-pass fail-fast:
+ *
+ *   1. Validate config (baseUrl, every page's route + fields),
+ *      check duplicate routes, build resolved entry list.
+ *   2. Serialise to canonical JSON.
+ *
+ * Output JSON is byte-deterministic:
+ *   - Top-level keys in fixed order: `version`, `baseUrl`
+ *     (if present), `routes`.
+ *   - `routes` object keys sorted lexicographically (using the
+ *     route string, which is already canonical).
+ *   - Each route entry's keys in fixed order:
+ *     `route → outputPath → contentType → sizeBytes → sha256 →
+ *     lastmod` (lastmod only if present).
+ *   - JSON formatted with 2-space indent + trailing newline so
+ *     it diffs cleanly and matches what most editors emit.
+ *
+ * @module generate
+ */
+
+import { sha256Base64, utf8ByteLength } from "./hash.js";
+import { routeToOutputPath } from "./path.js";
+import type { PageBundleConfig, RouteEntry } from "./types.js";
+import { validateBaseUrl, validateRoute, validateString } from "./validate.js";
+
+const DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8";
+
+/**
+ * Build a deploy bundle manifest JSON string from a
+ * `PageBundleConfig`.  Synchronous, pure, deterministic.
+ *
+ * ```ts
+ * const manifest = generatePageBundle({
+ *   baseUrl: "https://example.com",
+ *   pages: [
+ *     { route: "/", html: "<!doctype html>..." },
+ *     { route: "/about", html: "<!doctype html>..." },
+ *     { route: "/feed.xml", html: "<?xml ...?>",
+ *       contentType: "application/rss+xml" },
+ *   ],
+ * });
+ * // {
+ * //   "version": 1,
+ * //   "baseUrl": "https://example.com",
+ * //   "routes": {
+ * //     "/":         { "route": "/", "outputPath": "index.html", ... },
+ * //     "/about":    { "route": "/about", "outputPath": "about/index.html", ... },
+ * //     "/feed.xml": { "route": "/feed.xml", "outputPath": "feed.xml", ... }
+ * //   }
+ * // }
+ * ```
+ *
+ * Routes are sorted alphabetically in the output regardless
+ * of input order.  Duplicate routes throw.
+ */
+export function generatePageBundle(config: PageBundleConfig): string {
+  if (config === null || typeof config !== "object") {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: config must be a non-null object; got ${typeof config}`,
+    );
+  }
+  if (!Array.isArray(config.pages)) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: pages must be an array; got ${typeof config.pages}`,
+    );
+  }
+  const baseUrl = config.baseUrl === undefined
+    ? undefined
+    : validateBaseUrl(config.baseUrl);
+
+  // Validate every page; check duplicates.
+  const seenRoutes = new Set<string>();
+  const resolved: RouteEntry[] = new Array(config.pages.length);
+  for (let i = 0; i < config.pages.length; i++) {
+    const page = config.pages[i];
+    if (page === null || typeof page !== "object") {
+      throw new TypeError(
+        `forme-aot-page-bundle-emitter: pages[${i}] must be a non-null object; got ${typeof page}`,
+      );
+    }
+    const route = validateRoute(page.route, `pages[${i}].route`);
+    if (seenRoutes.has(route)) {
+      throw new TypeError(
+        `forme-aot-page-bundle-emitter: pages[${i}].route duplicates an earlier entry: ${JSON.stringify(route)}`,
+      );
+    }
+    seenRoutes.add(route);
+
+    const html = validateString(page.html, `pages[${i}].html`);
+    const contentType = page.contentType === undefined
+      ? DEFAULT_CONTENT_TYPE
+      : validateString(page.contentType, `pages[${i}].contentType`);
+    const lastmod = page.lastmod === undefined
+      ? undefined
+      : validateString(page.lastmod, `pages[${i}].lastmod`);
+
+    resolved[i] = {
+      route,
+      outputPath: routeToOutputPath(route),
+      contentType,
+      sizeBytes: utf8ByteLength(html),
+      sha256: sha256Base64(html),
+      lastmod,
+    };
+  }
+
+  // Sort by route lexicographically for deterministic output.
+  resolved.sort((a, b) => (a.route < b.route ? -1 : a.route > b.route ? 1 : 0));
+
+  // Serialise.  We build the object explicitly key-by-key
+  // rather than using `JSON.stringify(obj, null, 2)` directly
+  // on a plain object — JSON.stringify *does* use insertion
+  // order for object keys, but constructing the inner objects
+  // in fixed key order is clearer and more obviously correct.
+  const routesObj: Record<string, Record<string, unknown>> = {};
+  for (const entry of resolved) {
+    const inner: Record<string, unknown> = {
+      route: entry.route,
+      outputPath: entry.outputPath,
+      contentType: entry.contentType,
+      sizeBytes: entry.sizeBytes,
+      sha256: entry.sha256,
+    };
+    if (entry.lastmod !== undefined) {
+      inner.lastmod = entry.lastmod;
+    }
+    routesObj[entry.route] = inner;
+  }
+
+  // Top-level object in fixed key order.
+  const top: Record<string, unknown> = { version: 1 };
+  if (baseUrl !== undefined) top.baseUrl = baseUrl;
+  top.routes = routesObj;
+
+  // 2-space indent, trailing newline.
+  return `${JSON.stringify(top, null, 2)}\n`;
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/src/hash.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/src/hash.ts
@@ -1,0 +1,27 @@
+/**
+ * hash.ts — SHA-256 of a string, base64-encoded.
+ *
+ * Uses Node's built-in `node:crypto`.  No external dependency,
+ * no network, no allocator surprises.
+ *
+ * @module hash
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Compute the base64-encoded SHA-256 digest of `s` (UTF-8
+ * encoded).  Standard base64 (with `+`, `/`, `=` padding).
+ */
+export function sha256Base64(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("base64");
+}
+
+/**
+ * Compute the UTF-8 byte length of `s`.  Uses TextEncoder
+ * (built-in, no allocator) — `Buffer.byteLength` would also
+ * work but we avoid Buffer for portability.
+ */
+export function utf8ByteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * @coding-adventures/forme-aot-page-bundle-emitter
+ *
+ * Deploy-stage emitter: take an array of HTML pages with their
+ * routes, produce a deterministic JSON manifest describing
+ * where each page should be written and its SHA-256 content
+ * hash.  The downstream deploy tool reads the manifest and
+ * writes the actual files.
+ *
+ * Pure transform.  Uses Node's built-in `node:crypto` for
+ * SHA-256 hashing.  No I/O, no fs, no network, no env, no
+ * shell.  Capabilities: `[]`.
+ *
+ * ```ts
+ * import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+ *
+ * const manifest = generatePageBundle({
+ *   baseUrl: "https://example.com",
+ *   pages: [
+ *     { route: "/",         html: indexHtml },
+ *     { route: "/about",    html: aboutHtml },
+ *     { route: "/feed.xml", html: rssXml, contentType: "application/rss+xml" },
+ *   ],
+ * });
+ * // → JSON string with sorted routes, each entry having
+ * //   { route, outputPath, contentType, sizeBytes, sha256 [, lastmod] }
+ * ```
+ *
+ * Nineteenth FM00 v0 stage package.
+ *
+ * @module index
+ */
+
+export { generatePageBundle } from "./generate.js";
+export { routeToOutputPath } from "./path.js";
+export { sha256Base64, utf8ByteLength } from "./hash.js";
+export {
+  validateRoute,
+  validateBaseUrl,
+  validateString,
+} from "./validate.js";
+export type {
+  PageBundleConfig,
+  PageEntry,
+  RouteEntry,
+  PageBundleManifest,
+} from "./types.js";

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/src/path.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/src/path.ts
@@ -1,0 +1,41 @@
+/**
+ * path.ts — deterministic route → output-path derivation.
+ *
+ * Rule set:
+ *
+ *   `/`                  →  `"index.html"`
+ *   `/about`             →  `"about/index.html"`
+ *   `/posts/x`           →  `"posts/x/index.html"`
+ *   `/page.html`         →  `"page.html"`            (extension preserved
+ *                                                    when the last segment
+ *                                                    has one)
+ *   `/feed.xml`          →  `"feed.xml"`
+ *   `/posts/x.html`      →  `"posts/x.html"`
+ *   `/x/`                →  invalid (trailing slash) — `validateRoute`
+ *                          would have already rejected the empty
+ *                          trailing segment.
+ *
+ * "Has an extension" = the last segment contains a `.` after the
+ * first character.  We deliberately don't try to enumerate
+ * extensions — any `.ext` is preserved.
+ *
+ * @module path
+ */
+
+/**
+ * Convert a validated route to its deterministic output path.
+ * Caller MUST validate the route first via `validateRoute`.
+ */
+export function routeToOutputPath(route: string): string {
+  if (route === "/") return "index.html";
+  // route starts with "/", validated.  Strip leading slash.
+  const trimmed = route.slice(1);
+  const lastSlash = trimmed.lastIndexOf("/");
+  const lastSeg = lastSlash === -1 ? trimmed : trimmed.slice(lastSlash + 1);
+  // "Has extension" — `.` at index > 0 in the last segment.
+  const dotIdx = lastSeg.indexOf(".");
+  if (dotIdx > 0) {
+    return trimmed;
+  }
+  return `${trimmed}/index.html`;
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/src/types.ts
@@ -1,0 +1,105 @@
+/**
+ * types.ts — public signatures for the page bundle emitter.
+ *
+ * A "page bundle" is the deploy-time representation of a static
+ * site: a route table mapping URL paths to file output paths,
+ * with content metadata (size, hash, content-type, last-modified)
+ * for each page.  The downstream deploy tool reads this manifest
+ * to decide which files to write where.
+ *
+ * Pages are passed as in-memory strings (the FM00 pipeline holds
+ * everything in memory until the deploy step); the manifest
+ * doesn't include the page bodies themselves — just the
+ * metadata.  This keeps the manifest small enough to inspect /
+ * diff between builds.
+ *
+ * @module types
+ */
+
+/**
+ * One page in the bundle.
+ *
+ *   - `route`        — required.  Root-relative URL path,
+ *                      e.g. `"/"`, `"/about"`, `"/posts/x"`.
+ *                      MUST start with `/`; MUST NOT contain
+ *                      `..` segments, `//` (protocol-relative
+ *                      hint), or `\` (Windows / backslash
+ *                      variant).
+ *   - `html`         — required.  The page's HTML string (the
+ *                      output of `generateHtmlDocument(...)`
+ *                      from `forme-aot-html-doc-emitter`).
+ *                      Passthrough — the bundle emitter hashes
+ *                      and measures it but never escapes it.
+ *   - `lastmod`      — optional `lastModified` ISO 8601 string.
+ *                      Pass-through into the manifest;
+ *                      validated only as "must be a string"
+ *                      (date-format validation is the caller's
+ *                      job).
+ *   - `contentType`  — optional MIME content-type.  Defaults
+ *                      to `"text/html; charset=utf-8"`.  Pure
+ *                      pass-through string (validated only as
+ *                      "must be a string"; allowlist would lock
+ *                      callers out of valid MIMEs).
+ */
+export interface PageEntry {
+  readonly route: string;
+  readonly html: string;
+  readonly lastmod?: string;
+  readonly contentType?: string;
+}
+
+/**
+ * Top-level config consumed by `generatePageBundle`.
+ *
+ *   - `pages`    — required array of page entries.  Empty
+ *                  array yields an empty manifest.
+ *   - `baseUrl`  — optional canonical site URL.  When provided,
+ *                  the manifest includes a top-level `baseUrl`
+ *                  field; downstream tooling can use it to
+ *                  prefix routes when generating sitemap / RSS
+ *                  / etc.  Validated as http(s):// only.
+ */
+export interface PageBundleConfig {
+  readonly pages: readonly PageEntry[];
+  readonly baseUrl?: string;
+}
+
+/**
+ * One entry in the emitted route table (manifest).
+ *
+ *   - `route`       — the input route (preserved verbatim).
+ *   - `outputPath`  — relative file path (no leading `/`)
+ *                     derived deterministically from route:
+ *                       `/`         → `"index.html"`
+ *                       `/about`    → `"about/index.html"`
+ *                       `/p/x`      → `"p/x/index.html"`
+ *                       `/p/x.html` → `"p/x.html"`  (extension
+ *                                                    preserved
+ *                                                    when the
+ *                                                    last segment
+ *                                                    already has
+ *                                                    one)
+ *   - `contentType` — defaulted if absent on input.
+ *   - `sizeBytes`   — UTF-8 byte length of `html`.
+ *   - `sha256`      — base64-encoded SHA-256 of `html`.
+ *   - `lastmod`     — present only if the input had it.
+ */
+export interface RouteEntry {
+  readonly route: string;
+  readonly outputPath: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly sha256: string;
+  readonly lastmod?: string;
+}
+
+/**
+ * The decoded manifest shape — what `parsePageBundle` would
+ * return (we don't export a parser here, but the shape is
+ * documented for downstream consumers).
+ */
+export interface PageBundleManifest {
+  readonly version: 1;
+  readonly baseUrl?: string;
+  readonly routes: Readonly<Record<string, RouteEntry>>;
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/src/validate.ts
@@ -1,0 +1,154 @@
+/**
+ * validate.ts — route, baseUrl, and field validators.
+ *
+ * The route validator is path-traversal defence.  Routes
+ * become file output paths via `routeToOutputPath`, so any
+ * `..` segment or absolute prefix would let an attacker write
+ * outside the deploy root.  We reject everything except a
+ * narrow set of "safe" root-relative paths.
+ *
+ * @module validate
+ */
+
+// Segment charset: RFC 3986 unreserved (A-Z a-z 0-9 . _ ~ -) +
+// sub-delims (! $ & ' ( ) * + , ; =) + colon + at-sign.
+// IMPORTANT: `%` is deliberately NOT in this set — percent-
+// encoded sequences like `%2e%2e` (a `..` traversal) or `%00`
+// (NUL byte) would bypass the segment-by-segment `..` and
+// control-byte checks below.  We reject `%` wholesale rather
+// than try to decode and re-check.  Callers must pre-decode
+// routes (or never percent-encode them in the first place;
+// routes are internal config, not user-typed URLs).
+const ROUTE_SEGMENT_RE = /^[A-Za-z0-9._~!$&'()*+,;=:@\-]+$/;
+
+/**
+ * Validate a route string.  Returns the canonicalised route
+ * (currently identity — we don't lower-case or trim because
+ * routes are case-sensitive URLs).
+ *
+ * Rejects:
+ *   - non-string / empty / undefined / null
+ *   - not starting with `/`
+ *   - starting with `//` (protocol-relative)
+ *   - starting with `/\` (backslash variant)
+ *   - containing `\` anywhere (Windows path separator)
+ *   - containing `..` as a segment (path traversal)
+ *   - containing `.` as a sole segment (relative path)
+ *   - containing an empty segment (`//` mid-path)
+ *   - containing a segment with disallowed characters (only
+ *     URL unreserved + sub-delims + `:`/`@` allowed; no `?`,
+ *     no `#`, no whitespace, no NUL)
+ *   - exceeding length 2048 (sanity cap)
+ */
+export function validateRoute(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must be a string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  if (value.length === 0) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must be non-empty`,
+    );
+  }
+  if (value.length > 2048) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must be ≤ 2048 chars`,
+    );
+  }
+  if (value[0] !== "/") {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must start with "/"; got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+  if (value === "/") return value;
+  if (value[1] === "/") {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must not start with "//" (protocol-relative); got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+  if (value[1] === "\\") {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must not start with "/\\" (backslash variant); got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+  if (value.indexOf("\\") !== -1) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must not contain "\\"; got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+
+  // Walk the segments.  Note: split on "/" yields the empty
+  // string before the first "/" (which we discard); also
+  // catches `//` mid-path (yields an empty interior segment).
+  const segments = value.slice(1).split("/");
+  for (const seg of segments) {
+    if (seg.length === 0) {
+      throw new TypeError(
+        `forme-aot-page-bundle-emitter: ${field} must not contain empty segments (//); got ${JSON.stringify(shorten(value))}`,
+      );
+    }
+    if (seg === "..") {
+      throw new TypeError(
+        `forme-aot-page-bundle-emitter: ${field} must not contain ".." segments (path traversal); got ${JSON.stringify(shorten(value))}`,
+      );
+    }
+    if (seg === ".") {
+      throw new TypeError(
+        `forme-aot-page-bundle-emitter: ${field} must not contain "." segments; got ${JSON.stringify(shorten(value))}`,
+      );
+    }
+    if (!ROUTE_SEGMENT_RE.test(seg)) {
+      throw new TypeError(
+        `forme-aot-page-bundle-emitter: ${field} segment ${JSON.stringify(seg)} contains disallowed characters; only [A-Za-z0-9._~!$&'()*+,;=:@-] permitted`,
+      );
+    }
+  }
+  return value;
+}
+
+/**
+ * Validate `baseUrl` — http(s):// only.
+ */
+export function validateBaseUrl(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: baseUrl must be a non-empty string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  if (value.length > 2048) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: baseUrl must be ≤ 2048 chars`,
+    );
+  }
+  const head = value.slice(0, 8).toLowerCase();
+  if (!head.startsWith("http://") && !head.startsWith("https://")) {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: baseUrl must be http(s)://; got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate that a value is a string (used for `html`,
+ * `lastmod`, `contentType`).
+ */
+export function validateString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-page-bundle-emitter: ${field} must be a string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  return value;
+}
+
+function shorten(s: string): string {
+  return s.length > 100 ? `${s.slice(0, 100)}…` : s;
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/tests/generate.test.ts
@@ -1,0 +1,256 @@
+/**
+ * generate.test.ts — end-to-end generatePageBundle.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generatePageBundle } from "../src/index.js";
+
+describe("generatePageBundle — shape", () => {
+  it("null config throws", () => {
+    expect(() => generatePageBundle(null as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("non-array pages throws", () => {
+    expect(() => generatePageBundle({ pages: "x" } as unknown as never))
+      .toThrow(/pages must be an array/);
+  });
+  it("empty pages → minimal manifest", () => {
+    const out = generatePageBundle({ pages: [] });
+    expect(JSON.parse(out)).toEqual({ version: 1, routes: {} });
+    expect(out.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("generatePageBundle — single page", () => {
+  it("minimal /", () => {
+    const out = generatePageBundle({ pages: [{ route: "/", html: "<!doctype html>" }] });
+    const m = JSON.parse(out);
+    expect(m.version).toBe(1);
+    expect(m.routes["/"]).toMatchObject({
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 15, // "<!doctype html>" = 15 bytes
+    });
+    expect(m.routes["/"].sha256).toMatch(/^[A-Za-z0-9+/]+=*$/);
+  });
+  it("custom contentType", () => {
+    const m = JSON.parse(generatePageBundle({
+      pages: [{ route: "/feed.xml", html: "<?xml?>", contentType: "application/rss+xml" }],
+    }));
+    expect(m.routes["/feed.xml"].contentType).toBe("application/rss+xml");
+  });
+  it("lastmod present in entry only when provided", () => {
+    const without = JSON.parse(generatePageBundle({
+      pages: [{ route: "/", html: "" }],
+    }));
+    const withLm = JSON.parse(generatePageBundle({
+      pages: [{ route: "/", html: "", lastmod: "2026-05-19" }],
+    }));
+    expect("lastmod" in without.routes["/"]).toBe(false);
+    expect(withLm.routes["/"].lastmod).toBe("2026-05-19");
+  });
+});
+
+describe("generatePageBundle — multiple pages", () => {
+  it("routes sorted alphabetically regardless of input order", () => {
+    const out = generatePageBundle({
+      pages: [
+        { route: "/zebra", html: "z" },
+        { route: "/about", html: "a" },
+        { route: "/posts/x", html: "p" },
+        { route: "/", html: "i" },
+      ],
+    });
+    const lines = out.split("\n");
+    const routeOrder = lines.filter((l) => l.includes(`"route":`));
+    expect(routeOrder[0]).toContain(`"route": "/"`);
+    expect(routeOrder[1]).toContain(`"route": "/about"`);
+    expect(routeOrder[2]).toContain(`"route": "/posts/x"`);
+    expect(routeOrder[3]).toContain(`"route": "/zebra"`);
+  });
+  it("duplicate routes throw", () => {
+    expect(() => generatePageBundle({
+      pages: [
+        { route: "/", html: "a" },
+        { route: "/", html: "b" },
+      ],
+    })).toThrow(/duplicates an earlier entry: "\/"/);
+  });
+});
+
+describe("generatePageBundle — baseUrl", () => {
+  it("included when provided", () => {
+    const m = JSON.parse(generatePageBundle({
+      baseUrl: "https://example.com",
+      pages: [{ route: "/", html: "" }],
+    }));
+    expect(m.baseUrl).toBe("https://example.com");
+  });
+  it("omitted when absent", () => {
+    const m = JSON.parse(generatePageBundle({ pages: [{ route: "/", html: "" }] }));
+    expect("baseUrl" in m).toBe(false);
+  });
+  it("javascript: baseUrl throws", () => {
+    expect(() => generatePageBundle({
+      baseUrl: "javascript:alert(1)",
+      pages: [],
+    })).toThrow(/baseUrl must be http\(s\)/);
+  });
+});
+
+describe("generatePageBundle — route validation", () => {
+  it("traversal /a/.. throws", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "/a/..", html: "" }],
+    })).toThrow(/path traversal/);
+  });
+  it("protocol-relative //x throws", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "//x", html: "" }],
+    })).toThrow(/protocol-relative/);
+  });
+  it("backslash /\\x throws", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "/\\x", html: "" }],
+    })).toThrow(/backslash variant/);
+  });
+  it("absolute https://... throws (must start with /)", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "https://evil.com", html: "" }],
+    })).toThrow(/must start with "\/"/);
+  });
+});
+
+describe("generatePageBundle — page field validation", () => {
+  it("non-string html throws", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "/", html: 42 as unknown as string }],
+    })).toThrow(/pages\[0\]\.html must be a string/);
+  });
+  it("non-string contentType throws", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "/", html: "", contentType: 42 as unknown as string }],
+    })).toThrow(/contentType must be a string/);
+  });
+  it("non-string lastmod throws", () => {
+    expect(() => generatePageBundle({
+      pages: [{ route: "/", html: "", lastmod: 42 as unknown as string }],
+    })).toThrow(/lastmod must be a string/);
+  });
+  it("null page entry throws", () => {
+    expect(() => generatePageBundle({
+      pages: [null as unknown as never],
+    })).toThrow(/pages\[0\] must be a non-null object/);
+  });
+});
+
+describe("generatePageBundle — output format", () => {
+  it("2-space indented JSON", () => {
+    const out = generatePageBundle({ pages: [{ route: "/", html: "" }] });
+    expect(out).toContain('\n  "version": 1');
+  });
+  it("trailing newline", () => {
+    const out = generatePageBundle({ pages: [] });
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.endsWith("\n\n")).toBe(false);
+  });
+  it("top-level key order: version → baseUrl → routes", () => {
+    const out = generatePageBundle({
+      baseUrl: "https://x",
+      pages: [{ route: "/", html: "" }],
+    });
+    const vIdx = out.indexOf(`"version"`);
+    const bIdx = out.indexOf(`"baseUrl"`);
+    const rIdx = out.indexOf(`"routes"`);
+    expect(vIdx).toBeLessThan(bIdx);
+    expect(bIdx).toBeLessThan(rIdx);
+  });
+  it("entry key order: route → outputPath → contentType → sizeBytes → sha256 → lastmod", () => {
+    const out = generatePageBundle({
+      pages: [{ route: "/", html: "", lastmod: "2026-05-19" }],
+    });
+    const order = ["route", "outputPath", "contentType", "sizeBytes", "sha256", "lastmod"];
+    let lastIdx = -1;
+    for (const key of order) {
+      const idx = out.indexOf(`"${key}"`);
+      expect(idx).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+  });
+});
+
+describe("generatePageBundle — determinism", () => {
+  it("same input → byte-identical output", () => {
+    const cfg = {
+      baseUrl: "https://example.com",
+      pages: [
+        { route: "/", html: "<!doctype html>" },
+        { route: "/about", html: "<!doctype html>...about" },
+      ],
+    };
+    expect(generatePageBundle(cfg)).toBe(generatePageBundle(cfg));
+  });
+  it("reordering input does not change output", () => {
+    const a = generatePageBundle({
+      pages: [
+        { route: "/a", html: "a" },
+        { route: "/b", html: "b" },
+      ],
+    });
+    const b = generatePageBundle({
+      pages: [
+        { route: "/b", html: "b" },
+        { route: "/a", html: "a" },
+      ],
+    });
+    expect(a).toBe(b);
+  });
+  it("does not mutate input", () => {
+    const pages = [{ route: "/", html: "x" }];
+    const before = JSON.stringify(pages);
+    generatePageBundle({ pages });
+    expect(JSON.stringify(pages)).toBe(before);
+  });
+});
+
+describe("generatePageBundle — content hashing", () => {
+  it("different html → different sha256", () => {
+    const a = JSON.parse(generatePageBundle({ pages: [{ route: "/", html: "a" }] }));
+    const b = JSON.parse(generatePageBundle({ pages: [{ route: "/", html: "b" }] }));
+    expect(a.routes["/"].sha256).not.toBe(b.routes["/"].sha256);
+  });
+  it("same html → same sha256 across runs", () => {
+    const a = JSON.parse(generatePageBundle({ pages: [{ route: "/", html: "abc" }] }));
+    const b = JSON.parse(generatePageBundle({ pages: [{ route: "/", html: "abc" }] }));
+    expect(a.routes["/"].sha256).toBe(b.routes["/"].sha256);
+  });
+  it("sizeBytes counts UTF-8 bytes (not chars)", () => {
+    const m = JSON.parse(generatePageBundle({ pages: [{ route: "/", html: "café" }] }));
+    expect(m.routes["/"].sizeBytes).toBe(5); // c+a+f+é(2 bytes)
+  });
+});
+
+describe("generatePageBundle — full real-world example", () => {
+  it("multi-page site with baseUrl + feed", () => {
+    const out = generatePageBundle({
+      baseUrl: "https://example.com",
+      pages: [
+        { route: "/", html: "<!doctype html><title>Home</title>" },
+        { route: "/about", html: "<!doctype html><title>About</title>" },
+        { route: "/posts/first", html: "<!doctype html><title>First</title>", lastmod: "2026-05-19" },
+        { route: "/feed.xml", html: "<?xml version=\"1.0\"?><rss/>", contentType: "application/rss+xml" },
+      ],
+    });
+    const m = JSON.parse(out);
+    expect(m.version).toBe(1);
+    expect(m.baseUrl).toBe("https://example.com");
+    expect(Object.keys(m.routes)).toEqual(["/", "/about", "/feed.xml", "/posts/first"]);
+    expect(m.routes["/"].outputPath).toBe("index.html");
+    expect(m.routes["/about"].outputPath).toBe("about/index.html");
+    expect(m.routes["/posts/first"].outputPath).toBe("posts/first/index.html");
+    expect(m.routes["/feed.xml"].outputPath).toBe("feed.xml");
+    expect(m.routes["/feed.xml"].contentType).toBe("application/rss+xml");
+    expect(m.routes["/posts/first"].lastmod).toBe("2026-05-19");
+  });
+});

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/tests/hash.test.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/tests/hash.test.ts
@@ -1,0 +1,47 @@
+/**
+ * hash.test.ts — SHA-256 base64 + UTF-8 byte length.
+ */
+
+import { describe, it, expect } from "vitest";
+import { sha256Base64, utf8ByteLength } from "../src/index.js";
+
+describe("sha256Base64", () => {
+  it("empty string has known digest", () => {
+    // SHA-256("") = 47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU= (URL-safe)
+    // standard base64: 47DEQpj8HBSa+_TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+    // Actual: 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+    expect(sha256Base64("")).toBe("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=");
+  });
+  it("'abc' has known digest", () => {
+    // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad (hex)
+    // base64: ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=
+    expect(sha256Base64("abc")).toBe("ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=");
+  });
+  it("deterministic — same input → same output", () => {
+    expect(sha256Base64("hello world")).toBe(sha256Base64("hello world"));
+  });
+  it("different inputs → different hashes", () => {
+    expect(sha256Base64("a")).not.toBe(sha256Base64("b"));
+  });
+  it("output is 44 chars (SHA-256 base64 with padding)", () => {
+    expect(sha256Base64("any string").length).toBe(44);
+  });
+});
+
+describe("utf8ByteLength", () => {
+  it("ASCII chars are 1 byte each", () => {
+    expect(utf8ByteLength("hello")).toBe(5);
+  });
+  it("empty string is 0 bytes", () => {
+    expect(utf8ByteLength("")).toBe(0);
+  });
+  it("multi-byte UTF-8 (é = 2 bytes)", () => {
+    expect(utf8ByteLength("é")).toBe(2);
+  });
+  it("emoji (4 bytes)", () => {
+    expect(utf8ByteLength("🎉")).toBe(4);
+  });
+  it("mixed", () => {
+    expect(utf8ByteLength("hi 🎉")).toBe(3 + 4); // h + i + space + emoji
+  });
+});

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/tests/path.test.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/tests/path.test.ts
@@ -1,0 +1,39 @@
+/**
+ * path.test.ts — route → output-path derivation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { routeToOutputPath } from "../src/index.js";
+
+describe("routeToOutputPath", () => {
+  it("/ → index.html", () => { expect(routeToOutputPath("/")).toBe("index.html"); });
+  it("/about → about/index.html", () => {
+    expect(routeToOutputPath("/about")).toBe("about/index.html");
+  });
+  it("/posts/x → posts/x/index.html", () => {
+    expect(routeToOutputPath("/posts/x")).toBe("posts/x/index.html");
+  });
+  it("/page.html → page.html", () => {
+    expect(routeToOutputPath("/page.html")).toBe("page.html");
+  });
+  it("/feed.xml → feed.xml", () => {
+    expect(routeToOutputPath("/feed.xml")).toBe("feed.xml");
+  });
+  it("/posts/x.html → posts/x.html", () => {
+    expect(routeToOutputPath("/posts/x.html")).toBe("posts/x.html");
+  });
+  it("/p/x.json → p/x.json", () => {
+    expect(routeToOutputPath("/p/x.json")).toBe("p/x.json");
+  });
+  it("deep path with no extension", () => {
+    expect(routeToOutputPath("/a/b/c/d")).toBe("a/b/c/d/index.html");
+  });
+  it(".hidden does NOT count as extension (dot at index 0)", () => {
+    // ".hidden" → no extension (dot at first char) → treated as directory
+    expect(routeToOutputPath("/.hidden")).toBe(".hidden/index.html");
+  });
+  it("compound .a.b.c uses first dot after index 0", () => {
+    // /file.tar.gz → file.tar.gz (last segment has `.` at index 4)
+    expect(routeToOutputPath("/file.tar.gz")).toBe("file.tar.gz");
+  });
+});

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/tests/validate.test.ts
@@ -1,0 +1,130 @@
+/**
+ * validate.test.ts — route / baseUrl / string validators.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateBaseUrl,
+  validateRoute,
+  validateString,
+} from "../src/index.js";
+
+describe("validateRoute — accept", () => {
+  it("bare /", () => { expect(validateRoute("/", "f")).toBe("/"); });
+  it("/about", () => { expect(validateRoute("/about", "f")).toBe("/about"); });
+  it("/posts/x", () => { expect(validateRoute("/posts/x", "f")).toBe("/posts/x"); });
+  it("/p/x.html (with extension)", () => { expect(validateRoute("/p/x.html", "f")).toBe("/p/x.html"); });
+  it("/feed.xml", () => { expect(validateRoute("/feed.xml", "f")).toBe("/feed.xml"); });
+  it("dashes + underscores", () => { expect(validateRoute("/my-post_x", "f")).toBe("/my-post_x"); });
+  it("digits", () => { expect(validateRoute("/page-2026", "f")).toBe("/page-2026"); });
+  it("mixed-case (case preserved)", () => { expect(validateRoute("/AboutUs", "f")).toBe("/AboutUs"); });
+  it("colon segment (RFC 3986 sub-delim)", () => {
+    expect(validateRoute("/a:b", "f")).toBe("/a:b");
+  });
+});
+
+describe("validateRoute — reject", () => {
+  it("non-string", () => { expect(() => validateRoute(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null", () => { expect(() => validateRoute(null, "f")).toThrow(/got null/); });
+  it("empty", () => { expect(() => validateRoute("", "f")).toThrow(/non-empty/); });
+  it("over 2048 chars", () => {
+    expect(() => validateRoute("/" + "a".repeat(2050), "f")).toThrow(/≤ 2048/);
+  });
+  it("no leading /", () => { expect(() => validateRoute("about", "f")).toThrow(/must start with "\/"/); });
+  it("protocol-relative //evil.com", () => {
+    expect(() => validateRoute("//evil.com", "f")).toThrow(/protocol-relative/);
+  });
+  it("backslash variant /\\evil", () => {
+    expect(() => validateRoute("/\\evil", "f")).toThrow(/backslash variant/);
+  });
+  it("contains \\ later in path", () => {
+    expect(() => validateRoute("/p/x\\y", "f")).toThrow(/must not contain/);
+  });
+  it("path traversal /..", () => {
+    expect(() => validateRoute("/..", "f")).toThrow(/path traversal/);
+  });
+  it("path traversal /a/..", () => {
+    expect(() => validateRoute("/a/..", "f")).toThrow(/path traversal/);
+  });
+  it("path traversal /a/../b", () => {
+    expect(() => validateRoute("/a/../b", "f")).toThrow(/path traversal/);
+  });
+  it("dot segment /.", () => {
+    expect(() => validateRoute("/.", "f")).toThrow(/"\." segment/);
+  });
+  it("dot segment /a/./b", () => {
+    expect(() => validateRoute("/a/./b", "f")).toThrow(/"\." segment/);
+  });
+  it("empty mid-segment /a//b", () => {
+    expect(() => validateRoute("/a//b", "f")).toThrow(/empty segments/);
+  });
+  it("trailing slash /a/", () => {
+    expect(() => validateRoute("/a/", "f")).toThrow(/empty segments/);
+  });
+  it("query string /a?b=c (contains ?)", () => {
+    expect(() => validateRoute("/a?b=c", "f")).toThrow(/disallowed characters/);
+  });
+  it("hash /a#b", () => {
+    expect(() => validateRoute("/a#b", "f")).toThrow(/disallowed characters/);
+  });
+  it("whitespace /a b", () => {
+    expect(() => validateRoute("/a b", "f")).toThrow(/disallowed characters/);
+  });
+  it("NUL /a\\x00b", () => {
+    expect(() => validateRoute("/a\x00b", "f")).toThrow(/disallowed characters/);
+  });
+  it("unicode segment", () => {
+    expect(() => validateRoute("/café", "f")).toThrow(/disallowed characters/);
+  });
+  it("percent-encoded traversal /%2e%2e rejected (no decode)", () => {
+    expect(() => validateRoute("/%2e%2e", "f")).toThrow(/disallowed characters/);
+  });
+  it("percent-encoded slash /%2f rejected", () => {
+    expect(() => validateRoute("/%2f", "f")).toThrow(/disallowed characters/);
+  });
+  it("percent-encoded NUL /%00 rejected", () => {
+    expect(() => validateRoute("/%00", "f")).toThrow(/disallowed characters/);
+  });
+  it("error contains field name", () => {
+    expect(() => validateRoute("../bad", "pages[3].route"))
+      .toThrow(/pages\[3\]\.route/);
+  });
+  it("long route truncated in error", () => {
+    const long = "/" + "a".repeat(200) + "\\evil";
+    try {
+      validateRoute(long, "f");
+      expect.fail("expected throw");
+    } catch (e) {
+      expect((e as Error).message).toContain("…");
+    }
+  });
+});
+
+describe("validateBaseUrl — accept", () => {
+  it("https", () => { expect(validateBaseUrl("https://example.com")).toBe("https://example.com"); });
+  it("http", () => { expect(validateBaseUrl("http://example.com")).toBe("http://example.com"); });
+  it("HTTPS uppercase", () => { expect(validateBaseUrl("HTTPS://example.com")).toBe("HTTPS://example.com"); });
+  it("with path", () => { expect(validateBaseUrl("https://example.com/blog")).toBe("https://example.com/blog"); });
+});
+
+describe("validateBaseUrl — reject", () => {
+  it("non-string", () => { expect(() => validateBaseUrl(42 as unknown as string)).toThrow(/non-empty/); });
+  it("null", () => { expect(() => validateBaseUrl(null)).toThrow(/got null/); });
+  it("empty", () => { expect(() => validateBaseUrl("")).toThrow(/non-empty/); });
+  it("javascript:", () => { expect(() => validateBaseUrl("javascript:alert(1)")).toThrow(/http\(s\)/); });
+  it("data:", () => { expect(() => validateBaseUrl("data:text/x,1")).toThrow(/http\(s\)/); });
+  it("file:", () => { expect(() => validateBaseUrl("file:///etc")).toThrow(/http\(s\)/); });
+  it("ftp:", () => { expect(() => validateBaseUrl("ftp://x")).toThrow(/http\(s\)/); });
+  it("/relative", () => { expect(() => validateBaseUrl("/about")).toThrow(/http\(s\)/); });
+  it("over 2048", () => {
+    expect(() => validateBaseUrl("https://" + "a".repeat(2100) + ".com"))
+      .toThrow(/≤ 2048/);
+  });
+});
+
+describe("validateString", () => {
+  it("string passes", () => { expect(validateString("hello", "f")).toBe("hello"); });
+  it("empty allowed", () => { expect(validateString("", "f")).toBe(""); });
+  it("non-string rejected", () => { expect(() => validateString(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null rejected", () => { expect(() => validateString(null, "f")).toThrow(/got null/); });
+});

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-page-bundle-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-page-bundle-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Nineteenth FM00 v0 stage package — **deploy-stage** emitter for the FM00 v0 pipeline.
- Takes an array of HTML pages with their routes (`/`, `/about`, `/feed.xml`, ...) and produces a deterministic JSON manifest mapping each route to a file output path, content type, SHA-256 hash, byte size, and optional last-modified.
- Downstream deploy tools consume the manifest and write the actual files.
- Two-pass fail-fast: validates everything (baseUrl, every route, html/contentType/lastmod types, duplicates) before emitting any JSON.
- 101 tests, **100% line / 98.82% branch** coverage (single missing branch is the sort-comparator equality case, unreachable because duplicates throw at validation time).
- `required_capabilities.json` → `[]` (uses Node's built-in `node:crypto`; no I/O / fs / network).

## Security posture

Six concerns explicitly addressed. Pre-push security review (general-purpose agent) found **no HIGH issues**. One MED was documentation-only (`%` is already rejected — agent suggested a maintainer-targeted comment to prevent future regression; comment added at `ROUTE_SEGMENT_RE`, with new tests covering `%2e%2e` / `%2f` / `%00` rejection).

1. **Path traversal.** Routes validated against strict shape regex + segment-by-segment `..` / `.` / empty checks before becoming file paths. `..`, `.`, `//` mid-path, trailing `/` all rejected. **Percent-encoded sequences (`%2e%2e`, `%00`) are rejected wholesale** — `%` isn't in the segment charset, so we don't risk a decode-then-recheck race.
2. **Protocol confusion.** Routes starting with `//` (treated as URL by some CDNs) or `/\` (backslash variant) rejected.
3. **Windows path separators.** Any `\` anywhere in the route rejected — prevents `..\..\etc` on Windows-target deploys.
4. **`baseUrl` scheme injection.** `javascript:` / `data:` / `file:` / `ftp:` / scheme-less / non-http(s) all rejected.
5. **Hashing.** SHA-256 via Node's built-in `node:crypto`, base64-encoded. No external dep, no algorithm-choice surprises.
6. **Determinism.** Same input → byte-identical manifest, byte-identical hashes. Routes sorted alphabetically; top-level + entry keys in fixed order. Two builds diff cleanly.

## Route → output path

| Route          | Output path               |
| -------------- | ------------------------- |
| `/`            | `index.html`              |
| `/about`       | `about/index.html`        |
| `/posts/x`     | `posts/x/index.html`      |
| `/feed.xml`    | `feed.xml`                |
| `/page.html`   | `page.html`               |
| `/file.tar.gz` | `file.tar.gz`             |
| `/.hidden`     | `.hidden/index.html`      |

"Has extension" check looks at the last segment for a `.` at index > 0 (so dotfiles don't count).

## JSON output format

- 2-space indent, trailing newline.
- Top-level: `version → baseUrl (if present) → routes`.
- `routes` sorted lexicographically.
- Entry keys: `route → outputPath → contentType → sizeBytes → sha256 → lastmod (if present)`.

## v0 simplifications (documented)

- No gzip/brotli precompression metadata.
- No per-page redirect / rewrite rules.
- No multi-locale routing logic.
- No content-addressed output paths (v1 may add).

## Test plan

- [x] All 101 vitest tests pass locally
- [x] Coverage 100% line / 98.82% branch on source files with logic
- [x] Security review via Agent — no HIGH findings; MED was doc-only (addressed)
- [x] CHANGELOG + README with usage examples + security rationale
- [x] `required_capabilities.json` set to `[]` with justification
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)