### PR TITLE
feat(mosaic-pkg-grid): U29-P1 — first userland package

### DIFF
--- a/code/packages/mosaic-pkg-grid/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-grid/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to `mosaic-pkg-grid` are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/) and
+the package follows semantic versioning.
+
+## 0.1.0 — 2026-05-19
+
+Initial release. Exports Grid, Cell, Column. Built on UI29 kernel
+primitives (Box, Row, Text, HostInput, HostTable + sub-tags, If, For).
+
+### Added
+
+- `mosaic-package.toml` manifest declaring `[components].exports =
+  ["Grid", "Cell", "Column"]` and targeting UI29 kernel version `"1"`.
+- `Cell.mil` / `Cell.mll` / `Cell.dark.msl`: an editable spreadsheet
+  cell composed of `Box` + `If`/`Else` + `HostInput` + `Text`.
+- `Column.mil` / `Column.mll`: a metadata-only column declaration with
+  a single hollow `Box` marker layout (moslayout currently requires a
+  single root node per component).
+- `Grid.mil` / `Grid.mll` / `Grid.dark.msl`: the data grid itself,
+  composed of `HostTable` + `HostTableHead` + `HostTableBody` + `Row` +
+  `For` + the package's own `Cell` component.
+- `tests/package_compiles.rs`: integration smoke test that round-trips
+  every source file through `mosmodel-compiler`, `moslayout-compiler`,
+  and `mosstyle-compiler`.
+
+### Known limitations
+
+- **Header row is empty in v0.1.0.**  Rendering one header cell per
+  declared Column requires the Grid interface to accept a `columns`
+  list slot (v0.2.0).
+- **Body rows show `row` only.**  Full per-column iteration needs the
+  same `columns` slot plus the expression-grammar `row[c]` field-access
+  syntax defined in UI29 §3.3 but not yet landed (UI29-G3).
+- **Backend lowerings still landing.**  `For`, `If`, `HostInput`, and
+  `HostTable` (with `HostTableHead` / `HostTableBody` / `Row` slots) are
+  kernel primitives whose per-backend lowerings are in flight under
+  `U29-K-react`, `U29-K-swiftui`, `U29-K-qt`, `U29-K-webcomp`, and
+  `U29-K-html`.  The smoke test asserts language-frontend correctness
+  (parse + analyze + validate at the .mil/.mll/.msl layer); end-to-end
+  backend artifact generation lights up once those PRs land.
+- **No theming cascade.**  The package ships `dark.msl` only; light-mode
+  styles and host overrides arrive once the multi-theme cascade lands
+  in mosstyle.
+
+The architecture (manifest-driven, kernel-primitive-only composition,
+backend-agnostic) is what v0.1.0 proves.  v0.2.0 fills in the Grid
+behaviour once the supporting grammar / resolver / kernel-coverage PRs
+land.

--- a/code/packages/mosaic-pkg-grid/Cargo.toml
+++ b/code/packages/mosaic-pkg-grid/Cargo.toml
@@ -1,0 +1,36 @@
+# Cargo.toml — smoke-test harness for mosaic-pkg-grid.
+#
+# This package's primary deliverables are .mil / .mll / .msl source files
+# (consumed by mosaic-compile and downstream emitters), NOT a Rust crate.
+# The Cargo.toml exists ONLY to host an integration smoke test that runs
+# each source file through its respective compiler crate and asserts the
+# whole package round-trips at the language-frontend layer.
+#
+# `[workspace]` is empty so this Cargo project does NOT join the main
+# code/packages/rust workspace.  It lives at code/packages/mosaic-pkg-grid
+# (outside the rust/ tree), is conceptually a Mosaic package (not a Rust
+# crate), and runs as a standalone Cargo project via `cargo test`.
+
+[workspace]
+# Intentionally empty: opt out of the parent workspace.
+
+[package]
+name        = "mosaic-pkg-grid"
+version     = "0.1.0"
+edition     = "2021"
+description = "Smoke-test harness for the mosaic-pkg-grid component package"
+publish     = false
+
+# The crate has no library code — it exists for the integration test below.
+[lib]
+path       = "src/lib.rs"
+
+[dev-dependencies]
+mosmodel-compiler   = { path = "../rust/mosmodel-compiler" }
+moslayout-compiler  = { path = "../rust/moslayout-compiler" }
+mosstyle-compiler   = { path = "../rust/mosstyle-compiler" }
+toml                = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic-pkg-grid/README.md
+++ b/code/packages/mosaic-pkg-grid/README.md
@@ -1,0 +1,144 @@
+# mosaic-pkg-grid
+
+> Spreadsheet-style data grid built on UI29 kernel primitives.
+
+This is the first userland Mosaic component package — the headline
+deliverable of **UI29 (Primitive Kernel + Userland Component Packages)**.
+It proves the architecture: the framework core ships only ~15 kernel
+primitives, and useful components like Grid live *outside* the core, in
+plain moslayout source files, the same shape as any user component.
+
+## What this package exports
+
+Three components, listed in `mosaic-package.toml`'s `[components].exports`:
+
+| Component | Role | File trio |
+|---|---|---|
+| `Grid`   | the spreadsheet itself — header row + data rows | `Grid.mil` / `Grid.mll` / `Grid.dark.msl` |
+| `Cell`   | one editable cell (read display ↔ edit input) | `Cell.mil` / `Cell.mll` / `Cell.dark.msl` |
+| `Column` | declarative column metadata (no rendered output) | `Column.mil` / `Column.mll` |
+
+Column ships no `.msl`: it produces no visible tree, so there is nothing
+to style.
+
+## How it fits in the stack
+
+```
+              ┌────────────────────────────────────────────┐
+              │  Host application (.mll uses `Grid`)       │
+              └─────────────────────┬──────────────────────┘
+                                    │ component reference
+                                    ▼
+              ┌────────────────────────────────────────────┐
+              │  mosaic-pkg-grid (this package)            │
+              │  Grid → HostTable + For + Cell             │
+              │  Cell → Box + If + HostInput + Text        │
+              │  Column → metadata-only Box marker         │
+              └─────────────────────┬──────────────────────┘
+                                    │ kernel primitives only
+                                    ▼
+              ┌────────────────────────────────────────────┐
+              │  UI29 kernel (15 primitives)               │
+              │  Box / Row / Column / Stack / Text /       │
+              │  Image / Spacer / Divider / Icon /         │
+              │  If / For / HostInput / HostButton /       │
+              │  HostTable / HostScroll                    │
+              └─────────────────────┬──────────────────────┘
+                                    │ per-backend lowering
+                                    ▼
+                  React / SwiftUI / Qt / WebComponent / HTML
+```
+
+A host that wants a Grid adds `mosaic-pkg-grid` to its package
+dependencies; a host that doesn't, pays nothing.  A host that wants a
+*richer* Grid can fork this package and publish their own — the same way
+React's ecosystem treats data-grid libraries as userland.
+
+## v0.1.0 architecture (what is proven)
+
+* Three components, all manifest-declared.
+* Three components, all composed entirely from kernel primitives — no
+  bespoke per-backend code.
+* Three components, all expressed in plain moslayout source files (the
+  same `.mil` / `.mll` / `.msl` trio any user component uses).
+* The smoke test at `tests/package_compiles.rs` round-trips every source
+  file through its respective compiler crate.
+
+## v0.2.0 caveats (deliberate scope cuts)
+
+* **Header row is empty.**  `Grid.mll`'s `HostTableHead` contains a Row
+  with no cells.  Rendering one `<th>` per declared Column requires
+  Grid's interface to accept a `columns` list slot so a
+  `For (each: slot: columns, as: col)` can drive the header.
+* **Body emits ONE Cell per row.**  Each row shows `row` (the For-bound
+  iteration variable resolved as a Keyword-valued prop), not `row[0]`,
+  `row[1]`, ... — full per-column iteration needs the same `columns`
+  slot, plus the expression-grammar `row[c]` field-access syntax that
+  UI29 §3.3 defines but UI29-G3 has not yet landed.
+* **No theming cascade.**  The package ships `dark.msl` only; light-mode
+  styles and host overrides arrive once the multi-theme cascade lands
+  in mosstyle.
+
+These are not bugs.  The architecture (manifest-driven, kernel-
+primitive-only composition, backend-agnostic) is what v0.1.0 proves;
+v0.2.0 fills in the Grid behaviour once the underlying grammar and
+resolver PRs land.
+
+## Usage (conceptual; resolver lands in U29-R2)
+
+```moslayout
+// In a host component's .mll:
+layout SpreadsheetApp {
+  Column [ root ] {
+    Grid (
+      viewport-rows: slot: data-rows ,
+      edit-row:      slot: app-edit-row ,
+      edit-col:      slot: app-edit-col ,
+      onEditCommit:  emit: handleCommit
+    ) {
+      // Future v0.2.0: Column children declare the columns.
+      Column ( key: "name",  header: "Name",  width: 120 , editable: true ,
+               cell-type: "text" , default-alignment: "left" )
+      Column ( key: "price", header: "Price", width:  80 , editable: true ,
+               cell-type: "number" , default-alignment: "right" )
+    }
+  }
+}
+```
+
+## Smoke test
+
+```bash
+cd code/packages/mosaic-pkg-grid
+cargo test
+```
+
+The smoke test asserts:
+
+1. `mosaic-package.toml` parses and declares the three expected exports.
+2. Each `.mil` compiles via `mosmodel-compiler`.
+3. Each `.mll` compiles via `moslayout-compiler` against its `.mil`
+   interface descriptor.
+4. Each `.dark.msl` compiles via `mosstyle-compiler` against its `.mll`
+   part map.
+
+If `Grid.mll` ever stops compiling (because a future resolver PR
+tightens its tag-validation to reject unknown primitives), the test
+documents the upgrade path: flip Grid's `.mll` assertion to `expect_err`
+until U29-R2 + all U29-K-* resolvers cover `HostTable` / `For` / `If` /
+userland component references.
+
+## Position in UI29's roadmap
+
+* **U29-P1 (this package)**: ship the source tree, declare the manifest,
+  prove the smoke test.
+* **U29-D1**: migrate `demo/visicalc` to import this package's `Grid`
+  instead of carrying its own bespoke copy.
+* **U29-X1**: remove dead `emit_grid_jsx_*` / `emit_input_jsx` /
+  `emit_cell_jsx_*` / `emit_column_jsx_*` from every backend now that
+  Grid is userland and only kernel-primitive lowering is on the
+  critical path.
+
+## License
+
+MIT OR Apache-2.0.

--- a/code/packages/mosaic-pkg-grid/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-grid/mosaic-package.toml
@@ -1,0 +1,22 @@
+# mosaic-package.toml — manifest for mosaic-pkg-grid.
+#
+# Conforms to the UI29 §4.2 package-manifest shape: a [package] table for
+# identity, [components] listing the publicly exported components, an empty
+# [dependencies] table (this package is built only from UI29 kernel
+# primitives — no other userland packages), and a [kernel] table declaring
+# the UI29 kernel revision the package targets.
+
+[package]
+name = "mosaic-pkg-grid"
+version = "0.1.0"
+description = "Spreadsheet-style data grid built on UI29 kernel primitives"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Grid", "Cell", "Column"]
+
+[dependencies]
+# no other packages — built only from UI29 kernel primitives
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic-pkg-grid/src/Cell.dark.msl
+++ b/code/packages/mosaic-pkg-grid/src/Cell.dark.msl
@@ -1,0 +1,25 @@
+// Cell.dark.msl — dark theme style for the Cell component.
+//
+// Targets exactly one part: `cell` (the Box wrapping the Text/HostInput).
+// State `editing` is appended via class suffix at render time — when the
+// host promotes a Cell to editing, the React/SwiftUI/Qt emitter adds the
+// `editing` state class so this block's rules apply.
+//
+// Colour palette:
+//   #1e1e1e   — VS Code dark surface, matches Grid sheet background
+//   #cccccc   — VS Code dark foreground text
+//   #007acc   — VS Code accent blue, used for editing outline
+//   #1f4f3f   — desaturated green tint signalling an active edit field
+
+style Cell {
+  part cell {
+    padding:    4px ;
+    background: #1e1e1e ;
+    color:      #cccccc ;
+
+    state editing {
+      outline:    1px solid #007acc ;
+      background: #1f4f3f ;
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-grid/src/Cell.mil
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mil
@@ -1,0 +1,38 @@
+// Cell.mil — interface for one editable spreadsheet cell.
+//
+// A Cell is the smallest unit of a Grid: a single rendered slot whose
+// display flips between a static Text and an editable HostInput based on
+// the is-editing slot.  Composed by Grid; usable standalone if a host
+// wants a one-off editable cell outside a Grid.
+//
+// Slot vocabulary
+// ---------------
+//   value         the text currently displayed (and the seed for the
+//                 editor's initial value when editing begins)
+//   editable      whether this cell may transition into edit mode at all
+//                 (advisory; the Grid host enforces the policy by setting
+//                 is-editing or not)
+//   is-editing    when true, the cell renders HostInput; otherwise Text
+//   alignment     visual alignment hint ("left" | "right" | "center")
+//   cell-type     advisory type hint ("text" | "number"); v1 treats both
+//                 the same — number-specific formatting/validation is a
+//                 v0.2.0 concern
+//
+// Emit vocabulary
+// ---------------
+//   onClick       fired when the cell is activated (host promotes to edit)
+//   onCommit      fired when an in-progress edit confirms; carries the
+//                 final string value the host should persist
+//   onCancel      fired when an in-progress edit is abandoned
+
+component Cell {
+  slot value      : text ;
+  slot editable   : bool ;
+  slot is-editing : bool ;
+  slot alignment  : text ;
+  slot cell-type  : text ;
+
+  emit onClick ;
+  emit onCommit ( value : text ) ;
+  emit onCancel ;
+}

--- a/code/packages/mosaic-pkg-grid/src/Cell.mll
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mll
@@ -1,0 +1,40 @@
+// Cell.mll — layout for one editable spreadsheet cell.
+//
+// Decomposition (kernel primitives only):
+//
+//   Box [cell]                       ← stylable container, the only `part`
+//     If (when: slot: is-editing)    ← conditional render (UI29 §3.2)
+//       HostInput                    ← native single-line text editor
+//     Else
+//       Text                         ← static read-only display
+//
+// Why a Box wrapper?  mosstyle scoping: the `cell` part is what
+// Cell.dark.msl targets for padding/background/outline.  Without the Box,
+// the rendered child (HostInput vs Text) would have to wear those styles
+// itself — which leaks Cell-shaped concerns into kernel primitives.
+//
+// Why `If` + `Else` and not a single `If`?  We must always render
+// SOMETHING; an absent `Else` would yield an empty cell while not editing,
+// which is the v1 default value's intended display path.
+//
+// IMPORTANT (UI29-P1, v0.1.0): `If` / `Else` / `HostInput` are kernel
+// primitives whose grammar productions and backend lowerings are landing
+// in parallel PRs.  This file is parsed by the existing moslayout grammar
+// (every tag is a NAME token, so `If`/`Else`/`HostInput` look like any
+// other primitive) — so the .mll compiles cleanly.  Whether an emitter
+// can actually lower it depends on which U29-K-* PR has landed.
+
+layout Cell {
+  Box [ cell ] {
+    If ( when: slot: is-editing ) {
+      HostInput (
+        value:    slot: value ,
+        onCommit: emit: onCommit ,
+        onCancel: emit: onCancel
+      )
+    }
+    Else {
+      Text ( content: slot: value )
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-grid/src/Column.mil
+++ b/code/packages/mosaic-pkg-grid/src/Column.mil
@@ -1,0 +1,23 @@
+// Column.mil — interface for a Grid column declaration (metadata-only).
+//
+// Column has no visible output of its own.  Authors place Column nodes as
+// children of a Grid in the host's layout to describe one column's
+// metadata: a stable key, a display header, a width, edit policy,
+// type-class, and a default alignment.  The Grid component reads these
+// fields off its child Column instances at compose time and threads them
+// into the per-row Cell renderings.
+//
+// In other words: Column is a *declarative metadata bag* the framework
+// reads.  Its .mll exists only because moslayout currently requires every
+// component to have a (single) root layout node — Column's is a hollow
+// Box marker.  v0.2.0 may collapse the marker once the resolver accepts
+// declaration-only components.
+
+component Column {
+  slot key               : text ;
+  slot header            : text ;
+  slot width             : number ;
+  slot editable          : bool ;
+  slot cell-type         : text ;
+  slot default-alignment : text ;
+}

--- a/code/packages/mosaic-pkg-grid/src/Column.mll
+++ b/code/packages/mosaic-pkg-grid/src/Column.mll
@@ -1,0 +1,14 @@
+// Column.mll — metadata-only marker for Column.
+//
+// Column produces no visible output; Grid reads its slot values from each
+// child Column instance and threads them into per-row Cell renderings.
+//
+// The single empty `Box [column-marker]` is required because moslayout's
+// current root-count rule (analyze() in moslayout-compiler) demands
+// exactly one root node per layout.  A declaration-only component without
+// any rendered tree is a v0.2.0 concern that needs a grammar/resolver
+// extension allowing zero-root layouts.
+
+layout Column {
+  Box [ column-marker ]
+}

--- a/code/packages/mosaic-pkg-grid/src/Grid.dark.msl
+++ b/code/packages/mosaic-pkg-grid/src/Grid.dark.msl
@@ -1,0 +1,40 @@
+// Grid.dark.msl — dark theme style for the Grid component.
+//
+// Targets two parts:
+//   sheet      — the HostTable element wrapping the whole grid
+//   data-row   — each body row.  State `selected` raises the row when
+//                the host's selected-row index points at it; state
+//                `hover` lifts the row under the pointer.
+//
+// Why not zebra striping?  mosstyle's v1 state vocabulary is the fixed
+// set { hover, pressed, focused, disabled, selected, editing, error }
+// (mosstyle-compiler's `validate_state_name`).  "even" / "odd" are not
+// in that set, so per-row alternation must be done at the colour-token
+// layer (a future $color-row-alt token) or by the backend emitter
+// generating `:nth-child(even)` rules — out of scope for v0.1.0.
+//
+// Colour palette mirrors Cell.dark.msl:
+//   #1e1e1e   — VS Code dark surface (matches Cell background)
+//   #2a2d2e   — VS Code hover surface
+//   #094771   — VS Code selection blue (matches active-row highlight)
+//   #3f3f46   — subtle border colour between cells
+
+style Grid {
+  part sheet {
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #3f3f46 ;
+    background:   #1e1e1e ;
+  }
+
+  part data-row {
+    background: #1e1e1e ;
+
+    state hover {
+      background: #2a2d2e ;
+    }
+    state selected {
+      background: #094771 ;
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-grid/src/Grid.mil
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mil
@@ -1,0 +1,40 @@
+// Grid.mil — interface for the spreadsheet-style data grid.
+//
+// Grid is the headline composition of UI29: a Cell-and-Column composer
+// built entirely from kernel primitives (HostTable + HostTableHead +
+// HostTableBody + Row + For + Cell).  No bespoke per-backend code; the
+// React, SwiftUI, Qt, WebComponent and HTML emitters lower this purely
+// by running their kernel-primitive lowerings.
+//
+// Slot vocabulary
+// ---------------
+//   viewport-rows   the data to render, one inner list per row.  Each
+//                   row[c] is the cell text for column c.  In v0.1.0
+//                   only row[0] is wired (see Grid.mll comment) — full
+//                   per-column iteration arrives with the v0.2.0
+//                   `columns` metadata slot.
+//   selected-row    the row index currently selected (for highlight)
+//   selected-col    the column index currently selected (for highlight)
+//   edit-row        the row index currently being edited (-1 = none)
+//   edit-col        the column index currently being edited (-1 = none)
+//   edit-content    the in-progress edit value (echoed back to the cell
+//                   so the host owns the edit-buffer state)
+//
+// Emit vocabulary
+// ---------------
+//   onNavigate      fired when a different cell is activated
+//   onEditCommit    fired when the in-progress edit confirms
+//   onEditCancel    fired when the in-progress edit is abandoned
+
+component Grid {
+  slot viewport-rows : list<list<text>> ;
+  slot selected-row  : number ;
+  slot selected-col  : number ;
+  slot edit-row      : number ;
+  slot edit-col      : number ;
+  slot edit-content  : text ;
+
+  emit onNavigate    ( row : number , col : number ) ;
+  emit onEditCommit  ( value : text ) ;
+  emit onEditCancel ;
+}

--- a/code/packages/mosaic-pkg-grid/src/Grid.mll
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mll
@@ -1,0 +1,58 @@
+// Grid.mll — layout for the spreadsheet-style data grid.
+//
+// Composition (kernel primitives only):
+//
+//   HostTable [sheet]                  ← semantic data table (UI29 §2.1)
+//     HostTableHead
+//       Row                            ← header row (intentionally empty
+//                                        in v0.1.0 — see note below)
+//     HostTableBody
+//       For (each: slot: viewport-rows, as: row, index: r)
+//         Row [data-row]
+//           Cell [body] ( value: row, ... )
+//
+// Why this shape?  HostTable carries the screen-reader-accessible
+// `<table role="grid">` semantics that "div-soup" cannot provide.
+// HostTableHead / HostTableBody select the `<thead>` / `<tbody>`
+// children.  Row maps to `<tr>` (or SwiftUI's row builder / Qt's row
+// delegate).  For iterates the data slot; Cell is the userland Cell
+// component from this same package.
+//
+// v0.1.0 caveats (intentional — full fix in v0.2.0)
+// -------------------------------------------------
+//   1. Header row is left empty.  Rendering one `<th>` per declared
+//      Column requires Grid's interface to accept a `columns` list slot
+//      so a `For (each: slot: columns, ...)` can drive the header — out
+//      of scope for v0.1.0.
+//   2. Body emits ONE Cell per row, displaying `row` (which here
+//      resolves to a NAME-valued prop — Keyword("row") — picked up by
+//      the resolver as the For-bound iteration variable).  Full
+//      per-column iteration also needs the `columns` slot.
+//
+// IMPORTANT (UI29-P1, v0.1.0): `For`, `HostTable`, `HostTableHead`,
+// `HostTableBody`, `Row`, and `Cell` are all NAME tokens in the current
+// moslayout grammar, so this file parses today.  Backend emitters lower
+// them as their respective U29-K-* PRs land; until then the artifact
+// builder may refuse Grid.  That is expected.
+
+layout Grid {
+  HostTable [ sheet ] {
+    HostTableHead {
+      Row { }
+    }
+    HostTableBody {
+      For ( each: slot: viewport-rows , as: row , index: r ) {
+        Row [ data-row ] {
+          Cell [ body ] (
+            value:      row ,
+            editable:   true ,
+            is-editing: slot: edit-row ,
+            onCommit:   emit: onEditCommit ,
+            onCancel:   emit: onEditCancel ,
+            onClick:    emit: onNavigate
+          )
+        }
+      }
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-grid/src/lib.rs
+++ b/code/packages/mosaic-pkg-grid/src/lib.rs
@@ -1,0 +1,12 @@
+//! mosaic-pkg-grid — userland Mosaic component package.
+//!
+//! This crate is intentionally empty.  The package's real deliverables are
+//! the `.mil` / `.mll` / `.msl` source files under `src/` and the
+//! `mosaic-package.toml` manifest at the package root — they describe
+//! three components (Grid, Cell, Column) composed entirely from UI29
+//! kernel primitives.
+//!
+//! The Rust crate exists only so a smoke-test integration test can run
+//! each component's three source files through the mosmodel /
+//! moslayout / mosstyle compilers and assert the whole package round-
+//! trips at the language-frontend layer.  See `tests/package_compiles.rs`.

--- a/code/packages/mosaic-pkg-grid/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-grid/tests/package_compiles.rs
@@ -1,0 +1,254 @@
+//! package_compiles — smoke test for the mosaic-pkg-grid package.
+//!
+//! Asserts that the four-file shape of the package (manifest + three
+//! components, each with .mil / .mll / .msl) is internally consistent at
+//! the language-frontend layer:
+//!
+//!   1. The manifest parses as TOML and declares the expected exports.
+//!   2. Each <Component>.mil compiles via mosmodel_compiler::compile.
+//!   3. Each <Component>.mll compiles via moslayout_compiler::compile,
+//!      validated against the matching .mil interface descriptor.
+//!   4. Each <Component>.dark.msl compiles via mosstyle_compiler::compile,
+//!      validated against the matching .mll part map.
+//!
+//! Expected v0.1.0 state — what passes and what is documented to fail
+//! ------------------------------------------------------------------
+//! * Cell + Column .mil / .mll / .msl: all compile clean.
+//! * Grid.mil: compiles clean.
+//! * Grid.mll: relies on kernel primitives whose backend lowerings (and
+//!   in some cases their full grammar-level resolver semantics) are
+//!   landing in parallel UI29 PRs.  Today the moslayout compiler treats
+//!   every tag as a NAME token and validates only slot / emit references
+//!   against the .mil, so Grid.mll's `For` / `If` / `HostTable` /
+//!   `HostTableHead` / `HostTableBody` / `Cell` nodes all PARSE and the
+//!   slot / emit references all resolve.  Should that change as the
+//!   resolver gains more checks (e.g. forbidding unknown primitives, or
+//!   requiring expression syntax for `is-editing: slot: edit-row` to
+//!   become `r == slot: edit-row`), this test should be revisited — the
+//!   point is to document the expected current behaviour, not lock the
+//!   package into one specific compiler state.
+//! * Grid.dark.msl: compiles clean (its parts — `sheet`, `data-row` —
+//!   match the Grid.mll part declarations).
+//!
+//! The test deliberately uses simple assertions and prints helpful
+//! diagnostics so a future contributor running it against an updated
+//! compiler can immediately see what changed and where.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// The list of exported components, in the order they appear in the
+/// manifest.  Used to drive the per-component compile loop.
+const COMPONENTS: &[&str] = &["Grid", "Cell", "Column"];
+
+/// Path helpers — anchor everything to the package root (the directory
+/// containing this crate's Cargo.toml).  CARGO_MANIFEST_DIR is set by
+/// Cargo when running the test, so the path is deterministic regardless
+/// of the directory `cargo test` was invoked from.
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn src_path(name: &str) -> PathBuf {
+    package_root().join("src").join(name)
+}
+
+fn read_source(name: &str) -> String {
+    let path = src_path(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest
+// ---------------------------------------------------------------------------
+
+/// Parses `mosaic-package.toml` and asserts the expected exports.
+///
+/// The schema this test enforces is the UI29 §4.2 minimum surface:
+///   [package].name / .version / .description / .license
+///   [components].exports = [...]
+///   [dependencies] (may be empty)
+///   [kernel].version
+#[test]
+fn manifest_declares_expected_exports() {
+    let manifest_src = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("manifest mosaic-package.toml must exist at the package root");
+
+    let value: toml::Value = toml::from_str(&manifest_src)
+        .expect("mosaic-package.toml must parse as valid TOML");
+
+    // [package].name
+    let name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("[package].name must be set");
+    assert_eq!(name, "mosaic-pkg-grid", "[package].name mismatch");
+
+    // [package].version
+    let version = value
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[package].version must be set");
+    assert_eq!(version, "0.1.0", "[package].version must be 0.1.0 for U29-P1");
+
+    // [components].exports
+    let exports = value
+        .get("components")
+        .and_then(|c| c.get("exports"))
+        .and_then(|e| e.as_array())
+        .expect("[components].exports must be an array");
+    let export_names: Vec<&str> = exports.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        export_names,
+        vec!["Grid", "Cell", "Column"],
+        "[components].exports must list exactly Grid, Cell, Column in that order"
+    );
+
+    // [kernel].version
+    let kernel_version = value
+        .get("kernel")
+        .and_then(|k| k.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[kernel].version must be set");
+    assert_eq!(kernel_version, "1", "[kernel].version must target UI29 kernel v1");
+}
+
+// ---------------------------------------------------------------------------
+// 2. mosmodel — .mil compilation
+// ---------------------------------------------------------------------------
+
+/// Each component's `.mil` must compile via mosmodel_compiler.  We hold
+/// onto the descriptor_json output to thread into the .mll compile step.
+#[test]
+fn each_mil_compiles() {
+    for component in COMPONENTS {
+        let src = read_source(&format!("{}.mil", component));
+        let result = mosmodel_compiler::compile(&src);
+        match result {
+            Ok(out) => {
+                assert_eq!(
+                    out.component.component, *component,
+                    "{}.mil declared component name must equal '{}'",
+                    component, component
+                );
+            }
+            Err(errs) => panic!(
+                "{}.mil failed to compile via mosmodel_compiler:\n{:#?}",
+                component, errs
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. moslayout — .mll compilation
+// ---------------------------------------------------------------------------
+
+/// Compiles each `<Component>.mll` against its `<Component>.mil` interface
+/// descriptor.  For Cell and Column the layout is trivially kernel-only
+/// (`Box` is a real primitive) and validates clean.  For Grid we still
+/// expect a clean compile under the current moslayout-compiler — the
+/// tag-name validation is intentionally lax today; should a future R2 PR
+/// tighten it to reject unknown primitives, this assertion should flip
+/// to `expect_err` for Grid until U29-R2 + all U29-K-* resolvers cover
+/// `HostTable` / `For` / `If` / `Cell`.
+#[test]
+fn each_mll_compiles_against_its_interface() {
+    for component in COMPONENTS {
+        let mil_src = read_source(&format!("{}.mil", component));
+        let mil_out = mosmodel_compiler::compile(&mil_src)
+            .unwrap_or_else(|e| panic!("{}.mil precompile failed: {:#?}", component, e));
+
+        let mll_src = read_source(&format!("{}.mll", component));
+        let mll_result =
+            moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json));
+
+        match mll_result {
+            Ok(_) => { /* expected — see test docstring above */ }
+            Err(errs) => panic!(
+                "{}.mll failed to compile via moslayout_compiler:\n{:#?}\n\
+                 NOTE: this MAY be the expected state if the resolver has\n\
+                 been tightened to reject `HostTable` / `For` / `If` / userland\n\
+                 component references — in which case flip this test to\n\
+                 `expect_err` for Grid and document the gap in CHANGELOG.md.",
+                component, errs
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. mosstyle — .msl compilation
+// ---------------------------------------------------------------------------
+
+/// Compiles each available `<Component>.dark.msl` against the part map
+/// produced by `<Component>.mll`.  Column ships no .msl (it has no
+/// visible output), so we only check Grid and Cell.
+#[test]
+fn each_msl_compiles_against_its_part_map() {
+    for component in ["Grid", "Cell"] {
+        let msl_filename = format!("{}.dark.msl", component);
+        let msl_path = src_path(&msl_filename);
+        assert!(
+            msl_path.exists(),
+            "{} must ship a dark-theme stylesheet at {}",
+            component,
+            msl_path.display()
+        );
+
+        // We need the part map produced by the .mll.  Compile the .mll
+        // (with no interface) to get a part map; mosstyle then validates
+        // its `part X { ... }` declarations against that map.
+        let mll_src = read_source(&format!("{}.mll", component));
+        let mll_out = moslayout_compiler::compile(&mll_src, None)
+            .unwrap_or_else(|e| panic!("{}.mll precompile failed: {:#?}", component, e));
+
+        let msl_src = read_source(&msl_filename);
+        let msl_result = mosstyle_compiler::compile(&msl_src, Some(&mll_out.part_map_json));
+
+        if let Err(errs) = msl_result {
+            panic!(
+                "{} failed to compile via mosstyle_compiler:\n{:#?}",
+                msl_filename, errs
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Source-shape sanity
+// ---------------------------------------------------------------------------
+
+/// Belt-and-suspenders check: every file the package promises is on disk.
+#[test]
+fn source_tree_has_expected_shape() {
+    let expected = [
+        "Grid.mil",
+        "Grid.mll",
+        "Grid.dark.msl",
+        "Cell.mil",
+        "Cell.mll",
+        "Cell.dark.msl",
+        "Column.mil",
+        "Column.mll",
+    ];
+    for name in expected {
+        let path = src_path(name);
+        assert!(
+            path.exists(),
+            "expected package source file missing: {}",
+            path.display()
+        );
+    }
+
+    // Column has no .msl on purpose — guard the negative case too.
+    let column_msl = src_path("Column.dark.msl");
+    assert!(
+        !column_msl.exists(),
+        "Column is metadata-only and must not ship a .msl ({} exists unexpectedly)",
+        column_msl.display()
+    );
+}


### PR DESCRIPTION
## Summary

The headline deliverable of **UI29 — Primitive Kernel + Userland Component Packages**: a Grid + Cell + Column component package written entirely in moslayout source, consuming only UI29 kernel primitives.

This is the architectural proof. Backends never see the word "Grid"; they just lower the 15 kernel primitives. Userland composes.

### What lands

```
code/packages/mosaic-pkg-grid/
├── mosaic-package.toml            # [components].exports = [Grid, Cell, Column]
├── README.md / CHANGELOG.md
├── src/
│   ├── Cell.{mil,mll,dark.msl}    # Box + If/Else + HostInput + Text
│   ├── Column.{mil,mll}           # metadata-only marker
│   └── Grid.{mil,mll,dark.msl}    # HostTable + HostTableHead/Body + Row + For + Cell
├── Cargo.toml                     # standalone (empty `[workspace]`) — smoke-test only
└── tests/package_compiles.rs      # manifest + 3-language pipeline round-trip
```

### Spec mapping

- §4.1 package shape: `mosaic-package.toml` + `src/<Component>.{mil,mll,msl}` ✓
- §4.2 manifest schema: `[package]` / `[components].exports` / `[dependencies]` / `[kernel].version = "1"` ✓
- §5.3 demo-migration target: this is the package the VisiCalc demo will import in U29-D1.

### v0.1.0 caveats (deliberate)

- **Header row empty**, **body row shows one Cell with `row` as a Keyword-valued prop**. Full per-column iteration needs Grid's interface to grow a `columns` list slot — out of scope for v0.1.0, planned for v0.2.0.
- **No theming cascade**; ships dark theme only.
- **Backend lowerings are still landing under U29-K-*.** The smoke test asserts language-frontend correctness today; end-to-end artifact generation lights up once each U29-K-* PR ships.

### v0.1.0 substitutions vs the spec's example syntax

- `Grid.dark.msl` uses `state hover` / `state selected` on `data-row` instead of `even`/`odd` because mosstyle's v1 state set is fixed at `{hover, pressed, focused, disabled, selected, editing, error}`. The zebra-stripe pattern needs a colour-token or `:nth-child` lowering — documented in `Grid.dark.msl`'s header comment.

## Test plan

- [x] `cd code/packages/mosaic-pkg-grid && cargo test` — 5/5 pass
  - `manifest_declares_expected_exports` — TOML parses, exports = ["Grid","Cell","Column"], kernel.version = "1"
  - `each_mil_compiles` — three `.mil` files through `mosmodel_compiler::compile`
  - `each_mll_compiles_against_its_interface` — three `.mll` files through `moslayout_compiler::compile` with each .mil's descriptor JSON
  - `each_msl_compiles_against_its_part_map` — two `.dark.msl` files through `mosstyle_compiler::compile` with each .mll's part map JSON (Column has no .msl)
  - `source_tree_has_expected_shape` — every file the package promises exists; Column.dark.msl is verified absent
- [ ] U29-K-* PRs land; rerun against the artifact builder once those are in.
- [ ] U29-D1 imports this package's `Grid` from the VisiCalc demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)