### PR TITLE
Expose Chief of Staff scheduler action labels

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this package will be documented in this file.
   and summaries.
 - Stable, parseable supervisor drain scheduler action recommendations for host
   loops.
+- Report-level scheduler action labels for supervisor drain runs.
 - Typed scheduler action intent helpers for continuation, follow-up routing, and
   plan-drift investigation branches.
 - Batch audit write summaries for host flush loops.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -57,7 +57,7 @@ The crate keeps the boundary narrow:
   combine plan-drift and count-drift signals
 - supervisor drain reports and summaries expose stable host-investigation
   classifications for plan drift, count drift, or combined drift
-- supervisor drain summaries expose stable, parseable scheduler action
+- supervisor drain reports and summaries expose stable, parseable scheduler action
   recommendations for continuation, follow-up routing, and plan-drift
   investigation
 - scheduler action recommendations expose typed intent helpers so hosts can

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -921,6 +921,11 @@ impl ToolAuditSupervisorDrainRunReport {
         self.outcome().scheduler_action()
     }
 
+    /// Return the stable scheduler-action label for this drain run.
+    pub fn scheduler_action_label(&self) -> &'static str {
+        self.scheduler_action().as_str()
+    }
+
     /// Return whether the host should investigate preflight/drain drift.
     pub fn requires_plan_drift_investigation(&self) -> bool {
         self.scheduler_action().requires_plan_drift_investigation()
@@ -3420,6 +3425,7 @@ mod tests {
             report.scheduler_action(),
             ToolAuditSupervisorDrainSchedulerAction::ScheduleContinuation
         );
+        assert_eq!(report.scheduler_action_label(), "schedule_continuation");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a report-level scheduler action label helper for Chief of Staff drain runs
- cover the report helper in the existing action-label test
- document report and summary scheduler action label parity

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD