### PR TITLE
[codex] Add Arduino Pro Nicla Opta descriptors

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -16,10 +16,19 @@ The first matrix covers representative Arduino families:
   Rev2 for SAM/SAMD/megaAVR/Renesas/Nordic coverage
 - Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi, and Portenta H7 for modern
   maker/pro Arduino boards
+- Portenta H7 Lite, Portenta H7 Lite Connected, Portenta C33, Nicla Vision,
+  Nicla Sense ME, Nicla Voice, and the Opta Lite/RS485/WiFi variants for
+  Pro, Nicla, and industrial PLC-style Arduino coverage
 
 Each target currently proves the shared GPIO/time backend path. Board-specific
 firmware/upload crates can extend the same descriptor with richer peripherals
 without falling back to Uno R4 assumptions.
+
+Opta terminals are modeled as board-local input and relay-output pins instead
+of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware
+is similarly registered as its own target family so follow-up capability work
+can add the real sensor, camera, microphone, and wireless paths without changing
+language frontends.
 
 Host-side validation:
 

--- a/code/packages/rust/board-vm-arduino/src/lib.rs
+++ b/code/packages/rust/board-vm-arduino/src/lib.rs
@@ -334,6 +334,150 @@ pub const ARDUINO_NANO_ESP32_DIGITAL_PINS: [DigitalPinDescriptor; 22] = generate
 pub const ARDUINO_GIGA_R1_DIGITAL_PINS: [DigitalPinDescriptor; 76] = generated_pins::<76>(54, 12);
 pub const ARDUINO_PORTENTA_H7_DIGITAL_PINS: [DigitalPinDescriptor; 80] =
     generated_pins::<80>(54, 12);
+pub const ARDUINO_PORTENTA_C33_DIGITAL_PINS: [DigitalPinDescriptor; 7] = generated_pins::<7>(7, 0);
+pub const ARDUINO_NICLA_DIGITAL_PINS: [DigitalPinDescriptor; 12] = generated_pins::<12>(10, 2);
+pub const ARDUINO_OPTA_TERMINAL_PINS: [DigitalPinDescriptor; 12] = [
+    DigitalPinDescriptor {
+        pin: 0,
+        label: "I1",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 1,
+        label: "I2",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 2,
+        label: "I3",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 3,
+        label: "I4",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 4,
+        label: "I5",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 5,
+        label: "I6",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 6,
+        label: "I7",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 7,
+        label: "I8",
+        supports_input: true,
+        supports_output: false,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: true,
+        supports_pwm: false,
+        notes:
+            "Opta industrial analog/digital input terminal; backend owns terminal voltage mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 8,
+        label: "O1",
+        supports_input: false,
+        supports_output: true,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: false,
+        supports_pwm: false,
+        notes: "Opta relay output terminal; backend owns relay actuation mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 9,
+        label: "O2",
+        supports_input: false,
+        supports_output: true,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: false,
+        supports_pwm: false,
+        notes: "Opta relay output terminal; backend owns relay actuation mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 10,
+        label: "O3",
+        supports_input: false,
+        supports_output: true,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: false,
+        supports_pwm: false,
+        notes: "Opta relay output terminal; backend owns relay actuation mapping",
+    },
+    DigitalPinDescriptor {
+        pin: 11,
+        label: "O4",
+        supports_input: false,
+        supports_output: true,
+        supports_pullup: false,
+        supports_pulldown: false,
+        supports_adc: false,
+        supports_pwm: false,
+        notes: "Opta relay output terminal; backend owns relay actuation mapping",
+    },
+];
 
 pub const ARDUINO_UNO_R3: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-uno-r3",
@@ -658,7 +802,179 @@ pub const ARDUINO_PORTENTA_H7: ArduinoTargetDescriptor = ArduinoTargetDescriptor
     notes: "Portenta H7 backend contract keeps high-end Arduino Pro hardware in the target matrix.",
 };
 
-pub const ARDUINO_TARGETS: [ArduinoTargetDescriptor; 17] = [
+pub const ARDUINO_PORTENTA_H7_LITE: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-portenta-h7-lite",
+    display_name: "Arduino Portenta H7 Lite",
+    family: ArduinoFamily::Mbed,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747XI",
+    core: "dual Arm Cortex-M7/M4",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: Some(66),
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_PORTENTA_H7_DIGITAL_PINS,
+    notes: "Portenta H7 Lite descriptor keeps lower-cost H7 modules visible without routing them through the base Portenta H7 board id.",
+};
+
+pub const ARDUINO_PORTENTA_H7_LITE_CONNECTED: ArduinoTargetDescriptor =
+    ArduinoTargetDescriptor {
+        board_id: "arduino-portenta-h7-lite-connected",
+        display_name: "Arduino Portenta H7 Lite Connected",
+        family: ArduinoFamily::Mbed,
+        runtime_profile: RuntimeProfile::Full,
+        mcu: "STM32H747XI",
+        core: "dual Arm Cortex-M7/M4 with WiFi/BLE module",
+        isa: "armv7e-m",
+        rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+        clock_hz: 480_000_000,
+        flash_bytes: 2 * 1024 * 1024,
+        sram_bytes: 1024 * 1024,
+        operating_voltage_mv: 3300,
+        onboard_led_pin: Some(66),
+        capabilities: blink_capabilities(),
+        digital_pins: &ARDUINO_PORTENTA_H7_DIGITAL_PINS,
+        notes: "Portenta H7 Lite Connected keeps wireless-capable H7 modules discoverable; network capabilities are a later descriptor tranche.",
+    };
+
+pub const ARDUINO_PORTENTA_C33: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-portenta-c33",
+    display_name: "Arduino Portenta C33",
+    family: ArduinoFamily::RenesasRa,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "R7FA6M5BH2CBG",
+    core: "Arm Cortex-M33 with ESP32-C3 WiFi/BLE module",
+    isa: "armv8-m.main",
+    rust_target: RustTargetStatus::Stable("thumbv8m.main-none-eabihf"),
+    clock_hz: 200_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 512 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_PORTENTA_C33_DIGITAL_PINS,
+    notes: "Renesas RA6M5 Pro-family descriptor; firmware/upload support should be implemented as a Portenta C33 adapter, not through Uno R4.",
+};
+
+pub const ARDUINO_NICLA_VISION: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nicla-vision",
+    display_name: "Arduino Nicla Vision",
+    family: ArduinoFamily::Mbed,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747AII6",
+    core: "dual Arm Cortex-M7/M4 with camera and WiFi/BLE module",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 3300,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NICLA_DIGITAL_PINS,
+    notes: "Nicla Vision descriptor keeps vision-class Arduino hardware in the shared backend matrix; camera, microphone, and wireless capabilities are later tranches.",
+};
+
+pub const ARDUINO_NICLA_SENSE_ME: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nicla-sense-me",
+    display_name: "Arduino Nicla Sense ME",
+    family: ArduinoFamily::Nordic,
+    runtime_profile: RuntimeProfile::Small,
+    mcu: "nRF52832",
+    core: "Arm Cortex-M4F with Bosch smart sensor hub",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 64_000_000,
+    flash_bytes: 512 * 1024,
+    sram_bytes: 64 * 1024,
+    operating_voltage_mv: 1800,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NICLA_DIGITAL_PINS,
+    notes: "Nicla Sense ME descriptor tracks the nRF52832 Arduino core separately from Nano BLE and leaves Bosch sensor fusion as a later backend capability.",
+};
+
+pub const ARDUINO_NICLA_VOICE: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-nicla-voice",
+    display_name: "Arduino Nicla Voice",
+    family: ArduinoFamily::Nordic,
+    runtime_profile: RuntimeProfile::Small,
+    mcu: "nRF52832",
+    core: "Arm Cortex-M4F with Syntiant NDP120",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 64_000_000,
+    flash_bytes: 512 * 1024,
+    sram_bytes: 64 * 1024,
+    operating_voltage_mv: 1800,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_NICLA_DIGITAL_PINS,
+    notes: "Nicla Voice descriptor keeps voice/ML Arduino hardware discoverable; NDP120 and microphone paths are later capability tranches.",
+};
+
+pub const ARDUINO_OPTA_LITE: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-opta-lite",
+    display_name: "Arduino Opta Lite",
+    family: ArduinoFamily::Stm32,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747XI",
+    core: "dual Arm Cortex-M7/M4 with Ethernet",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 24_000,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_OPTA_TERMINAL_PINS,
+    notes: "Industrial Opta Lite descriptor models terminal inputs and relays as board-local GPIO abstractions; Ethernet and PLC metadata are later tranches.",
+};
+
+pub const ARDUINO_OPTA_RS485: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-opta-rs485",
+    display_name: "Arduino Opta RS485",
+    family: ArduinoFamily::Stm32,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747XI",
+    core: "dual Arm Cortex-M7/M4 with Ethernet and RS-485",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 24_000,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_OPTA_TERMINAL_PINS,
+    notes: "Opta RS485 descriptor keeps industrial serial hardware distinct from generic STM32 and Uno R4 adapters.",
+};
+
+pub const ARDUINO_OPTA_WIFI: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
+    board_id: "arduino-opta-wifi",
+    display_name: "Arduino Opta WiFi",
+    family: ArduinoFamily::Stm32,
+    runtime_profile: RuntimeProfile::Full,
+    mcu: "STM32H747XI",
+    core: "dual Arm Cortex-M7/M4 with Ethernet, RS-485, and WiFi/BLE",
+    isa: "armv7e-m",
+    rust_target: RustTargetStatus::Stable("thumbv7em-none-eabihf"),
+    clock_hz: 480_000_000,
+    flash_bytes: 2 * 1024 * 1024,
+    sram_bytes: 1024 * 1024,
+    operating_voltage_mv: 24_000,
+    onboard_led_pin: None,
+    capabilities: blink_capabilities(),
+    digital_pins: &ARDUINO_OPTA_TERMINAL_PINS,
+    notes: "Opta WiFi descriptor keeps PLC wireless hardware discoverable; Ethernet, RS-485, WiFi, and BLE capabilities are later tranches.",
+};
+
+pub const ARDUINO_TARGETS: [ArduinoTargetDescriptor; 26] = [
     ARDUINO_UNO_R3,
     ARDUINO_NANO_CLASSIC,
     ARDUINO_PRO_MINI,
@@ -676,6 +992,15 @@ pub const ARDUINO_TARGETS: [ArduinoTargetDescriptor; 17] = [
     ARDUINO_NANO_ESP32,
     ARDUINO_GIGA_R1_WIFI,
     ARDUINO_PORTENTA_H7,
+    ARDUINO_PORTENTA_H7_LITE,
+    ARDUINO_PORTENTA_H7_LITE_CONNECTED,
+    ARDUINO_PORTENTA_C33,
+    ARDUINO_NICLA_VISION,
+    ARDUINO_NICLA_SENSE_ME,
+    ARDUINO_NICLA_VOICE,
+    ARDUINO_OPTA_LITE,
+    ARDUINO_OPTA_RS485,
+    ARDUINO_OPTA_WIFI,
 ];
 
 pub fn arduino_device_descriptor(
@@ -771,12 +1096,25 @@ mod tests {
         assert!(ARDUINO_TARGETS
             .iter()
             .any(|target| target.family == ArduinoFamily::Stm32));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .any(|target| target.family == ArduinoFamily::Mbed));
+        assert!(ARDUINO_TARGETS
+            .iter()
+            .all(|target| target.digital_pins.iter().any(|pin| pin.supports_output)));
     }
 
     #[test]
     fn every_arduino_target_runs_blink_through_shared_backend() {
         for target in ARDUINO_TARGETS.iter() {
-            let pin = target.onboard_led_pin.unwrap_or(target.digital_pins[0].pin);
+            let pin = target.onboard_led_pin.unwrap_or_else(|| {
+                target
+                    .digital_pins
+                    .iter()
+                    .find(|pin| pin.supports_output)
+                    .unwrap()
+                    .pin
+            });
             let board = ArduinoBoard::new(target, FakeBackend::new());
             let mut runtime: Runtime<_, 8, 4> = Runtime::new(board);
             let mut module = [0u8; BLINK_MODULE_LEN];

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -3772,6 +3772,9 @@ mod tests {
         let nano_ble = known_target("arduino-nano-33-ble-rev2").unwrap();
         let nano_esp32 = known_target("arduino-nano-esp32").unwrap();
         let giga = known_target("arduino-giga-r1-wifi").unwrap();
+        let portenta_c33 = known_target("arduino-portenta-c33").unwrap();
+        let nicla_vision = known_target("arduino-nicla-vision").unwrap();
+        let opta_wifi = known_target("arduino-opta-wifi").unwrap();
         let pico_w = known_target("raspberry-pi-pico-w").unwrap();
 
         assert!(targets
@@ -3799,6 +3802,19 @@ mod tests {
         assert_eq!(nano_esp32.mcu, "ESP32-S3");
         assert_eq!(giga.family, LanguageBoardFamily::Arduino);
         assert_eq!(giga.mcu, "STM32H747XI");
+        assert_eq!(portenta_c33.family, LanguageBoardFamily::Arduino);
+        assert_eq!(portenta_c33.mcu, "R7FA6M5BH2CBG");
+        assert_eq!(portenta_c33.rust_target, "thumbv8m.main-none-eabihf");
+        assert_eq!(portenta_c33.digital_pin_count, 7);
+        assert_eq!(nicla_vision.family, LanguageBoardFamily::Arduino);
+        assert_eq!(nicla_vision.mcu, "STM32H747AII6");
+        assert_eq!(opta_wifi.family, LanguageBoardFamily::Arduino);
+        assert_eq!(opta_wifi.mcu, "STM32H747XI");
+        assert_eq!(opta_wifi.digital_pin_count, 12);
+        assert_eq!(opta_wifi.digital_pins[0].label, "I1");
+        assert!(!opta_wifi.digital_pins[0].supports_output);
+        assert_eq!(opta_wifi.digital_pins[11].label, "O4");
+        assert!(opta_wifi.digital_pins[11].supports_output);
         assert_eq!(
             uno.led_matrix,
             Some(LanguageLedMatrix {

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -15,7 +15,15 @@ Arduino coverage is deliberately split in two:
 - `board-vm-arduino` registers the broader Arduino-family backend contract for
   non-Uno-R4 boards such as Uno R3, Nano, Mega 2560, Leonardo/Micro, Due, Zero,
   MKR WiFi 1010, Nano Every, Nano R4, Nano 33 IoT, Nano 33 BLE Rev2, Nano RP2040
-  Connect, Nano ESP32, GIGA R1 WiFi, and Portenta H7.
+  Connect, Nano ESP32, GIGA R1 WiFi, Portenta H7, Portenta H7 Lite, Portenta H7
+  Lite Connected, Portenta C33, Nicla Vision, Nicla Sense ME, Nicla Voice, and
+  Opta Lite/RS485/WiFi.
+
+Opta targets expose industrial terminal inputs and relay outputs through the
+same target registry shape, but they do not pretend to share Uno header pins.
+Nicla and Portenta targets likewise carry their own MCU/runtime descriptors so
+the next board-specific firmware and upload adapters can attach without adding
+special cases to Ruby, Python, Lua, or other language frontends.
 
 Wireless metadata separates physical support from the generic front-end sugar:
 

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -467,6 +467,24 @@ pub const ARDUINO_GIGA_R1_WIFI_DIGITAL_PINS: [DigitalPinInfo; 76] =
     map_arduino_digital_pins(board_vm_arduino::ARDUINO_GIGA_R1_DIGITAL_PINS);
 pub const ARDUINO_PORTENTA_H7_DIGITAL_PINS: [DigitalPinInfo; 80] =
     map_arduino_digital_pins(board_vm_arduino::ARDUINO_PORTENTA_H7_DIGITAL_PINS);
+pub const ARDUINO_PORTENTA_H7_LITE_DIGITAL_PINS: [DigitalPinInfo; 80] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_PORTENTA_H7_DIGITAL_PINS);
+pub const ARDUINO_PORTENTA_H7_LITE_CONNECTED_DIGITAL_PINS: [DigitalPinInfo; 80] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_PORTENTA_H7_DIGITAL_PINS);
+pub const ARDUINO_PORTENTA_C33_DIGITAL_PINS: [DigitalPinInfo; 7] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_PORTENTA_C33_DIGITAL_PINS);
+pub const ARDUINO_NICLA_VISION_DIGITAL_PINS: [DigitalPinInfo; 12] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NICLA_DIGITAL_PINS);
+pub const ARDUINO_NICLA_SENSE_ME_DIGITAL_PINS: [DigitalPinInfo; 12] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NICLA_DIGITAL_PINS);
+pub const ARDUINO_NICLA_VOICE_DIGITAL_PINS: [DigitalPinInfo; 12] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_NICLA_DIGITAL_PINS);
+pub const ARDUINO_OPTA_LITE_DIGITAL_PINS: [DigitalPinInfo; 12] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_OPTA_TERMINAL_PINS);
+pub const ARDUINO_OPTA_RS485_DIGITAL_PINS: [DigitalPinInfo; 12] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_OPTA_TERMINAL_PINS);
+pub const ARDUINO_OPTA_WIFI_DIGITAL_PINS: [DigitalPinInfo; 12] =
+    map_arduino_digital_pins(board_vm_arduino::ARDUINO_OPTA_TERMINAL_PINS);
 
 const fn map_arduino_digital_pins<const N: usize>(
     source: [board_vm_arduino::DigitalPinDescriptor; N],
@@ -777,7 +795,7 @@ const fn arduino_board_target(
     }
 }
 
-pub const BOARD_TARGETS: [BoardTargetInfo; 22] = [
+pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
     BoardTargetInfo {
         board_id: board_vm_uno_r4::UNO_R4_MINIMA.board_id,
         display_name: board_vm_uno_r4::UNO_R4_MINIMA.display_name,
@@ -894,6 +912,42 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 22] = [
     arduino_board_target(
         board_vm_arduino::ARDUINO_PORTENTA_H7,
         &ARDUINO_PORTENTA_H7_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_PORTENTA_H7_LITE,
+        &ARDUINO_PORTENTA_H7_LITE_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_PORTENTA_H7_LITE_CONNECTED,
+        &ARDUINO_PORTENTA_H7_LITE_CONNECTED_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_PORTENTA_C33,
+        &ARDUINO_PORTENTA_C33_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NICLA_VISION,
+        &ARDUINO_NICLA_VISION_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NICLA_SENSE_ME,
+        &ARDUINO_NICLA_SENSE_ME_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_NICLA_VOICE,
+        &ARDUINO_NICLA_VOICE_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_OPTA_LITE,
+        &ARDUINO_OPTA_LITE_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_OPTA_RS485,
+        &ARDUINO_OPTA_RS485_DIGITAL_PINS,
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_OPTA_WIFI,
+        &ARDUINO_OPTA_WIFI_DIGITAL_PINS,
     ),
     BoardTargetInfo {
         board_id: board_vm_esp32::ESP32_DEVKIT_V1.board_id,
@@ -1013,6 +1067,13 @@ mod tests {
         assert!(find_target("arduino-nano-esp32").is_some());
         assert!(find_target("arduino-giga-r1-wifi").is_some());
         assert!(find_target("arduino-portenta-h7").is_some());
+        assert!(find_target("arduino-portenta-c33").is_some());
+        assert!(find_target("arduino-nicla-vision").is_some());
+        assert!(find_target("arduino-nicla-sense-me").is_some());
+        assert!(find_target("arduino-nicla-voice").is_some());
+        assert!(find_target("arduino-opta-lite").is_some());
+        assert!(find_target("arduino-opta-rs485").is_some());
+        assert!(find_target("arduino-opta-wifi").is_some());
         assert!(find_target("esp32-devkit-v1").is_some());
         assert!(find_target("raspberry-pi-pico").is_some());
         assert!(find_target("raspberry-pi-pico-w").is_some());
@@ -1056,6 +1117,32 @@ mod tests {
             find_target("arduino-giga-r1-wifi").unwrap().mcu,
             "STM32H747XI"
         );
+        assert_eq!(
+            find_target("arduino-portenta-c33").unwrap().mcu,
+            "R7FA6M5BH2CBG"
+        );
+        assert_eq!(
+            find_target("arduino-portenta-c33")
+                .unwrap()
+                .digital_pin_count,
+            7
+        );
+        assert_eq!(
+            find_target("arduino-nicla-vision").unwrap().mcu,
+            "STM32H747AII6"
+        );
+        assert_eq!(find_target("arduino-nicla-voice").unwrap().mcu, "nRF52832");
+        assert_eq!(find_target("arduino-opta-wifi").unwrap().mcu, "STM32H747XI");
+        assert_eq!(
+            find_target("arduino-opta-wifi").unwrap().digital_pins[0].label,
+            "I1"
+        );
+        assert_eq!(
+            find_target("arduino-opta-wifi").unwrap().digital_pins[11].label,
+            "O4"
+        );
+        assert!(!find_target("arduino-opta-wifi").unwrap().digital_pins[0].supports_output);
+        assert!(find_target("arduino-opta-wifi").unwrap().digital_pins[11].supports_output);
     }
 
     #[test]

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -99,6 +99,20 @@ contract for representative Arduino families:
 - maker/pro 32-bit boards: Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi,
   Portenta H7.
 
+The second descriptor tranche adds the next Pro/Nicla/Opta families:
+
+- Portenta H7 Lite, Portenta H7 Lite Connected, and Portenta C33,
+- Nicla Vision, Nicla Sense ME, and Nicla Voice,
+- Opta Lite, Opta RS485, and Opta WiFi.
+
+Opta targets use industrial terminal and relay-output descriptors rather than
+pretending they have Uno-style GPIO headers. Nicla and Portenta targets stay
+distinct from their MCU cousins so later camera, microphone, sensor-fusion,
+wireless, Ethernet, RS-485, and upload adapters can attach to the correct board
+identity. Companion/sensor boards whose microcontrollers are not directly
+user-programmable, such as Nicla Sense Env, should be modeled as board
+peripherals or carrier-managed adapters instead of fake firmware runtimes.
+
 The next tranches should add board-specific firmware/upload adapters and richer
 peripheral tables for each family without moving generic Arduino discovery into
 `board-vm-uno-r4`.


### PR DESCRIPTION
## Summary
- add shared Arduino descriptors for Portenta H7 Lite, Portenta H7 Lite Connected, Portenta C33, Nicla Vision, Nicla Sense ME, Nicla Voice, and Opta Lite/RS485/WiFi
- register the new boards in the Rust-owned target registry and language-core known-target coverage
- document Opta terminal/relay modeling and keep companion-only boards like Nicla Sense Env out of fake firmware runtime descriptors

## Source checks
- Arduino Portenta C33 docs/datasheet: https://docs.arduino.cc/hardware/portenta-c33/
- Arduino Nicla Vision docs: https://docs.arduino.cc/hardware/nicla-vision/
- Arduino Nicla Sense ME datasheet: https://docs.arduino.cc/resources/datasheets/ABX00050-datasheet.pdf
- Arduino Nicla Voice docs/datasheet: https://docs.arduino.cc/hardware/nicla-voice
- Arduino Opta docs/datasheet: https://docs.arduino.cc/hardware/opta

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-pro-nicla-opta-descriptors cargo fmt -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-pro-nicla-opta-descriptors cargo test -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-pro-nicla-opta-descriptors bash BUILD in code/packages/rust/board-vm-arduino
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-pro-nicla-opta-descriptors bash BUILD in code/packages/rust/board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-pro-nicla-opta-descriptors cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check