### PR TITLE
feat(moslayout): U29-G3 — add expr non-terminal

### DIFF
--- a/code/grammars/moslayout.grammar
+++ b/code/grammars/moslayout.grammar
@@ -124,7 +124,45 @@ prop_list = prop { COMMA prop } ;
 prop = NAME    COLON prop_value
      | KEYWORD COLON NAME ;
 
-prop_value = KEYWORD COLON NAME
-           | NAME
-           | NUMBER
-           | STRING ;
+# ============================================================================
+# Expressions (UI29 §3.3 — U29-G3)
+# ============================================================================
+# `prop_value` is an expression. Expressions cover:
+#   • The four legacy prop-value forms (slot ref, NAME, NUMBER, STRING)
+#     because every one of them is a valid `primary`.
+#   • Comparison and logical combinations for For `each:` and If `when:`
+#     (e.g. `r == editRow`, `editing && !readonly`, `cols.visible`).
+#   • Field access (`row.cells`) and index access (`row[c]`).
+#
+# Deliberately excluded by UI29 §3.3 (do not add without a spec amendment):
+#   • Arithmetic (`+ - * /`)
+#   • String concatenation
+#   • Ternary (`? :`)
+#   • Function / method calls
+#
+# Operator precedence (low → high):
+#   or_expr   ||
+#   and_expr  &&
+#   eq_expr   == !=
+#   rel_expr  <  <=  >  >=
+#   unary     !
+#   postfix   . []
+#   primary   slot ref | NAME | NUMBER | STRING | ( expr )
+#
+# The grammar is LL(1) because each level's first-token set is disjoint
+# from the operator token that starts the next-higher level.
+
+prop_value = expr ;
+
+expr     = or_expr ;
+or_expr  = and_expr { OR  and_expr } ;
+and_expr = eq_expr  { AND eq_expr  } ;
+eq_expr  = rel_expr [ ( EQ | NEQ ) rel_expr ] ;
+rel_expr = unary    [ ( LT | LE | GT | GE ) unary ] ;
+unary    = NOT unary | postfix ;
+postfix  = primary { DOT NAME | LBRACKET expr RBRACKET } ;
+primary  = KEYWORD COLON NAME
+         | NAME
+         | NUMBER
+         | STRING
+         | LPAREN expr RPAREN ;

--- a/code/grammars/moslayout.tokens
+++ b/code/grammars/moslayout.tokens
@@ -76,3 +76,34 @@ LBRACKET = "["
 RBRACKET = "]"
 COLON    = ":"
 COMMA    = ","
+
+# ============================================================================
+# Expression operators (UI29 §3.3 — U29-G3)
+# ============================================================================
+# These tokens carry the expression non-terminal used by For `each:`, If
+# `when:`, and any future expression-valued prop. The grammar deliberately
+# stops at comparison + logical + member/index access — no arithmetic, no
+# string concatenation, no ternary, no function calls.
+#
+# Two-character operators (EQ, NEQ, LE, GE, AND, OR) must be listed BEFORE
+# any single-character prefix they share so the maximal-munch lexer prefers
+# the longer match. Specifically:
+#
+#   • EQ  (==) before any future `=` token
+#   • NEQ (!=) before NOT (!)
+#   • LE  (<=) before LT  (<)
+#   • GE  (>=) before GT  (>)
+#
+# AND (&&) and OR (||) have no single-character variants in the language so
+# their relative order doesn't matter.
+
+EQ       = "=="
+NEQ      = "!="
+LE       = "<="
+GE       = ">="
+LT       = "<"
+GT       = ">"
+AND      = "&&"
+OR       = "||"
+NOT      = "!"
+DOT      = "."

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -425,6 +425,10 @@ fn build_text_attribute(node: &LayoutNode) -> Option<String> {
         LayoutPropValue::Keyword(k) => format!("text: \"{k}\""),
         LayoutPropValue::Number(n) => format!("text: \"{n}\""),
         LayoutPropValue::EmitRef(_) => "text: \"\"".to_string(),
+        // U29-G3 expression. Surface as an empty text — Qt/QML emission for
+        // bound expressions needs UI29 §3.4 scope analysis to know how to
+        // map names to QML property bindings.
+        LayoutPropValue::Expr(_) => "text: \"\"".to_string(),
     })
 }
 
@@ -445,6 +449,9 @@ fn build_image_source_attribute(node: &LayoutNode) -> Option<String> {
         LayoutPropValue::Keyword(k) => format!("source: \"{k}\""),
         LayoutPropValue::Number(n) => format!("source: \"{n}\""),
         LayoutPropValue::EmitRef(_) => "source: \"\"".to_string(),
+        // U29-G3 expression. Surface as an empty source — Qt/QML emission
+        // for bound expressions needs UI29 §3.4 scope analysis.
+        LayoutPropValue::Expr(_) => "source: \"\"".to_string(),
     })
 }
 

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -1464,6 +1464,14 @@ where
         }),
         LayoutPropValue::String(s) => Some(format!("\"{}\"", escape_for_jsx_double_quoted(s))),
         LayoutPropValue::EmitRef(_) => None,
