### PR TITLE
[codex] Add Board VM upload profiles

### DIFF
--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -77,7 +77,9 @@ use board_vm_targets::{
     all_targets, BoardFamily, BoardTargetInfo, DigitalPinInfo as TargetDigitalPin,
     I2cBusInfo as TargetI2cBus, NetworkInterfaceInfo as TargetNetworkInterface,
     NetworkProtocol as TargetNetworkProtocol, OnboardLed as TargetOnboardLed,
-    SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus,
+    SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
+    UploadImageFormat as TargetUploadImageFormat, UploadInfo as TargetUploadInfo,
+    UploadResetMethod as TargetUploadResetMethod, UploadTransport as TargetUploadTransport,
     WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
 };
 
@@ -430,6 +432,7 @@ pub struct LanguageTargetInfo {
     pub wireless: Vec<LanguageWirelessInterface>,
     pub network_interfaces: Vec<LanguageNetworkInterface>,
     pub connection_options: Vec<LanguageConnectionOption>,
+    pub upload: Option<LanguageUploadOptions>,
     pub capabilities: Vec<String>,
 }
 
@@ -508,6 +511,17 @@ pub struct LanguagePicoUf2UploadOptions {
     pub volume_label: String,
     pub image_extension: String,
     pub auto_detect_mount: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageUploadOptions {
+    pub board_id: String,
+    pub adapter: String,
+    pub image_format: String,
+    pub transport: String,
+    pub reset_method: String,
+    pub command: String,
+    pub notes: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -673,6 +687,37 @@ pub const fn host_endpoint_transport_name(
     }
 }
 
+pub const fn upload_adapter_name(adapter: TargetUploadAdapter) -> &'static str {
+    match adapter {
+        TargetUploadAdapter::ArduinoCli => "arduino_cli",
+        TargetUploadAdapter::EspRomSerial => "esp_rom_serial",
+        TargetUploadAdapter::PicoUf2MassStorage => "pico_uf2_mass_storage",
+    }
+}
+
+pub const fn upload_image_format_name(format: TargetUploadImageFormat) -> &'static str {
+    match format {
+        TargetUploadImageFormat::ArduinoCliBuildOutput => "arduino_cli_build_output",
+        TargetUploadImageFormat::EspFlashImage => "esp_flash_image",
+        TargetUploadImageFormat::Uf2 => "uf2",
+    }
+}
+
+pub const fn upload_transport_name(transport: TargetUploadTransport) -> &'static str {
+    match transport {
+        TargetUploadTransport::Serial => "serial",
+        TargetUploadTransport::MassStorage => "mass_storage",
+    }
+}
+
+pub const fn upload_reset_method_name(method: TargetUploadResetMethod) -> &'static str {
+    match method {
+        TargetUploadResetMethod::ArduinoBoardPackage => "arduino_board_package",
+        TargetUploadResetMethod::EspRomBootPins => "esp_rom_boot_pins",
+        TargetUploadResetMethod::PicoBootsel => "pico_bootsel",
+    }
+}
+
 pub fn capability_flag_names(flags: u16, out: &mut [&'static str]) -> usize {
     let mut count = 0;
     if capability_bytecode_callable(flags) {
@@ -766,6 +811,10 @@ pub fn pico_uf2_upload_options_for_target(selector: &str) -> Option<LanguagePico
         image_extension: ".uf2".to_owned(),
         auto_detect_mount: true,
     })
+}
+
+pub fn upload_options_for_target(selector: &str) -> Option<LanguageUploadOptions> {
+    detect_target(selector)?.upload
 }
 
 pub fn connection_options_for_target(selector: &str) -> Option<Vec<LanguageConnectionOption>> {
@@ -1162,6 +1211,9 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             .map(language_network_interface)
             .collect(),
         connection_options: language_connection_options(target),
+        upload: target
+            .upload
+            .map(|upload| language_upload_options(target.board_id, upload)),
         capabilities: target
             .capabilities
             .iter()
@@ -1245,6 +1297,18 @@ fn language_network_interface(interface: &TargetNetworkInterface) -> LanguageNet
             .collect(),
         max_sockets: interface.max_sockets,
         notes: interface.notes.to_owned(),
+    }
+}
+
+fn language_upload_options(board_id: &str, upload: TargetUploadInfo) -> LanguageUploadOptions {
+    LanguageUploadOptions {
+        board_id: board_id.to_owned(),
+        adapter: upload_adapter_name(upload.adapter).to_owned(),
+        image_format: upload_image_format_name(upload.image_format).to_owned(),
+        transport: upload_transport_name(upload.transport).to_owned(),
+        reset_method: upload_reset_method_name(upload.reset_method).to_owned(),
+        command: upload.command.to_owned(),
+        notes: upload.notes.to_owned(),
     }
 }
 
