### PR TITLE
Add generated HTML fixture manifest check

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -21,6 +21,9 @@ documented in this file.
   same stable `--check` path.
 - The html5lib tokenizer normalizer shares the same checked fixture IO path,
   including `--check` stale detection for `html5lib-smoke.json`.
+- A generated HTML fixture manifest check runs the self-contained lexer and
+  parser fixture stale checks from one command, with optional inputs for
+  upstream-only html5lib and WHATWG entity sources.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -101,6 +101,9 @@ binary while production code continues to link only static Rust source.
   exercise the normalization path toward broader upstream corpora
 - `normalize_html5lib_fixtures.py`: importer that lowers supported raw
   html5lib-style tokenizer cases into Venture's portable fixture schema
+- `check_generated_html_fixtures.py`: manifest check that runs every
+  self-contained generated lexer/parser fixture stale check from checked-in
+  inputs, with optional flags for upstream-only source inputs
 - the parser fixture audit can pin the current html5lib tokenizer counts with
   `--expect-tokenizer-upstream-cases 6806`,
   `--expect-tokenizer-local-raw-cases 7015`,
@@ -280,6 +283,17 @@ skipped runtime gaps.
 The same audit can verify the checked
 `html-parser/tests/fixtures/html5lib-coverage-audit.json` report with
 `--check-report`, so fixture-count and missing-source drift stays visible in CI.
+
+For a single local stale check over all checked-in generated HTML fixtures that
+do not require fresh upstream downloads, run:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+```
+
+Pass `--html5lib-tests /path/to/html5lib-tests` to include the parser coverage
+audit report and pinned-count checks, or `--entities-json /path/to/entities.json`
+to include the generated WHATWG named-character-reference table.
 
 ## WPT Path
 

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+"""Check all locally reproducible generated HTML fixture outputs.
+
+This manifest intentionally covers the lexer and parser fixture generators that
+can be checked from checked-in inputs. Generators that require upstream source
+downloads are included when their source path is provided explicitly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+RUST_DIR = FIXTURE_DIR.parents[2]
+WORKTREE_ROOT = RUST_DIR.parents[2]
+PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
+
+
+@dataclass(frozen=True)
+class FixtureCheck:
+    name: str
+    command: tuple[str, ...]
+
+
+def main() -> int:
+    args = parse_args()
+    checks = default_checks()
+
+    if args.entities_json is not None:
+        checks.append(
+            FixtureCheck(
+                "whatwg-entities",
+                (
+                    str(FIXTURE_DIR / "generate_whatwg_entities_fixture.py"),
+                    str(Path(args.entities_json).expanduser().resolve()),
+                    "--check",
+                ),
+            )
+        )
+
+    if args.html5lib_tests is not None:
+        html5lib_tests = str(Path(args.html5lib_tests).expanduser().resolve())
+        checks.extend(
+            [
+                FixtureCheck(
+                    "html5lib-coverage-audit-report",
+                    (
+                        str(PARSER_FIXTURE_DIR / "audit_html5lib_coverage.py"),
+                        html5lib_tests,
+                        "--check-report",
+                    ),
+                ),
+                FixtureCheck(
+                    "html5lib-coverage-audit-counts",
+                    (
+                        str(PARSER_FIXTURE_DIR / "audit_html5lib_coverage.py"),
+                        html5lib_tests,
+                        "--expect-tree-upstream-cases",
+                        "1778",
+                        "--expect-tree-local-cases",
+                        "2485",
+                        "--expect-tokenizer-upstream-cases",
+                        "6806",
+                        "--expect-tokenizer-local-raw-cases",
+                        "7015",
+                        "--expect-normalized-cases",
+                        "7242",
+                        "--expect-normalized-skipped",
+                        "0",
+                    ),
+                ),
+            ]
+        )
+
+    for check in checks:
+        run_check(check)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run generated HTML lexer/parser fixture stale checks."
+    )
+    parser.add_argument(
+        "--entities-json",
+        help="Optional WHATWG entities.json source table for the entities fixture.",
+    )
+    parser.add_argument(
+        "--html5lib-tests",
+        help="Optional html5lib-tests checkout for coverage audit report checks.",
+    )
+    return parser.parse_args()
+
+
+def default_checks() -> list[FixtureCheck]:
+    return [
+        FixtureCheck(
+            "html5lib-tokenizer-normalized",
+            (
+                str(FIXTURE_DIR / "normalize_html5lib_fixtures.py"),
+                str(FIXTURE_DIR / "upstream-html5lib-smoke.test"),
+                str(FIXTURE_DIR / "html5lib-smoke.json"),
+                "--check",
+            ),
+        ),
+        *lexer_fixture_checks(),
+        FixtureCheck(
+            "whatwg-tree-insertion-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_tree_insertion_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+    ]
+
+
+def lexer_fixture_checks() -> list[FixtureCheck]:
+    names = (
+        "numeric_references",
+        "character_reference_boundaries",
+        "input_stream",
+        "chunk_boundaries",
+        "eof_recovery",
+        "text_mode_delimiters",
+        "script_escape_boundaries",
+        "cdata_boundaries",
+        "markup_declarations",
+        "comment_boundaries",
+        "attribute_edges",
+        "attribute_boundaries",
+        "tag_open_recovery",
+        "doctype_boundaries",
+        "text_mode_boundaries",
+    )
+    return [
+        FixtureCheck(
+            f"whatwg-{name.replace('_', '-')}",
+            (str(FIXTURE_DIR / f"generate_whatwg_{name}_fixture.py"), "--check"),
+        )
+        for name in names
+    ]
+
+
+def run_check(check: FixtureCheck) -> None:
+    command = (sys.executable, *check.command)
+    print(f"checking {check.name}", flush=True)
+    subprocess.run(command, cwd=WORKTREE_ROOT, check=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -19,6 +19,9 @@ documented in this file.
 - A parser integration test verifies that the checked coverage-audit report
   still matches the checked tree-construction, raw tokenizer, and normalized
   tokenizer fixture corpora.
+- The shared generated HTML fixture manifest check can include parser coverage
+  report and pinned-count checks alongside the self-contained lexer/parser
+  fixture stale checks.
 - Stack-of-open-elements tree construction seed with void element handling,
   adjacent text merging, simple implied end tags, and unmatched end-tag
   diagnostics.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -114,6 +114,16 @@ Both the broad smoke test and the focused tree-insertion audit use the shared
 `tests/common` html5lib parser and DOM dump helpers, so new parser conformance
 fixtures exercise the same normalization path.
 
+The lexer fixture directory also provides one umbrella stale check for all
+self-contained generated HTML lexer/parser fixtures:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+```
+
+Pass `--html5lib-tests /path/to/html5lib-tests` to fold the checked coverage
+audit report and pinned-count checks into the same local guard.
+
 ## Usage
 
 ```rust


### PR DESCRIPTION
## Summary
- add a manifest-style Python guard for self-contained generated HTML lexer/parser fixture stale checks
- include optional html5lib-tests and WHATWG entities inputs for upstream-backed checks
- document the umbrella command in lexer/parser fixture docs and changelogs

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser