### PR TITLE
Resolve Board VM targets from Arduino FQBN selectors

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -32,3 +32,8 @@ Firmware flashing follows the same rule: frontends can present native options,
 but they should query `upload_plan_for_target` to learn the artifact kind,
 transport requirements, reset behavior, adapter steps, and Arduino CLI
 platform/FQBN metadata for each board family.
+
+Frontends that already have an Arduino CLI platform or FQBN should pass it back
+to Rust rather than carrying their own selector table. `detect_target` resolves
+unique FQBNs to a concrete board target, and `targets_for_upload_selector`
+returns every target for broader or intentionally shared package identities.

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -765,6 +765,19 @@ pub fn detect_target(selector: &str) -> Option<LanguageTargetInfo> {
     detect_board_target(selector).map(language_target_info)
 }
 
+pub fn targets_for_upload_selector(selector: &str) -> Vec<LanguageTargetInfo> {
+    let normalized = normalize_target_selector(selector);
+    if normalized.is_empty() {
+        return Vec::new();
+    }
+
+    all_targets()
+        .iter()
+        .filter(|target| upload_selector_matches(target, &normalized))
+        .map(language_target_info)
+        .collect()
+}
+
 fn known_board_target(board_id: &str) -> Option<&'static BoardTargetInfo> {
     all_targets()
         .iter()
@@ -783,6 +796,10 @@ fn detect_board_target(selector: &str) -> Option<&'static BoardTargetInfo> {
         {
             return Some(target);
         }
+    }
+
+    if let Some(target) = unique_upload_selector_target(&normalized) {
+        return Some(target);
     }
 
     let board_id = match normalized.as_str() {
@@ -805,6 +822,32 @@ fn detect_board_target(selector: &str) -> Option<&'static BoardTargetInfo> {
         _ => return None,
     };
     known_board_target(board_id)
+}
+
+fn unique_upload_selector_target(normalized: &str) -> Option<&'static BoardTargetInfo> {
+    let mut match_target = None;
+    for target in all_targets() {
+        if upload_selector_matches(target, normalized) {
+            if match_target.is_some() {
+                return None;
+            }
+            match_target = Some(target);
+        }
+    }
+    match_target
+}
+
+fn upload_selector_matches(target: &BoardTargetInfo, normalized: &str) -> bool {
+    let Some(upload) = target.upload else {
+        return false;
+    };
+
+    upload
+        .fqbn
+        .is_some_and(|fqbn| normalize_target_selector(fqbn) == normalized)
+        || upload
+            .platform_id
+            .is_some_and(|platform_id| normalize_target_selector(platform_id) == normalized)
 }
 
 pub fn esp_upload_options_for_target(selector: &str) -> Option<LanguageEspUploadOptions> {
@@ -4736,6 +4779,12 @@ mod tests {
             detect_target("UNO R4 WiFi").unwrap().board_id,
             "arduino-uno-r4-wifi"
         );
+        assert_eq!(
+            detect_target("arduino:renesas_uno:nanor4")
+                .unwrap()
+                .board_id,
+            "arduino-nano-r4"
+        );
         assert_eq!(detect_target("esp32").unwrap().board_id, "esp32-devkit-v1");
         assert_eq!(
             detect_target("pico-w").unwrap().board_id,
@@ -4749,7 +4798,38 @@ mod tests {
             normalize_target_selector("ESP32 DevKit V1"),
             "esp32_devkit_v1"
         );
+        assert!(detect_target("arduino:mbed_opta:opta").is_none());
         assert!(detect_target("definitely-not-a-board").is_none());
+    }
+
+    #[test]
+    fn rust_core_resolves_upload_selectors_from_target_metadata() {
+        let renesas_uno_targets = targets_for_upload_selector("arduino:renesas_uno");
+        assert_eq!(renesas_uno_targets.len(), 3);
+        assert!(renesas_uno_targets
+            .iter()
+            .any(|target| target.board_id == "arduino-uno-r4-wifi"));
+        assert!(renesas_uno_targets
+            .iter()
+            .any(|target| target.board_id == "arduino-nano-r4"));
+
+        let mega = targets_for_upload_selector("arduino:avr:mega:cpu=atmega2560");
+        assert_eq!(mega.len(), 1);
+        assert_eq!(mega[0].board_id, "arduino-mega-2560");
+
+        let opta_targets = targets_for_upload_selector("arduino:mbed_opta:opta");
+        assert_eq!(opta_targets.len(), 3);
+        assert!(opta_targets
+            .iter()
+            .any(|target| target.board_id == "arduino-opta-lite"));
+        assert!(opta_targets
+            .iter()
+            .any(|target| target.board_id == "arduino-opta-rs485"));
+        assert!(opta_targets
+            .iter()
+            .any(|target| target.board_id == "arduino-opta-wifi"));
+
+        assert!(targets_for_upload_selector("not-a-board").is_empty());
     }
 
     #[test]
@@ -4793,6 +4873,10 @@ mod tests {
         assert_eq!(opta.platform_id.as_deref(), Some("arduino:mbed_opta"));
         assert_eq!(opta.fqbn.as_deref(), Some("arduino:mbed_opta:opta"));
 
+        let nano_r4 = upload_options_for_target("arduino:renesas_uno:nanor4").unwrap();
+        assert_eq!(nano_r4.board_id, "arduino-nano-r4");
+        assert_eq!(nano_r4.fqbn.as_deref(), Some("arduino:renesas_uno:nanor4"));
+
         let esp32 = upload_options_for_target("esp32").unwrap();
         assert_eq!(esp32.board_id, "esp32-devkit-v1");
         assert_eq!(esp32.adapter, "esp_rom_serial");
@@ -4831,6 +4915,13 @@ mod tests {
                 "delegate_reset_to_board_package",
                 "upload_with_arduino_cli",
             ]
+        );
+
+        let mega = upload_plan_for_target("arduino:avr:mega:cpu=atmega2560").unwrap();
+        assert_eq!(mega.board_id, "arduino-mega-2560");
+        assert_eq!(
+            mega.fqbn.as_deref(),
+            Some("arduino:avr:mega:cpu=atmega2560")
         );
 
         let esp32 = upload_plan_for_target("esp32").unwrap();

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -203,6 +203,12 @@ serial or mount-path requirements, bootloader reset behavior, Arduino CLI
 platform/FQBN metadata, and transfer steps remain shared across Ruby, Python,
 Lua, Java, JS, and future CLIs.
 
+Selector handling follows the same ownership boundary. If a frontend receives
+an Arduino CLI FQBN such as `arduino:renesas_uno:nanor4`, it should ask the Rust
+language core to resolve that selector instead of maintaining a language-local
+board mapping. Shared package selectors may return multiple board targets so
+variant choices, such as Opta Lite/RS485/WiFi, remain explicit.
+
 ## Error Handling
 
 Every SDK maps protocol errors to language-native exceptions or result types,

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -124,6 +124,11 @@ artifact kind, artifact extension when one exists, serial or mount-path
 requirements, reset method, board package identity, and adapter steps are
 emitted by Rust language core for each supported upload profile.
 
+The FQBN selector tranche lets the same Rust target matrix resolve Arduino CLI
+platform/FQBN strings back to Board VM board targets. Unique FQBNs can resolve
+directly to one target; shared package identities return every matching board
+so language frontends do not guess between variants.
+
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino
 discovery into `board-vm-uno-r4`.


### PR DESCRIPTION
## Summary
- resolve unique Arduino CLI FQBN selectors through the Rust-owned target matrix
- add `targets_for_upload_selector` so shared platform/FQBN identities return all matching Board VM targets instead of forcing frontend guesses
- route upload options/plans through the same selector path for unique board package identities
- document that language SDKs should hand Arduino CLI selectors back to Rust

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-fqbn-selectors cargo fmt -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-fqbn-selectors cargo test -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-fqbn-selectors cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-fqbn-selectors bash BUILD` in `code/packages/rust/board-vm-language-core`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`