### PR TITLE
Expose Chief of Staff count drift investigation

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this package will be documented in this file.
 - Count-drift presence flags for supervisor drain run reports and summaries.
 - Stable count-drift classifications for supervisor drain run reports and
   summaries.
+- Count-drift investigation flags for supervisor drain run reports and
+  summaries.
 - Stable, parseable supervisor drain scheduler action recommendations for host
   loops.
 - Typed scheduler action intent helpers for continuation, follow-up routing, and

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -49,6 +49,8 @@ The crate keeps the boundary narrow:
   signed deltas for host logs
 - supervisor drain run summaries expose stable count-drift classifications so
   hosts can distinguish row, follow-up pressure, and combined drift
+- supervisor drain reports and summaries expose explicit count-drift
+  investigation flags for host schedulers
 - supervisor drain summaries expose stable, parseable scheduler action
   recommendations for continuation, follow-up routing, and plan-drift
   investigation

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -940,6 +940,7 @@ impl ToolAuditSupervisorDrainRunReport {
             has_record_count_drift: self.has_record_count_drift(),
             has_follow_up_record_count_drift: self.has_follow_up_record_count_drift(),
             count_drift_kind: self.count_drift_kind(),
+            requires_count_drift_investigation: self.requires_count_drift_investigation(),
             matches_planned_record_count: self.matches_planned_record_count(),
             matches_planned_follow_up_record_count: self.matches_planned_follow_up_record_count(),
             reached_end_of_log: self.reached_end_of_log(),
@@ -999,6 +1000,11 @@ impl ToolAuditSupervisorDrainRunReport {
     /// Return the stable count-drift classification label.
     pub fn count_drift_label(&self) -> &'static str {
         self.count_drift_kind().as_str()
+    }
+
+    /// Return whether count drift should be investigated by the host.
+    pub fn requires_count_drift_investigation(&self) -> bool {
+        self.count_drift_kind().requires_investigation()
     }
 
     /// Return whether the actual run replayed at least one row.
@@ -1072,6 +1078,8 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub has_follow_up_record_count_drift: bool,
     /// Stable classification of observed planned-vs-actual count drift.
     pub count_drift_kind: ToolAuditSupervisorDrainCountDriftKind,
+    /// Whether count drift should be investigated by the host.
+    pub requires_count_drift_investigation: bool,
     /// Whether the actual run delivered the planned number of rows.
     pub matches_planned_record_count: bool,
     /// Whether the actual run preserved the planned follow-up pressure count.
@@ -1127,6 +1135,11 @@ impl ToolAuditSupervisorDrainRunSummary {
     /// Return the stable count-drift classification label.
     pub fn count_drift_label(&self) -> &'static str {
         self.count_drift_kind.as_str()
+    }
+
+    /// Return whether count drift should be investigated by the host.
+    pub fn requires_count_drift_investigation(&self) -> bool {
+        self.requires_count_drift_investigation
     }
 
     /// Return whether the actual run replayed more rows than planned.
@@ -1369,6 +1382,11 @@ impl ToolAuditSupervisorDrainCountDriftKind {
     /// Return whether any planned-vs-actual count drift was observed.
     pub fn has_count_drift(self) -> bool {
         !matches!(self, Self::NoDrift)
+    }
+
+    /// Return whether this count drift classification needs investigation.
+    pub fn requires_investigation(self) -> bool {
+        self.has_count_drift()
     }
 }
 
@@ -2875,6 +2893,7 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::NoDrift
         );
         assert_eq!(report.count_drift_label(), "no_count_drift");
+        assert!(!report.requires_count_drift_investigation());
         assert!(report.requires_follow_up());
         assert!(report.reached_end_of_log());
         assert!(!report.exhausted_tick_budget());
@@ -2902,6 +2921,8 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::NoDrift
         );
         assert_eq!(summary.count_drift_label(), "no_count_drift");
+        assert!(!summary.requires_count_drift_investigation);
+        assert!(!summary.requires_count_drift_investigation());
         assert!(!summary.replayed_extra_records());
         assert!(!summary.missed_planned_records());
         assert!(!summary.replayed_extra_follow_up_records());
@@ -3161,6 +3182,10 @@ mod tests {
                 kind.has_count_drift(),
                 has_record_count_drift || has_follow_up_record_count_drift
             );
+            assert_eq!(
+                kind.requires_investigation(),
+                has_record_count_drift || has_follow_up_record_count_drift
+            );
         }
         assert_eq!(
             ToolAuditSupervisorDrainCountDriftKind::from_label("driftish"),
@@ -3246,6 +3271,8 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::NoDrift
         );
         assert_eq!(summary.count_drift_label(), "no_count_drift");
+        assert!(!summary.requires_count_drift_investigation);
+        assert!(!summary.requires_count_drift_investigation());
         assert!(summary.matches_planned_record_count);
         assert!(summary.matches_planned_follow_up_record_count);
         assert!(summary.matches_follow_up_pressure());
@@ -3293,6 +3320,7 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::RecordCountDrift
         );
         assert_eq!(report.count_drift_label(), "record_count_drift");
+        assert!(report.requires_count_drift_investigation());
         assert_eq!(summary.record_count_delta, 1);
         assert!(summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
@@ -3302,6 +3330,8 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::RecordCountDrift
         );
         assert_eq!(summary.count_drift_label(), "record_count_drift");
+        assert!(summary.requires_count_drift_investigation);
+        assert!(summary.requires_count_drift_investigation());
         assert!(summary.replayed_extra_records());
         assert!(!summary.missed_planned_records());
         assert!(summary.requires_scheduler_action());
@@ -3333,6 +3363,7 @@ mod tests {
             report.count_drift_kind(),
             ToolAuditSupervisorDrainCountDriftKind::RecordCountDrift
         );
+        assert!(report.requires_count_drift_investigation());
         assert_eq!(summary.record_count_delta, -1);
         assert!(summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
@@ -3341,6 +3372,8 @@ mod tests {
             summary.count_drift_kind,
             ToolAuditSupervisorDrainCountDriftKind::RecordCountDrift
         );
+        assert!(summary.requires_count_drift_investigation);
+        assert!(summary.requires_count_drift_investigation());
         assert!(!summary.replayed_extra_records());
         assert!(summary.missed_planned_records());
         assert_eq!(
@@ -3377,6 +3410,7 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::FollowUpRecordCountDrift
         );
         assert_eq!(report.count_drift_label(), "follow_up_record_count_drift");
+        assert!(report.requires_count_drift_investigation());
         assert_eq!(summary.record_count_delta, 0);
         assert_eq!(summary.follow_up_record_count_delta, -1);
         assert!(!summary.has_record_count_drift);
@@ -3387,6 +3421,8 @@ mod tests {
             ToolAuditSupervisorDrainCountDriftKind::FollowUpRecordCountDrift
         );
         assert_eq!(summary.count_drift_label(), "follow_up_record_count_drift");
+        assert!(summary.requires_count_drift_investigation);
+        assert!(summary.requires_count_drift_investigation());
         assert!(summary.matches_planned_record_count);
         assert!(!summary.matches_planned_follow_up_record_count);
         assert!(!summary.matches_follow_up_pressure());


### PR DESCRIPTION
## Summary
- add explicit count-drift investigation helpers to Chief of Staff drain run reports
- expose the investigation flag in flattened supervisor drain summaries
- cover no-drift, row-count drift, and follow-up-pressure drift cases

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD