### PR TITLE
fix(sql-planner): SELECT * ORDER BY N accepts N > 1 (wildcard expansion)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.56.0] - 2026-05-19
+
+### Fixed
+
+- **``SELECT * ORDER BY N`` for N > 1** (via ``sql-planner 0.33.0``).
+  Previously ``SELECT * FROM t ORDER BY 2`` raised
+  ``InternalError: ValueError: tuple.index(x): x not in tuple``
+  because the planner's positional-index validator treated the
+  Wildcard as a single SELECT item.  Now the planner accepts any
+  ordinal ≥ 1 when a wildcard is present and sets the position-
+  based index directly.
+
+  12 new oracle tests in
+  ``test_tier3_order_by_positional_select_star.py`` cover the fix
+  across single-table SELECT *, cross-joins, inner joins, multiple
+  sort keys, mixed direction, and the regression-guard case of
+  explicit projections.
+
 ## [1.55.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.55.0"
+version = "1.56.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_order_by_positional_select_star.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_order_by_positional_select_star.py
@@ -1,0 +1,130 @@
+"""Oracle tests for positional ``ORDER BY N`` with ``SELECT *``.
+
+Before the fix in ``sql-planner``'s ``_resolve_order_key``, the planner
+rejected positional ORDER BY indices greater than the number of
+*unexpanded* SELECT items.  For ``SELECT *`` the only SELECT item is a
+Wildcard, so ``ORDER BY 2`` (or any N > 1) would fall through to the
+column-name resolution path, set ``column=""``, and the VM's
+``columns.index("")`` would raise ``ValueError: tuple.index(x): x not in
+tuple``::
+
+    SELECT * FROM t ORDER BY 2
+    -- before: InternalError: ValueError: tuple.index(x): x not in tuple
+    -- now:    matches SQLite
+
+The planner now accepts ``ORDER BY N`` for any N ≥ 1 when at least one
+SELECT item is a Wildcard, setting ``positional_index = N-1`` directly
+so the VM uses position-based ``row[N-1]`` lookup.  Out-of-range
+indices error out at runtime (matching SQLite for this corner case).
+
+All assertions compare against real ``sqlite3``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(setup: list[str], query: str) -> None:
+    conn_m = mini_sqlite.connect(":memory:")
+    conn_r = sqlite3.connect(":memory:")
+    for s in setup:
+        conn_m.execute(s)
+        conn_r.execute(s)
+    m = conn_m.execute(query).fetchall()
+    r = conn_r.execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref: {r}"
+
+
+# ---------------------------------------------------------------------------
+# SELECT * ORDER BY N — the headline fix
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarOrderByPositional:
+    SETUP = [
+        "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER)",
+        "INSERT INTO t VALUES (3, 10, 100), (1, 20, 200), (2, 30, 300)",
+    ]
+
+    def test_order_by_1(self) -> None:
+        _check(self.SETUP, "SELECT * FROM t ORDER BY 1")
+
+    def test_order_by_2(self) -> None:
+        _check(self.SETUP, "SELECT * FROM t ORDER BY 2")
+
+    def test_order_by_3(self) -> None:
+        _check(self.SETUP, "SELECT * FROM t ORDER BY 3")
+
+    def test_order_by_desc(self) -> None:
+        _check(self.SETUP, "SELECT * FROM t ORDER BY 2 DESC")
+
+    def test_order_by_with_nulls(self) -> None:
+        # SQLite default NULL ordering: ASC → NULLs first, DESC → NULLs last.
+        setup = [
+            "CREATE TABLE u (a INTEGER, b INTEGER)",
+            "INSERT INTO u VALUES (1, 10), (2, NULL), (3, 20)",
+        ]
+        _check(setup, "SELECT * FROM u ORDER BY 2")
+
+    def test_multiple_keys(self) -> None:
+        setup = [
+            "CREATE TABLE m (a INTEGER, b INTEGER, c INTEGER)",
+            "INSERT INTO m VALUES (1, 2, 30), (1, 1, 40), (2, 1, 10), (2, 2, 20)",
+        ]
+        _check(setup, "SELECT * FROM m ORDER BY 1, 2")
+
+    def test_multiple_keys_mixed_direction(self) -> None:
+        setup = [
+            "CREATE TABLE m (a INTEGER, b INTEGER, c INTEGER)",
+            "INSERT INTO m VALUES (1, 2, 30), (1, 1, 40), (2, 1, 10), (2, 2, 20)",
+        ]
+        _check(setup, "SELECT * FROM m ORDER BY 1 ASC, 2 DESC")
+
+
+# ---------------------------------------------------------------------------
+# SELECT * + ORDER BY positional across joins
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStarOrderByPositionalJoin:
+    def test_cross_join_order_by_first(self) -> None:
+        setup = [
+            "CREATE TABLE a (x INTEGER)",
+            "CREATE TABLE b (y INTEGER)",
+            "INSERT INTO a VALUES (3), (1), (2)",
+            "INSERT INTO b VALUES (100)",
+        ]
+        _check(setup, "SELECT * FROM a, b ORDER BY 1")
+
+    def test_inner_join_order_by_second_table_column(self) -> None:
+        setup = [
+            "CREATE TABLE a (id INTEGER, name TEXT)",
+            "CREATE TABLE b (id INTEGER, val INTEGER)",
+            "INSERT INTO a VALUES (1, 'x'), (2, 'y')",
+            "INSERT INTO b VALUES (1, 30), (2, 10)",
+        ]
+        _check(setup, "SELECT * FROM a JOIN b ON a.id = b.id ORDER BY 4")
+
+
+# ---------------------------------------------------------------------------
+# Regression — non-wildcard SELECT with positional ORDER BY still works
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitProjectionPositionalNoRegression:
+    SETUP = [
+        "CREATE TABLE t (a INTEGER, b INTEGER)",
+        "INSERT INTO t VALUES (3, 10), (1, 20), (2, 30)",
+    ]
+
+    def test_explicit_order_by_1(self) -> None:
+        _check(self.SETUP, "SELECT a, b FROM t ORDER BY 1")
+
+    def test_explicit_order_by_2(self) -> None:
+        _check(self.SETUP, "SELECT a, b FROM t ORDER BY 2")
+
+    def test_swapped_order_by_2(self) -> None:
+        _check(self.SETUP, "SELECT b, a FROM t ORDER BY 2")

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.33.0] - 2026-05-19
+
+### Fixed
+
+- **``SELECT * ORDER BY N`` now accepts N greater than the number of
+  *unexpanded* SELECT items** (``planner._resolve_order_key``).
+  Previously the validator compared the ordinal against
+  ``len(resolved_items)``, which counted a Wildcard as a single item.
+  So ``SELECT * ORDER BY 2`` fell through to the column-name
+  resolution path, set ``column=""``, and the VM blew up with
+  ``ValueError: tuple.index(x): x not in tuple``.
+
+  The resolver now accepts any ``ordinal ≥ 1`` when at least one
+  SELECT item is a Wildcard, sets ``positional_index = ordinal - 1``
+  directly, and lets the VM use position-based ``row[N-1]`` lookup.
+  Out-of-range indices error out at runtime, matching SQLite.
+
 ## [0.32.0] - 2026-05-19
 
 ### Added

--- a/code/packages/python/sql-planner/pyproject.toml
+++ b/code/packages/python/sql-planner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-planner"
-version = "0.32.0"
+version = "0.33.0"
 description = "Translates a structured SQL AST into a Logical Plan Tree of relational-algebra nodes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-planner/src/sql_planner/planner.py
+++ b/code/packages/python/sql-planner/src/sql_planner/planner.py
@@ -314,6 +314,19 @@ def _plan_select(
                 # record the 0-based column index for the codegen.
                 k_expr = resolved_items[ordinal - 1].expr
                 positional_index = ordinal - 1
+            elif ordinal >= 1 and any(
+                isinstance(it.expr, Wildcard) for it in resolved_items
+            ):
+                # ``SELECT * ORDER BY N`` with N > the unexpanded item count:
+                # the wildcard expands at runtime to one column per source
+                # column, so the "real" select-list length is only known
+                # later.  Trust the user's positional index — the codegen
+                # emits ``column_idx=N-1`` directly and the VM does a
+                # positional ``row[N-1]`` lookup without consulting the
+                # column-name schema.  Out-of-range indices error out at
+                # runtime (matching SQLite's behaviour for invalid ORDER BY
+                # positions in this corner case).
+                positional_index = ordinal - 1
         elif (
             isinstance(k_expr, Column)
             and k_expr.table is None


### PR DESCRIPTION
## Summary

Fixes a latent crash where `SELECT * FROM t ORDER BY 2` raised:

```
InternalError: ValueError: tuple.index(x): x not in tuple
```

Common pattern in user SQL — sorting by the second column of a `SELECT *` result. mini-sqlite errored out where SQLite would just sort.

## Root cause

`_resolve_order_key` in sql-planner validates positional ORDER BY indices against `len(resolved_items)`. For `SELECT *`, that count is **1** (the unexpanded Wildcard item), so `ORDER BY 2` failed the bounds check and fell through to the column-name resolution path. The codegen emitted `SortKey(column="")`, and the VM's `columns.index("")` raised `ValueError`.

## Fix

Extend the positional-index path: if `ordinal > len(resolved_items)` **and** at least one item is a Wildcard, set `positional_index = ordinal - 1` directly. The codegen emits `column_idx=N-1`, and the VM does `row[N-1]` lookup without consulting the column-name schema. Out-of-range indices error at runtime, matching SQLite.

```python
if isinstance(k_expr, Literal) and isinstance(k_expr.value, int):
    ordinal = k_expr.value
    if 1 <= ordinal <= len(resolved_items):
        # existing path
    elif ordinal >= 1 and any(isinstance(it.expr, Wildcard) for it in resolved_items):
        # NEW: SELECT * with N > 1 — trust the positional index
        positional_index = ordinal - 1
```

## Version bumps

- `sql-planner`: 0.32.0 → 0.33.0
- `mini-sqlite`: 1.55.0 → 1.56.0

## Test plan

- [x] `pytest code/packages/python/sql-planner/tests/` — 210 pass, coverage 80.30%
- [x] `pytest code/packages/python/mini-sqlite/tests/` — 1529 pass (12 new), coverage 91.29%
- [x] 12 new oracle tests in `test_tier3_order_by_positional_select_star.py`:
  - Single-table SELECT * with ORDER BY 1, 2, 3, DESC, with NULLs
  - Multiple sort keys (1, 2), mixed direction
  - Cross-join + ORDER BY positional
  - Inner-join ORDER BY a column on the second table
  - Regression guard: explicit projection (non-wildcard) positional ORDER BY still works
- [x] Manual security review: trivial relaxation of validator, no new attack surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)