### PR TITLE
Add WHATWG frameset audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -26,6 +26,8 @@ documented in this file.
   upstream-only html5lib and WHATWG entity sources.
 - A fixture manifest unit test keeps every self-contained WHATWG fixture
   generator covered by that umbrella stale check.
+- The generated fixture manifest now includes the parser frameset audit
+  generator alongside the tree-insertion audit.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -117,6 +117,13 @@ def default_checks() -> list[FixtureCheck]:
                 "--check",
             ),
         ),
+        FixtureCheck(
+            "whatwg-frameset-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_frameset_audit_fixture.py"),
+                "--check",
+            ),
+        ),
     ]
 
 

--- a/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
@@ -32,9 +32,16 @@ class GeneratedHtmlFixtureManifestTest(unittest.TestCase):
 
     def test_default_manifest_keeps_parser_and_html5lib_checks_visible(self) -> None:
         checked_scripts = scripts_in(manifest.default_checks())
+        parser_generators = {
+            path.name
+            for path in manifest.PARSER_FIXTURE_DIR.glob("generate_whatwg_*_fixture.py")
+        }
 
         self.assertIn("normalize_html5lib_fixtures.py", checked_scripts)
-        self.assertIn("generate_whatwg_tree_insertion_audit_fixture.py", checked_scripts)
+        self.assertEqual(
+            checked_scripts & parser_generators,
+            parser_generators,
+        )
 
     def test_default_manifest_check_names_are_unique_and_use_check_mode(self) -> None:
         checks = manifest.default_checks()

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -11,8 +11,11 @@ documented in this file.
 - Generated WHATWG tree-insertion audit fixture over the html5lib
   adoption-agency, table/foster-parenting, template, foreign-content fragment,
   and HTML fragment-shell families, with a dedicated parser regression test.
+- Generated WHATWG frameset audit fixture over html5lib frameset, frame,
+  noframes, foreign-content, body-compatibility, and template-boundary cases,
+  with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
-  tree-insertion audit checks on the same parser and DOM dump path.
+  tree-insertion and frameset audit checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -110,7 +110,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_inser
   --check
 ```
 
-Both the broad smoke test and the focused tree-insertion audit use the shared
+The generated `tests/fixtures/whatwg-frameset-audit.json` fixture similarly
+indexes frameset, frame, noframes, foreign-content, body-compatibility, and
+template-boundary recovery cases:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py \
+  --check
+```
+
+Both the broad smoke test and the focused audit fixtures use the shared
 `tests/common` html5lib parser and DOM dump helpers, so new parser conformance
 fixtures exercise the same normalization path.
 

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -57,3 +57,13 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_inser
 python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py \
   --check
 ```
+
+`whatwg-frameset-audit.json` is a generated index over tree-construction cases
+that stress frameset, frame, noframes, body-compatibility, foreign-content, and
+template-boundary recovery:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py \
+  --check
+```

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG frameset audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-frameset-audit.json"
+
+FRAMESET_MARKUP = re.compile(r"</?(?:frameset|frame|noframes)(?:\s|/|>)", re.I)
+
+CASE_AXES = (
+    {
+        "axis": "frameset-shell",
+        "reason": "top-level frameset shell creation and trailing boundary recovery",
+    },
+    {
+        "axis": "frame-element",
+        "reason": "frame element insertion, void behavior, and frameset nesting",
+    },
+    {
+        "axis": "noframes-content",
+        "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+    },
+    {
+        "axis": "body-compatibility",
+        "reason": "frameset acceptance or rejection after body-compatible content",
+    },
+    {
+        "axis": "foreign-boundary",
+        "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+    },
+    {
+        "axis": "template-boundary",
+        "reason": "frameset and frame handling inside template insertion contexts",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG frameset audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if FRAMESET_MARKUP.search(case_data):
+            cases.append(SmokeCase(source=source, data=case_data))
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any frameset audit cases")
+    return cases
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-frameset-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress frameset, frame, and noframes recovery."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data.lower()
+    if "<template" in data:
+        return "template-boundary"
+    if "<svg" in data or "<math" in data or "foreignobject" in data:
+        return "foreign-boundary"
+    if "<noframes" in data or "</noframes" in data:
+        return "noframes-content"
+    if re.search(r"<frame(?:\s|/|>)", data):
+        return "frame-element"
+    if re.search(r"<(?:p|div|body|pre|listing|li|dd|dt|button|table|textarea|select|input)\b", data):
+        return "body-compatibility"
+    return "frameset-shell"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown frameset audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-frameset-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-frameset-audit.json
@@ -1,0 +1,1108 @@
+{
+  "case_count": 182,
+  "cases": [
+    {
+      "axis": "frameset-shell",
+      "id": "domjs-unsafe-dat-160",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "domjs-unsafe.dat:160"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "domjs-unsafe-dat-161",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "domjs-unsafe.dat:161"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "domjs-unsafe-dat-162",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "domjs-unsafe.dat:162"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "noscript01-dat-336",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "noscript01.dat:336"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "pending-spec-changes-dat-346",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "pending-spec-changes.dat:346"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "plain-text-unsafe-dat-350",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "plain-text-unsafe.dat:350"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "plain-text-unsafe-dat-351",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "plain-text-unsafe.dat:351"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "plain-text-unsafe-dat-352",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "plain-text-unsafe.dat:352"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "plain-text-unsafe-dat-353",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "plain-text-unsafe.dat:353"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "plain-text-unsafe-dat-354",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "plain-text-unsafe.dat:354"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-364",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:364"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-365",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:365"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-366",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:366"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-367",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:367"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-368",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:368"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-369",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:369"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-370",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:370"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "plain-text-unsafe-dat-371",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "plain-text-unsafe.dat:371"
+    },
+    {
+      "axis": "template-boundary",
+      "id": "template-dat-494",
+      "reason": "frameset and frame handling inside template insertion contexts",
+      "source": "template.dat:494"
+    },
+    {
+      "axis": "template-boundary",
+      "id": "template-dat-495",
+      "reason": "frameset and frame handling inside template insertion contexts",
+      "source": "template.dat:495"
+    },
+    {
+      "axis": "template-boundary",
+      "id": "template-dat-496",
+      "reason": "frameset and frame handling inside template insertion contexts",
+      "source": "template.dat:496"
+    },
+    {
+      "axis": "template-boundary",
+      "id": "template-dat-497",
+      "reason": "frameset and frame handling inside template insertion contexts",
+      "source": "template.dat:497"
+    },
+    {
+      "axis": "template-boundary",
+      "id": "template-dat-521",
+      "reason": "frameset and frame handling inside template insertion contexts",
+      "source": "template.dat:521"
+    },
+    {
+      "axis": "template-boundary",
+      "id": "template-dat-547",
+      "reason": "frameset and frame handling inside template insertion contexts",
+      "source": "template.dat:547"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests1-dat-670",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests1.dat:670"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests1-dat-675",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests1-dat-676",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests1-dat-677",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests1.dat:677"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests10-dat-698",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests10.dat:698"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests10-dat-699",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests10.dat:699"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests15-dat-766",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests15.dat:766"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-857",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:857"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-858",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:858"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-954",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:954"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-955",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:955"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests18-dat-995",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests18.dat:995"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests18-dat-996",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests18.dat:996"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests18-dat-998",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests18.dat:998"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-1008",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:1008"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-1009",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:1009"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-1010",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:1010"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-1011",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:1011"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests19-dat-1049",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests19.dat:1049"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1051",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1051"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1052",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1052"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1053",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1053"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1054",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1054"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1055",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1055"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1056",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1056"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1057",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1057"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1058",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1058"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests19-dat-1059",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests19.dat:1059"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1060",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1060"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests19-dat-1061",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests19.dat:1061"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1062",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1062"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1063",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1063"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1064",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1064"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1065",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1065"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1066",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1066"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1067",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1067"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1068",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1068"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1069",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1069"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1070",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1070"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1071",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1071"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1072",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1072"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1073",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1073"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1074",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1074"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1075",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1075"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1076",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1076"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1077",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1077"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1078",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1078"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1079",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1079"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1080",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1080"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1081",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1081"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1082",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1082"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1083",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1083"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1084",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1084"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1085",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1085"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-1086",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:1086"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-1087",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:1087"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-1088",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:1088"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-1089",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:1089"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-1090",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:1090"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1091",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1091"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-1092",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:1092"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1093",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1093"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-1094",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:1094"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests25-dat-1231",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests25.dat:1231"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests2-dat-5",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests2.dat:5"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests2-dat-6",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests2.dat:6"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests2-dat-7",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests2.dat:7"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests2-dat-8",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests2.dat:8"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests2-dat-9",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests2.dat:9"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests9-dat-22",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests9.dat:22"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests9-dat-23",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests9.dat:23"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-8",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:8"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests6-dat-9",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests6.dat:9"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests6-dat-10",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests6.dat:10"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-11",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:11"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-12",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:12"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests6-dat-29",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests6.dat:29"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-31",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:31"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-46",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:46"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-48",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:48"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-49",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:49"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-50",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:50"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-51",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:51"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests6-dat-52",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests6.dat:52"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests6-dat-30",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests6.dat:30"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests-innerhtml-1-dat-5",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests_innerHTML_1.dat:5"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests-innerhtml-1-dat-6",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests_innerHTML_1.dat:6"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests-innerhtml-1-dat-7",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests_innerHTML_1.dat:7"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests-innerhtml-1-dat-8",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests_innerHTML_1.dat:8"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests-innerhtml-1-dat-80",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests_innerHTML_1.dat:80"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests1-dat-105",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests1.dat:105"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests1-dat-110",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests1-dat-111",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests1-dat-112",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests1.dat:112"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests10-dat-21",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests10.dat:21"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests10-dat-22",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests10.dat:22"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests15-dat-13",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests15.dat:13"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-90",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:90"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-91",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:91"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-187",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:187"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests16-dat-188",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests16.dat:188"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests18-dat-18",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests18.dat:18"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests18-dat-19",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests18.dat:19"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests18-dat-21",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests18.dat:21"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-31",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:31"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-32",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:32"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-33",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:33"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests18-dat-34",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests18.dat:34"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "tests19-dat-36",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "tests19.dat:36"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-38",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:38"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-39",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:39"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-40",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:40"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-41",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:41"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-42",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:42"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-43",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:43"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-44",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:44"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-45",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:45"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests19-dat-46",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests19.dat:46"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-47",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:47"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests19-dat-48",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests19.dat:48"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-49",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:49"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-50",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:50"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-51",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:51"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-52",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:52"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-53",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:53"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-54",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:54"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-55",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:55"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-56",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:56"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-57",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:57"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-58",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:58"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-59",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:59"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-60",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:60"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-61",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:61"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-62",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:62"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-63",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:63"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-64",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:64"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-65",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:65"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-66",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:66"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-67",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:67"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-68",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:68"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-69",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:69"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-70",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:70"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-71",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:71"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-72",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:72"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-73",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:73"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-74",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:74"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-75",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:75"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-76",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:76"
+    },
+    {
+      "axis": "foreign-boundary",
+      "id": "tests19-dat-77",
+      "reason": "frameset recovery around SVG/MathML foreign-content boundaries",
+      "source": "tests19.dat:77"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-78",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:78"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "tests19-dat-79",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "tests19.dat:79"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-80",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:80"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "tests19-dat-81",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "tests19.dat:81"
+    },
+    {
+      "axis": "frame-element",
+      "id": "tests25-dat-10",
+      "reason": "frame element insertion, void behavior, and frameset nesting",
+      "source": "tests25.dat:10"
+    },
+    {
+      "axis": "frameset-shell",
+      "id": "foreign-fragment-dat-52",
+      "reason": "top-level frameset shell creation and trailing boundary recovery",
+      "source": "foreign-fragment.dat:52"
+    },
+    {
+      "axis": "noframes-content",
+      "id": "webkit01-dat-31",
+      "reason": "noframes RAWTEXT handoff and post-frameset recovery",
+      "source": "webkit01.dat:31"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "webkit01-dat-51",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "webkit01.dat:51"
+    },
+    {
+      "axis": "body-compatibility",
+      "id": "webkit01-dat-52",
+      "reason": "frameset acceptance or rejection after body-compatible content",
+      "source": "webkit01.dat:52"
+    }
+  ],
+  "counts_by_axis": {
+    "body-compatibility": 35,
+    "foreign-boundary": 24,
+    "frame-element": 9,
+    "frameset-shell": 79,
+    "noframes-content": 29,
+    "template-boundary": 6
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress frameset, frame, and noframes recovery.",
+  "format": "whatwg-html-frameset-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_frameset_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_frameset_audit_test.rs
@@ -1,0 +1,85 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct FramesetAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<FramesetAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FramesetAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_frameset_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-frameset-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 180);
+    assert_axis_count(&suite, "frameset-shell", 70);
+    assert_axis_count(&suite, "frame-element", 8);
+    assert_axis_count(&suite, "noframes-content", 25);
+    assert_axis_count(&suite, "body-compatibility", 30);
+    assert_axis_count(&suite, "foreign-boundary", 20);
+    assert_axis_count(&suite, "template-boundary", 5);
+}
+
+#[test]
+fn whatwg_frameset_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> FramesetAuditSuite {
+    serde_json::from_str(WHATWG_FRAMESET_AUDIT)
+        .expect("WHATWG frameset audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &FramesetAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add a generated WHATWG frameset audit fixture covering frameset shells, frame elements, noframes content, body compatibility, foreign boundaries, and template boundaries.
- Add a Rust parser regression test that runs each selected smoke case through the existing html5lib DOM dump harness.
- Include the frameset generator in the generated fixture manifest check so future stale fixture checks cover it automatically.

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_frameset_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser