### PR TITLE
Test generated HTML fixture manifest coverage

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -24,6 +24,8 @@ documented in this file.
 - A generated HTML fixture manifest check runs the self-contained lexer and
   parser fixture stale checks from one command, with optional inputs for
   upstream-only html5lib and WHATWG entity sources.
+- A fixture manifest unit test keeps every self-contained WHATWG fixture
+  generator covered by that umbrella stale check.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -104,6 +104,9 @@ binary while production code continues to link only static Rust source.
 - `check_generated_html_fixtures.py`: manifest check that runs every
   self-contained generated lexer/parser fixture stale check from checked-in
   inputs, with optional flags for upstream-only source inputs
+- `test_generated_html_fixture_manifest.py`: regression test that keeps the
+  stale-check manifest aligned with the self-contained WHATWG fixture
+  generators in this directory
 - the parser fixture audit can pin the current html5lib tokenizer counts with
   `--expect-tokenizer-upstream-cases 6806`,
   `--expect-tokenizer-local-raw-cases 7015`,
@@ -294,6 +297,13 @@ python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtur
 Pass `--html5lib-tests /path/to/html5lib-tests` to include the parser coverage
 audit report and pinned-count checks, or `--entities-json /path/to/entities.json`
 to include the generated WHATWG named-character-reference table.
+
+To verify that new self-contained WHATWG fixture generators are added to the
+manifest, run:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+```
 
 ## WPT Path
 

--- a/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""Regression tests for the generated HTML fixture stale-check manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import check_generated_html_fixtures as manifest
+
+
+EXTERNAL_SOURCE_GENERATORS = {
+    "generate_whatwg_entities_fixture.py",
+}
+
+
+class GeneratedHtmlFixtureManifestTest(unittest.TestCase):
+    def test_default_manifest_covers_all_self_contained_lexer_generators(self) -> None:
+        checked_scripts = scripts_in(manifest.default_checks())
+        generator_scripts = {
+            path.name
+            for path in manifest.FIXTURE_DIR.glob("generate_whatwg_*_fixture.py")
+        }
+        self_contained_generators = generator_scripts - EXTERNAL_SOURCE_GENERATORS
+
+        self.assertEqual(
+            checked_scripts & self_contained_generators,
+            self_contained_generators,
+        )
+        self.assertNotIn("generate_whatwg_entities_fixture.py", checked_scripts)
+
+    def test_default_manifest_keeps_parser_and_html5lib_checks_visible(self) -> None:
+        checked_scripts = scripts_in(manifest.default_checks())
+
+        self.assertIn("normalize_html5lib_fixtures.py", checked_scripts)
+        self.assertIn("generate_whatwg_tree_insertion_audit_fixture.py", checked_scripts)
+
+    def test_default_manifest_check_names_are_unique_and_use_check_mode(self) -> None:
+        checks = manifest.default_checks()
+        check_names = [check.name for check in checks]
+
+        self.assertEqual(len(check_names), len(set(check_names)))
+        for check in checks:
+            self.assertIn("--check", check.command)
+
+
+def scripts_in(checks: list[manifest.FixtureCheck]) -> set[str]:
+    return {Path(check.command[0]).name for check in checks}
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a regression test for the generated HTML fixture stale-check manifest
- assert every self-contained WHATWG lexer fixture generator is included in the umbrella manifest
- document the manifest coverage test in the lexer fixture docs/changelog

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser