### PR TITLE
[codex] Add Arduino Board VM backend matrix

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "rope",
     "blas-library",
     "bootloader",
+    "board-vm-arduino",
     "board-vm-eject",
     "board-vm-protocol",
     "board-vm-host",

--- a/code/packages/rust/board-vm-arduino/BUILD
+++ b/code/packages/rust/board-vm-arduino/BUILD
@@ -1,0 +1,1 @@
+cargo test -p board-vm-arduino -- --nocapture

--- a/code/packages/rust/board-vm-arduino/Cargo.toml
+++ b/code/packages/rust/board-vm-arduino/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "board-vm-arduino"
+version = "0.1.0"
+edition = "2021"
+description = "Shared Board VM backend descriptors for Arduino board families beyond Uno R4"
+
+[dependencies]
+board-vm-device = { path = "../board-vm-device" }
+board-vm-ir = { path = "../board-vm-ir" }
+board-vm-runtime = { path = "../board-vm-runtime" }
+
+[dev-dependencies]
+board-vm-host = { path = "../board-vm-host" }
+
+[lib]
+path = "src/lib.rs"

--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -1,0 +1,28 @@
+# board-vm-arduino
+
+Shared Board VM target descriptors and abstract HAL backend for Arduino boards
+beyond the Uno R4-specific crate.
+
+This crate keeps generic Arduino-family support from being folded into
+`board-vm-uno-r4`. It exposes one backend shape for classic AVR, SAM/SAMD,
+megaAVR, RP2040, ESP32, STM32/Mbed-style Arduino boards, and future Arduino
+families. Concrete firmware crates can provide hardware-specific backends while
+host SDKs and target discovery stay on the shared Board VM contract.
+
+The first matrix covers representative Arduino families:
+
+- Uno R3, Nano classic, Pro Mini, Mega 2560, Leonardo, and Micro for classic AVR
+- Due, Zero, MKR WiFi 1010, Nano Every, Nano R4, Nano 33 IoT, and Nano 33 BLE
+  Rev2 for SAM/SAMD/megaAVR/Renesas/Nordic coverage
+- Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi, and Portenta H7 for modern
+  maker/pro Arduino boards
+
+Each target currently proves the shared GPIO/time backend path. Board-specific
+firmware/upload crates can extend the same descriptor with richer peripherals
+without falling back to Uno R4 assumptions.
+
+Host-side validation:
+
+```sh
+cargo test -p board-vm-arduino
+```

--- a/code/packages/rust/board-vm-arduino/required_capabilities.json
+++ b/code/packages/rust/board-vm-arduino/required_capabilities.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "fs": {
+      "read": [],
+      "write": []
+    }
+  }
+}

--- a/code/packages/rust/board-vm-arduino/src/lib.rs
+++ b/code/packages/rust/board-vm-arduino/src/lib.rs
@@ -1,0 +1,837 @@
+#![no_std]
+
+use board_vm_device::{BoardVmDevice, BLINK_MVP_CAPABILITIES, DEFAULT_MAX_FRAME_PAYLOAD};
+use board_vm_ir::CapabilitySet;
+use board_vm_runtime::{BoardHal, GpioMode, HalError, Level};
+
+pub const ARDUINO_VM_RUNTIME_ID: &str = "board-vm-arduino";
+pub const ARDUINO_VM_MAX_PROGRAM_BYTES: usize = 1024;
+pub const ARDUINO_VM_MAX_STACK_VALUES: usize = 8;
+pub const ARDUINO_VM_MAX_HANDLES: usize = 4;
+
+pub type ArduinoDevice<B> = BoardVmDevice<
+    'static,
+    ArduinoBoard<B>,
+    ARDUINO_VM_MAX_PROGRAM_BYTES,
+    ARDUINO_VM_MAX_STACK_VALUES,
+    ARDUINO_VM_MAX_HANDLES,
+>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArduinoFamily {
+    ClassicAvr,
+    MegaAvr,
+    Sam,
+    Samd,
+    RenesasRa,
+    Mbed,
+    Nordic,
+    Rp2040,
+    Esp32,
+    Stm32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeProfile {
+    Tiny,
+    Small,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RustTargetStatus {
+    Stable(&'static str),
+    Nightly(&'static str),
+    BackendNeeded(&'static str),
+}
+
+impl RustTargetStatus {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Stable(target) | Self::Nightly(target) | Self::BackendNeeded(target) => target,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArduinoTargetDescriptor {
+    pub board_id: &'static str,
+    pub display_name: &'static str,
+    pub family: ArduinoFamily,
+    pub runtime_profile: RuntimeProfile,
+    pub mcu: &'static str,
+    pub core: &'static str,
+    pub isa: &'static str,
+    pub rust_target: RustTargetStatus,
+    pub clock_hz: u32,
+    pub flash_bytes: u32,
+    pub sram_bytes: u32,
+    pub operating_voltage_mv: u16,
+    pub onboard_led_pin: Option<u8>,
+    pub capabilities: CapabilitySet,
+    pub digital_pins: &'static [DigitalPinDescriptor],
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DigitalPinDescriptor {
+    pub pin: u8,
+    pub label: &'static str,
+    pub supports_input: bool,
+    pub supports_output: bool,
+    pub supports_pullup: bool,
+    pub supports_pulldown: bool,
+    pub supports_adc: bool,
+    pub supports_pwm: bool,
+    pub notes: &'static str,
+}
+
+impl DigitalPinDescriptor {
+    pub const fn supports_mode(self, mode: GpioMode) -> bool {
+        match mode {
+            GpioMode::Input => self.supports_input,
+            GpioMode::Output => self.supports_output,
+            GpioMode::InputPullup => self.supports_input && self.supports_pullup,
+            GpioMode::InputPulldown => self.supports_input && self.supports_pulldown,
+        }
+    }
+}
+
+pub trait ArduinoBackend {
+    fn gpio_open(&mut self, pin: u8, _mode: GpioMode) -> Result<u32, HalError> {
+        Ok(pin as u32)
+    }
+
+    fn gpio_write(&mut self, _token: u32, _level: Level) -> Result<(), HalError> {
+        Ok(())
+    }
+
+    fn gpio_read(&mut self, _token: u32) -> Result<Level, HalError> {
+        Ok(Level::Low)
+    }
+
+    fn gpio_close(&mut self, _token: u32) -> Result<(), HalError> {
+        Ok(())
+    }
+
+    fn sleep_ms(&mut self, _duration_ms: u16) -> Result<(), HalError> {
+        Ok(())
+    }
+
+    fn now_ms(&self) -> u32 {
+        0
+    }
+}
+
+pub struct ArduinoBoard<B> {
+    target: &'static ArduinoTargetDescriptor,
+    backend: B,
+}
+
+impl<B> ArduinoBoard<B> {
+    pub const fn new(target: &'static ArduinoTargetDescriptor, backend: B) -> Self {
+        Self { target, backend }
+    }
+
+    pub const fn target(&self) -> &'static ArduinoTargetDescriptor {
+        self.target
+    }
+
+    pub const fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    pub fn backend_mut(&mut self) -> &mut B {
+        &mut self.backend
+    }
+}
+
+impl<B> BoardHal for ArduinoBoard<B>
+where
+    B: ArduinoBackend,
+{
+    fn capabilities(&self) -> CapabilitySet {
+        self.target.capabilities
+    }
+
+    fn gpio_open(&mut self, pin: u16, mode: GpioMode) -> Result<u32, HalError> {
+        let pin = normalize_digital_pin(self.target, pin, mode)?;
+        self.backend.gpio_open(pin, mode)
+    }
+
+    fn gpio_write(&mut self, token: u32, level: Level) -> Result<(), HalError> {
+        validate_token(self.target, token)?;
+        self.backend.gpio_write(token, level)
+    }
+
+    fn gpio_read(&mut self, token: u32) -> Result<Level, HalError> {
+        validate_token(self.target, token)?;
+        self.backend.gpio_read(token)
+    }
+
+    fn gpio_close(&mut self, token: u32) -> Result<(), HalError> {
+        validate_token(self.target, token)?;
+        self.backend.gpio_close(token)
+    }
+
+    fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
+        self.backend.sleep_ms(duration_ms)
+    }
+
+    fn now_ms(&self) -> u32 {
+        self.backend.now_ms()
+    }
+}
+
+pub const fn blink_capabilities() -> CapabilitySet {
+    CapabilitySet::blink_mvp()
+}
+
+pub fn digital_pin(
+    target: &'static ArduinoTargetDescriptor,
+    pin: u16,
+) -> Option<DigitalPinDescriptor> {
+    if pin > u8::MAX as u16 {
+        return None;
+    }
+    let pin = pin as u8;
+    let mut index = 0;
+    while index < target.digital_pins.len() {
+        if target.digital_pins[index].pin == pin {
+            return Some(target.digital_pins[index]);
+        }
+        index += 1;
+    }
+    None
+}
+
+pub fn is_valid_digital_pin(
+    target: &'static ArduinoTargetDescriptor,
+    pin: u16,
+    mode: GpioMode,
+) -> bool {
+    digital_pin(target, pin).is_some_and(|descriptor| descriptor.supports_mode(mode))
+}
+
+pub fn normalize_digital_pin(
+    target: &'static ArduinoTargetDescriptor,
+    pin: u16,
+    mode: GpioMode,
+) -> Result<u8, HalError> {
+    let descriptor = digital_pin(target, pin).ok_or(HalError::InvalidPin)?;
+    if descriptor.supports_mode(mode) {
+        Ok(descriptor.pin)
+    } else {
+        Err(HalError::UnsupportedMode)
+    }
+}
+
+fn validate_token(target: &'static ArduinoTargetDescriptor, token: u32) -> Result<u8, HalError> {
+    if token > u16::MAX as u32 {
+        return Err(HalError::InvalidPin);
+    }
+    digital_pin(target, token as u16)
+        .map(|descriptor| descriptor.pin)
+        .ok_or(HalError::InvalidPin)
+}
+
+const fn pin(
+    pin: u8,
+    label: &'static str,
+    supports_adc: bool,
+    supports_pwm: bool,
+) -> DigitalPinDescriptor {
+    DigitalPinDescriptor {
+        pin,
+        label,
+        supports_input: true,
+        supports_output: true,
+        supports_pullup: true,
+        supports_pulldown: false,
+        supports_adc,
+        supports_pwm,
+        notes: "Arduino abstract GPIO pin; concrete backend owns MCU port mapping",
+    }
+}
+
+const fn generated_pin(pin: u8, supports_adc: bool, supports_pwm: bool) -> DigitalPinDescriptor {
+    DigitalPinDescriptor {
+        pin,
+        label: "GPIO",
+        supports_input: true,
+        supports_output: true,
+        supports_pullup: true,
+        supports_pulldown: false,
+        supports_adc,
+        supports_pwm,
+        notes:
+            "Generated Arduino-family GPIO descriptor; backend maps board header pin to MCU port",
+    }
+}
+
+const fn generated_pins<const N: usize>(
+    analog_start: u8,
+    analog_count: u8,
+) -> [DigitalPinDescriptor; N] {
+    let mut pins = [DigitalPinDescriptor {
+        pin: 0,
+        label: "GPIO",
+        supports_input: true,
+        supports_output: true,
+        supports_pullup: true,
+        supports_pulldown: false,
+        supports_adc: false,
+        supports_pwm: false,
+        notes:
+            "Generated Arduino-family GPIO descriptor; backend maps board header pin to MCU port",
+    }; N];
+    let mut index = 0;
+    while index < N {
+        let pin = index as u8;
+        pins[index] = generated_pin(
+            pin,
+            pin >= analog_start && pin < analog_start + analog_count,
+            pin == 3 || pin == 5 || pin == 6 || pin == 9 || pin == 10 || pin == 11,
+        );
+        index += 1;
+    }
+    pins
+}
+
+pub const ARDUINO_STANDARD_DIGITAL_PINS: [DigitalPinDescriptor; 20] = [
+    pin(0, "D0/RX", false, false),
+    pin(1, "D1/TX", false, false),
+    pin(2, "D2", false, false),
+    pin(3, "D3/PWM", false, true),
+    pin(4, "D4", false, false),
+    pin(5, "D5/PWM", false, true),
+    pin(6, "D6/PWM", false, true),
+    pin(7, "D7", false, false),
+    pin(8, "D8", false, false),
+    pin(9, "D9/PWM", false, true),
+    pin(10, "D10/PWM/SS", false, true),
+    pin(11, "D11/PWM/MOSI", false, true),
+    pin(12, "D12/MISO", false, false),
+    pin(13, "D13/SCK/LED", false, false),
+    pin(14, "A0/D14", true, false),
+    pin(15, "A1/D15", true, false),
+    pin(16, "A2/D16", true, false),
+    pin(17, "A3/D17", true, false),
+    pin(18, "A4/D18/SDA", true, false),
+    pin(19, "A5/D19/SCL", true, false),
+];
+
+pub const ARDUINO_MEGA_2560_DIGITAL_PINS: [DigitalPinDescriptor; 70] = generated_pins::<70>(54, 16);
+pub const ARDUINO_LEONARDO_DIGITAL_PINS: [DigitalPinDescriptor; 24] = generated_pins::<24>(18, 6);
+pub const ARDUINO_DUE_DIGITAL_PINS: [DigitalPinDescriptor; 76] = generated_pins::<76>(54, 12);
+pub const ARDUINO_NANO_EVERY_DIGITAL_PINS: [DigitalPinDescriptor; 22] = generated_pins::<22>(14, 8);
+pub const ARDUINO_NANO_R4_DIGITAL_PINS: [DigitalPinDescriptor; 22] = generated_pins::<22>(14, 8);
+pub const ARDUINO_NANO_33_BLE_DIGITAL_PINS: [DigitalPinDescriptor; 22] =
+    generated_pins::<22>(14, 8);
+pub const ARDUINO_NANO_RP2040_DIGITAL_PINS: [DigitalPinDescriptor; 22] =
+    generated_pins::<22>(14, 8);
+pub const ARDUINO_NANO_ESP32_DIGITAL_PINS: [DigitalPinDescriptor; 22] = generated_pins::<22>(14, 8);
+pub const ARDUINO_GIGA_R1_DIGITAL_PINS: [DigitalPinDescriptor; 76] = generated_pins::<76>(54, 12);
+pub const ARDUINO_PORTENTA_H7_DIGITAL_PINS: [DigitalPinDescriptor; 80] =
+    generated_pins::<80>(54, 12);
+
+pub const ARDUINO_UNO_R3: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-uno-r3",
+    display_name: "Arduino UNO R3",
+    family: ArduinoFamily::ClassicAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega328P",
+    core: "8-bit AVR",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega328p"),
+    clock_hz: 16_000_000,
+    flash_bytes: 32 * 1024,
+    sram_bytes: 2 * 1024,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_STANDARD_DIGITAL_PINS,
+    notes: "Classic Arduino Uno backend contract; tiny profile starts with GPIO/time over the shared Arduino HAL shape.",
+};
+
+pub const ARDUINO_NANO_CLASSIC: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-classic",
+    display_name: "Arduino Nano",
+    family: ArduinoFamily::ClassicAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega328P",
+    core: "8-bit AVR",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega328p"),
+    clock_hz: 16_000_000,
+    flash_bytes: 32 * 1024,
+    sram_bytes: 2 * 1024,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_STANDARD_DIGITAL_PINS,
+    notes: "Classic Nano backend contract; shares the ATmega328P tiny-profile backend with Uno R3.",
+};
+
+pub const ARDUINO_PRO_MINI: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-pro-mini",
+    display_name: "Arduino Pro Mini",
+    family: ArduinoFamily::ClassicAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega328P",
+    core: "8-bit AVR",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega328p"),
+    clock_hz: 16_000_000,
+    flash_bytes: 32 * 1024,
+    sram_bytes: 2 * 1024,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_STANDARD_DIGITAL_PINS,
+    notes: "External serial adapter expected; backend contract is still the same tiny-profile AVR GPIO/time path.",
+};
+
+pub const ARDUINO_MEGA_2560: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-mega-2560",
+    display_name: "Arduino Mega 2560 Rev3",
+    family: ArduinoFamily::ClassicAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega2560",
+    core: "8-bit AVR",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega2560"),
+    clock_hz: 16_000_000,
+    flash_bytes: 256 * 1024,
+    sram_bytes: 8 * 1024,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_MEGA_2560_DIGITAL_PINS,
+    notes: "Larger AVR backend contract with more GPIO/UART surface than Uno R3.",
+};
+
+pub const ARDUINO_LEONARDO: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-leonardo",
+    display_name: "Arduino Leonardo",
+    family: ArduinoFamily::ClassicAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega32U4",
+    core: "8-bit AVR with USB",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega32u4"),
+    clock_hz: 16_000_000,
+    flash_bytes: 32 * 1024,
+    sram_bytes: 2_560,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_LEONARDO_DIGITAL_PINS,
+    notes: "ATmega32U4 backend contract keeps native USB boards separate from Uno R3 serial assumptions.",
+};
+
+pub const ARDUINO_MICRO: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-micro",
+    display_name: "Arduino Micro",
+    family: ArduinoFamily::ClassicAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega32U4",
+    core: "8-bit AVR with USB",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega32u4"),
+    clock_hz: 16_000_000,
+    flash_bytes: 32 * 1024,
+    sram_bytes: 2_560,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_LEONARDO_DIGITAL_PINS,
+    notes: "Micro uses the same ATmega32U4 backend family as Leonardo with a different board form factor.",
+};
+
+pub const ARDUINO_DUE: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-due",
+    display_name: "Arduino Due",
+    family: ArduinoFamily::Sam,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "SAM3X8E",
+    core: "Arm Cortex-M3",
+    isa: "armv7-m",
+    rust_target: RustTargetStatus::Stable("thumbv7m-none-eabi"),
+    clock_hz: 84_000_000,
+    flash_bytes: 512 * 1024,
+    sram_bytes: 96 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_DUE_DIGITAL_PINS,
+    notes: "SAM backend contract proves the Arduino line is not restricted to AVR or Renesas RA.",
+};
+
+pub const ARDUINO_ZERO: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-zero",
+    display_name: "Arduino Zero",
+    family: ArduinoFamily::Samd,
+    runtime_profile: RuntimeProfile::Small,
+    mcu: "SAMD21G18",
+    core: "Arm Cortex-M0+",
+    isa: "armv6-m",
+    rust_target: RustTargetStatus::Stable("thumbv6m-none-eabi"),
+    clock_hz: 48_000_000,
+    flash_bytes: 256 * 1024,
+    sram_bytes: 32 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_STANDARD_DIGITAL_PINS,
+    notes: "SAMD21 backend contract for Zero/MKR-class Arduino boards.",
+};
+
+pub const ARDUINO_MKR_WIFI_1010: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-mkr-wifi-1010",
+    display_name: "Arduino MKR WiFi 1010",
+    family: ArduinoFamily::Samd,
+    runtime_profile: RuntimeProfile::Small,
+    mcu: "SAMD21G18",
+    core: "Arm Cortex-M0+ with u-blox NINA-W102",
+    isa: "armv6-m",
+    rust_target: RustTargetStatus::Stable("thumbv6m-none-eabi"),
+    clock_hz: 48_000_000,
+    flash_bytes: 256 * 1024,
+    sram_bytes: 32 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(6),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_STANDARD_DIGITAL_PINS,
+    notes: "MKR WiFi backend starts with the shared SAMD21 GPIO/time path; wireless is a later capability tranche.",
+};
+
+pub const ARDUINO_NANO_EVERY: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-every",
+    display_name: "Arduino Nano Every",
+    family: ArduinoFamily::MegaAvr,
+    runtime_profile: RuntimeProfile::Tiny,
+    mcu: "ATmega4809",
+    core: "8-bit megaAVR 0-series",
+    isa: "avr",
+    rust_target: RustTargetStatus::BackendNeeded("avr-atmega4809"),
+    clock_hz: 20_000_000,
+    flash_bytes: 48 * 1024,
+    sram_bytes: 6 * 1024,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NANO_EVERY_DIGITAL_PINS,
+    notes: "megaAVR backend contract keeps newer Nano AVR boards out of the Uno R3 bucket.",
+};
+
+pub const ARDUINO_NANO_R4: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-r4",
+    display_name: "Arduino Nano R4",
+    family: ArduinoFamily::RenesasRa,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "RA4M1",
+    core: "Arm Cortex-M4F",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 48_000_000,
+    flash_bytes: 256 * 1024,
+    sram_bytes: 32 * 1024,
+    operating_voltage_mv: 5000,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NANO_R4_DIGITAL_PINS,
+    notes: "Renesas RA Nano-family backend contract; separate from Uno R4 despite the shared RA4M1 MCU class.",
+};
+
+pub const ARDUINO_NANO_33_IOT: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-33-iot",
+    display_name: "Arduino Nano 33 IoT",
+    family: ArduinoFamily::Samd,
+    runtime_profile: RuntimeProfile::Small,
+    mcu: "SAMD21G18",
+    core: "Arm Cortex-M0+ with u-blox NINA-W102",
+    isa: "armv6-m",
+    rust_target: RustTargetStatus::Stable("thumbv6m-none-eabi"),
+    clock_hz: 48_000_000,
+    flash_bytes: 256 * 1024,
+    sram_bytes: 32 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_STANDARD_DIGITAL_PINS,
+    notes: "Nano 33 IoT backend contract shares SAMD21 runtime support with Zero/MKR but stays discoverable as its own board.",
+};
+
+pub const ARDUINO_NANO_33_BLE_REV2: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-33-ble-rev2",
+    display_name: "Arduino Nano 33 BLE Rev2",
+    family: ArduinoFamily::Nordic,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "nRF52840",
+    core: "Arm Cortex-M4F with Bluetooth LE",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 64_000_000,
+    flash_bytes: 1024 * 1024,
+    sram_bytes: 256 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NANO_33_BLE_DIGITAL_PINS,
+    notes: "Nordic nRF52 Arduino backend contract; Bluetooth capabilities land in a later descriptor tranche.",
+};
+
+pub const ARDUINO_NANO_RP2040_CONNECT: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-rp2040-connect",
+    display_name: "Arduino Nano RP2040 Connect",
+    family: ArduinoFamily::Rp2040,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "RP2040",
+    core: "dual Arm Cortex-M0+ with u-blox NINA-W102",
+    isa: "armv6-m",
+    rust_target: RustTargetStatus::Stable("thumbv6m-none-eabi"),
+    clock_hz: 133_000_000,
+    flash_bytes: 16 * 1024 * 1024,
+    sram_bytes: 264 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(13),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NANO_RP2040_DIGITAL_PINS,
+    notes: "Arduino RP2040 backend contract reuses the Board VM RP2040 direction without pretending it is a Raspberry Pi Pico board.",
+};
+
+pub const ARDUINO_NANO_ESP32: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nano-esp32",
+    display_name: "Arduino Nano ESP32",
+    family: ArduinoFamily::Esp32,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "ESP32-S3",
+    core: "Xtensa LX7",
+    isa: "xtensa-lx7",
+    rust_target: RustTargetStatus::Nightly("xtensa-esp32s3-none-elf"),
+    clock_hz: 240_000_000,
+    flash_bytes: 16 * 1024 * 1024,
+    sram_bytes: 512 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NANO_ESP32_DIGITAL_PINS,
+    notes: "Arduino Nano ESP32 backend contract tracks Arduino's ESP32-S3 board separately from generic ESP32 DevKit descriptors.",
+};
+
+pub const ARDUINO_GIGA_R1_WIFI: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-giga-r1-wifi",
+    display_name: "Arduino GIGA R1 WiFi",
+    family: ArduinoFamily::Stm32,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747XI",
+    core: "dual Arm Cortex-M7/M4",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_GIGA_R1_DIGITAL_PINS,
+    notes: "STM32H7 Arduino backend contract; richer storage/network/peripheral capabilities should land as descriptor-backed follow-ups.",
+};
+
+pub const ARDUINO_PORTENTA_H7: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-portenta-h7",
+    display_name: "Arduino Portenta H7",
+    family: ArduinoFamily::Mbed,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747XI",
+    core: "dual Arm Cortex-M7/M4",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(66),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_PORTENTA_H7_DIGITAL_PINS,
+    notes: "Portenta H7 backend contract keeps high-end Arduino Pro hardware in the target matrix.",
+};
+
+pub const ARDUINO_TARGETS: [ArduinoTargetDescriptor; 17] = [
+    ARDUINO_UNO_R3,
+    ARDUINO_NANO_CLASSIC,
+    ARDUINO_PRO_MINI,
+    ARDUINO_MEGA_2560,
+    ARDUINO_LEONARDO,
+    ARDUINO_MICRO,
+    ARDUINO_DUE,
+    ARDUINO_ZERO,
+    ARDUINO_MKR_WIFI_1010,
+    ARDUINO_NANO_EVERY,
+    ARDUINO_NANO_R4,
+    ARDUINO_NANO_33_IOT,
+    ARDUINO_NANO_33_BLE_REV2,
+    ARDUINO_NANO_RP2040_CONNECT,
+    ARDUINO_NANO_ESP32,
+    ARDUINO_GIGA_R1_WIFI,
+    ARDUINO_PORTENTA_H7,
+];
+
+pub fn arduino_device_descriptor(
+    target: &'static ArduinoTargetDescriptor,
+    board_nonce: u32,
+) -> board_vm_device::DeviceDescriptor<'static> {
+    board_vm_device::DeviceDescriptor {
+        board_id: target.board_id,
+        runtime_id: ARDUINO_VM_RUNTIME_ID,
+        board_nonce,
+        max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
+        supports_store_program: false,
+        capabilities: &BLINK_MVP_CAPABILITIES,
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use board_vm_host::{write_blink_module, BlinkProgram, BLINK_MODULE_LEN};
+    use board_vm_ir::parse_module;
+    use board_vm_runtime::{RunStatus, Runtime};
+    use std::vec;
+    use std::vec::Vec;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Event {
+        Configure(u8, GpioMode),
+        Write(u32, Level),
+        Sleep(u16),
+    }
+
+    #[derive(Default)]
+    struct FakeBackend {
+        events: Vec<Event>,
+        now_ms: u32,
+    }
+
+    impl FakeBackend {
+        fn new() -> Self {
+            Self {
+                events: Vec::new(),
+                now_ms: 0,
+            }
+        }
+    }
+
+    impl ArduinoBackend for FakeBackend {
+        fn gpio_open(&mut self, pin: u8, mode: GpioMode) -> Result<u32, HalError> {
+            self.events.push(Event::Configure(pin, mode));
+            Ok(pin as u32)
+        }
+
+        fn gpio_write(&mut self, token: u32, level: Level) -> Result<(), HalError> {
+            self.events.push(Event::Write(token, level));
+            Ok(())
+        }
+
+        fn sleep_ms(&mut self, duration_ms: u16) -> Result<(), HalError> {
+            self.events.push(Event::Sleep(duration_ms));
+            self.now_ms += duration_ms as u32;
+            Ok(())
+        }
+
+        fn now_ms(&self) -> u32 {
+            self.now_ms
+        }
+    }
+
+    #[test]
+    fn target_list_includes_multiple_arduino_backend_families() {
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::ClassicAvr));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::Samd));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::RenesasRa));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::Nordic));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::Rp2040));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::Esp32));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::Stm32));
+    }
+
+    #[test]
+    fn every_arduino_target_runs_blink_through_shared_backend() {
+        for target in ARDUINO_TARGETS.iter() {
+            let pin = target.onboard_led_pin.unwrap_or(target.digital_pins[0].pin);
+            let board = ArduinoBoard::new(target, FakeBackend::new());
+            let mut runtime: Runtime<_, 8, 4> = Runtime::new(board);
+            let mut module = [0u8; BLINK_MODULE_LEN];
+            let len = write_blink_module(
+                BlinkProgram {
+                    pin,
+                    high_ms: 25,
+                    low_ms: 25,
+                    max_stack: 4,
+                },
+                &mut module,
+            )
+            .unwrap();
+            let module = parse_module(&module[..len]).unwrap();
+            let report = runtime.run_module(&module, 13).unwrap();
+
+            assert_eq!(
+                report.status,
+                RunStatus::BudgetExceeded,
+                "{}",
+                target.board_id
+            );
+            assert_eq!(
+                runtime.hal().backend().events,
+                vec![
+                    Event::Configure(pin, GpioMode::Output),
+                    Event::Write(pin as u32, Level::High),
+                    Event::Sleep(25),
+                    Event::Write(pin as u32, Level::Low),
+                    Event::Sleep(25),
+                ],
+                "{}",
+                target.board_id
+            );
+        }
+    }
+
+    #[test]
+    fn backend_rejects_unknown_pins_before_backend_io() {
+        let mut board = ArduinoBoard::new(&ARDUINO_UNO_R3, FakeBackend::new());
+        assert_eq!(
+            board.gpio_open(255, GpioMode::Output),
+            Err(HalError::InvalidPin)
+        );
+        assert!(board.backend().events.is_empty());
+    }
+
+    #[test]
+    fn descriptors_map_to_device_descriptor_contract() {
+        let descriptor = arduino_device_descriptor(&ARDUINO_MEGA_2560, 0xA0D1_0001);
+        assert_eq!(descriptor.board_id, ARDUINO_MEGA_2560.board_id);
+        assert_eq!(descriptor.runtime_id, ARDUINO_VM_RUNTIME_ID);
+        assert_eq!(descriptor.board_nonce, 0xA0D1_0001);
+        assert_eq!(descriptor.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
+        assert!(!descriptor.supports_store_program);
+        assert_eq!(descriptor.capabilities.len(), BLINK_MVP_CAPABILITIES.len());
+    }
+}

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -292,6 +292,7 @@ pub struct LanguageBoardDescriptor {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageBoardFamily {
+    Arduino,
     ArduinoUnoR4,
     Esp32,
     RaspberryPiPico,
@@ -621,6 +622,7 @@ pub const fn capability_board_metadata(flags: u16) -> bool {
 
 pub const fn board_family_name(family: LanguageBoardFamily) -> &'static str {
     match family {
+        LanguageBoardFamily::Arduino => "arduino",
         LanguageBoardFamily::ArduinoUnoR4 => "arduino_uno_r4",
         LanguageBoardFamily::Esp32 => "esp32",
         LanguageBoardFamily::RaspberryPiPico => "raspberry_pi_pico",
@@ -1354,6 +1356,7 @@ fn bluetooth_endpoint_scheme(endpoint: &str) -> &str {
 
 fn language_family(family: BoardFamily) -> LanguageBoardFamily {
     match family {
+        BoardFamily::Arduino => LanguageBoardFamily::Arduino,
         BoardFamily::ArduinoUnoR4 => LanguageBoardFamily::ArduinoUnoR4,
         BoardFamily::Esp32 => LanguageBoardFamily::Esp32,
         BoardFamily::RaspberryPiPico => LanguageBoardFamily::RaspberryPiPico,
@@ -3764,15 +3767,38 @@ mod tests {
         let targets = known_targets();
         let esp32 = known_target("esp32-devkit-v1").unwrap();
         let uno = known_target("arduino-uno-r4-wifi").unwrap();
+        let mega = known_target("arduino-mega-2560").unwrap();
+        let nano_r4 = known_target("arduino-nano-r4").unwrap();
+        let nano_ble = known_target("arduino-nano-33-ble-rev2").unwrap();
+        let nano_esp32 = known_target("arduino-nano-esp32").unwrap();
+        let giga = known_target("arduino-giga-r1-wifi").unwrap();
         let pico_w = known_target("raspberry-pi-pico-w").unwrap();
 
         assert!(targets
             .iter()
             .any(|target| target.board_id == esp32.board_id));
+        assert!(targets
+            .iter()
+            .any(|target| target.board_id == mega.board_id));
         assert_eq!(esp32.family, LanguageBoardFamily::Esp32);
         assert_eq!(board_family_name(esp32.family), "esp32");
         assert_eq!(esp32.runtime_id, "board-vm-esp32");
         assert_eq!(esp32.onboard_led, Some(LanguageOnboardLed::Gpio(2)));
+        assert_eq!(mega.family, LanguageBoardFamily::Arduino);
+        assert_eq!(board_family_name(mega.family), "arduino");
+        assert_eq!(mega.runtime_id, "board-vm-arduino");
+        assert_eq!(mega.digital_pin_count, 70);
+        assert!(mega.capabilities.contains(&"transport.serial".to_owned()));
+        assert!(mega.capabilities.contains(&"gpio.open".to_owned()));
+        assert!(mega.capabilities.contains(&"program.ram_exec".to_owned()));
+        assert_eq!(nano_r4.family, LanguageBoardFamily::Arduino);
+        assert_eq!(nano_r4.mcu, "RA4M1");
+        assert_eq!(nano_ble.family, LanguageBoardFamily::Arduino);
+        assert_eq!(nano_ble.mcu, "nRF52840");
+        assert_eq!(nano_esp32.family, LanguageBoardFamily::Arduino);
+        assert_eq!(nano_esp32.mcu, "ESP32-S3");
+        assert_eq!(giga.family, LanguageBoardFamily::Arduino);
+        assert_eq!(giga.mcu, "STM32H747XI");
         assert_eq!(
             uno.led_matrix,
             Some(LanguageLedMatrix {

--- a/code/packages/rust/board-vm-targets/Cargo.toml
+++ b/code/packages/rust/board-vm-targets/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Host-side Board VM target registry for supported boards"
 
 [dependencies]
+board-vm-arduino = { path = "../board-vm-arduino" }
 board-vm-esp32 = { path = "../board-vm-esp32" }
 board-vm-pico = { path = "../board-vm-pico" }
 board-vm-uno-r4 = { path = "../board-vm-uno-r4" }

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -8,6 +8,15 @@ compile for, where their onboard LED lives, and which host transports are
 available. Board-specific runtime crates remain responsible for HAL behavior,
 pin validation, wireless stack integration, and upload mechanics.
 
+Arduino coverage is deliberately split in two:
+
+- `board-vm-uno-r4` remains the rich, board-specific Renesas RA4M1 target for
+  Uno R4 Minima and Uno R4 WiFi.
+- `board-vm-arduino` registers the broader Arduino-family backend contract for
+  non-Uno-R4 boards such as Uno R3, Nano, Mega 2560, Leonardo/Micro, Due, Zero,
+  MKR WiFi 1010, Nano Every, Nano R4, Nano 33 IoT, Nano 33 BLE Rev2, Nano RP2040
+  Connect, Nano ESP32, GIGA R1 WiFi, and Portenta H7.
+
 Wireless metadata separates physical support from the generic front-end sugar:
 
 - every current target exposes `transport.serial`

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoardFamily {
+    Arduino,
     ArduinoUnoR4,
     Esp32,
     RaspberryPiPico,
@@ -432,6 +433,71 @@ pub const ESP32_DIGITAL_PINS: [DigitalPinInfo; 30] =
 pub const PICO_DIGITAL_PINS: [DigitalPinInfo; 29] =
     map_pico_digital_pins(board_vm_pico::PICO_DIGITAL_PINS);
 
+pub const ARDUINO_UNO_R3_DIGITAL_PINS: [DigitalPinInfo; 20] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_STANDARD_DIGITAL_PINS);
+pub const ARDUINO_NANO_CLASSIC_DIGITAL_PINS: [DigitalPinInfo; 20] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_STANDARD_DIGITAL_PINS);
+pub const ARDUINO_PRO_MINI_DIGITAL_PINS: [DigitalPinInfo; 20] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_STANDARD_DIGITAL_PINS);
+pub const ARDUINO_MEGA_2560_DIGITAL_PINS: [DigitalPinInfo; 70] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_MEGA_2560_DIGITAL_PINS);
+pub const ARDUINO_LEONARDO_DIGITAL_PINS: [DigitalPinInfo; 24] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_LEONARDO_DIGITAL_PINS);
+pub const ARDUINO_MICRO_DIGITAL_PINS: [DigitalPinInfo; 24] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_LEONARDO_DIGITAL_PINS);
+pub const ARDUINO_DUE_DIGITAL_PINS: [DigitalPinInfo; 76] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_DUE_DIGITAL_PINS);
+pub const ARDUINO_ZERO_DIGITAL_PINS: [DigitalPinInfo; 20] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_STANDARD_DIGITAL_PINS);
+pub const ARDUINO_MKR_WIFI_1010_DIGITAL_PINS: [DigitalPinInfo; 20] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_STANDARD_DIGITAL_PINS);
+pub const ARDUINO_NANO_EVERY_DIGITAL_PINS: [DigitalPinInfo; 22] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NANO_EVERY_DIGITAL_PINS);
+pub const ARDUINO_NANO_R4_DIGITAL_PINS: [DigitalPinInfo; 22] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NANO_R4_DIGITAL_PINS);
+pub const ARDUINO_NANO_33_IOT_DIGITAL_PINS: [DigitalPinInfo; 20] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_STANDARD_DIGITAL_PINS);
+pub const ARDUINO_NANO_33_BLE_REV2_DIGITAL_PINS: [DigitalPinInfo; 22] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NANO_33_BLE_DIGITAL_PINS);
+pub const ARDUINO_NANO_RP2040_CONNECT_DIGITAL_PINS: [DigitalPinInfo; 22] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NANO_RP2040_DIGITAL_PINS);
+pub const ARDUINO_NANO_ESP32_DIGITAL_PINS: [DigitalPinInfo; 22] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NANO_ESP32_DIGITAL_PINS);
+pub const ARDUINO_GIGA_R1_WIFI_DIGITAL_PINS: [DigitalPinInfo; 76] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_GIGA_R1_DIGITAL_PINS);
+pub const ARDUINO_PORTENTA_H7_DIGITAL_PINS: [DigitalPinInfo; 80] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_PORTENTA_H7_DIGITAL_PINS);
+
+const fn map_arduino_digital_pins<const N: usize>(
+    source: [board_vm_arduino::DigitalPinDescriptor; N],
+) -> [DigitalPinInfo; N] {
+    let mut pins = [DigitalPinInfo::placeholder(); N];
+    let mut index = 0;
+    while index < N {
+        pins[index] = arduino_digital_pin(source[index]);
+        index += 1;
+    }
+    pins
+}
+
+const fn arduino_digital_pin(pin: board_vm_arduino::DigitalPinDescriptor) -> DigitalPinInfo {
+    DigitalPinInfo {
+        pin: pin.pin,
+        label: pin.label,
+        supports_input: pin.supports_input,
+        supports_output: pin.supports_output,
+        supports_pullup: pin.supports_pullup,
+        supports_pulldown: pin.supports_pulldown,
+        supports_adc: pin.supports_adc,
+        supports_pwm: pin.supports_pwm,
+        supports_dac: false,
+        supports_touch: false,
+        supports_interrupt: pin.supports_input,
+        boot_strap: false,
+        notes: pin.notes,
+    }
+}
+
 const fn map_uno_r4_digital_pins<const N: usize>(
     source: [board_vm_uno_r4::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -677,7 +743,41 @@ const fn pico_digital_pin(pin: board_vm_pico::DigitalPinDescriptor) -> DigitalPi
     }
 }
 
-pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
+const fn arduino_board_target(
+    target: board_vm_arduino::ArduinoTargetDescriptor,
+    digital_pins: &'static [DigitalPinInfo],
+) -> BoardTargetInfo {
+    BoardTargetInfo {
+        board_id: target.board_id,
+        display_name: target.display_name,
+        family: BoardFamily::Arduino,
+        runtime_id: board_vm_arduino::ARDUINO_VM_RUNTIME_ID,
+        mcu: target.mcu,
+        core: target.core,
+        rust_target: target.rust_target.name(),
+        clock_hz: target.clock_hz,
+        operating_voltage_mv: target.operating_voltage_mv,
+        onboard_led: match target.onboard_led_pin {
+            Some(pin) => Some(OnboardLed::Gpio(pin)),
+            None => None,
+        },
+        led_matrix: None,
+        digital_pin_count: digital_pins.len(),
+        digital_pins,
+        i2c_buses: &[],
+        spi_buses: &[],
+        uart_buses: &[],
+        can_buses: &[],
+        rtc: None,
+        watchdog: None,
+        storage_regions: &[],
+        wireless: &[],
+        network_interfaces: &[],
+        capabilities: &BLINK_MVP_CAPABILITIES,
+    }
+}
+
+pub const BOARD_TARGETS: [BoardTargetInfo; 22] = [
     BoardTargetInfo {
         board_id: board_vm_uno_r4::UNO_R4_MINIMA.board_id,
         display_name: board_vm_uno_r4::UNO_R4_MINIMA.display_name,
@@ -736,6 +836,65 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 5] = [
         network_interfaces: &UNO_R4_WIFI_NETWORK_INTERFACES,
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_UNO_R3,
+        &ARDUINO_UNO_R3_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_CLASSIC,
+        &ARDUINO_NANO_CLASSIC_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_PRO_MINI,
+        &ARDUINO_PRO_MINI_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_MEGA_2560,
+        &ARDUINO_MEGA_2560_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_LEONARDO,
+        &ARDUINO_LEONARDO_DIGITAL_PINS,
+    ),
+    arduino_board_target(board_vm_arduino::ARDUINO_MICRO, &ARDUINO_MICRO_DIGITAL_PINS),
+    arduino_board_target(board_vm_arduino::ARDUINO_DUE, &ARDUINO_DUE_DIGITAL_PINS),
+    arduino_board_target(board_vm_arduino::ARDUINO_ZERO, &ARDUINO_ZERO_DIGITAL_PINS),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_MKR_WIFI_1010,
+        &ARDUINO_MKR_WIFI_1010_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_EVERY,
+        &ARDUINO_NANO_EVERY_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_R4,
+        &ARDUINO_NANO_R4_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_33_IOT,
+        &ARDUINO_NANO_33_IOT_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_33_BLE_REV2,
+        &ARDUINO_NANO_33_BLE_REV2_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_RP2040_CONNECT,
+        &ARDUINO_NANO_RP2040_CONNECT_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NANO_ESP32,
+        &ARDUINO_NANO_ESP32_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_GIGA_R1_WIFI,
+        &ARDUINO_GIGA_R1_WIFI_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_PORTENTA_H7,
+        &ARDUINO_PORTENTA_H7_DIGITAL_PINS,
+    ),
     BoardTargetInfo {
         board_id: board_vm_esp32::ESP32_DEVKIT_V1.board_id,
         display_name: board_vm_esp32::ESP32_DEVKIT_V1.display_name,
@@ -845,9 +1004,58 @@ mod tests {
     #[test]
     fn registry_lists_current_board_families() {
         assert!(find_target("arduino-uno-r4-wifi").is_some());
+        assert!(find_target("arduino-uno-r3").is_some());
+        assert!(find_target("arduino-mega-2560").is_some());
+        assert!(find_target("arduino-due").is_some());
+        assert!(find_target("arduino-nano-r4").is_some());
+        assert!(find_target("arduino-nano-33-ble-rev2").is_some());
+        assert!(find_target("arduino-nano-rp2040-connect").is_some());
+        assert!(find_target("arduino-nano-esp32").is_some());
+        assert!(find_target("arduino-giga-r1-wifi").is_some());
+        assert!(find_target("arduino-portenta-h7").is_some());
         assert!(find_target("esp32-devkit-v1").is_some());
         assert!(find_target("raspberry-pi-pico").is_some());
         assert!(find_target("raspberry-pi-pico-w").is_some());
+    }
+
+    #[test]
+    fn registry_imports_every_shared_arduino_target() {
+        for arduino_target in board_vm_arduino::ARDUINO_TARGETS.iter() {
+            let target = find_target(arduino_target.board_id).unwrap();
+            assert_eq!(target.display_name, arduino_target.display_name);
+            assert_eq!(target.family, BoardFamily::Arduino);
+            assert_eq!(target.runtime_id, board_vm_arduino::ARDUINO_VM_RUNTIME_ID);
+            assert_eq!(target.mcu, arduino_target.mcu);
+            assert_eq!(target.rust_target, arduino_target.rust_target.name());
+            assert_eq!(target.digital_pin_count, arduino_target.digital_pins.len());
+            assert!(target.capabilities.contains(&"transport.serial"));
+            assert!(target.capabilities.contains(&"gpio.open"));
+            assert!(target.capabilities.contains(&"gpio.write"));
+            assert!(target.capabilities.contains(&"time.sleep_ms"));
+            assert!(target.capabilities.contains(&"program.ram_exec"));
+        }
+    }
+
+    #[test]
+    fn shared_arduino_targets_cover_more_than_uno_r4() {
+        let arduino_targets = BOARD_TARGETS
+            .iter()
+            .filter(|target| target.family == BoardFamily::Arduino)
+            .count();
+        assert_eq!(arduino_targets, board_vm_arduino::ARDUINO_TARGETS.len());
+        assert!(find_target("arduino-uno-r3").unwrap().digital_pin_count >= 20);
+        assert!(find_target("arduino-mega-2560").unwrap().digital_pin_count >= 70);
+        assert!(find_target("arduino-due").unwrap().digital_pin_count >= 76);
+        assert_eq!(find_target("arduino-nano-r4").unwrap().mcu, "RA4M1");
+        assert_eq!(
+            find_target("arduino-nano-33-ble-rev2").unwrap().mcu,
+            "nRF52840"
+        );
+        assert_eq!(find_target("arduino-nano-esp32").unwrap().mcu, "ESP32-S3");
+        assert_eq!(
+            find_target("arduino-giga-r1-wifi").unwrap().mcu,
+            "STM32H747XI"
+        );
     }
 
     #[test]

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -81,9 +81,27 @@ descriptor for its actual limits and compiles accordingly.
 | Board family | First boards | Core / ISA | Profile | Notes |
 |---|---|---|---|---|
 | Arduino Uno R4 | Uno R4 Minima, Uno R4 WiFi | Renesas RA4M1, Arm Cortex-M4F, Armv7E-M | `full` | First implementation target. Good modern Arduino baseline. |
+| Arduino Nano R4 | Nano R4 | Renesas RA4M1, Arm Cortex-M4F, Armv7E-M | `full` | Same MCU class as Uno R4, but Nano form factor; must not be hidden inside the Uno R4 crate. |
+| Arduino Portenta C33 | Portenta C33 | Renesas RA6M5, Arm Cortex-M33 | `full` | Later Pro-family Renesas target; shares Board VM runtime shape but needs its own descriptor and upload metadata. |
 
 Uno R4 is the first target because it is the hardware in hand and has enough
-memory for a comfortable runtime.
+memory for a comfortable runtime. It is not the only Arduino target. Generic
+Arduino-family support lives in a separate backend contract so Nano, MKR, Mega,
+Due, GIGA, Portenta, Nicla, Opta, and future Arduino boards do not get squeezed
+through Uno R4 assumptions.
+
+The first concrete `board-vm-arduino` slice registers a GPIO/time backend
+contract for representative Arduino families:
+
+- classic AVR: Uno R3, Nano classic, Pro Mini, Mega 2560, Leonardo, Micro,
+- SAM/SAMD/megaAVR/Renesas/Nordic: Due, Zero, MKR WiFi 1010, Nano Every,
+  Nano R4, Nano 33 IoT, Nano 33 BLE Rev2,
+- maker/pro 32-bit boards: Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi,
+  Portenta H7.
+
+The next tranches should add board-specific firmware/upload adapters and richer
+peripheral tables for each family without moving generic Arduino discovery into
+`board-vm-uno-r4`.
 
 ### Raspberry Pi Pico
 


### PR DESCRIPTION
## Summary
- add a shared board-vm-arduino crate for non-Uno-R4 Arduino board families
- register 17 Arduino targets in board-vm-targets and expose them through language-core
- update the Board VM target-matrix spec to keep Arduino coverage separate from Uno R4 assumptions

## Validation
- cargo fmt -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-arduino
- bash BUILD in code/packages/rust/board-vm-targets
- build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check