### PR TITLE
Expose Chief of Staff scheduler intent helpers

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this package will be documented in this file.
 - Stable, parseable supervisor drain scheduler action recommendations for host
   loops.
 - Report-level scheduler action labels for supervisor drain runs.
+- Report-level scheduler action intent helpers for supervisor drain runs.
 - Typed scheduler action intent helpers for continuation, follow-up routing, and
   plan-drift investigation branches.
 - Batch audit write summaries for host flush loops.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -60,7 +60,8 @@ The crate keeps the boundary narrow:
 - supervisor drain reports and summaries expose stable, parseable scheduler action
   recommendations for continuation, follow-up routing, and plan-drift
   investigation
-- scheduler action recommendations expose typed intent helpers so hosts can
+- scheduler action recommendations expose typed intent helpers on reports and
+  summaries so hosts can
   branch on continuation, follow-up routing, or plan-drift investigation
   without parsing labels
 

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -926,6 +926,16 @@ impl ToolAuditSupervisorDrainRunReport {
         self.scheduler_action().as_str()
     }
 
+    /// Return whether the scheduler should run another drain pass.
+    pub fn requests_continuation(&self) -> bool {
+        self.scheduler_action().requests_continuation()
+    }
+
+    /// Return whether follow-up pressure should be routed to the host.
+    pub fn routes_follow_up(&self) -> bool {
+        self.scheduler_action().routes_follow_up()
+    }
+
     /// Return whether the host should investigate preflight/drain drift.
     pub fn requires_plan_drift_investigation(&self) -> bool {
         self.scheduler_action().requires_plan_drift_investigation()
@@ -3414,6 +3424,8 @@ mod tests {
         );
         assert_eq!(report.outcome_label(), "needs_continuation");
         assert!(report.requires_scheduler_action());
+        assert!(report.requests_continuation());
+        assert!(!report.routes_follow_up());
         assert!(!report.requires_plan_drift_investigation());
         assert_eq!(
             report.host_investigation_kind(),


### PR DESCRIPTION
## Summary
- add report-level scheduler intent helpers for continuation and follow-up routing
- cover the report helpers in the existing scheduler action test
- document report and summary scheduler intent parity

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD