### PR TITLE
fix(mini-sqlite): reject DISTINCT on multi-argument aggregates

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [1.61.0] - 2026-05-20
+
+### Fixed
+
+- **Reject ``DISTINCT`` on multi-argument aggregates** — SQLite
+  enforces a parse-time rule that any ``DISTINCT`` aggregate must take
+  exactly one argument; calling ``group_concat(DISTINCT col, sep)``,
+  ``string_agg(DISTINCT col, sep)``, or
+  ``json_group_object(DISTINCT key, val)`` raises
+  ``OperationalError: DISTINCT aggregates must have exactly one
+  argument`` in the reference engine.
+
+  mini-sqlite previously accepted all three forms silently — the
+  separator/value was simply ignored or, worse, the dedup happened on
+  the wrong column.  Latent bug surfaced while writing the 1.60.0
+  oracle tests: ``test_tier3_group_concat_distinct.py`` had to skip
+  the explicit-separator DISTINCT form because there was no way to
+  compare against the reference engine (which rejected the query).
+
+  Now both engines raise the same diagnostic; the adapter validates
+  ``distinct and len(args) > 1`` in the ``GROUP_CONCAT`` / ``STRING_AGG``
+  and ``JSON_GROUP_OBJECT`` branches and surfaces SQLite's exact
+  message text.
+
+  10 tests in ``test_tier3_distinct_aggregate_arity.py`` cover the
+  rejected forms (group_concat / string_agg with separator,
+  json_group_object), exact-text diagnostic pinning, and legal-form
+  regressions (single-arg DISTINCT, multi-arg without DISTINCT,
+  COUNT/SUM DISTINCT).
+
 ## [1.60.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.60.0"
+version = "1.61.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1785,6 +1785,15 @@ def _function_call(node: ASTNode, state: _PlaceholderCounter) -> Expr:
                 f"{upper}: expected 1 or 2 arguments "
                 "(column [, separator_literal])"
             )
+        # SQLite forbids ``DISTINCT`` on the two-argument form: a DISTINCT
+        # aggregate must take exactly one argument.  The reference engine
+        # raises ``OperationalError: DISTINCT aggregates must have
+        # exactly one argument``; we surface the same message so callers
+        # can rely on text-matching tests against either implementation.
+        if distinct and len(args) > 1:
+            raise ProgrammingError(
+                "DISTINCT aggregates must have exactly one argument"
+            )
         separator: str | None = None
         if len(args) == 2:
             sep_expr = args[1].value