+        // U29-G3: expression-valued props (`each: cols.visible`, `when: r == editRow`).
+        // The React emitter doesn't yet know how to lower these into a JSX
+        // expression — that requires the bound-name scope analysis from
+        // UI29 §3.4. For now we surface the raw source text so the test
+        // suite (and downstream code that already special-cases For/If
+        // outside this function) can see the value, and so the match stays
+        // exhaustive without silently dropping the expression.
+        LayoutPropValue::Expr(text) => Some(format!("/* expr: {text} */")),
     }
 }
 

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -405,6 +405,12 @@ fn swift_text_expression(node: &LayoutNode) -> String {
                     // Emit refs are not valid for Text content; fall through
                     // to the empty placeholder.
                 }
+                LayoutPropValue::Expr(_) => {
+                    // U29-G3 expression-valued content. SwiftUI emission for
+                    // bound expressions requires UI29 §3.4 scope analysis;
+                    // for now fall through to the empty placeholder rather
+                    // than emit a Swift compile error.
+                }
             }
         }
     }

--- a/code/packages/rust/moslayout-compiler/CHANGELOG.md
+++ b/code/packages/rust/moslayout-compiler/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Added — U29-G3: `expr` non-terminal in prop values
+
+- Ten new tokens in `moslayout.tokens` for the expression grammar:
+  `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`, `.`.
+  Maximal-munch ordering lists each two-character operator before any
+  single-character prefix it shares (e.g. `<=` before `<`).
+- Seven new productions in `moslayout.grammar`:
+  `expr`, `or_expr`, `and_expr`, `eq_expr`, `rel_expr`, `unary`,
+  `postfix`, `primary`. Operator precedence (low→high):
+  `||`, `&&`, `== !=`, `< <= > >=`, prefix `!`, postfix `.`/`[]`.
+- `prop_value` is now an alias for `expr`. `primary` still includes the
+  four legacy forms (slot ref, NAME, NUMBER, STRING) so the chain-rule
+  descent collapses cleanly for the no-operator case.
+- New `LayoutPropValue::Expr(String)` variant carrying the reconstructed
+  source substring (tokens joined with spaces). Backends parse it
+  themselves until a future PR lowers it to a typed expression AST.
+- `validate_for_node` and `validate_if_node` now accept `SlotRef` OR
+  `Expr` for their `each:` / `when:` props. Error messages updated to
+  document both shapes.
+- Twelve new tests cover comparison, logical-AND, NOT, field access,
+  index access, parenthesised, and nested expressions plus regression
+  guards that `slot: x`, bare NAME, NUMBER, and STRING values still
+  come back in their legacy variants — never as `Expr`.
+- Per UI29 §3.3, arithmetic (`+`/`-`/`*`/`/`), string concatenation,
+  ternary, and function/method calls are deliberately excluded.
+- Grammar version stays at `1`.
+
 ### Added — STRING token + string-literal prop values
 
 - New `STRING` token in `moslayout.tokens`: a double-quoted string

--- a/code/packages/rust/moslayout-compiler/src/_grammar.rs
+++ b/code/packages/rust/moslayout-compiler/src/_grammar.rs
@@ -25,8 +25,7 @@ pub fn token_grammar() -> TokenGrammar {
         definitions: vec![
             TokenDefinition {
                 name: r#"STRING"#.to_string(),
-                pattern: r#""([^"\\
-]|\\.)*""#.to_string(),
+                pattern: r#""([^"\\\n]|\\.)*""#.to_string(),
                 is_regex: true,
                 line_number: 36,
                 alias: None,
@@ -42,63 +41,133 @@ pub fn token_grammar() -> TokenGrammar {
                 name: r#"NAME"#.to_string(),
                 pattern: r#"[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z][a-zA-Z0-9]*)*"#.to_string(),
                 is_regex: true,
-                line_number: 55,
+                line_number: 65,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"LBRACE"#.to_string(),
                 pattern: r#"{"#.to_string(),
                 is_regex: false,
-                line_number: 61,
+                line_number: 71,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"RBRACE"#.to_string(),
                 pattern: r#"}"#.to_string(),
                 is_regex: false,
-                line_number: 62,
+                line_number: 72,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"LPAREN"#.to_string(),
                 pattern: r#"("#.to_string(),
                 is_regex: false,
-                line_number: 63,
+                line_number: 73,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"RPAREN"#.to_string(),
                 pattern: r#")"#.to_string(),
                 is_regex: false,
-                line_number: 64,
+                line_number: 74,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"LBRACKET"#.to_string(),
                 pattern: r#"["#.to_string(),
                 is_regex: false,
-                line_number: 65,
+                line_number: 75,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"RBRACKET"#.to_string(),
                 pattern: r#"]"#.to_string(),
                 is_regex: false,
-                line_number: 66,
+                line_number: 76,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"COLON"#.to_string(),
                 pattern: r#":"#.to_string(),
                 is_regex: false,
-                line_number: 67,
+                line_number: 77,
                 alias: None,
             },
             TokenDefinition {
                 name: r#"COMMA"#.to_string(),
                 pattern: r#","#.to_string(),
                 is_regex: false,
-                line_number: 68,
+                line_number: 78,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"=="#.to_string(),
+                is_regex: false,
+                line_number: 100,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEQ"#.to_string(),
+                pattern: r#"!="#.to_string(),
+                is_regex: false,
+                line_number: 101,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<="#.to_string(),
+                is_regex: false,
+                line_number: 102,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">="#.to_string(),
+                is_regex: false,
+                line_number: 103,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LT"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 104,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GT"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 105,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"AND"#.to_string(),
+                pattern: r#"&&"#.to_string(),
+                is_regex: false,
+                line_number: 106,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"OR"#.to_string(),
+                pattern: r#"||"#.to_string(),
+                is_regex: false,
+                line_number: 107,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NOT"#.to_string(),
+                pattern: r#"!"#.to_string(),
+                is_regex: false,
+                line_number: 108,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DOT"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: false,
+                line_number: 109,
                 alias: None,
             },
         ],
@@ -107,8 +176,7 @@ pub fn token_grammar() -> TokenGrammar {
         skip_definitions: vec![
             TokenDefinition {
                 name: r#"LINE_COMMENT"#.to_string(),
-                pattern: r#"\/\/[^
-]*"#.to_string(),
+                pattern: r#"\/\/[^\n]*"#.to_string(),
                 is_regex: true,
                 line_number: 20,
                 alias: None,
@@ -122,8 +190,7 @@ pub fn token_grammar() -> TokenGrammar {
             },
             TokenDefinition {
                 name: r#"WHITESPACE"#.to_string(),
-                pattern: r#"[ 	
-]+"#.to_string(),
+                pattern: r#"[ \t\r\n]+"#.to_string(),
                 is_regex: true,
                 line_number: 22,
                 alias: None,
@@ -201,7 +268,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"prop"#.to_string() },
                     ] }) },
             ] },
-            line_number: 106,
+            line_number: 110,
         },
         GrammarRule {
             name: r#"prop"#.to_string(),
@@ -217,10 +284,101 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 ] },
             ] },
-            line_number: 120,
+            line_number: 124,
         },
         GrammarRule {
             name: r#"prop_value"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 155,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"or_expr"#.to_string() },
+            line_number: 157,
+        },
+        GrammarRule {
+            name: r#"or_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"and_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"OR"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"and_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 158,
+        },
+        GrammarRule {
+            name: r#"and_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"eq_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"AND"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"eq_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 159,
+        },
+        GrammarRule {
+            name: r#"eq_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"rel_expr"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NEQ"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"rel_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 160,
+        },
+        GrammarRule {
+            name: r#"rel_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 161,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NOT"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+            ] },
+            line_number: 162,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"primary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                        ] },
+                    ] }) },
+            ] },
+            line_number: 163,
+        },
+        GrammarRule {
+            name: r#"primary"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
                 GrammarElement::Sequence { elements: vec![
                     GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
@@ -230,8 +388,13 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
             ] },
-            line_number: 127,
+            line_number: 164,
         },
     ],
         version: 1,

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -41,8 +41,8 @@
 //! | `Image` | no        | `slot: <name>` (must be image-typed)        |
 //! | `Spacer`| no        | optional `grow: <number>`                   |
 //! | `Grid`  | no        | `headers: slot: <name>`, `rows: slot: <name>`, … |
-//! | `For`   | yes       | `each: slot: <name>, as: <NAME>, index: <NAME>?` (UI29 §3.1) |
-//! | `If`    | yes       | `when: slot: <name>` (boolean slot for now; full `expr` lands in U29-G3) |
+//! | `For`   | yes       | `each: <expr>` (slot ref or expression), `as: <NAME>`, `index: <NAME>?` (UI29 §3.1, §3.3) |
+//! | `If`    | yes       | `when: <expr>` (slot ref or expression) (UI29 §3.2, §3.3) |
 //! | `Else`  | yes       | no props; must follow an `If` sibling (UI29 §3.2) |
 //!
 //! # Quick start
@@ -205,6 +205,19 @@ pub enum LayoutPropValue {
     /// strips them and resolves `\n`, `\t`, `\\`, `\"`, etc. so downstream
     /// emitters can treat the value as the literal text the author meant.
     String(String),
+    /// An expression in the moslayout `expr` non-terminal (UI29 §3.3).
+    ///
+    /// Stored as the reconstructed source substring (tokens joined with
+    /// spaces). Backends parse it themselves for now — a future PR can
+    /// lower this to a typed expression AST.
+    ///
+    /// Only constructed when the parsed `expr` contains at least one
+    /// operator (`==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`),
+    /// member access (`.`), index access (`[...]`), or grouping (`(...)`).
+    /// The four legacy primary forms (slot ref, NAME, NUMBER, STRING)
+    /// still come back as `SlotRef`/`EmitRef`/`Keyword`/`Number`/`String`
+    /// so all G1/G2 tests and downstream backends keep working unchanged.
+    Expr(String),
 }
 
 /// A named part exported by this layout (consumed by the mosstyle compiler).
@@ -517,11 +530,22 @@ fn validate_for_node(node: &LayoutNode, errors: &mut Vec<CompileError>) {
         match prop.name.as_str() {
             "each" => {
                 saw_each = true;
-                if !matches!(prop.value, LayoutPropValue::SlotRef(_)) {
+                // Pre-G3 this was SlotRef-only. U29-G3 lifted the restriction
+                // so `each:` can be either a slot reference (`each: slot: rows`)
+                // or any expression that evaluates to a list at runtime
+                // (`each: cols.visible`, `each: row.cells`). Type-of-list
+                // checking still belongs in a later pass with .mil-aware
+                // analysis; here we only enforce that the value is something
+                // list-shaped (SlotRef or Expr — never Number/String/Keyword).
+                if !matches!(
+                    prop.value,
+                    LayoutPropValue::SlotRef(_) | LayoutPropValue::Expr(_)
+                ) {
                     errors.push(CompileError {
                         kind: ErrorKind::InvalidPrimitiveUsage,
                         message:
-                            "`For` prop `each:` must be a slot reference (e.g. `each: slot: rows`)"
+                            "`For` prop `each:` must be a slot reference or expression \
+                             (e.g. `each: slot: rows` or `each: cols.visible`)"
                                 .to_string(),
                     });
                 }
@@ -613,15 +637,24 @@ fn validate_if_node(node: &LayoutNode, errors: &mut Vec<CompileError>) {
         match prop.name.as_str() {
             "when" => {
                 saw_when = true;
-                // Pre-U29-G3 we accept only a SlotRef (a boolean-typed slot).
-                // When `expr` lands, this match arm will accept any expr.
-                if !matches!(prop.value, LayoutPropValue::SlotRef(_)) {
+                // U29-G3 broadened the accepted shape: a boolean slot ref
+                // (`when: slot: editing`) OR any expression (`when: r == editRow`,
+                // `when: editing && !readonly`, `when: !disabled`). Bare NAME
+                // values (parsed as `Keyword(...)`) are still rejected — those
+                // mean a name in the *property-value enum* sense (`row`,
+                // `true`, `false`, `center`), not a bound-name reference.
+                // Once scoping (UI29 §3.4) is implemented we can let those in
+                // too, but for now require either a slot ref or an explicit
+                // expression with at least one operator / `.` / `[]` / `(`.
+                if !matches!(
+                    prop.value,
+                    LayoutPropValue::SlotRef(_) | LayoutPropValue::Expr(_)
+                ) {
                     errors.push(CompileError {
                         kind: ErrorKind::InvalidPrimitiveUsage,
                         message:
-                            "`If` prop `when:` must currently be a slot reference \
-                             (e.g. `when: slot: editing`); richer expressions arrive \
-                             with U29-G3"
+                            "`If` prop `when:` must be a slot reference or expression \
+                             (e.g. `when: slot: editing` or `when: r == editRow`)"
                                 .to_string(),
                     });
                 }
@@ -1055,60 +1088,127 @@ fn extract_prop(prop_ast: &GrammarASTNode) -> Result<LayoutProp, CompileError> {
 
 /// Extract a `prop_value` from its AST node.
 ///
-/// Grammar: `prop_value = KEYWORD COLON NAME | NAME | NUMBER | STRING`
+/// # Grammar context (UI29 §3.3, U29-G3)
 ///
-/// The four alternatives are distinguished by the first child token's type:
-/// - Keyword → slot/emit binding
-/// - Name    → keyword value
-/// - Number  → numeric value
-/// - String  → string literal (surrounding quotes are stripped and
-///             standard `\`-escapes are resolved by `unescape_string_literal`)
+/// `prop_value` is now an expression — `prop_value = expr` — and `expr`
+/// reaches down through `or_expr → and_expr → eq_expr → rel_expr → unary
+/// → postfix → primary`. A `primary` is one of:
+///
+/// * `KEYWORD COLON NAME` — slot/emit binding
+/// * `NAME`               — keyword value (`row`, `true`, `center`)
+/// * `NUMBER`             — numeric literal
+/// * `STRING`             — quoted string literal
+/// * `LPAREN expr RPAREN` — parenthesised sub-expression
+///
+/// # Strategy
+///
+/// We start at `prop_value` and descend through any chain of single-child
+/// rule references. If we land at a `primary` whose only content is one of
+/// the four legacy forms, we emit the same variant as pre-G3 — `SlotRef`,
+/// `EmitRef`, `Keyword`, `Number`, or `String`. That keeps every G1/G2
+/// test and every downstream backend (mosaic-emit-react, mosaic-vm, etc.)
+/// working unchanged.
+///
+/// If anywhere along the descent we hit a node whose body is *more* than
+/// a single rule reference (i.e. it actually used an operator: `||`,
+/// `&&`, `==`, `!=`, comparison, `!`, postfix `.` / `[]`, or parenthesised
+/// grouping), we treat the value as an opaque expression and emit
+/// `Expr(text)`, where `text` is the reconstructed source substring
+/// (tokens joined with spaces).
 fn extract_prop_value(pv_ast: &GrammarASTNode) -> Result<LayoutPropValue, CompileError> {
-    let children = &pv_ast.children;
-
-    match children.as_slice() {
-        // KEYWORD COLON NAME — slot: column-headers OR emit: onNavigate
-        [
-            ASTNodeOrToken::Token(kw),
-            ASTNodeOrToken::Token(_colon),
-            ASTNodeOrToken::Token(name_tok),
-        ] if kw.type_ == TokenType::Keyword => {
-            let ref_name = name_tok.value.clone();
-            if kw.value == "slot" {
-                Ok(LayoutPropValue::SlotRef(ref_name))
-            } else if kw.value == "emit" {
-                Ok(LayoutPropValue::EmitRef(ref_name))
-            } else {
-                Err(CompileError {
-                    kind: ErrorKind::InternalError,
-                    message: format!(
-                        "Unknown binding keyword '{}' in prop_value (expected 'slot' or 'emit')",
-                        kw.value
-                    ),
-                })
+    // ── Descend the chain rules (prop_value → expr → or_expr → and_expr →
+    //    eq_expr → rel_expr → unary → postfix) while each level has exactly
+    //    one structural child (a single nested rule node). Stop when we
+    //    either reach `primary` or hit a node that carries an actual operator.
+    let mut cur = pv_ast;
+    loop {
+        // A node is "transparent" when its only child is one nested rule node.
+        // That happens for `prop_value`, `expr`, and for any of the precedence
+        // wrappers whose RHS produced no operator at this level.
+        if cur.children.len() == 1 {
+            if let ASTNodeOrToken::Node(inner) = &cur.children[0] {
+                cur = inner;
+                continue;
             }
         }
-        // NAME — keyword value: row, column, true, false, center, …
-        [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::Name => {
-            Ok(LayoutPropValue::Keyword(t.value.clone()))
+        break;
+    }
+
+    // ── If we're at `primary`, try the four legacy shapes first. The
+    //    primary rule's children are direct token references (no nesting),
+    //    except for the parenthesised form which contains an `expr` child.
+    if cur.rule_name == "primary" {
+        match cur.children.as_slice() {
+            // KEYWORD COLON NAME — slot: column-headers OR emit: onNavigate
+            [
+                ASTNodeOrToken::Token(kw),
+                ASTNodeOrToken::Token(_colon),
+                ASTNodeOrToken::Token(name_tok),
+            ] if kw.type_ == TokenType::Keyword => {
+                let ref_name = name_tok.value.clone();
+                if kw.value == "slot" {
+                    return Ok(LayoutPropValue::SlotRef(ref_name));
+                } else if kw.value == "emit" {
+                    return Ok(LayoutPropValue::EmitRef(ref_name));
+                } else {
+                    return Err(CompileError {
+                        kind: ErrorKind::InternalError,
+                        message: format!(
+                            "Unknown binding keyword '{}' in primary (expected 'slot' or 'emit')",
+                            kw.value
+                        ),
+                    });
+                }
+            }
+            // NAME — keyword value: row, column, true, false, center, …
+            [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::Name => {
+                return Ok(LayoutPropValue::Keyword(t.value.clone()));
+            }
+            // NUMBER — numeric value: 1.5, 0, 2
+            [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::Number => {
+                let n = t.value.parse::<f64>().map_err(|_| CompileError {
+                    kind: ErrorKind::InternalError,
+                    message: format!("Invalid number literal '{}'", t.value),
+                })?;
+                return Ok(LayoutPropValue::Number(n));
+            }
+            // STRING — quoted literal: "Enter formula", "system-ui", …
+            [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::String => {
+                return Ok(LayoutPropValue::String(unescape_string_literal(&t.value)?));
+            }
+            // LPAREN expr RPAREN — parenthesised expression. Fall through to
+            // the expression-reconstruction path below; even `(x)` carries
+            // meaningful grouping semantics worth preserving as `Expr`.
+            _ => {}
         }
-        // NUMBER — numeric value: 1.5, 0, 2
-        [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::Number => {
-            let n = t.value.parse::<f64>().map_err(|_| CompileError {
-                kind: ErrorKind::InternalError,
-                message: format!("Invalid number literal '{}'", t.value),
-            })?;
-            Ok(LayoutPropValue::Number(n))
+    }
+
+    // ── Otherwise reconstruct the source substring from the tokens under
+    //    this subtree. The grammar guarantees this only happens when the
+    //    author actually wrote an operator, member access, index access,
+    //    or grouping — i.e. when they meant an expression.
+    let text = reconstruct_expr_text(pv_ast);
+    Ok(LayoutPropValue::Expr(text))
+}
+
+/// Flatten an AST subtree to its underlying source-token string.
+///
+/// Tokens are joined with single spaces. This is lossy with respect to the
+/// original formatting but preserves every token, which is what the backend
+/// needs to re-parse the expression. A future PR can replace this with a
+/// proper typed expression AST.
+fn reconstruct_expr_text(node: &GrammarASTNode) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    collect_tokens(node, &mut parts);
+    parts.join(" ")
+}
+
+fn collect_tokens(node: &GrammarASTNode, out: &mut Vec<String>) {
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(t) => out.push(t.value.clone()),
+            ASTNodeOrToken::Node(n) => collect_tokens(n, out),
         }
-        // STRING — quoted literal: "Enter formula", "system-ui", …
-        // The lexer emits the value with surrounding `"`s; strip and unescape.
-        [ASTNodeOrToken::Token(t)] if t.type_ == TokenType::String => {
-            Ok(LayoutPropValue::String(unescape_string_literal(&t.value)?))
-        }
-        other => Err(CompileError {
-            kind: ErrorKind::InternalError,
-            message: format!("Unexpected prop_value shape: {:?}", other.len()),
-        }),
     }
 }
 
@@ -1812,9 +1912,13 @@ mod tests {
     }
 
     #[test]
-    fn if_when_must_be_slot_ref_pre_g3() {
-        // Until U29-G3 lands, `when:` must be a slot ref. A NAME-keyword
-        // (`when: true`) would be a richer expression we don't yet accept.
+    fn if_when_bare_name_rejected() {
+        // `when: true` parses as a bare NAME → `Keyword("true")`. After G3,
+        // `when:` accepts SlotRef or Expr only — bare NAMEs without any
+        // operator/access are still rejected. (Once UI29 §3.4 scoping is in
+        // and bound-name resolution exists, this can be revisited.) This
+        // test guards that "must be a slot reference or expression" still
+        // fires for the no-operator NAME case.
         let src = r#"
           layout L {
             Column [ root ] {
@@ -1824,11 +1928,11 @@ mod tests {
             }
           }
         "#;
-        let errors = compile(src, None).expect_err("non-slot when: rejected pre-G3");
+        let errors = compile(src, None).expect_err("bare-name when: rejected");
         assert_error(
             &errors,
             ErrorKind::InvalidPrimitiveUsage,
-            "must currently be a slot reference",
+            "must be a slot reference or expression",
         );
     }
 
@@ -1959,6 +2063,310 @@ mod tests {
     fn if_and_else_are_in_primitives() {
         assert!(PRIMITIVES.contains(&"If"));
         assert!(PRIMITIVES.contains(&"Else"));
+    }
+
+    // =====================================================================
+    // U29-G3 — `expr` non-terminal parse/compile tests
+    // =====================================================================
+    //
+    // These pin down the new expression grammar (UI29 §3.3). The tests live
+    // at the `compile()` level so the whole pipeline (lex → parse → analyze)
+    // is exercised end-to-end. The shape we're checking is always the
+    // resulting `LayoutPropValue`: for the four legacy primary forms it must
+    // *still* be `SlotRef`/`Keyword`/`Number`/`String`; for anything that
+    // uses an operator, member access, index access, or grouping it must
+    // come back as `Expr(text)` with all the source tokens preserved.
+    //
+    // Operators excluded by UI29 §3.3 (arithmetic, ternary, function calls,
+    // string concatenation) are NOT tested for parse-error here — they
+    // simply never made it into the tokens file, so the lexer fails earlier
+    // and that failure mode is not the contract this PR is pinning.
+
+    /// Helper: pull the first prop value off the first child of the root.
+    fn first_prop_value(src: &str) -> LayoutPropValue {
+        let result = compile(src, None).expect("compile should succeed");
+        let child = &result.def.root.children[0];
+        child.props[0].value.clone()
+    }
+
+    /// G3-1: A comparison expression (`r == editRow`) round-trips through
+    /// the parser into a `LayoutPropValue::Expr` carrying every source token.
+    #[test]
+    fn g3_comparison_expr_parses_as_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: r == editRow ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("r"), "Expr text should include LHS: {text:?}");
+                assert!(text.contains("=="), "Expr text should include ==: {text:?}");
+                assert!(
+                    text.contains("editRow"),
+                    "Expr text should include RHS: {text:?}"
+                );
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-2: A logical-AND expression (`editing && readonly`) lands as an Expr.
+    #[test]
+    fn g3_logical_and_expr_parses_as_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: editing && readonly ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("&&"), "Expr should include &&: {text:?}");
+                assert!(text.contains("editing") && text.contains("readonly"));
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-3: Field access (`col.editable`) lands as an Expr — the postfix
+    /// `DOT NAME` form makes this non-trivial even with no top-level operator.
+    #[test]
+    fn g3_field_access_parses_as_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: col.editable ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("col"), "Expr should mention base: {text:?}");
+                assert!(text.contains("."), "Expr should include DOT: {text:?}");
+                assert!(
+                    text.contains("editable"),
+                    "Expr should include field name: {text:?}"
+                );
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-4: Index access (`row[c]`) lands as an Expr.
+    #[test]
+    fn g3_index_access_parses_as_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: row[c] ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("row"), "Expr should include base: {text:?}");
+                assert!(text.contains("["), "Expr should include LBRACKET: {text:?}");
+                assert!(text.contains("c"), "Expr should include index: {text:?}");
+                assert!(text.contains("]"), "Expr should include RBRACKET: {text:?}");
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-5: A nested expression mixing comparison + logical-AND parses cleanly.
+    /// This is the canonical visicalc "this cell is the editing cell" predicate.
+    #[test]
+    fn g3_nested_expr_parses() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: r == editRow && c == editCol ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("=="), "should contain ==: {text:?}");
+                assert!(text.contains("&&"), "should contain &&: {text:?}");
+                assert!(text.contains("editRow"));
+                assert!(text.contains("editCol"));
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-6: A parenthesised expression (`(a && b)`) parses as an Expr. The
+    /// LPAREN ... RPAREN form is the `primary` alternative that always
+    /// produces an Expr regardless of inner shape — even `(x)` is grouping
+    /// and worth preserving as such.
+    #[test]
+    fn g3_parenthesised_expr_parses_as_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: (a && b) ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("("), "should include LPAREN: {text:?}");
+                assert!(text.contains("&&"));
+                assert!(text.contains(")"), "should include RPAREN: {text:?}");
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-7: Prefix NOT (`!editing`) parses as an Expr.
+    #[test]
+    fn g3_not_operator_parses_as_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: !editing ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("!"), "Expr should include NOT: {text:?}");
+                assert!(text.contains("editing"));
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// G3-8: `For` accepts an expression for `each:` — the canonical
+    /// "iterate only the visible columns" use case from UI29 §3.1 examples.
+    #[test]
+    fn g3_for_each_accepts_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              For ( each: cols.visible, as: col ) {
+                Text ( slot: col )
+              }
+            }
+          }
+        "#;
+        let result = compile(src, None).expect("For with expr `each:` should compile");
+        let for_node = &result.def.root.children[0];
+        assert_eq!(for_node.tag, "For");
+        assert_eq!(for_node.props[0].name, "each");
+        assert!(
+            matches!(for_node.props[0].value, LayoutPropValue::Expr(_)),
+            "each: expression should land as Expr, got {:?}",
+            for_node.props[0].value
+        );
+    }
+
+    /// G3-9: `If` accepts an expression for `when:` — the comparison
+    /// `r == editRow` is what U29-G3 was created to enable.
+    #[test]
+    fn g3_if_when_accepts_expr() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: r == editRow ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        let result = compile(src, None).expect("If with expr `when:` should compile");
+        let if_node = &result.def.root.children[0];
+        assert_eq!(if_node.tag, "If");
+        assert_eq!(if_node.props[0].name, "when");
+        assert!(
+            matches!(if_node.props[0].value, LayoutPropValue::Expr(_)),
+            "when: expression should land as Expr, got {:?}",
+            if_node.props[0].value
+        );
+    }
+
+    /// G3-10: Regression guard for G2 — `when: slot: editing` STILL parses
+    /// as a `SlotRef`, not as an `Expr`. The grammar change must not break
+    /// the legacy primary form.
+    #[test]
+    fn g3_if_when_slot_ref_still_slot_ref() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: slot: editing ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        let result = compile(src, None).expect("legacy SlotRef `when:` still compiles");
+        let if_node = &result.def.root.children[0];
+        assert_eq!(
+            if_node.props[0].value,
+            LayoutPropValue::SlotRef("editing".to_string()),
+            "when: slot: editing must still come back as SlotRef, not Expr"
+        );
+    }
+
+    /// G3-11: Regression guard for G1 — `each: slot: rows` STILL parses
+    /// as a `SlotRef`, not as an `Expr`.
+    #[test]
+    fn g3_for_each_slot_ref_still_slot_ref() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              For ( each: slot: rows, as: row ) {
+                Text ( slot: row )
+              }
+            }
+          }
+        "#;
+        let result = compile(src, None).expect("legacy SlotRef `each:` still compiles");
+        let for_node = &result.def.root.children[0];
+        assert_eq!(
+            for_node.props[0].value,
+            LayoutPropValue::SlotRef("rows".to_string()),
+            "each: slot: rows must still come back as SlotRef, not Expr"
+        );
+    }
+
+    /// G3-12: Regression guard — bare NAME prop values (`direction: row`)
+    /// must STILL parse as `Keyword("row")` and NOT as `Expr("row")`. The
+    /// chain-rule descent must collapse cleanly through the precedence
+    /// levels to `primary → NAME` for the no-operator case.
+    #[test]
+    fn g3_bare_name_prop_still_keyword() {
+        let src = r#"
+          layout L {
+            Box [ root ] ( direction: row ) { }
+          }
+        "#;
+        let result = compile(src, None).expect("direction: row still compiles");
+        let root = &result.def.root;
+        assert_eq!(root.props[0].name, "direction");
+        assert_eq!(
+            root.props[0].value,
+            LayoutPropValue::Keyword("row".to_string()),
+            "bare NAME values must stay as Keyword, not become Expr"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

UI29 §3.3 — add a small expression grammar so `For each:` and `If when:`
can carry comparisons, logical ops, field access, and index access.

* New tokens: `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`, `.`
  (10 total). Two-character ops listed before any single-character prefix
  for maximal-munch lexing.
* New productions: `expr`, `or_expr`, `and_expr`, `eq_expr`, `rel_expr`,
  `unary`, `postfix`, `primary` (LL(1)). Precedence low→high:
  `||`, `&&`, `== !=`, `< <= > >=`, prefix `!`, postfix `.`/`[]`.
* `prop_value = expr`. The four legacy primary forms (slot ref, NAME,
  NUMBER, STRING) still come back as `SlotRef`/`Keyword`/`Number`/`String`
  — only operator/access/grouping shapes produce the new `Expr(String)`
  variant.
* `LayoutPropValue::Expr(String)` stores the reconstructed source
  substring (tokens joined with spaces); backends parse it themselves
  until a future PR introduces a typed expression AST.
* `validate_for_node` and `validate_if_node` now accept `SlotRef` OR
  `Expr` for `each:` / `when:`. Bare NAMEs are still rejected — those
  need UI29 §3.4 scope analysis to resolve.
* Grammar version unchanged (`version = 1`).
* Arithmetic, string concat, ternary, function calls deliberately
  excluded per UI29 §3.3.

## Stack

Base branch: `feat/u29-g2-if-grammar` (#3623). Merges into that PR's
target after it merges into main.

## Test plan

- [x] `cargo test -p moslayout-compiler` — 54 pass (42 existing + 12 new)
- [x] `cargo check -p moslayout-compiler` — clean
- [x] Dependent crates compile: mosaic-emit-react, mosaic-emit-swiftui,
      mosaic-emit-qt, mosaic-compile, mosaic-driver
- [x] Dependent crate tests: mosaic-emit-react (107), mosaic-emit-swiftui
      (13), mosaic-emit-qt (17) all green
- [ ] CI green on this PR
- [ ] Manual review of regenerated `_grammar.rs` for stitch shape parity
      with previous version

## Notes

* Clippy errors visible in CI for this crate are pre-existing on the
  G2 base branch (PRIMITIVES dead-code, doc indentation, `children.get(0)`
  → `children.first()`) — confirmed by re-running clippy on the base
  branch before applying these changes. They are not introduced by G3.
* `code/specs/UI29-primitive-kernel.md` is not yet in the repo; §3.3 /
  §3.4 references in commits and tests come from the task description.
  A spec PR should land before or alongside the next U29 work item.
* `mosaic-emit-react/qt/swiftui` get exhaustive-match arms for the new
  variant only — no real lowering yet. Bound-name resolution requires
  UI29 §3.4 scoping, which is informational in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)