### PR TITLE
feat(mini-sqlite): STRING_AGG as alias for GROUP_CONCAT (SQLite 3.44+)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.59.0] - 2026-05-19
+
+### Added
+
+- **``STRING_AGG(expr, sep)`` aggregate** — SQLite 3.44+ synonym for
+  ``GROUP_CONCAT``.  Standard SQL spells string aggregation with this
+  name; mini-sqlite previously raised ``unknown scalar function:
+  'string_agg'`` because the alias wasn't wired into the adapter's
+  aggregate dispatch.  Routed through the same code path as
+  ``GROUP_CONCAT`` (planner emits the same ``AggregateExpr`` IR; VM
+  handles both via ``AggFunc.GROUP_CONCAT``).
+
+  10 oracle tests in ``test_tier3_string_agg.py`` cover separator
+  variants, GROUP BY composition, NULL skipping, all-NULL groups, and
+  GROUP_CONCAT regression guards.
+
 ## [1.58.0] - 2026-05-19
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.58.0"
+version = "1.59.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1768,9 +1768,13 @@ def _function_call(node: ASTNode, state: _PlaceholderCounter) -> Expr:
             filter_expr=filter_expr_val,
         )
 
-    if upper == "GROUP_CONCAT":
+    if upper in ("GROUP_CONCAT", "STRING_AGG"):
         # GROUP_CONCAT(col)          — SQLite default separator ','
         # GROUP_CONCAT(col, sep)     — explicit string literal separator
+        # STRING_AGG(col, sep)       — SQLite 3.44+ synonym for GROUP_CONCAT;
+        #                              separator is mandatory in standard SQL
+        #                              but SQLite is permissive and accepts a
+        #                              single-arg form too (defaults to ',').
         #
         # SQL:2003 §10.9 requires the separator to be a character-string
         # literal; we enforce that at parse time so the codegen can bake the
@@ -1778,7 +1782,7 @@ def _function_call(node: ASTNode, state: _PlaceholderCounter) -> Expr:
         # dynamically each time.
         if len(args) == 0 or len(args) > 2:
             raise ProgrammingError(
-                "GROUP_CONCAT: expected 1 or 2 arguments "
+                f"{upper}: expected 1 or 2 arguments "
                 "(column [, separator_literal])"
             )
         separator: str | None = None
@@ -1786,7 +1790,7 @@ def _function_call(node: ASTNode, state: _PlaceholderCounter) -> Expr:
             sep_expr = args[1].value
             if not isinstance(sep_expr, Literal) or not isinstance(sep_expr.value, str):
                 raise ProgrammingError(
-                    "GROUP_CONCAT: separator must be a string literal, "
+                    f"{upper}: separator must be a string literal, "
                     f"got {type(sep_expr).__name__}"
                 )
             separator = sep_expr.value

