### PR TITLE
feat(sql-vm): add concat / concat_ws / octet_length scalar functions (SQLite 3.44+)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.57.0] - 2026-05-19
+
+### Added
+
+Three SQLite 3.44+ string-family scalar functions now available (via
+``sql-vm 1.35.0``):
+
+- **``concat(...)``** — variadic concat; NULL args treated as empty.
+- **``concat_ws(sep, ...)``** — concat with separator; NULL sep
+  returns NULL but NULL values are skipped.
+- **``octet_length(x)``** — byte length of UTF-8-encoded text or BLOB.
+
+Application SQL relying on these (especially common in modern SQLite
+code) previously raised ``InternalError: unknown scalar function``.
+
+22 new oracle tests in ``test_tier3_concat_octet_length.py``:
+two-/three-arg concat, NULL-as-empty semantics, numeric coercion,
+single-arg form, in-WHERE-clause usage, concat_ws NULL-skipping vs
+NULL-separator-propagation, multi-char separators, empty separator,
+all-NULL inputs, ASCII vs non-ASCII byte counts, length vs
+octet_length distinction for unicode, integer/negative coercion.
+
 ## [1.56.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.56.0"
+version = "1.57.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_concat_octet_length.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_concat_octet_length.py
@@ -1,0 +1,144 @@
+"""Oracle tests for ``concat``, ``concat_ws``, and ``octet_length``.
+
+Three SQLite 3.44+ string-family scalar functions that mini-sqlite was
+missing.  Application SQL that depends on them previously raised::
+
+    InternalError: unknown scalar function: 'concat'
+
+All assertions compare against real ``sqlite3`` byte-for-byte.
+
+NULL semantics differences pinned by tests:
+- ``concat(NULL, x, NULL)`` → ``concat(x)`` (NULLs treated as '')
+- ``concat_ws(NULL, ...)`` → NULL (NULL separator propagates)
+- ``concat_ws(sep, x, NULL, y)`` → ``x`` ``sep`` ``y`` (NULL value skipped)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(sql: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(sql).fetchone()
+    r = sqlite3.connect(":memory:").execute(sql).fetchone()
+    assert m == r, f"SQL: {sql!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# concat(...)
+# ---------------------------------------------------------------------------
+
+
+class TestConcat:
+    def test_two_strings(self) -> None:
+        _check("SELECT concat('a', 'b')")
+
+    def test_three_strings(self) -> None:
+        _check("SELECT concat('a', 'b', 'c')")
+
+    def test_null_arg_treated_as_empty(self) -> None:
+        _check("SELECT concat('a', NULL, 'c')")
+
+    def test_all_nulls(self) -> None:
+        _check("SELECT concat(NULL, NULL)")
+
+    def test_numeric_coerced(self) -> None:
+        _check("SELECT concat('id=', 42)")
+
+    def test_float_coerced(self) -> None:
+        _check("SELECT concat('value=', 3.14)")
+
+    def test_single_arg_string(self) -> None:
+        _check("SELECT concat('hello')")
+
+    def test_in_where_clause(self) -> None:
+        # Common usage: build composite key in WHERE / GROUP BY.
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in [
+            "CREATE TABLE t (a TEXT, b TEXT)",
+            "INSERT INTO t VALUES ('hello', 'world'), ('foo', 'bar')",
+        ]:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        sql = "SELECT * FROM t WHERE concat(a, ' ', b) = 'hello world'"
+        assert conn_m.execute(sql).fetchall() == conn_r.execute(sql).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# concat_ws(sep, ...)
+# ---------------------------------------------------------------------------
+
+
+class TestConcatWs:
+    def test_basic_separator(self) -> None:
+        _check("SELECT concat_ws('-', 'a', 'b', 'c')")
+
+    def test_null_arg_skipped(self) -> None:
+        # NULL skipped — separator NOT doubled around it.
+        _check("SELECT concat_ws('-', 'a', NULL, 'c')")
+
+    def test_null_separator_returns_null(self) -> None:
+        _check("SELECT concat_ws(NULL, 'a', 'b')")
+
+    def test_multi_char_separator(self) -> None:
+        _check("SELECT concat_ws(' | ', 'a', 'b', 'c')")
+
+    def test_empty_separator(self) -> None:
+        _check("SELECT concat_ws('', 'a', 'b', 'c')")
+
+    def test_numeric_args(self) -> None:
+        _check("SELECT concat_ws(',', 1, 2, 3)")
+
+    def test_all_nulls_returns_empty(self) -> None:
+        # When all values (after sep) are NULL, the join joins zero pieces.
+        _check("SELECT concat_ws('-', NULL, NULL)")
+
+
+# ---------------------------------------------------------------------------
+# octet_length(x)
+# ---------------------------------------------------------------------------
+
+
+class TestOctetLength:
+    def test_ascii(self) -> None:
+        _check("SELECT octet_length('hello')")
+
+    def test_empty(self) -> None:
+        _check("SELECT octet_length('')")
+
+    def test_non_ascii(self) -> None:
+        # 'café' — 4 chars but 5 bytes (é = 2 bytes in UTF-8).
+        _check("SELECT octet_length('café')")
+
+    def test_null(self) -> None:
+        _check("SELECT octet_length(NULL)")
+
+    def test_integer(self) -> None:
+        # 3 chars = '1','2','3'
+        _check("SELECT octet_length(123)")
+
+    def test_negative_integer(self) -> None:
+        # 3 chars = '-','4','2'
+        _check("SELECT octet_length(-42)")
+
+    def test_distinct_from_length_for_unicode(self) -> None:
+        # length and octet_length disagree on non-ASCII text.
+        # mini-sqlite vs sqlite3 should both report the same disagreement.
+        m_l = mini_sqlite.connect(":memory:").execute(
+            "SELECT length('café')"
+        ).fetchone()[0]
+        m_o = mini_sqlite.connect(":memory:").execute(
+            "SELECT octet_length('café')"
+        ).fetchone()[0]
+        r_l = sqlite3.connect(":memory:").execute(
+            "SELECT length('café')"
+        ).fetchone()[0]
+        r_o = sqlite3.connect(":memory:").execute(
+            "SELECT octet_length('café')"
+        ).fetchone()[0]
+        assert m_l == r_l == 4
+        assert m_o == r_o == 5
+        assert m_l < m_o  # length < octet_length when non-ASCII present

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.35.0 — 2026-05-19
+
+### Added
+
+Three SQLite 3.44+ string-family scalar functions
+(``scalar_functions.py``):
+
+- **``concat(...)``** — variadic, NULL args treated as empty string
+  (NOT NULL-propagating).  Non-string args coerced via ``str()``.
+  Requires ≥ 1 argument.  Example::
+
+      CONCAT('a', NULL, 'b', 42)  → 'ab42'
+
+- **``concat_ws(sep, ...)``** — concatenate with a separator.  Distinct
+  NULL semantics from ``concat``:
+
+  - NULL **separator** → NULL result (propagates).
+  - NULL **value** → skipped (separator NOT doubled).
+
+  Example::
+
+      CONCAT_WS('-', 'a', NULL, 'b')   → 'a-b'
+      CONCAT_WS(NULL, 'a', 'b')        → NULL
+
+- **``octet_length(x)``** — byte length of a UTF-8-encoded string or
+  BLOB.  Differs from ``length()`` for non-ASCII text::
+
+      LENGTH('café')        → 4   (4 characters)
+      OCTET_LENGTH('café')  → 5   ('é' = 2 bytes)
+      LENGTH('🦀')          → 1   (1 character)
+      OCTET_LENGTH('🦀')    → 4   (4-byte emoji)
+
+  Numeric inputs coerced via decimal string representation
+  (``OCTET_LENGTH(123) → 3``).
+
 ## 1.34.0 — 2026-05-19
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.34.0"
+version = "1.35.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -777,6 +777,101 @@ def _length(x: SqlValue) -> SqlValue:
     return len(str(x))
 
 
+@register("octet_length")
+def _octet_length(x: SqlValue) -> SqlValue:
+    """Return the number of **bytes** in a string (UTF-8) or BLOB.
+
+    Differs from ``length()`` for non-ASCII text:
+
+        LENGTH('café')        → 4       (4 characters)
+        OCTET_LENGTH('café')  → 5       ('é' is 2 bytes in UTF-8)
+
+    For ASCII strings, ``length()`` and ``octet_length()`` agree.
+
+    Numeric inputs are coerced via decimal string representation, so
+    ``OCTET_LENGTH(123)`` is ``3`` (the byte-length of ``"123"``).
+
+    NULL input propagates as NULL.
+    """
+    if x is None:
+        return None
+    if isinstance(x, str):
+        return len(x.encode("utf-8"))
+    if isinstance(x, (bytes, bytearray)):
+        return len(x)
+    # Numeric — convert to string first (matches LENGTH semantics).
+    return len(str(x).encode("utf-8"))
+
+
+@register("concat")
+def _concat(*args: SqlValue) -> SqlValue:
+    """Concatenate one or more arguments into a single TEXT string.
+
+    SQLite 3.44+ built-in.  NULL arguments are treated as empty strings
+    (do NOT propagate to a NULL result — that's ``concat_ws``'s job for
+    the separator).  At least one argument is required; calling with
+    zero arguments matches SQLite's error.
+
+    Non-string arguments are coerced via ``str()`` (their SQL text
+    representation), so ``CONCAT(1, '+', 2) → '1+2'``.
+
+    Examples::
+
+        CONCAT('a', 'b', 'c')   → 'abc'
+        CONCAT('a', NULL, 'c')  → 'ac'
+        CONCAT('id=', 42)       → 'id=42'
+    """
+    # Variadic with minimum 1.  ``_arity`` only supports a fixed set of
+    # accepted counts; for "≥ 1" we do the check inline.
+    if len(args) < 1:
+        raise WrongNumberOfArguments(name="concat", expected="≥ 1", got=len(args))
+    parts: list[str] = []
+    for a in args:
+        if a is None:
+            continue
+        # Preserve already-string inputs; coerce others via str().
+        parts.append(a if isinstance(a, str) else str(a))
+    return "".join(parts)
+
+
+@register("concat_ws")
+def _concat_ws(*args: SqlValue) -> SqlValue:
+    """Concatenate arguments with a separator (``concat_ws`` = "with separator").
+
+    SQLite 3.44+ built-in.  The first argument is the separator; the
+    remaining arguments are values to concatenate.
+
+    Distinct NULL semantics:
+
+    - **Separator is NULL** → result is NULL.
+    - **A value is NULL**   → skip it (does NOT terminate the result).
+
+    Examples::
+
+        CONCAT_WS('-', 'a', 'b', 'c')   → 'a-b-c'
+        CONCAT_WS('-', 'a', NULL, 'c')  → 'a-c'      (NULL skipped)
+        CONCAT_WS(NULL, 'a', 'b')       → NULL        (NULL sep)
+        CONCAT_WS(',', 1, 2, 3)         → '1,2,3'
+
+    A minimum of two arguments (separator + one value) is required to
+    match SQLite's documented signature, though SQLite is permissive and
+    accepts just the separator (returning the empty string); we mirror
+    that.
+    """
+    if len(args) < 1:
+        raise WrongNumberOfArguments(name="concat_ws", expected="≥ 1", got=len(args))
+    sep = args[0]
+    if sep is None:
+        return None
+    sep_str = sep if isinstance(sep, str) else str(sep)
+    parts: list[str] = []
+    for a in args[1:]:
+        if a is None:
+            continue
+        parts.append(a if isinstance(a, str) else str(a))
+    return sep_str.join(parts)
+
+
 @register("trim")
 def _trim(*args: SqlValue) -> SqlValue:
     """Strip leading and trailing characters from *x*.

--- a/code/packages/python/sql-vm/tests/test_scalar_functions.py
+++ b/code/packages/python/sql-vm/tests/test_scalar_functions.py
@@ -1727,3 +1727,107 @@ class TestStrftimeLowerCaseAmPm:
         assert (
             fn("strftime", "%I:%M %P", "2024-03-15 14:30:00") == "02:30 pm"
         )
+
+
+# ---------------------------------------------------------------------------
+# concat / concat_ws / octet_length (SQLite 3.44+ string family additions)
+# ---------------------------------------------------------------------------
+
+
+class TestConcat:
+    """``CONCAT(...)`` — variadic, NULLs treated as empty string."""
+
+    def test_two_strings(self) -> None:
+        assert fn("concat", "a", "b") == "ab"
+
+    def test_three_strings(self) -> None:
+        assert fn("concat", "a", "b", "c") == "abc"
+
+    def test_null_skipped(self) -> None:
+        # NULLs are treated as empty strings — NOT as NULL-propagation.
+        assert fn("concat", "a", None, "c") == "ac"
+
+    def test_all_nulls_returns_empty(self) -> None:
+        assert fn("concat", None, None, None) == ""
+
+    def test_numeric_coerced(self) -> None:
+        # SQLite coerces non-strings via their text representation.
+        assert fn("concat", "id=", 42) == "id=42"
+
+    def test_float_coerced(self) -> None:
+        assert fn("concat", "v=", 3.14) == "v=3.14"
+
+    def test_single_arg(self) -> None:
+        # Minimum 1 arg — single-arg form is just identity-via-str.
+        assert fn("concat", "hello") == "hello"
+
+    def test_zero_args_raises(self) -> None:
+        from sql_vm.errors import WrongNumberOfArguments
+
+        try:
+            fn("concat")
+            raise AssertionError("expected WrongNumberOfArguments")
+        except WrongNumberOfArguments:
+            pass
+
+
+class TestConcatWs:
+    """``CONCAT_WS(sep, ...)`` — separator-aware concatenation."""
+
+    def test_basic(self) -> None:
+        assert fn("concat_ws", "-", "a", "b", "c") == "a-b-c"
+
+    def test_null_arg_skipped(self) -> None:
+        # Distinct from concat: NULL values are SKIPPED, separator not doubled.
+        assert fn("concat_ws", "-", "a", None, "c") == "a-c"
+
+    def test_null_separator_returns_null(self) -> None:
+        # Unlike CONCAT, a NULL separator propagates — the whole result is NULL.
+        assert fn("concat_ws", None, "a", "b") is None
+
+    def test_multi_char_separator(self) -> None:
+        assert fn("concat_ws", " | ", "a", "b", "c") == "a | b | c"
+
+    def test_empty_separator(self) -> None:
+        # Empty-string sep behaves like concat.
+        assert fn("concat_ws", "", "a", "b", "c") == "abc"
+
+    def test_numeric_args_coerced(self) -> None:
+        assert fn("concat_ws", ",", 1, 2, 3) == "1,2,3"
+
+    def test_only_separator(self) -> None:
+        # SQLite accepts just the sep and returns an empty string.
+        assert fn("concat_ws", "-") == ""
+
+
+class TestOctetLength:
+    """``OCTET_LENGTH(s)`` — byte length of UTF-8-encoded text."""
+
+    def test_ascii(self) -> None:
+        # ASCII: bytes = chars.
+        assert fn("octet_length", "hello") == 5
+
+    def test_empty_string(self) -> None:
+        assert fn("octet_length", "") == 0
+
+    def test_non_ascii_utf8(self) -> None:
+        # 'café' is 4 chars but 5 bytes ('é' = 2 bytes in UTF-8).
+        assert fn("octet_length", "café") == 5
+
+    def test_emoji_4_bytes(self) -> None:
+        # '🦀' is 1 char but 4 bytes in UTF-8.
+        assert fn("octet_length", "🦀") == 4
+
+    def test_null_propagates(self) -> None:
+        assert fn("octet_length", None) is None
+
+    def test_blob(self) -> None:
+        assert fn("octet_length", b"\x01\x02\x03\xff") == 4
+
+    def test_integer_uses_decimal_string(self) -> None:
+        # SQLite: OCTET_LENGTH(123) → 3 (the byte length of "123")
+        assert fn("octet_length", 123) == 3
+
+    def test_negative_integer(self) -> None:
+        # OCTET_LENGTH(-42) → 3 (chars '-', '4', '2')
+        assert fn("octet_length", -42) == 3


### PR DESCRIPTION
## Summary

Three string-family scalar functions that mini-sqlite was missing. Application SQL using them previously raised `InternalError: unknown scalar function`.

| Function | Behaviour | NULL semantics |
|----------|-----------|----------------|
| `concat(...)` | Variadic string join | NULL args → empty string (NOT propagating) |
| `concat_ws(sep, ...)` | Join with separator | NULL **sep** → NULL; NULL **value** → skip |
| `octet_length(x)` | Byte length of UTF-8 text/BLOB | NULL → NULL |

## NULL semantics — pinned by tests

```sql
SELECT concat('a', NULL, 'b');              -- 'ab'    (NULL = empty string)
SELECT concat_ws('-', 'a', NULL, 'b');      -- 'a-b'   (NULL value skipped)
SELECT concat_ws(NULL, 'a', 'b');           -- NULL    (NULL sep propagates)
```

## length vs octet_length

```sql
SELECT length('café'),       octet_length('café');        -- 4, 5
SELECT length('🦀'),         octet_length('🦀');          -- 1, 4
SELECT length(123),          octet_length(123);             -- 3, 3
```

## Version bumps

- `sql-vm`: 1.34.0 → 1.35.0
- `mini-sqlite`: 1.56.0 → 1.57.0

## Test plan

- [x] `pytest code/packages/python/sql-vm/tests/` — 737 pass (23 new), coverage 80.42%
- [x] `pytest code/packages/python/mini-sqlite/tests/` — 22 new oracle tests pass (full suite to be run by CI)
- [x] All oracle tests compare against real `sqlite3`
- [x] Manual security review: pure string ops at the existing VM trust boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)