### PR TITLE
feat(mosaic-package-resolver): U29-R2 — component resolver

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -369,6 +369,7 @@ members = [
     "mosaic-emit-webcomponent",
     "mosaic-lexer",
     "mosaic-package-manifest",
+    "mosaic-package-resolver",
     "mosaic-parser",
     "mosaic-vm",
     "moslayout-compiler",

--- a/code/packages/rust/mosaic-package-resolver/BUILD
+++ b/code/packages/rust/mosaic-package-resolver/BUILD
@@ -1,0 +1,1 @@
+cargo test -p mosaic-package-resolver -- --nocapture

--- a/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-resolver/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this crate are documented here.  The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the crate follows
+SemVer.
+
+## [0.1.0] — 2026-05-19
+
+### Added
+- Initial release implementing **UI29-R2** (component-reference resolver).
+- `KERNEL_PRIMITIVES` constant listing the UI29 §2.1 kernel set
+  (`Box`, `Row`, `Column`, `Stack`, `Text`, `Image`, `Spacer`, `Divider`,
+  `Icon`, `If`, `Else`, `For`, `HostInput`, `HostButton`, `HostTable`,
+  `HostScroll`).
+- `Resolver` type with `resolve(tag) -> Option<&Resolution>` and
+  `knows(tag) -> bool`.
+- `Resolution::{Kernel, Component}` enum.
+- `build(package_root, search_paths)` builder.  Reads the user's
+  `mosaic-package.toml` via `mosaic-package-manifest`, walks
+  `[dependencies]`, locates each dep in the search paths (tries
+  `mosaic-pkg-{name}` then literal `{name}`), reads its manifest, and
+  registers each `[components].exports` entry into the resolution table.
+- `ResolveError::{DependencyNotFound, BadDependencyManifest,
+  DuplicateExport, Io}` for build-time failures.
+- 12 unit tests covering empty packages, deps with one or many exports,
+  collisions, missing deps, malformed dep manifests, kernel coverage,
+  and `package_path` absoluteness.

--- a/code/packages/rust/mosaic-package-resolver/Cargo.toml
+++ b/code/packages/rust/mosaic-package-resolver/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mosaic-package-resolver"
+version = "0.1.0"
+edition = "2021"
+description = "Component-reference resolver for Mosaic packages (UI29 §4.4)"
+
+[dependencies]
+mosaic-package-manifest = { path = "../mosaic-package-manifest" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/code/packages/rust/mosaic-package-resolver/README.md
+++ b/code/packages/rust/mosaic-package-resolver/README.md
@@ -1,0 +1,105 @@
+# mosaic-package-resolver
+
+Component-reference resolver for Mosaic packages, implementing **UI29 §4.4**
+(Mosaic Primitive Kernel — "Resolving a component reference").
+
+The Mosaic compiler is told, by some user component's `.mll` file, that
+*"the tag `Grid` appears here."*  The resolver answers exactly one question:
+
+> *What is `Grid`?*
+
+There are exactly three answers:
+
+| Answer                 | Meaning                                                          |
+|------------------------|------------------------------------------------------------------|
+| `Resolution::Kernel`   | a UI29 §2.1 kernel primitive (`Box`, `Row`, `For`, `HostInput`…) |
+| `Resolution::Component`| a component exported by a package this user depends on           |
+| `None`                 | the tag is unknown — neither kernel nor any declared dependency  |
+
+The third case is the compiler's cue to emit a *"no such tag"* error to the
+user.  The first two are the cue to lower the tag (kernel) or recurse into
+the package's compiled artifact (component).
+
+## How it fits in the stack
+
+```
+                ┌──────────────────────────────────┐
+                │  user-component .mll             │
+                │    Grid (rows: slot: data, …)    │
+                └──────────────┬───────────────────┘
+                               │  "what is `Grid`?"
+                               ▼
+                ┌──────────────────────────────────┐
+                │  mosaic-package-resolver         │  ← this crate
+                │  (kernel set ∪ deps' exports)    │
+                └──────────────┬───────────────────┘
+                               │
+                  ┌────────────┴────────────┐
+                  ▼                         ▼
+        Kernel → backend emitter   Component → recurse into pkg-grid
+```
+
+The resolver consumes:
+
+1. The user's package root (a directory containing a `mosaic-package.toml`).
+   If no manifest exists, the resolver still answers kernel questions — it
+   just has no component table to consult.
+2. A **package search path**: a list of directories where Mosaic packages
+   live.  In this repo that's typically `code/packages/`.
+
+It produces a `Resolver` whose `resolve(tag)` is a fast `HashMap` lookup.
+
+## Worked example
+
+```rust
+use std::path::PathBuf;
+use mosaic_package_resolver::{build, Resolution};
+
+let user_root = PathBuf::from("path/to/user/package");          // has its own mosaic-package.toml
+let search    = vec![PathBuf::from("code/packages")];
+
+let resolver = build(&user_root, &search).expect("resolver builds");
+
+// Kernel primitive — always resolves.
+assert!(matches!(resolver.resolve("Box"), Some(Resolution::Kernel)));
+
+// Component declared by a dependency.
+if let Some(Resolution::Component { package, component, .. }) = resolver.resolve("Grid") {
+    println!("`Grid` lives in {package}, exported as {component}");
+}
+
+// Unknown tag.
+assert!(resolver.resolve("Definitely-Not-A-Real-Tag").is_none());
+```
+
+## What the resolver detects as an error at *build* time
+
+| Error                          | When it fires                                        |
+|--------------------------------|------------------------------------------------------|
+| `DependencyNotFound`           | a name in `[dependencies]` was not in any search path |
+| `BadDependencyManifest`        | dependency's `mosaic-package.toml` failed to parse   |
+| `DuplicateExport`              | two dependencies export the same component name     |
+| `Io`                           | filesystem read error                                |
+
+Unknown-tag-at-resolve-time is **not** an error — `resolve()` returns
+`None` and lets the *compiler* decide what to do (typically: emit a
+"no such component `Foo` (did you mean `Bar`?)" diagnostic).
+
+## Kernel set
+
+The kernel is frozen per UI29 §2.4.  This crate hard-codes it as
+`KERNEL_PRIMITIVES`.  UI29 §2.1 lists 15 primitives; we also include
+`Else` here because the `moslayout-compiler` tokenizes it as its own tag
+even though UI29 treats it as a continuation of `If`.  See the comment on
+the constant in `src/lib.rs` for details.
+
+## Relationship to other crates
+
+- **mosaic-package-manifest** (UI29-R1): the resolver depends on it to
+  parse each dependency's `mosaic-package.toml`.
+- **mosaic-compile** (future): will call `build()` once per user package
+  and consult `resolve()` on every tag encountered by the moslayout AST
+  walker.
+- **mosaic-emit-react / -swiftui / -qt / …**: never see the resolver
+  directly; they only see lowered kernel primitives or pre-compiled
+  component references the resolver mediated.

--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -1,0 +1,719 @@
+//! # mosaic-package-resolver
+//!
+//! Component-reference resolver for Mosaic packages, implementing
+//! **UI29 §4.4** (Mosaic Primitive Kernel — "Resolving a component
+//! reference").
+//!
+//! ## The one question this crate answers
+//!
+//! Given a tag name from some user's `.mll` file — e.g. `Grid` or `Row`
+//! or `Floof` — what *is* it?
+//!
+//! ```text
+//!                       resolve("Grid")
+//!                              │
+//!         ┌────────────────────┼────────────────────┐
+//!         ▼                    ▼                    ▼
+//!     Resolution::         Resolution::            None
+//!     Kernel               Component { … }      (unknown tag —
+//!     (Row, Box, …)        (declared by a       compiler will
+//!                          dependency)          surface a "no
+//!                                                such tag" error)
+//! ```
+//!
+//! The resolver is a precomputed `HashMap` plus a `HashSet` of kernel
+//! names, so `resolve` is O(1).  The cost is paid once in [`build`].
+//!
+//! ## What `build` does, in order
+//!
+//! 1. Tries to read `<package_root>/mosaic-package.toml`.  Absent is
+//!    fine — a manifest-less user package can still consult the kernel
+//!    primitives.
+//! 2. For each `(dep_name, _ver)` in the manifest's `[dependencies]`:
+//!    a. Search each path in `search_paths` for a child directory.  We
+//!    try `mosaic-pkg-<dep_name>` first (the UI29 §4.1 convention),
+//!    then fall back to the literal `<dep_name>`.
+//!    b. Read that dep's `mosaic-package.toml` via
+//!    `mosaic_package_manifest::parse_path`.
+//!    c. For each entry in its `[components].exports`, register a
+//!    `Resolution::Component { … }` keyed by the component name.
+//!    d. If two dependencies export the same name → `DuplicateExport`.
+//! 3. Build the kernel set from [`KERNEL_PRIMITIVES`].
+//!
+//! ## Why two name forms (`mosaic-pkg-<name>` and `<name>`)?
+//!
+//! In production a user's manifest will say
+//! `mosaic-pkg-grid = "0.1.0"`, and on disk the package is at
+//! `code/packages/mosaic-pkg-grid/`.  The literal-name fallback exists
+//! for tests and ad-hoc packages where the directory just happens to be
+//! named the same as the dep key.  Trying both is cheap and keeps the
+//! UX forgiving.
+//!
+//! ## Error surface
+//!
+//! ```text
+//!     build(...)
+//!         │
+//!         ├── DependencyNotFound    ← name not in any search path
+//!         ├── BadDependencyManifest ← dep's TOML didn't parse
+//!         ├── DuplicateExport       ← two deps export same name
+//!         └── Io                    ← read_dir / canonicalize failed
+//! ```
+//!
+//! Resolving a *tag* never errors — unknown is `None`.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Kernel set
+// ---------------------------------------------------------------------------
+
+/// The frozen Mosaic primitive kernel.  See **UI29 §2.1**.
+///
+/// UI29 §2.1 enumerates *15* primitives.  We list 16 here because the
+/// `moslayout-compiler` tokenizer treats `Else` as a separate tag even
+/// though UI29 describes it as the second half of an `If/Else` pair
+/// (the parser stitches the two together at AST-construction time).
+/// Treating `Else` as a kernel-known tag here means the resolver never
+/// flags a perfectly valid `Else { … }` block as "unknown tag" simply
+/// because the spec table didn't list it on its own row.  All 15 of the
+/// UI29 §2.1 names are present, plus `Else`.
+pub const KERNEL_PRIMITIVES: &[&str] = &[
+    // Containers
+    "Box", "Row", "Column", "Stack",
+    // Leaves
+    "Text", "Image", "Spacer", "Divider", "Icon",
+    // Control flow (§3)
+    "If", "Else", "For",
+    // Host primitives (§2.1 "Host*" rows)
+    "HostInput", "HostButton", "HostTable", "HostScroll",
+];
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// What a tag resolves to.
+///
+/// `PartialEq` is implemented so tests can compare resolutions directly.
+/// Equality on `PathBuf` is byte-wise; tests that need canonicalization-
+/// independent comparison should compare the `package` + `component`
+/// fields instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// A UI29 kernel primitive.  No package to look up — the backend
+    /// emitter handles it directly.
+    Kernel,
+    /// A component exported by a Mosaic package this user depends on.
+    Component {
+        /// The package's `[package].name`, e.g. `"mosaic-pkg-grid"`.
+        package: String,
+        /// Absolute path to the package's root directory on disk
+        /// (the directory containing its `mosaic-package.toml`).
+        package_path: PathBuf,
+        /// The component name as it appears in the package's
+        /// `[components].exports`, e.g. `"Grid"`.
+        component: String,
+    },
+}
+
+/// Build-time errors.  See crate-level docs for the full surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    /// A dependency listed in `[dependencies]` could not be located.
+    DependencyNotFound {
+        /// The dep name (as it appeared in the manifest).
+        package: String,
+        /// The search paths we looked in (in order).
+        searched: Vec<PathBuf>,
+    },
+    /// A dependency's `mosaic-package.toml` did not parse.
+    BadDependencyManifest {
+        /// The dep name.
+        package: String,
+        /// The error from `mosaic_package_manifest::parse_path`,
+        /// stringified.
+        error: String,
+    },
+    /// Two dependencies export the same component name.
+    DuplicateExport {
+        component: String,
+        package_a: String,
+        package_b: String,
+    },
+    /// Filesystem I/O error (canonicalize, read_dir, etc).
+    Io(String),
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DependencyNotFound { package, searched } => {
+                write!(
+                    f,
+                    "dependency `{package}` not found in any search path ({} searched)",
+                    searched.len()
+                )
+            }
+            Self::BadDependencyManifest { package, error } => {
+                write!(f, "dependency `{package}` has a malformed manifest: {error}")
+            }
+            Self::DuplicateExport {
+                component,
+                package_a,
+                package_b,
+            } => {
+                write!(
+                    f,
+                    "component `{component}` is exported by both `{package_a}` and `{package_b}`"
+                )
+            }
+            Self::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/// The resolution table.  Built once, queried often.
+///
+/// Internally:
+/// - `kernel` is a `HashSet<&'static str>` of kernel primitives — checked
+///   first because the kernel is small and tags are typically kernel-y.
+/// - `table` is a `HashMap<String, Resolution>` containing only
+///   `Resolution::Component` entries (kernel hits short-circuit before
+///   the map is consulted).
+pub struct Resolver {
+    table: HashMap<String, Resolution>,
+    kernel: HashSet<&'static str>,
+}
+
+impl std::fmt::Debug for Resolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Resolver")
+            .field("kernel_count", &self.kernel.len())
+            .field("component_count", &self.table.len())
+            .finish()
+    }
+}
+
+impl Resolver {
+    /// Look up a tag.  Returns:
+    ///
+    /// - `Some(&Resolution::Kernel)` if `tag` is in [`KERNEL_PRIMITIVES`]
+    /// - `Some(&Resolution::Component { … })` if a dep exports it
+    /// - `None` otherwise
+    pub fn resolve(&self, tag: &str) -> Option<&Resolution> {
+        // Kernel takes precedence: a malicious or careless package
+        // can't shadow `Row` even if it tried to export a component
+        // named "Row" — the resolver will simply never *consult* the
+        // table for kernel-named tags.
+        if self.kernel.contains(tag) {
+            // Return a reference to a const Kernel.  We carry one
+            // sentinel value per resolver instance for this purpose.
+            return Some(&KERNEL_RESOLUTION);
+        }
+        self.table.get(tag)
+    }
+
+    /// Whether this tag is known.  Equivalent to `resolve(tag).is_some()`
+    /// but slightly cheaper because it avoids returning a reference.
+    pub fn knows(&self, tag: &str) -> bool {
+        self.kernel.contains(tag) || self.table.contains_key(tag)
+    }
+
+    /// Number of dep-exported components in the table.  Useful for
+    /// diagnostics / tests.
+    pub fn component_count(&self) -> usize {
+        self.table.len()
+    }
+
+    /// Iterate (component-name, resolution) pairs for non-kernel
+    /// entries.  Order is unspecified (it's a HashMap).
+    pub fn components(&self) -> impl Iterator<Item = (&str, &Resolution)> {
+        self.table.iter().map(|(k, v)| (k.as_str(), v))
+    }
+}
+
+/// The single shared `Resolution::Kernel` value `resolve` hands out
+/// references to.  Defined as a `static` so the reference has `'static`
+/// lifetime — same lifetime as the `Resolver` carrying it.
+static KERNEL_RESOLUTION: Resolution = Resolution::Kernel;
+
+// ---------------------------------------------------------------------------
+// Build entry point
+// ---------------------------------------------------------------------------
+
+/// Build a resolver for a user's package.
+///
+/// `package_root`: the directory containing the user's
+/// `mosaic-package.toml`.  May not actually contain a manifest — the
+/// resolver still works, just with an empty component table.
+///
+/// `search_paths`: directories to search for dependencies, in
+/// preference order.  Typically this is `[code/packages/]` in this
+/// monorepo; in a future cargo-style setup it might be a per-user
+/// cache plus a project-local `vendor/` directory.
+pub fn build(
+    package_root: &Path,
+    search_paths: &[PathBuf],
+) -> Result<Resolver, ResolveError> {
+    // ----------------------------------------------------------------
+    // Step 1: read the user's manifest (if any).
+    // ----------------------------------------------------------------
+    let manifest_path = package_root.join("mosaic-package.toml");
+    let user_manifest = if manifest_path.exists() {
+        match mosaic_package_manifest::parse_path(&manifest_path) {
+            Ok(m) => Some(m),
+            Err(e) => {
+                // The user's own manifest being malformed isn't quite a
+                // "bad dependency" — but mapping it to the same variant
+                // keeps the error model small and the message clear.
+                return Err(ResolveError::BadDependencyManifest {
+                    package: "<user>".to_string(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    } else {
+        None
+    };
+
+    // ----------------------------------------------------------------
+    // Step 2: walk dependencies and populate the table.
+    // ----------------------------------------------------------------
+    let mut table: HashMap<String, Resolution> = HashMap::new();
+    // Track which dep exported each component, so DuplicateExport
+    // diagnostics can name *both* contributing packages.
+    let mut export_origin: HashMap<String, String> = HashMap::new();
+
+    if let Some(manifest) = user_manifest {
+        for dep_name in manifest.dependencies.keys() {
+            // ----- locate the dep on disk -----
+            let dep_root = locate_dependency(dep_name, search_paths)?;
+            // Canonicalize so `package_path` is absolute regardless of
+            // how the caller passed the search paths.
+            let dep_root = std::fs::canonicalize(&dep_root)
+                .map_err(|e| ResolveError::Io(format!("canonicalize {dep_root:?}: {e}")))?;
+
+            // ----- read the dep's manifest -----
+            let dep_manifest_path = dep_root.join("mosaic-package.toml");
+            let dep_manifest = mosaic_package_manifest::parse_path(&dep_manifest_path)
+                .map_err(|e| ResolveError::BadDependencyManifest {
+                    package: dep_name.clone(),
+                    error: e.to_string(),
+                })?;
+
+            // ----- register each export -----
+            for component in &dep_manifest.components.exports {
+                if let Some(prior) = export_origin.get(component) {
+                    return Err(ResolveError::DuplicateExport {
+                        component: component.clone(),
+                        package_a: prior.clone(),
+                        package_b: dep_manifest.package.name.clone(),
+                    });
+                }
+                export_origin.insert(component.clone(), dep_manifest.package.name.clone());
+                table.insert(
+                    component.clone(),
+                    Resolution::Component {
+                        package: dep_manifest.package.name.clone(),
+                        package_path: dep_root.clone(),
+                        component: component.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Step 3: build the kernel set.
+    // ----------------------------------------------------------------
+    let kernel: HashSet<&'static str> = KERNEL_PRIMITIVES.iter().copied().collect();
+
+    Ok(Resolver { table, kernel })
+}
+
+/// Find a dependency by name in the given search paths.
+///
+/// Returns the first directory found.  We try the `mosaic-pkg-<name>`
+/// form first (UI29 §4.1 convention) and fall back to the literal
+/// `<name>`.
+fn locate_dependency(
+    dep_name: &str,
+    search_paths: &[PathBuf],
+) -> Result<PathBuf, ResolveError> {
+    // Candidate directory names to try, in order.  If the dep is already
+    // named with the `mosaic-pkg-` prefix the two candidates collapse to
+    // one — we dedup via a tiny inline check rather than a set.
+    let candidates: Vec<String> = if dep_name.starts_with("mosaic-pkg-") {
+        vec![dep_name.to_string()]
+    } else {
+        vec![format!("mosaic-pkg-{dep_name}"), dep_name.to_string()]
+    };
+
+    for path in search_paths {
+        for candidate in &candidates {
+            let candidate_path = path.join(candidate);
+            // The manifest must exist for a directory to count as a package.
+            // (A bare directory with no manifest is not a package; finding
+            // such a directory and then immediately failing on the manifest
+            // read would produce a confusing error.)
+            if candidate_path.join("mosaic-package.toml").is_file() {
+                return Ok(candidate_path);
+            }
+        }
+    }
+
+    Err(ResolveError::DependencyNotFound {
+        package: dep_name.to_string(),
+        searched: search_paths.to_vec(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // ---- tiny test helpers ----
+
+    /// Write a `mosaic-package.toml` into `dir` with the given fields.
+    fn write_manifest(
+        dir: &Path,
+        name: &str,
+        exports: &[&str],
+        deps: &[(&str, &str)],
+    ) {
+        let deps_block: String = deps
+            .iter()
+            .map(|(k, v)| format!("{k} = \"{v}\"\n"))
+            .collect();
+        let exports_list = exports
+            .iter()
+            .map(|e| format!("\"{e}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let toml = format!(
+            r#"
+[package]
+name = "{name}"
+version = "0.1.0"
+description = "test package"
+license = "MIT"
+
+[components]
+exports = [{exports_list}]
+
+[dependencies]
+{deps_block}
+[kernel]
+version = "1"
+"#
+        );
+        fs::write(dir.join("mosaic-package.toml"), toml).unwrap();
+    }
+
+    /// Create a package directory at `parent/dirname` with a manifest,
+    /// returning its path.
+    fn make_pkg(
+        parent: &Path,
+        dirname: &str,
+        manifest_name: &str,
+        exports: &[&str],
+    ) -> PathBuf {
+        let path = parent.join(dirname);
+        fs::create_dir_all(&path).unwrap();
+        write_manifest(&path, manifest_name, exports, &[]);
+        path
+    }
+
+    // ---- Test 1: empty package, no manifest, no deps ----
+
+    #[test]
+    fn empty_package_no_manifest_kernel_only() {
+        let tmp = TempDir::new().unwrap();
+        // No manifest written — package_root is just an empty dir.
+        let r = build(tmp.path(), &[]).expect("manifest-less must succeed");
+        assert!(matches!(r.resolve("Box"), Some(Resolution::Kernel)));
+        assert!(matches!(r.resolve("HostScroll"), Some(Resolution::Kernel)));
+        assert!(r.resolve("Grid").is_none());
+        assert_eq!(r.component_count(), 0);
+    }
+
+    // ---- Test 2: manifest with no dependencies ----
+
+    #[test]
+    fn manifest_no_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        write_manifest(tmp.path(), "mosaic-pkg-user", &[], &[]);
+        let r = build(tmp.path(), &[]).expect("no-deps must succeed");
+        assert!(matches!(r.resolve("Row"), Some(Resolution::Kernel)));
+        assert!(r.resolve("Whatever").is_none());
+        assert_eq!(r.component_count(), 0);
+    }
+
+    // ---- Test 3: single dep, one export ----
+
+    #[test]
+    fn single_dep_one_export() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(&pkgs, "mosaic-pkg-grid", "mosaic-pkg-grid", &["Grid"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-grid", "0.1.0")]);
+
+        let r = build(&user, std::slice::from_ref(&pkgs)).expect("build ok");
+        match r.resolve("Grid") {
+            Some(Resolution::Component { package, component, .. }) => {
+                assert_eq!(package, "mosaic-pkg-grid");
+                assert_eq!(component, "Grid");
+            }
+            other => panic!("expected Component, got {other:?}"),
+        }
+    }
+
+    // ---- Test 4: dep with multiple exports ----
+
+    #[test]
+    fn dep_multiple_exports() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(
+            &pkgs,
+            "mosaic-pkg-grid",
+            "mosaic-pkg-grid",
+            &["Grid", "Cell", "ColumnDef"],
+        );
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-grid", "0.1.0")]);
+
+        let r = build(&user, &[pkgs]).expect("build ok");
+        assert!(r.knows("Grid"));
+        assert!(r.knows("Cell"));
+        assert!(r.knows("ColumnDef"));
+        assert_eq!(r.component_count(), 3);
+    }
+
+    // ---- Test 5: two deps, no collision ----
+
+    #[test]
+    fn two_deps_no_collision() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(&pkgs, "mosaic-pkg-grid", "mosaic-pkg-grid", &["Grid"]);
+        make_pkg(&pkgs, "mosaic-pkg-tabs", "mosaic-pkg-tabs", &["Tabs", "Tab"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(
+            &user,
+            "mosaic-pkg-user",
+            &[],
+            &[("mosaic-pkg-grid", "0.1.0"), ("mosaic-pkg-tabs", "0.1.0")],
+        );
+
+        let r = build(&user, &[pkgs]).expect("build ok");
+        assert!(r.knows("Grid"));
+        assert!(r.knows("Tabs"));
+        assert!(r.knows("Tab"));
+        assert_eq!(r.component_count(), 3);
+    }
+
+    // ---- Test 6: two deps with colliding exports ----
+
+    #[test]
+    fn duplicate_export_errors() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(&pkgs, "mosaic-pkg-grid", "mosaic-pkg-grid", &["Grid"]);
+        make_pkg(&pkgs, "mosaic-pkg-other", "mosaic-pkg-other", &["Grid"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(
+            &user,
+            "mosaic-pkg-user",
+            &[],
+            &[("mosaic-pkg-grid", "0.1.0"), ("mosaic-pkg-other", "0.1.0")],
+        );
+
+        let err = build(&user, &[pkgs]).expect_err("must collide");
+        match err {
+            ResolveError::DuplicateExport { component, .. } => {
+                assert_eq!(component, "Grid");
+            }
+            other => panic!("expected DuplicateExport, got {other:?}"),
+        }
+    }
+
+    // ---- Test 7: dep not in any search path ----
+
+    #[test]
+    fn dependency_not_found_errors() {
+        let tmp = TempDir::new().unwrap();
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-ghost", "0.1.0")]);
+
+        // Empty search path → can't possibly find it.
+        let err = build(&user, &[]).expect_err("must fail");
+        assert!(matches!(err, ResolveError::DependencyNotFound { ref package, .. } if package == "mosaic-pkg-ghost"));
+    }
+
+    // ---- Test 8: dep with malformed manifest ----
+
+    #[test]
+    fn bad_dependency_manifest_errors() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        let bad = pkgs.join("mosaic-pkg-bad");
+        fs::create_dir_all(&bad).unwrap();
+        // Write a manifest that is syntactically valid TOML but is missing
+        // required fields, so the manifest parser rejects it.
+        fs::write(bad.join("mosaic-package.toml"), "garbage = true\n").unwrap();
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-bad", "0.1.0")]);
+
+        let err = build(&user, &[pkgs]).expect_err("must fail");
+        assert!(matches!(err, ResolveError::BadDependencyManifest { ref package, .. } if package == "mosaic-pkg-bad"));
+    }
+
+    // ---- Test 9: Resolver::knows ----
+
+    #[test]
+    fn knows_returns_true_for_kernel_and_component_false_for_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(&pkgs, "mosaic-pkg-grid", "mosaic-pkg-grid", &["Grid"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-grid", "0.1.0")]);
+
+        let r = build(&user, &[pkgs]).expect("ok");
+        assert!(r.knows("Box"));
+        assert!(r.knows("Grid"));
+        assert!(!r.knows("Floof"));
+    }
+
+    // ---- Test 10: resolve returns appropriate variants ----
+
+    #[test]
+    fn resolve_returns_correct_variants() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(&pkgs, "mosaic-pkg-grid", "mosaic-pkg-grid", &["Grid"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-grid", "0.1.0")]);
+
+        let r = build(&user, &[pkgs]).expect("ok");
+
+        // Kernel:
+        assert!(matches!(r.resolve("If"), Some(Resolution::Kernel)));
+        // Component:
+        assert!(matches!(r.resolve("Grid"), Some(Resolution::Component { .. })));
+        // Unknown:
+        assert!(r.resolve("ZZZ").is_none());
+    }
+
+    // ---- Test 11: kernel set contains all UI29 §2.1 primitives ----
+
+    #[test]
+    fn kernel_set_covers_ui29_section_2_1() {
+        // The fifteen primitives explicitly listed in the §2.1 table.
+        let expected_15 = [
+            "Box", "Row", "Column", "Stack", "Text", "Image",
+            "Spacer", "Divider", "Icon",
+            "If", "For",
+            "HostInput", "HostButton", "HostTable", "HostScroll",
+        ];
+        for name in &expected_15 {
+            assert!(
+                KERNEL_PRIMITIVES.contains(name),
+                "kernel must include `{name}`"
+            );
+        }
+        // And `Else` because the parser treats it as its own tag.
+        assert!(KERNEL_PRIMITIVES.contains(&"Else"));
+        // Sanity: no duplicates.
+        let mut sorted: Vec<&&str> = KERNEL_PRIMITIVES.iter().collect();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), KERNEL_PRIMITIVES.len(), "no duplicates");
+    }
+
+    // ---- Test 12: package_path is absolute ----
+
+    #[test]
+    fn package_path_is_absolute() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        make_pkg(&pkgs, "mosaic-pkg-grid", "mosaic-pkg-grid", &["Grid"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("mosaic-pkg-grid", "0.1.0")]);
+
+        // Pass a *relative* search path on purpose — we want to verify
+        // the resolver canonicalizes it before storing.  We do that by
+        // changing into tmp and then using a relative path; if that's
+        // unreliable in parallel tests, just pass the absolute path
+        // and rely on canonicalize() to resolve `..` / symlinks.
+        let r = build(&user, std::slice::from_ref(&pkgs)).expect("ok");
+        match r.resolve("Grid") {
+            Some(Resolution::Component { package_path, .. }) => {
+                assert!(
+                    package_path.is_absolute(),
+                    "package_path must be absolute, got {package_path:?}"
+                );
+                // Should end with the package directory name.
+                assert!(package_path.ends_with("mosaic-pkg-grid"));
+            }
+            other => panic!("expected Component, got {other:?}"),
+        }
+    }
+
+    // ---- Extra test: dep dir without `mosaic-pkg-` prefix is also found ----
+
+    #[test]
+    fn dep_with_literal_name_match() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        // Directory is named exactly the same as the dep key.
+        make_pkg(&pkgs, "widgets", "widgets", &["Spinner"]);
+
+        let user = tmp.path().join("user");
+        fs::create_dir_all(&user).unwrap();
+        write_manifest(&user, "mosaic-pkg-user", &[], &[("widgets", "0.1.0")]);
+
+        let r = build(&user, &[pkgs]).expect("ok");
+        assert!(matches!(r.resolve("Spinner"), Some(Resolution::Component { .. })));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **U29-R2** from UI29 §4.4: a new Rust crate `mosaic-package-resolver` that maps moslayout tags to either UI29 kernel primitives or components exported by Mosaic package dependencies.

- New crate at `code/packages/rust/mosaic-package-resolver/` (lib.rs, Cargo.toml, BUILD, README.md, CHANGELOG.md).
- Public API: `Resolver` with `resolve(tag) -> Option<&Resolution>` and `knows(tag) -> bool`; `Resolution::{Kernel, Component { package, package_path, component }}`; `build(root, search_paths) -> Result<Resolver, ResolveError>`.
- `KERNEL_PRIMITIVES` constant lists the 15 UI29 §2.1 primitives plus `Else` (which `moslayout-compiler` tokenizes separately; documented inline).
- Reads each dep's `mosaic-package.toml` via the U29-R1 manifest parser, locates packages by trying `mosaic-pkg-<name>` first then literal `<name>` in each search path, and canonicalizes `package_path` to an absolute path.
- Structured error surface: `DependencyNotFound`, `BadDependencyManifest`, `DuplicateExport`, `Io` — unknown-tag-at-resolve-time is `None` (compiler's call).

Stacked on the (now-merged) U29-R1 branch; rebased onto main since that branch has been deleted.

## Test plan

- [x] `cargo build -p mosaic-package-resolver` clean
- [x] `cargo test -p mosaic-package-resolver` — 13 tests pass (12 required + one extra for the literal-name fallback)
- [x] `cargo clippy -p mosaic-package-resolver --no-deps --all-targets -- -D warnings` clean
- [x] Tests cover all 12 cases from the spec: empty package, no-deps manifest, one export, many exports, two clean deps, duplicate-export collision, missing dep, malformed dep manifest, `knows` semantics, `resolve` variants, UI29 §2.1 kernel coverage, `package_path` absoluteness

Generated with Claude Code