--- a/code/packages/python/mini-sqlite/tests/test_tier3_string_agg.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_string_agg.py
@@ -1,0 +1,138 @@
+"""Oracle tests for ``STRING_AGG`` — SQLite 3.44+ synonym for GROUP_CONCAT.
+
+Standard SQL spells string aggregation as ``STRING_AGG(expr, sep)``;
+SQLite added ``string_agg`` as an alias for ``group_concat`` in 3.44.
+Mini-sqlite previously raised ``unknown scalar function: 'string_agg'``
+because the alias wasn't wired into the adapter's aggregate dispatch.
+
+This PR routes ``STRING_AGG`` through the same code path as
+``GROUP_CONCAT`` (planner emits the same ``AggregateExpr`` IR; VM
+handles both via ``AggFunc.GROUP_CONCAT``).  Both forms now produce
+identical results.
+
+All assertions compare against real ``sqlite3`` byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(setup: list[str], query: str) -> None:
+    conn_m = mini_sqlite.connect(":memory:")
+    conn_r = sqlite3.connect(":memory:")
+    for s in setup:
+        conn_m.execute(s)
+        conn_r.execute(s)
+    m = conn_m.execute(query).fetchall()
+    r = conn_r.execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# string_agg basics
+# ---------------------------------------------------------------------------
+
+
+class TestStringAggBasics:
+    SETUP = [
+        "CREATE TABLE t (x INTEGER)",
+        "INSERT INTO t VALUES (1), (2), (3)",
+    ]
+
+    def test_comma_separator(self) -> None:
+        _check(self.SETUP, "SELECT string_agg(x, ',') FROM t")
+
+    def test_pipe_separator(self) -> None:
+        _check(self.SETUP, "SELECT string_agg(x, '|') FROM t")
+
+    def test_multi_char_separator(self) -> None:
+        _check(self.SETUP, "SELECT string_agg(x, ' -> ') FROM t")
+
+    def test_empty_separator(self) -> None:
+        _check(self.SETUP, "SELECT string_agg(x, '') FROM t")
+
+
+# ---------------------------------------------------------------------------
+# string_agg + GROUP BY
+# ---------------------------------------------------------------------------
+
+
+class TestStringAggGrouped:
+    def test_group_by_with_string_agg(self) -> None:
+        _check(
+            [
+                "CREATE TABLE orders (cust TEXT, item TEXT)",
+                "INSERT INTO orders VALUES "
+                "('alice', 'book'), "
+                "('alice', 'pen'), "
+                "('bob', 'apple'), "
+                "('bob', 'banana'), "
+                "('bob', 'cherry')",
+            ],
+            "SELECT cust, string_agg(item, ', ') FROM orders "
+            "GROUP BY cust ORDER BY cust",
+        )
+
+    def test_group_concat_and_string_agg_equivalent(self) -> None:
+        # Equivalence check — same query with both function names.
+        conn = mini_sqlite.connect(":memory:")
+        for s in [
+            "CREATE TABLE t (id INTEGER, label TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+        ]:
+            conn.execute(s)
+        gc = conn.execute("SELECT group_concat(label, ';') FROM t").fetchall()
+        sa = conn.execute("SELECT string_agg(label, ';') FROM t").fetchall()
+        assert gc == sa == [("a;b;c",)]
+
+
+# ---------------------------------------------------------------------------
+# string_agg NULL handling
+# ---------------------------------------------------------------------------
+
+
+class TestStringAggNulls:
+    def test_nulls_skipped(self) -> None:
+        # Both group_concat and string_agg skip NULL values, like SQLite.
+        _check(
+            [
+                "CREATE TABLE t (val TEXT)",
+                "INSERT INTO t VALUES ('a'), (NULL), ('b'), (NULL), ('c')",
+            ],
+            "SELECT string_agg(val, '+') FROM t",
+        )
+
+    def test_all_nulls_returns_null(self) -> None:
+        _check(
+            [
+                "CREATE TABLE t (val TEXT)",
+                "INSERT INTO t VALUES (NULL), (NULL)",
+            ],
+            "SELECT string_agg(val, ',') FROM t",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression — group_concat unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestGroupConcatRegression:
+    SETUP = [
+        "CREATE TABLE t (x INTEGER)",
+        "INSERT INTO t VALUES (1), (2), (3)",
+    ]
+
+    def test_group_concat_default_sep(self) -> None:
+        _check(self.SETUP, "SELECT group_concat(x) FROM t")
+
+    def test_group_concat_custom_sep(self) -> None:
+        _check(self.SETUP, "SELECT group_concat(x, '-') FROM t")
+
+    # Note: ``group_concat(DISTINCT x)`` is a separate latent bug — the
+    # DISTINCT modifier isn't honoured by the VM's aggregate state.
+    # Deliberately not asserted here; this PR's scope is the STRING_AGG
+    # alias, not DISTINCT handling.


### PR DESCRIPTION
## Summary

Standard SQL spells string aggregation as `STRING_AGG(expr, sep)`. SQLite 3.44 added it as an alias for `GROUP_CONCAT`. Mini-sqlite previously raised:

```
InternalError: unknown scalar function: 'string_agg'
```

The alias is now routed through the same adapter code path as `GROUP_CONCAT` (planner emits the same `AggregateExpr` IR; VM handles both via `AggFunc.GROUP_CONCAT`). Both forms produce identical results.

```sql
-- Both work and produce '1,2,3':
SELECT group_concat(x, ',') FROM t;
SELECT string_agg(x, ',') FROM t;
```

## Implementation

Two-line change in `adapter.py`:
```python
- if upper == "GROUP_CONCAT":
+ if upper in ("GROUP_CONCAT", "STRING_AGG"):
```

Plus updated error messages to reflect the active function name.

## Version bump

`mini-sqlite`: 1.58.0 → 1.59.0

## Test plan

- [x] `pytest code/packages/python/mini-sqlite/tests/` — 1585 pass (10 new), coverage 91.31%
- [x] 10 new oracle tests in `test_tier3_string_agg.py`: separator variants, GROUP BY composition, NULL handling, all-NULL groups, GROUP_CONCAT regression guards, group_concat / string_agg equivalence
- [x] Manual security review: trivial alias addition, no new attack surface

## Surfaced but deferred

`group_concat(DISTINCT x)` doesn't honour DISTINCT (test deliberately omitted). Separate latent bug; will be a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)