@@ -3815,6 +3879,7 @@ mod tests {
         assert!(!opta_wifi.digital_pins[0].supports_output);
         assert_eq!(opta_wifi.digital_pins[11].label, "O4");
         assert!(opta_wifi.digital_pins[11].supports_output);
+        assert_eq!(opta_wifi.upload.as_ref().unwrap().adapter, "arduino_cli");
         assert_eq!(
             uno.led_matrix,
             Some(LanguageLedMatrix {
@@ -4602,6 +4667,31 @@ mod tests {
         assert!(options.auto_detect_mount);
         assert!(pico_uf2_upload_options_for_target("pico-w").is_some());
         assert!(pico_uf2_upload_options_for_target("esp32").is_none());
+    }
+
+    #[test]
+    fn generic_upload_options_are_owned_by_rust_language_core() {
+        let opta = upload_options_for_target("arduino-opta-wifi").unwrap();
+        assert_eq!(opta.board_id, "arduino-opta-wifi");
+        assert_eq!(opta.adapter, "arduino_cli");
+        assert_eq!(opta.image_format, "arduino_cli_build_output");
+        assert_eq!(opta.transport, "serial");
+        assert_eq!(opta.reset_method, "arduino_board_package");
+        assert_eq!(opta.command, "arduino-cli upload");
+
+        let esp32 = upload_options_for_target("esp32").unwrap();
+        assert_eq!(esp32.board_id, "esp32-devkit-v1");
+        assert_eq!(esp32.adapter, "esp_rom_serial");
+        assert_eq!(esp32.image_format, "esp_flash_image");
+        assert_eq!(esp32.reset_method, "esp_rom_boot_pins");
+
+        let pico = upload_options_for_target("pico").unwrap();
+        assert_eq!(pico.adapter, "pico_uf2_mass_storage");
+        assert_eq!(pico.image_format, "uf2");
+        assert_eq!(pico.transport, "mass_storage");
+        assert_eq!(pico.reset_method, "pico_bootsel");
+
+        assert!(upload_options_for_target("not-a-board").is_none());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -6,7 +6,10 @@ The registry gives generic front ends and language bindings one stable place to
 ask which boards are known, what runtime id they use, what Rust target they
 compile for, where their onboard LED lives, and which host transports are
 available. Board-specific runtime crates remain responsible for HAL behavior,
-pin validation, wireless stack integration, and upload mechanics.
+pin validation, and wireless stack integration. Upload metadata stays in this
+registry so language frontends can ask Rust whether a target uses Arduino CLI,
+ESP ROM serial flashing, UF2 mass-storage copy, or another board-specific
+adapter.
 
 Arduino coverage is deliberately split in two:
 
@@ -24,6 +27,16 @@ same target registry shape, but they do not pretend to share Uno header pins.
 Nicla and Portenta targets likewise carry their own MCU/runtime descriptors so
 the next board-specific firmware and upload adapters can attach without adding
 special cases to Ruby, Python, Lua, or other language frontends.
+
+Upload metadata is intentionally profile-shaped rather than a frontend command
+builder:
+
+- Arduino-family targets use an Arduino CLI profile so the board package owns
+  bootloader reset, programmer selection, and firmware artifact layout.
+- ESP32 DevKit targets use an ESP ROM serial profile so image layout and boot
+  pin reset remain Rust-owned.
+- Raspberry Pi Pico targets use a Pico UF2 mass-storage profile so BOOTSEL mount
+  discovery and UF2 copy behavior are exposed without frontend special cases.
 
 Wireless metadata separates physical support from the generic front-end sugar:
 

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -122,6 +122,43 @@ pub struct StorageRegionInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadAdapter {
+    ArduinoCli,
+    EspRomSerial,
+    PicoUf2MassStorage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadImageFormat {
+    ArduinoCliBuildOutput,
+    EspFlashImage,
+    Uf2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadTransport {
+    Serial,
+    MassStorage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadResetMethod {
+    ArduinoBoardPackage,
+    EspRomBootPins,
+    PicoBootsel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UploadInfo {
+    pub adapter: UploadAdapter,
+    pub image_format: UploadImageFormat,
+    pub transport: UploadTransport,
+    pub reset_method: UploadResetMethod,
+    pub command: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DigitalPinInfo {
     pub pin: u8,
     pub label: &'static str,
@@ -182,6 +219,7 @@ pub struct BoardTargetInfo {
     pub storage_regions: &'static [StorageRegionInfo],
     pub wireless: &'static [WirelessInterfaceInfo],
     pub network_interfaces: &'static [NetworkInterfaceInfo],
+    pub upload: Option<UploadInfo>,
     pub capabilities: &'static [&'static str],
 }
 
@@ -407,6 +445,35 @@ pub const PICO_W_WIRELESS: [WirelessInterfaceInfo; 3] = [
         ota_update: false,
     },
 ];
+
+pub const ARDUINO_CLI_UPLOAD: UploadInfo = UploadInfo {
+    adapter: UploadAdapter::ArduinoCli,
+    image_format: UploadImageFormat::ArduinoCliBuildOutput,
+    transport: UploadTransport::Serial,
+    reset_method: UploadResetMethod::ArduinoBoardPackage,
+    command: "arduino-cli upload",
+    notes:
+        "Board-specific Arduino CLI package owns bootloader reset, programmer, and final firmware artifact shape.",
+};
+
+pub const ESP_ROM_SERIAL_UPLOAD: UploadInfo = UploadInfo {
+    adapter: UploadAdapter::EspRomSerial,
+    image_format: UploadImageFormat::EspFlashImage,
+    transport: UploadTransport::Serial,
+    reset_method: UploadResetMethod::EspRomBootPins,
+    command: "esp-rom",
+    notes:
+        "Serial ESP ROM flashing path with boot-pin reset and image-layout metadata owned by Rust.",
+};
+
+pub const PICO_UF2_UPLOAD: UploadInfo = UploadInfo {
+    adapter: UploadAdapter::PicoUf2MassStorage,
+    image_format: UploadImageFormat::Uf2,
+    transport: UploadTransport::MassStorage,
+    reset_method: UploadResetMethod::PicoBootsel,
+    command: "pico-uf2",
+    notes: "UF2 copy-to-volume flashing path with BOOTSEL mount discovery owned by Rust.",
+};
 
 pub const UNO_R4_DIGITAL_PINS: [DigitalPinInfo; 20] =
     map_uno_r4_digital_pins(board_vm_uno_r4::UNO_R4_DIGITAL_PINS);
@@ -791,6 +858,7 @@ const fn arduino_board_target(
         storage_regions: &[],
         wireless: &[],
         network_interfaces: &[],
+        upload: Some(ARDUINO_CLI_UPLOAD),
         capabilities: &BLINK_MVP_CAPABILITIES,
     }
 }
@@ -821,6 +889,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         storage_regions: &UNO_R4_STORAGE_REGIONS,
         wireless: &[],
         network_interfaces: &[],
+        upload: Some(ARDUINO_CLI_UPLOAD),
         capabilities: &UNO_R4_MINIMA_CAPABILITIES,
     },
     BoardTargetInfo {
@@ -852,6 +921,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         storage_regions: &UNO_R4_STORAGE_REGIONS,
         wireless: &UNO_R4_WIFI_WIRELESS,
         network_interfaces: &UNO_R4_WIFI_NETWORK_INTERFACES,
+        upload: Some(ARDUINO_CLI_UPLOAD),
         capabilities: &UNO_R4_WIFI_CAPABILITIES,
     },
     arduino_board_target(
@@ -975,6 +1045,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         storage_regions: &[],
         wireless: &ESP32_WIRELESS,
         network_interfaces: &[],
+        upload: Some(ESP_ROM_SERIAL_UPLOAD),
         capabilities: &ESP32_CAPABILITIES,
     },
     BoardTargetInfo {
@@ -1006,6 +1077,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         storage_regions: &[],
         wireless: &[],
         network_interfaces: &[],
+        upload: Some(PICO_UF2_UPLOAD),
         capabilities: &BLINK_MVP_CAPABILITIES,
     },
     BoardTargetInfo {
@@ -1037,6 +1109,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         storage_regions: &[],
         wireless: &PICO_W_WIRELESS,
         network_interfaces: &[],
+        upload: Some(PICO_UF2_UPLOAD),
         capabilities: &PICO_W_CAPABILITIES,
     },
 ];
@@ -1095,6 +1168,31 @@ mod tests {
             assert!(target.capabilities.contains(&"time.sleep_ms"));
             assert!(target.capabilities.contains(&"program.ram_exec"));
         }
+    }
+
+    #[test]
+    fn registry_exposes_upload_profiles() {
+        let uno = find_target("arduino-uno-r4-wifi").unwrap();
+        assert_eq!(uno.upload, Some(ARDUINO_CLI_UPLOAD));
+
+        let opta = find_target("arduino-opta-wifi").unwrap();
+        assert_eq!(opta.upload, Some(ARDUINO_CLI_UPLOAD));
+        assert_eq!(opta.upload.unwrap().command, "arduino-cli upload");
+        assert_eq!(
+            opta.upload.unwrap().reset_method,
+            UploadResetMethod::ArduinoBoardPackage
+        );
+
+        let esp32 = find_target("esp32-devkit-v1").unwrap();
+        assert_eq!(esp32.upload, Some(ESP_ROM_SERIAL_UPLOAD));
+        assert_eq!(
+            esp32.upload.unwrap().image_format,
+            UploadImageFormat::EspFlashImage
+        );
+
+        let pico = find_target("raspberry-pi-pico").unwrap();
+        assert_eq!(pico.upload, Some(PICO_UF2_UPLOAD));
+        assert_eq!(pico.upload.unwrap().transport, UploadTransport::MassStorage);
     }
 
     #[test]

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -194,6 +194,10 @@ The eject manifest:
 ```
 
 SDKs must validate the program against the board descriptor before ejecting.
+Firmware upload and artifact handoff must use the Rust-owned target upload
+profile for the selected board. Language SDKs can wrap that profile in native
+ergonomics, but they should not hard-code whether a board flashes through
+Arduino CLI, ESP ROM serial upload, UF2 mass storage, or another adapter.
 
 ## Error Handling
 

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -113,9 +113,15 @@ identity. Companion/sensor boards whose microcontrollers are not directly
 user-programmable, such as Nicla Sense Env, should be modeled as board
 peripherals or carrier-managed adapters instead of fake firmware runtimes.
 
-The next tranches should add board-specific firmware/upload adapters and richer
-peripheral tables for each family without moving generic Arduino discovery into
-`board-vm-uno-r4`.
+The upload profile tranche exposes the first Rust-owned flashing descriptors
+through the target matrix: Arduino-family boards use an Arduino CLI profile,
+ESP32 uses an ESP ROM serial profile, and Pico/Pico W use a UF2 mass-storage
+profile. Language frontends should consume these profiles instead of branching
+on board names.
+
+The next tranches should deepen board-specific firmware/upload adapters and
+richer peripheral tables for each family without moving generic Arduino
+discovery into `board-vm-uno-r4`.
 
 ### Raspberry Pi Pico
 


### PR DESCRIPTION
## Summary
- add Rust-owned upload profile metadata to Board VM target descriptors
- expose generic upload options through `board-vm-language-core` so language frontends do not branch on board names
- document the upload-profile contract in the host SDK and target matrix specs

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-profiles cargo fmt -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-profiles cargo test -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-profiles cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-profiles bash BUILD` in `code/packages/rust/board-vm-targets`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-profiles bash BUILD` in `code/packages/rust/board-vm-language-core`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`