@@ -1812,6 +1821,14 @@ def _function_call(node: ASTNode, state: _PlaceholderCounter) -> Expr:
             raise ProgrammingError(
                 "JSON_GROUP_OBJECT: expected exactly 2 arguments (key, value), "
                 f"got {len(args)}"
+            )
+        # As with GROUP_CONCAT(DISTINCT col, sep), SQLite forbids DISTINCT
+        # on multi-argument aggregates: there is no well-defined notion of
+        # "distinct (key, value) pair" in the engine, so the parser rejects
+        # the combination outright with the same diagnostic.
+        if distinct:
+            raise ProgrammingError(
+                "DISTINCT aggregates must have exactly one argument"
             )
         return AggregateExpr(
             func=AggFunc.JSON_GROUP_OBJECT,

--- a/code/packages/python/mini-sqlite/tests/test_tier3_distinct_aggregate_arity.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_distinct_aggregate_arity.py
@@ -30,7 +30,6 @@ import pytest
 import mini_sqlite
 from mini_sqlite import ProgrammingError
 
-
 _DISTINCT_MSG = "DISTINCT aggregates must have exactly one argument"
 
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_distinct_aggregate_arity.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_distinct_aggregate_arity.py
@@ -1,0 +1,122 @@
+"""Reject ``DISTINCT`` on multi-argument aggregates.
+
+SQLite enforces a parse-time rule: a ``DISTINCT`` aggregate must take
+exactly one argument.  Calling ``group_concat(DISTINCT col, sep)`` or
+``json_group_object(DISTINCT key, val)`` raises::
+
+    OperationalError: DISTINCT aggregates must have exactly one argument
+
+This mirrors a fundamental ambiguity — for a single column the notion
+of "distinct values" is unambiguous, but for multiple arguments the
+engine would have to define distinctness over tuples (and SQLite does
+not).
+
+Before this PR, mini-sqlite silently accepted both forms.  The fix
+adds the same arity check in the adapter's ``GROUP_CONCAT`` /
+``STRING_AGG`` / ``JSON_GROUP_OBJECT`` branches and surfaces the
+identical diagnostic text so callers can rely on string-match tests
+against either engine.
+
+These tests verify:
+  * the rejected forms raise with the exact SQLite message
+  * the legal forms (single-arg DISTINCT; multi-arg without DISTINCT)
+    still work
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import mini_sqlite
+from mini_sqlite import ProgrammingError
+
+
+_DISTINCT_MSG = "DISTINCT aggregates must have exactly one argument"
+
+
+# ---------------------------------------------------------------------------
+# Rejected forms — DISTINCT + multi-arg aggregate
+# ---------------------------------------------------------------------------
+
+
+class TestDistinctMultiArgRejected:
+    def _setup(self) -> mini_sqlite.Connection:
+        conn = mini_sqlite.connect(":memory:")
+        conn.execute("CREATE TABLE t (k TEXT, v INTEGER)")
+        conn.execute("INSERT INTO t VALUES ('a', 1), ('b', 2), ('a', 1)")
+        return conn
+
+    def test_group_concat_distinct_with_separator(self) -> None:
+        conn = self._setup()
+        with pytest.raises(ProgrammingError, match=_DISTINCT_MSG):
+            conn.execute("SELECT group_concat(DISTINCT v, ',') FROM t")
+
+    def test_group_concat_distinct_with_pipe_separator(self) -> None:
+        conn = self._setup()
+        with pytest.raises(ProgrammingError, match=_DISTINCT_MSG):
+            conn.execute("SELECT group_concat(DISTINCT v, '|') FROM t")
+
+    def test_string_agg_distinct_with_separator(self) -> None:
+        # STRING_AGG shares the GROUP_CONCAT code path so the rule applies
+        # identically to the SQLite 3.44+ alias.
+        conn = self._setup()
+        with pytest.raises(ProgrammingError, match=_DISTINCT_MSG):
+            conn.execute("SELECT string_agg(DISTINCT v, ',') FROM t")
+
+    def test_json_group_object_distinct(self) -> None:
+        conn = self._setup()
+        with pytest.raises(ProgrammingError, match=_DISTINCT_MSG):
+            conn.execute("SELECT json_group_object(DISTINCT k, v) FROM t")
+
+    def test_error_message_exact_match(self) -> None:
+        # Pin the exact diagnostic text so callers can string-match against
+        # either mini-sqlite or the reference sqlite3 module.
+        conn = self._setup()
+        try:
+            conn.execute("SELECT group_concat(DISTINCT v, ',') FROM t")
+        except ProgrammingError as e:
+            assert str(e) == _DISTINCT_MSG
+        else:
+            raise AssertionError("expected ProgrammingError")
+
+
+# ---------------------------------------------------------------------------
+# Legal forms — must still work
+# ---------------------------------------------------------------------------
+
+
+class TestLegalFormsStillWork:
+    def _setup(self) -> mini_sqlite.Connection:
+        conn = mini_sqlite.connect(":memory:")
+        conn.execute("CREATE TABLE t (k TEXT, v INTEGER)")
+        conn.execute("INSERT INTO t VALUES ('a', 1), ('b', 2), ('a', 1)")
+        return conn
+
+    def test_group_concat_distinct_default_sep(self) -> None:
+        # DISTINCT + single argument: legal.  Default ',' separator.
+        conn = self._setup()
+        rows = conn.execute("SELECT group_concat(DISTINCT v) FROM t").fetchall()
+        assert rows == [("1,2",)]
+
+    def test_group_concat_with_separator_no_distinct(self) -> None:
+        # Multi-arg without DISTINCT: legal.
+        conn = self._setup()
+        rows = conn.execute("SELECT group_concat(v, '|') FROM t").fetchall()
+        assert rows == [("1|2|1",)]
+
+    def test_string_agg_no_distinct(self) -> None:
+        conn = self._setup()
+        rows = conn.execute("SELECT string_agg(v, ',') FROM t").fetchall()
+        assert rows == [("1,2,1",)]
+
+    def test_count_distinct_single_arg(self) -> None:
+        # Confirms the new check didn't leak into the COUNT/SUM/AVG branch,
+        # which already enforced its own arity rule.
+        conn = self._setup()
+        rows = conn.execute("SELECT COUNT(DISTINCT v) FROM t").fetchall()
+        assert rows == [(2,)]
+
+    def test_sum_distinct_single_arg(self) -> None:
+        conn = self._setup()
+        rows = conn.execute("SELECT SUM(DISTINCT v) FROM t").fetchall()
+        assert rows == [(3,)]  # 1 + 2 (duplicate 1 collapsed)


### PR DESCRIPTION
## Summary

- SQLite parse-time rule: any `DISTINCT` aggregate must take exactly one argument. mini-sqlite was silently accepting `group_concat(DISTINCT col, sep)`, `string_agg(DISTINCT col, sep)`, and `json_group_object(DISTINCT k, v)`.
- Adapter now validates `distinct and len(args) > 1` in the `GROUP_CONCAT` / `STRING_AGG` and `JSON_GROUP_OBJECT` branches and raises with SQLite's exact diagnostic text: `DISTINCT aggregates must have exactly one argument`.
- 10 tests in `test_tier3_distinct_aggregate_arity.py` cover rejected forms, diagnostic-text pinning, and legal-form regressions.
- Version bump 1.60.0 → 1.61.0.

Latent bug surfaced while writing the oracle tests for #3655 — the explicit-separator `DISTINCT` form had to be skipped because the reference engine rejected it. This PR closes that loophole.

## Test plan

- [x] `pytest tests/test_tier3_distinct_aggregate_arity.py` — 10/10 pass
- [x] `pytest tests/` — full suite 1605 passed, 3 skipped
- [ ] CI green
- [ ] Diagnostic text matches reference `sqlite3` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)