### PR TITLE
Add Board VM Arduino upload port hints

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -24,7 +24,10 @@ Each target currently proves the shared GPIO/time backend path. Board-specific
 firmware/upload crates can extend the same descriptor with richer peripherals
 without falling back to Uno R4 assumptions. The descriptors also carry the
 Arduino CLI platform/FQBN for each board so host SDKs can ask Rust for upload
-metadata instead of maintaining language-local board tables.
+metadata instead of maintaining language-local board tables. The upload
+descriptor also records whether the board appears through a USB serial bridge,
+native USB bootloader, or external serial adapter, which keeps Pro Mini-style
+boards from being treated like onboard-USB Arduinos.
 
 Opta terminals are modeled as board-local input and relay-output pins instead
 of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware

--- a/code/packages/rust/board-vm-arduino/src/lib.rs
+++ b/code/packages/rust/board-vm-arduino/src/lib.rs
@@ -78,10 +78,26 @@ pub struct ArduinoTargetDescriptor {
 pub struct ArduinoCliUploadDescriptor {
     pub platform_id: &'static str,
     pub fqbn: &'static str,
+    pub port_hint: ArduinoCliPortHint,
 }
 
-const fn arduino_cli(platform_id: &'static str, fqbn: &'static str) -> ArduinoCliUploadDescriptor {
-    ArduinoCliUploadDescriptor { platform_id, fqbn }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArduinoCliPortHint {
+    UsbSerialBridge,
+    NativeUsb,
+    ExternalSerialAdapter,
+}
+
+const fn arduino_cli(
+    platform_id: &'static str,
+    fqbn: &'static str,
+    port_hint: ArduinoCliPortHint,
+) -> ArduinoCliUploadDescriptor {
+    ArduinoCliUploadDescriptor {
+        platform_id,
+        fqbn,
+        port_hint,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -494,7 +510,11 @@ pub const ARDUINO_UNO_R3: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-uno-r3",
     display_name: "Arduino UNO R3",
     family: ArduinoFamily::ClassicAvr,
-    arduino_cli: arduino_cli("arduino:avr", "arduino:avr:uno"),
+    arduino_cli: arduino_cli(
+        "arduino:avr",
+        "arduino:avr:uno",
+        ArduinoCliPortHint::UsbSerialBridge,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega328P",
     core: "8-bit AVR",
@@ -514,7 +534,11 @@ pub const ARDUINO_NANO_CLASSIC: ArduinoTargetDescriptor = ArduinoTargetDescripto
     board_id: "arduino-nano-classic",
     display_name: "Arduino Nano",
     family: ArduinoFamily::ClassicAvr,
-    arduino_cli: arduino_cli("arduino:avr", "arduino:avr:nano:cpu=atmega328"),
+    arduino_cli: arduino_cli(
+        "arduino:avr",
+        "arduino:avr:nano:cpu=atmega328",
+        ArduinoCliPortHint::UsbSerialBridge,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega328P",
     core: "8-bit AVR",
@@ -534,7 +558,11 @@ pub const ARDUINO_PRO_MINI: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-pro-mini",
     display_name: "Arduino Pro Mini",
     family: ArduinoFamily::ClassicAvr,
-    arduino_cli: arduino_cli("arduino:avr", "arduino:avr:pro:cpu=16MHzatmega328"),
+    arduino_cli: arduino_cli(
+        "arduino:avr",
+        "arduino:avr:pro:cpu=16MHzatmega328",
+        ArduinoCliPortHint::ExternalSerialAdapter,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega328P",
     core: "8-bit AVR",
@@ -554,7 +582,11 @@ pub const ARDUINO_MEGA_2560: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-mega-2560",
     display_name: "Arduino Mega 2560 Rev3",
     family: ArduinoFamily::ClassicAvr,
-    arduino_cli: arduino_cli("arduino:avr", "arduino:avr:mega:cpu=atmega2560"),
+    arduino_cli: arduino_cli(
+        "arduino:avr",
+        "arduino:avr:mega:cpu=atmega2560",
+        ArduinoCliPortHint::UsbSerialBridge,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega2560",
     core: "8-bit AVR",
@@ -574,7 +606,11 @@ pub const ARDUINO_LEONARDO: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-leonardo",
     display_name: "Arduino Leonardo",
     family: ArduinoFamily::ClassicAvr,
-    arduino_cli: arduino_cli("arduino:avr", "arduino:avr:leonardo"),
+    arduino_cli: arduino_cli(
+        "arduino:avr",
+        "arduino:avr:leonardo",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega32U4",
     core: "8-bit AVR with USB",
@@ -594,7 +630,11 @@ pub const ARDUINO_MICRO: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-micro",
     display_name: "Arduino Micro",
     family: ArduinoFamily::ClassicAvr,
-    arduino_cli: arduino_cli("arduino:avr", "arduino:avr:micro"),
+    arduino_cli: arduino_cli(
+        "arduino:avr",
+        "arduino:avr:micro",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega32U4",
     core: "8-bit AVR with USB",
@@ -614,7 +654,11 @@ pub const ARDUINO_DUE: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-due",
     display_name: "Arduino Due",
     family: ArduinoFamily::Sam,
-    arduino_cli: arduino_cli("arduino:sam", "arduino:sam:arduino_due_x"),
+    arduino_cli: arduino_cli(
+        "arduino:sam",
+        "arduino:sam:arduino_due_x",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "SAM3X8E",
     core: "Arm Cortex-M3",
@@ -634,7 +678,11 @@ pub const ARDUINO_ZERO: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-zero",
     display_name: "Arduino Zero",
     family: ArduinoFamily::Samd,
-    arduino_cli: arduino_cli("arduino:samd", "arduino:samd:arduino_zero_native"),
+    arduino_cli: arduino_cli(
+        "arduino:samd",
+        "arduino:samd:arduino_zero_native",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Small,
     mcu: "SAMD21G18",
     core: "Arm Cortex-M0+",
@@ -654,7 +702,11 @@ pub const ARDUINO_MKR_WIFI_1010: ArduinoTargetDescriptor = ArduinoTargetDescript
     board_id: "arduino-mkr-wifi-1010",
     display_name: "Arduino MKR WiFi 1010",
     family: ArduinoFamily::Samd,
-    arduino_cli: arduino_cli("arduino:samd", "arduino:samd:mkrwifi1010"),
+    arduino_cli: arduino_cli(
+        "arduino:samd",
+        "arduino:samd:mkrwifi1010",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Small,
     mcu: "SAMD21G18",
     core: "Arm Cortex-M0+ with u-blox NINA-W102",
@@ -674,7 +726,11 @@ pub const ARDUINO_NANO_EVERY: ArduinoTargetDescriptor = ArduinoTargetDescriptor 
     board_id: "arduino-nano-every",
     display_name: "Arduino Nano Every",
     family: ArduinoFamily::MegaAvr,
-    arduino_cli: arduino_cli("arduino:megaavr", "arduino:megaavr:nona4809:mode=off"),
+    arduino_cli: arduino_cli(
+        "arduino:megaavr",
+        "arduino:megaavr:nona4809:mode=off",
+        ArduinoCliPortHint::UsbSerialBridge,
+    ),
     runtime_profile: RuntimeProfile::Tiny,
     mcu: "ATmega4809",
     core: "8-bit megaAVR 0-series",
@@ -694,7 +750,11 @@ pub const ARDUINO_NANO_R4: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-nano-r4",
     display_name: "Arduino Nano R4",
     family: ArduinoFamily::RenesasRa,
-    arduino_cli: arduino_cli("arduino:renesas_uno", "arduino:renesas_uno:nanor4"),
+    arduino_cli: arduino_cli(
+        "arduino:renesas_uno",
+        "arduino:renesas_uno:nanor4",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "RA4M1",
     core: "Arm Cortex-M4F",
@@ -714,7 +774,11 @@ pub const ARDUINO_NANO_33_IOT: ArduinoTargetDescriptor = ArduinoTargetDescriptor
     board_id: "arduino-nano-33-iot",
     display_name: "Arduino Nano 33 IoT",
     family: ArduinoFamily::Samd,
-    arduino_cli: arduino_cli("arduino:samd", "arduino:samd:nano_33_iot"),
+    arduino_cli: arduino_cli(
+        "arduino:samd",
+        "arduino:samd:nano_33_iot",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Small,
     mcu: "SAMD21G18",
     core: "Arm Cortex-M0+ with u-blox NINA-W102",
@@ -734,7 +798,11 @@ pub const ARDUINO_NANO_33_BLE_REV2: ArduinoTargetDescriptor = ArduinoTargetDescr
     board_id: "arduino-nano-33-ble-rev2",
     display_name: "Arduino Nano 33 BLE Rev2",
     family: ArduinoFamily::Nordic,
-    arduino_cli: arduino_cli("arduino:mbed_nano", "arduino:mbed_nano:nano33ble"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_nano",
+        "arduino:mbed_nano:nano33ble",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "nRF52840",
     core: "Arm Cortex-M4F with Bluetooth LE",
@@ -757,6 +825,7 @@ pub const ARDUINO_NANO_RP2040_CONNECT: ArduinoTargetDescriptor = ArduinoTargetDe
     arduino_cli: arduino_cli(
         "arduino:mbed_nano",
         "arduino:mbed_nano:nanorp2040connect",
+        ArduinoCliPortHint::NativeUsb,
     ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "RP2040",
@@ -777,7 +846,11 @@ pub const ARDUINO_NANO_ESP32: ArduinoTargetDescriptor = ArduinoTargetDescriptor 
     board_id: "arduino-nano-esp32",
     display_name: "Arduino Nano ESP32",
     family: ArduinoFamily::Esp32,
-    arduino_cli: arduino_cli("arduino:esp32", "arduino:esp32:nano_nora"),
+    arduino_cli: arduino_cli(
+        "arduino:esp32",
+        "arduino:esp32:nano_nora",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "ESP32-S3",
     core: "Xtensa LX7",
@@ -797,7 +870,11 @@ pub const ARDUINO_GIGA_R1_WIFI: ArduinoTargetDescriptor = ArduinoTargetDescripto
     board_id: "arduino-giga-r1-wifi",
     display_name: "Arduino GIGA R1 WiFi",
     family: ArduinoFamily::Stm32,
-    arduino_cli: arduino_cli("arduino:mbed_giga", "arduino:mbed_giga:giga"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_giga",
+        "arduino:mbed_giga:giga",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747XI",
     core: "dual Arm Cortex-M7/M4",
@@ -817,7 +894,11 @@ pub const ARDUINO_PORTENTA_H7: ArduinoTargetDescriptor = ArduinoTargetDescriptor
     board_id: "arduino-portenta-h7",
     display_name: "Arduino Portenta H7",
     family: ArduinoFamily::Mbed,
-    arduino_cli: arduino_cli("arduino:mbed_portenta", "arduino:mbed_portenta:envie_m7"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_portenta",
+        "arduino:mbed_portenta:envie_m7",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747XI",
     core: "dual Arm Cortex-M7/M4",
@@ -837,7 +918,11 @@ pub const ARDUINO_PORTENTA_H7_LITE: ArduinoTargetDescriptor = ArduinoTargetDescr
     board_id: "arduino-portenta-h7-lite",
     display_name: "Arduino Portenta H7 Lite",
     family: ArduinoFamily::Mbed,
-    arduino_cli: arduino_cli("arduino:mbed_portenta", "arduino:mbed_portenta:envie_m7"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_portenta",
+        "arduino:mbed_portenta:envie_m7",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747XI",
     core: "dual Arm Cortex-M7/M4",
@@ -858,7 +943,11 @@ pub const ARDUINO_PORTENTA_H7_LITE_CONNECTED: ArduinoTargetDescriptor =
         board_id: "arduino-portenta-h7-lite-connected",
         display_name: "Arduino Portenta H7 Lite Connected",
         family: ArduinoFamily::Mbed,
-        arduino_cli: arduino_cli("arduino:mbed_portenta", "arduino:mbed_portenta:envie_m7"),
+        arduino_cli: arduino_cli(
+            "arduino:mbed_portenta",
+            "arduino:mbed_portenta:envie_m7",
+            ArduinoCliPortHint::NativeUsb,
+        ),
         runtime_profile: RuntimeProfile::Full,
         mcu: "STM32H747XI",
         core: "dual Arm Cortex-M7/M4 with WiFi/BLE module",
@@ -881,6 +970,7 @@ pub const ARDUINO_PORTENTA_C33: ArduinoTargetDescriptor = ArduinoTargetDescripto
     arduino_cli: arduino_cli(
         "arduino:renesas_portenta",
         "arduino:renesas_portenta:portenta_c33",
+        ArduinoCliPortHint::NativeUsb,
     ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "R7FA6M5BH2CBG",
@@ -901,7 +991,11 @@ pub const ARDUINO_NICLA_VISION: ArduinoTargetDescriptor = ArduinoTargetDescripto
     board_id: "arduino-nicla-vision",
     display_name: "Arduino Nicla Vision",
     family: ArduinoFamily::Mbed,
-    arduino_cli: arduino_cli("arduino:mbed_nicla", "arduino:mbed_nicla:nicla_vision"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_nicla",
+        "arduino:mbed_nicla:nicla_vision",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747AII6",
     core: "dual Arm Cortex-M7/M4 with camera and WiFi/BLE module",
@@ -921,7 +1015,11 @@ pub const ARDUINO_NICLA_SENSE_ME: ArduinoTargetDescriptor = ArduinoTargetDescrip
     board_id: "arduino-nicla-sense-me",
     display_name: "Arduino Nicla Sense ME",
     family: ArduinoFamily::Nordic,
-    arduino_cli: arduino_cli("arduino:mbed_nicla", "arduino:mbed_nicla:nicla_sense"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_nicla",
+        "arduino:mbed_nicla:nicla_sense",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Small,
     mcu: "nRF52832",
     core: "Arm Cortex-M4F with Bosch smart sensor hub",
@@ -941,7 +1039,11 @@ pub const ARDUINO_NICLA_VOICE: ArduinoTargetDescriptor = ArduinoTargetDescriptor
     board_id: "arduino-nicla-voice",
     display_name: "Arduino Nicla Voice",
     family: ArduinoFamily::Nordic,
-    arduino_cli: arduino_cli("arduino:mbed_nicla", "arduino:mbed_nicla:nicla_voice"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_nicla",
+        "arduino:mbed_nicla:nicla_voice",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Small,
     mcu: "nRF52832",
     core: "Arm Cortex-M4F with Syntiant NDP120",
@@ -961,7 +1063,11 @@ pub const ARDUINO_OPTA_LITE: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-opta-lite",
     display_name: "Arduino Opta Lite",
     family: ArduinoFamily::Stm32,
-    arduino_cli: arduino_cli("arduino:mbed_opta", "arduino:mbed_opta:opta"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_opta",
+        "arduino:mbed_opta:opta",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747XI",
     core: "dual Arm Cortex-M7/M4 with Ethernet",
@@ -981,7 +1087,11 @@ pub const ARDUINO_OPTA_RS485: ArduinoTargetDescriptor = ArduinoTargetDescriptor 
     board_id: "arduino-opta-rs485",
     display_name: "Arduino Opta RS485",
     family: ArduinoFamily::Stm32,
-    arduino_cli: arduino_cli("arduino:mbed_opta", "arduino:mbed_opta:opta"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_opta",
+        "arduino:mbed_opta:opta",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747XI",
     core: "dual Arm Cortex-M7/M4 with Ethernet and RS-485",
@@ -1001,7 +1111,11 @@ pub const ARDUINO_OPTA_WIFI: ArduinoTargetDescriptor = ArduinoTargetDescriptor {
     board_id: "arduino-opta-wifi",
     display_name: "Arduino Opta WiFi",
     family: ArduinoFamily::Stm32,
-    arduino_cli: arduino_cli("arduino:mbed_opta", "arduino:mbed_opta:opta"),
+    arduino_cli: arduino_cli(
+        "arduino:mbed_opta",
+        "arduino:mbed_opta:opta",
+        ArduinoCliPortHint::NativeUsb,
+    ),
     runtime_profile: RuntimeProfile::Full,
     mcu: "STM32H747XI",
     core: "dual Arm Cortex-M7/M4 with Ethernet, RS-485, and WiFi/BLE",
@@ -1145,6 +1259,26 @@ mod tests {
         assert!(ARDUINO_TARGETS
             .iter()
             .all(|target| target.digital_pins.iter().any(|pin| pin.supports_output)));
+    }
+
+    #[test]
+    fn arduino_cli_descriptors_carry_board_specific_port_hints() {
+        assert_eq!(
+            ARDUINO_UNO_R3.arduino_cli.port_hint,
+            ArduinoCliPortHint::UsbSerialBridge
+        );
+        assert_eq!(
+            ARDUINO_LEONARDO.arduino_cli.port_hint,
+            ArduinoCliPortHint::NativeUsb
+        );
+        assert_eq!(
+            ARDUINO_PRO_MINI.arduino_cli.port_hint,
+            ArduinoCliPortHint::ExternalSerialAdapter
+        );
+        assert_eq!(
+            ARDUINO_NANO_R4.arduino_cli.port_hint,
+            ArduinoCliPortHint::NativeUsb
+        );
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -30,8 +30,8 @@ they send and decode should come from this Rust core.
 
 Firmware flashing follows the same rule: frontends can present native options,
 but they should query `upload_plan_for_target` to learn the artifact kind,
-transport requirements, reset behavior, adapter steps, and Arduino CLI
-platform/FQBN metadata for each board family.
+transport requirements, reset behavior, port hint, adapter steps, and Arduino
+CLI platform/FQBN metadata for each board family.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -79,8 +79,9 @@ use board_vm_targets::{
     NetworkProtocol as TargetNetworkProtocol, OnboardLed as TargetOnboardLed,
     SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
     UploadImageFormat as TargetUploadImageFormat, UploadInfo as TargetUploadInfo,
-    UploadResetMethod as TargetUploadResetMethod, UploadTransport as TargetUploadTransport,
-    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
+    UploadPortHint as TargetUploadPortHint, UploadResetMethod as TargetUploadResetMethod,
+    UploadTransport as TargetUploadTransport, WirelessInterfaceInfo as TargetWirelessInterface,
+    WirelessTransport as TargetWirelessTransport,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -520,6 +521,7 @@ pub struct LanguageUploadOptions {
     pub image_format: String,
     pub transport: String,
     pub reset_method: String,
+    pub port_hint: Option<String>,
     pub command: String,
     pub platform_id: Option<String>,
     pub fqbn: Option<String>,
@@ -533,6 +535,7 @@ pub struct LanguageUploadPlan {
     pub image_format: String,
     pub transport: String,
     pub reset_method: String,
+    pub port_hint: Option<String>,
     pub command: String,
     pub platform_id: Option<String>,
     pub fqbn: Option<String>,
@@ -728,6 +731,16 @@ pub const fn upload_transport_name(transport: TargetUploadTransport) -> &'static
     match transport {
         TargetUploadTransport::Serial => "serial",
         TargetUploadTransport::MassStorage => "mass_storage",
+    }
+}
+
+pub const fn upload_port_hint_name(hint: TargetUploadPortHint) -> &'static str {
+    match hint {
+        TargetUploadPortHint::UsbSerialBridge => "usb_serial_bridge",
+        TargetUploadPortHint::NativeUsb => "native_usb",
+        TargetUploadPortHint::ExternalSerialAdapter => "external_serial_adapter",
+        TargetUploadPortHint::EspRomSerial => "esp_rom_serial",
+        TargetUploadPortHint::MassStorageBootloader => "mass_storage_bootloader",
     }
 }
 
@@ -1386,10 +1399,23 @@ fn language_upload_options(board_id: &str, upload: TargetUploadInfo) -> Language
         image_format: upload_image_format_name(upload.image_format).to_owned(),
         transport: upload_transport_name(upload.transport).to_owned(),
         reset_method: upload_reset_method_name(upload.reset_method).to_owned(),
+        port_hint: upload
+            .port_hint
+            .map(upload_port_hint_name)
+            .map(str::to_owned),
         command: upload.command.to_owned(),
         platform_id: upload.platform_id.map(str::to_owned),
         fqbn: upload.fqbn.map(str::to_owned),
         notes: upload.notes.to_owned(),
+    }
+}
+
+fn arduino_cli_port_selection_step(hint: Option<TargetUploadPortHint>) -> &'static str {
+    match hint {
+        Some(TargetUploadPortHint::UsbSerialBridge) => "select_usb_serial_port",
+        Some(TargetUploadPortHint::NativeUsb) => "select_native_usb_port",
+        Some(TargetUploadPortHint::ExternalSerialAdapter) => "select_external_serial_adapter",
+        _ => "select_serial_port",
     }
 }
 
@@ -1402,6 +1428,7 @@ fn language_upload_plan(board_id: &str, upload: TargetUploadInfo) -> LanguageUpl
             image_format: options.image_format,
             transport: options.transport,
             reset_method: options.reset_method,
+            port_hint: options.port_hint,
             command: options.command,
             platform_id: options.platform_id,
             fqbn: options.fqbn,
@@ -1413,7 +1440,7 @@ fn language_upload_plan(board_id: &str, upload: TargetUploadInfo) -> LanguageUpl
             steps: vec![
                 "resolve_arduino_board_package".to_owned(),
                 "build_firmware_artifact".to_owned(),
-                "select_serial_port".to_owned(),
+                arduino_cli_port_selection_step(upload.port_hint).to_owned(),
                 "delegate_reset_to_board_package".to_owned(),
                 "upload_with_arduino_cli".to_owned(),
             ],
@@ -1425,6 +1452,7 @@ fn language_upload_plan(board_id: &str, upload: TargetUploadInfo) -> LanguageUpl
             image_format: options.image_format,
             transport: options.transport,
             reset_method: options.reset_method,
+            port_hint: options.port_hint,
             command: options.command,
             platform_id: options.platform_id,
             fqbn: options.fqbn,
@@ -1448,6 +1476,7 @@ fn language_upload_plan(board_id: &str, upload: TargetUploadInfo) -> LanguageUpl
             image_format: options.image_format,
             transport: options.transport,
             reset_method: options.reset_method,
+            port_hint: options.port_hint,
             command: options.command,
             platform_id: options.platform_id,
             fqbn: options.fqbn,
@@ -4869,6 +4898,7 @@ mod tests {
         assert_eq!(opta.image_format, "arduino_cli_build_output");
         assert_eq!(opta.transport, "serial");
         assert_eq!(opta.reset_method, "arduino_board_package");
+        assert_eq!(opta.port_hint.as_deref(), Some("native_usb"));
         assert_eq!(opta.command, "arduino-cli upload");
         assert_eq!(opta.platform_id.as_deref(), Some("arduino:mbed_opta"));
         assert_eq!(opta.fqbn.as_deref(), Some("arduino:mbed_opta:opta"));
@@ -4876,12 +4906,20 @@ mod tests {
         let nano_r4 = upload_options_for_target("arduino:renesas_uno:nanor4").unwrap();
         assert_eq!(nano_r4.board_id, "arduino-nano-r4");
         assert_eq!(nano_r4.fqbn.as_deref(), Some("arduino:renesas_uno:nanor4"));
+        assert_eq!(nano_r4.port_hint.as_deref(), Some("native_usb"));
+
+        let pro_mini = upload_options_for_target("arduino-pro-mini").unwrap();
+        assert_eq!(
+            pro_mini.port_hint.as_deref(),
+            Some("external_serial_adapter")
+        );
 
         let esp32 = upload_options_for_target("esp32").unwrap();
         assert_eq!(esp32.board_id, "esp32-devkit-v1");
         assert_eq!(esp32.adapter, "esp_rom_serial");
         assert_eq!(esp32.image_format, "esp_flash_image");
         assert_eq!(esp32.reset_method, "esp_rom_boot_pins");
+        assert_eq!(esp32.port_hint.as_deref(), Some("esp_rom_serial"));
         assert_eq!(esp32.platform_id, None);
         assert_eq!(esp32.fqbn, None);
 
@@ -4890,6 +4928,7 @@ mod tests {
         assert_eq!(pico.image_format, "uf2");
         assert_eq!(pico.transport, "mass_storage");
         assert_eq!(pico.reset_method, "pico_bootsel");
+        assert_eq!(pico.port_hint.as_deref(), Some("mass_storage_bootloader"));
 
         assert!(upload_options_for_target("not-a-board").is_none());
     }
@@ -4902,6 +4941,7 @@ mod tests {
         assert_eq!(opta.artifact_kind, "arduino_cli_build_output");
         assert_eq!(opta.platform_id.as_deref(), Some("arduino:mbed_opta"));
         assert_eq!(opta.fqbn.as_deref(), Some("arduino:mbed_opta:opta"));
+        assert_eq!(opta.port_hint.as_deref(), Some("native_usb"));
         assert_eq!(opta.artifact_extension, None);
         assert!(opta.requires_serial_port);
         assert!(!opta.requires_mount_path);
@@ -4911,7 +4951,7 @@ mod tests {
             vec![
                 "resolve_arduino_board_package",
                 "build_firmware_artifact",
-                "select_serial_port",
+                "select_native_usb_port",
                 "delegate_reset_to_board_package",
                 "upload_with_arduino_cli",
             ]
@@ -4923,10 +4963,22 @@ mod tests {
             mega.fqbn.as_deref(),
             Some("arduino:avr:mega:cpu=atmega2560")
         );
+        assert_eq!(mega.port_hint.as_deref(), Some("usb_serial_bridge"));
+        assert!(mega.steps.contains(&"select_usb_serial_port".to_owned()));
+
+        let pro_mini = upload_plan_for_target("arduino-pro-mini").unwrap();
+        assert_eq!(
+            pro_mini.port_hint.as_deref(),
+            Some("external_serial_adapter")
+        );
+        assert!(pro_mini
+            .steps
+            .contains(&"select_external_serial_adapter".to_owned()));
 
         let esp32 = upload_plan_for_target("esp32").unwrap();
         assert_eq!(esp32.adapter, "esp_rom_serial");
         assert_eq!(esp32.artifact_kind, "esp_flash_image");
+        assert_eq!(esp32.port_hint.as_deref(), Some("esp_rom_serial"));
         assert_eq!(esp32.platform_id, None);
         assert_eq!(esp32.fqbn, None);
         assert_eq!(esp32.artifact_extension.as_deref(), Some(".bin"));
@@ -4938,6 +4990,7 @@ mod tests {
         assert_eq!(pico.board_id, "raspberry-pi-pico-w");
         assert_eq!(pico.adapter, "pico_uf2_mass_storage");
         assert_eq!(pico.artifact_kind, "uf2_file");
+        assert_eq!(pico.port_hint.as_deref(), Some("mass_storage_bootloader"));
         assert_eq!(pico.artifact_extension.as_deref(), Some(".uf2"));
         assert!(!pico.requires_serial_port);
         assert!(pico.requires_mount_path);

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -34,6 +34,9 @@ builder:
 - Arduino-family targets use an Arduino CLI profile so the board package owns
   bootloader reset, programmer selection, firmware artifact layout, and the
   selected platform/FQBN string for each concrete board descriptor.
+  Board-specific port hints distinguish USB-serial bridge boards, native-USB
+  bootloaders, and external serial adapter boards before a frontend calls the
+  shared Arduino CLI adapter.
 - ESP32 DevKit targets use an ESP ROM serial profile so image layout and boot
   pin reset remain Rust-owned.
 - Raspberry Pi Pico targets use a Pico UF2 mass-storage profile so BOOTSEL mount

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -142,6 +142,15 @@ pub enum UploadTransport {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadPortHint {
+    UsbSerialBridge,
+    NativeUsb,
+    ExternalSerialAdapter,
+    EspRomSerial,
+    MassStorageBootloader,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UploadResetMethod {
     ArduinoBoardPackage,
     EspRomBootPins,
@@ -154,6 +163,7 @@ pub struct UploadInfo {
     pub image_format: UploadImageFormat,
     pub transport: UploadTransport,
     pub reset_method: UploadResetMethod,
+    pub port_hint: Option<UploadPortHint>,
     pub command: &'static str,
     pub platform_id: Option<&'static str>,
     pub fqbn: Option<&'static str>,
@@ -448,12 +458,17 @@ pub const PICO_W_WIRELESS: [WirelessInterfaceInfo; 3] = [
     },
 ];
 
-const fn arduino_cli_upload(platform_id: &'static str, fqbn: &'static str) -> UploadInfo {
+const fn arduino_cli_upload(
+    platform_id: &'static str,
+    fqbn: &'static str,
+    port_hint: UploadPortHint,
+) -> UploadInfo {
     UploadInfo {
         adapter: UploadAdapter::ArduinoCli,
         image_format: UploadImageFormat::ArduinoCliBuildOutput,
         transport: UploadTransport::Serial,
         reset_method: UploadResetMethod::ArduinoBoardPackage,
+        port_hint: Some(port_hint),
         command: "arduino-cli upload",
         platform_id: Some(platform_id),
         fqbn: Some(fqbn),
@@ -461,17 +476,24 @@ const fn arduino_cli_upload(platform_id: &'static str, fqbn: &'static str) -> Up
     }
 }
 
-pub const UNO_R4_MINIMA_UPLOAD: UploadInfo =
-    arduino_cli_upload("arduino:renesas_uno", "arduino:renesas_uno:minima");
+pub const UNO_R4_MINIMA_UPLOAD: UploadInfo = arduino_cli_upload(
+    "arduino:renesas_uno",
+    "arduino:renesas_uno:minima",
+    UploadPortHint::NativeUsb,
+);
 
-pub const UNO_R4_WIFI_UPLOAD: UploadInfo =
-    arduino_cli_upload("arduino:renesas_uno", "arduino:renesas_uno:unor4wifi");
+pub const UNO_R4_WIFI_UPLOAD: UploadInfo = arduino_cli_upload(
+    "arduino:renesas_uno",
+    "arduino:renesas_uno:unor4wifi",
+    UploadPortHint::NativeUsb,
+);
 
 pub const ARDUINO_CLI_UPLOAD: UploadInfo = UploadInfo {
     adapter: UploadAdapter::ArduinoCli,
     image_format: UploadImageFormat::ArduinoCliBuildOutput,
     transport: UploadTransport::Serial,
     reset_method: UploadResetMethod::ArduinoBoardPackage,
+    port_hint: None,
     command: "arduino-cli upload",
     platform_id: None,
     fqbn: None,
@@ -484,6 +506,7 @@ pub const ESP_ROM_SERIAL_UPLOAD: UploadInfo = UploadInfo {
     image_format: UploadImageFormat::EspFlashImage,
     transport: UploadTransport::Serial,
     reset_method: UploadResetMethod::EspRomBootPins,
+    port_hint: Some(UploadPortHint::EspRomSerial),
     command: "esp-rom",
     platform_id: None,
     fqbn: None,
@@ -496,6 +519,7 @@ pub const PICO_UF2_UPLOAD: UploadInfo = UploadInfo {
     image_format: UploadImageFormat::Uf2,
     transport: UploadTransport::MassStorage,
     reset_method: UploadResetMethod::PicoBootsel,
+    port_hint: Some(UploadPortHint::MassStorageBootloader),
     command: "pico-uf2",
     platform_id: None,
     fqbn: None,
@@ -855,6 +879,16 @@ const fn pico_digital_pin(pin: board_vm_pico::DigitalPinDescriptor) -> DigitalPi
     }
 }
 
+const fn arduino_cli_port_hint(hint: board_vm_arduino::ArduinoCliPortHint) -> UploadPortHint {
+    match hint {
+        board_vm_arduino::ArduinoCliPortHint::UsbSerialBridge => UploadPortHint::UsbSerialBridge,
+        board_vm_arduino::ArduinoCliPortHint::NativeUsb => UploadPortHint::NativeUsb,
+        board_vm_arduino::ArduinoCliPortHint::ExternalSerialAdapter => {
+            UploadPortHint::ExternalSerialAdapter
+        }
+    }
+}
+
 const fn arduino_board_target(
     target: board_vm_arduino::ArduinoTargetDescriptor,
     digital_pins: &'static [DigitalPinInfo],
@@ -888,6 +922,7 @@ const fn arduino_board_target(
         upload: Some(arduino_cli_upload(
             target.arduino_cli.platform_id,
             target.arduino_cli.fqbn,
+            arduino_cli_port_hint(target.arduino_cli.port_hint),
         )),
         capabilities: &BLINK_MVP_CAPABILITIES,
     }
@@ -1200,6 +1235,10 @@ mod tests {
                 target.upload.unwrap().fqbn,
                 Some(arduino_target.arduino_cli.fqbn)
             );
+            assert_eq!(
+                target.upload.unwrap().port_hint,
+                Some(arduino_cli_port_hint(arduino_target.arduino_cli.port_hint))
+            );
             assert!(target.capabilities.contains(&"transport.serial"));
             assert!(target.capabilities.contains(&"gpio.open"));
             assert!(target.capabilities.contains(&"gpio.write"));
@@ -1217,14 +1256,28 @@ mod tests {
             uno.upload.unwrap().fqbn,
             Some("arduino:renesas_uno:unor4wifi")
         );
+        assert_eq!(
+            uno.upload.unwrap().port_hint,
+            Some(UploadPortHint::NativeUsb)
+        );
 
         let opta = find_target("arduino-opta-wifi").unwrap();
         assert_eq!(opta.upload.unwrap().command, "arduino-cli upload");
         assert_eq!(opta.upload.unwrap().platform_id, Some("arduino:mbed_opta"));
         assert_eq!(opta.upload.unwrap().fqbn, Some("arduino:mbed_opta:opta"));
         assert_eq!(
+            opta.upload.unwrap().port_hint,
+            Some(UploadPortHint::NativeUsb)
+        );
+        assert_eq!(
             opta.upload.unwrap().reset_method,
             UploadResetMethod::ArduinoBoardPackage
+        );
+
+        let pro_mini = find_target("arduino-pro-mini").unwrap();
+        assert_eq!(
+            pro_mini.upload.unwrap().port_hint,
+            Some(UploadPortHint::ExternalSerialAdapter)
         );
 
         let nano_esp32 = find_target("arduino-nano-esp32").unwrap();
@@ -1241,6 +1294,10 @@ mod tests {
         assert_eq!(esp32.upload, Some(ESP_ROM_SERIAL_UPLOAD));
         assert_eq!(esp32.upload.unwrap().fqbn, None);
         assert_eq!(
+            esp32.upload.unwrap().port_hint,
+            Some(UploadPortHint::EspRomSerial)
+        );
+        assert_eq!(
             esp32.upload.unwrap().image_format,
             UploadImageFormat::EspFlashImage
         );
@@ -1248,6 +1305,10 @@ mod tests {
         let pico = find_target("raspberry-pi-pico").unwrap();
         assert_eq!(pico.upload, Some(PICO_UF2_UPLOAD));
         assert_eq!(pico.upload.unwrap().transport, UploadTransport::MassStorage);
+        assert_eq!(
+            pico.upload.unwrap().port_hint,
+            Some(UploadPortHint::MassStorageBootloader)
+        );
     }
 
     #[test]

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -200,8 +200,11 @@ ergonomics, but they should not hard-code whether a board flashes through
 Arduino CLI, ESP ROM serial upload, UF2 mass storage, or another adapter.
 SDKs should ask the Rust language core for the upload plan so artifact kind,
 serial or mount-path requirements, bootloader reset behavior, Arduino CLI
-platform/FQBN metadata, and transfer steps remain shared across Ruby, Python,
-Lua, Java, JS, and future CLIs.
+platform/FQBN metadata, board-specific port hints, and transfer steps remain
+shared across Ruby, Python, Lua, Java, JS, and future CLIs. Arduino CLI plans
+must preserve whether the board expects an onboard USB serial bridge, a native
+USB bootloader port, or an external serial adapter so frontends do not infer
+that from board names.
 
 Selector handling follows the same ownership boundary. If a frontend receives
 an Arduino CLI FQBN such as `arduino:renesas_uno:nanor4`, it should ask the Rust

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -129,6 +129,11 @@ platform/FQBN strings back to Board VM board targets. Unique FQBNs can resolve
 directly to one target; shared package identities return every matching board
 so language frontends do not guess between variants.
 
+The Arduino upload adapter details tranche adds Rust-owned port hints to the
+same descriptors. Arduino CLI boards now report whether their upload path starts
+from a USB serial bridge, native USB bootloader port, or external serial
+adapter before delegating reset/programmer behavior to the board package.
+
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino
 discovery into `board-vm-uno-r4`.


### PR DESCRIPTION
## Summary
- add Arduino CLI upload port hints to shared Arduino descriptors for USB serial bridge, native USB, and external serial adapter boards
- propagate port hints through board-vm-targets and language-core upload options/plans, including board-specific port-selection steps
- document the Rust-owned upload-port boundary in Board VM specs and package READMEs

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-adapter-details cargo fmt -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-adapter-details cargo test -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-adapter-details cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-adapter-details bash BUILD in code/packages/rust/board-vm-arduino
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-adapter-details bash BUILD in code/packages/rust/board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-upload-adapter-details bash BUILD in code/packages/rust/board-vm-language-core
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check