### PR TITLE
feat(ruby-lexer): Phase 2 — ParserOracle + LexState + `f /x/` disambiguation

### DIFF
--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.3.0] - 2026-05-20
+
+### Added (Phase 2 — parser-feedback)
+- `LexState` enum (`ExprBeg`, `ExprMid`, `ExprEnd`, `ExprArg`, `ExprFname`, `ExprDot`) — tracked by the lexer and updated after every emitted token.  See `code/specs/ruby-lexer-state-machine.md` §1.
+- `ParserOracle` trait with default impls (`NoLocals`, `StaticLocals`).  Consulted by the lexer when `/` follows a name in `ExprArg` position — local-variable names get binary division, method-like names get a regex literal.  See `code/specs/ruby-lexer-state-machine.md` §3.
+- `RubyLexer::with_oracle(version, oracle)` constructor and `tokenize_ruby_with_oracle(source, oracle)` convenience entry point.
+- `regex_body` / `regex_escape` sub-states in `ruby-1.8.lexer.states.toml`.  Reached via `set_current_state` from the action interpreter once it has decided to open a regex literal; the engine then accumulates the body until the closing `/`.
+- Regex literals emit as `TokenType::String` tokens with the value framed as `/.../` so the parser can dispatch by lexeme until a dedicated `TokenType::Regex` lands in a later phase.
+
+### Changed
+- `tokenize_ruby` default semantics for `/` after a name now follow the spec: with the `NoLocals` oracle every name is a method, so `f /x/` lexes as a method call with a regex argument.  Callers that want binary division on locals must pass a `ParserOracle` via `tokenize_ruby_with_oracle` (or `RubyLexer::with_oracle`).
+- The Phase 1 `binary_operators_dispatch_to_dedicated_kinds` test was rewritten to pass an explicit `StaticLocals` oracle declaring its operands as locals.
+
+### Notes
+- Phase 2 leaves the `+` / `-` / `*` whitespace-sensitive disambiguation untouched — the spec defers it to a Phase 2b refinement.  Only `/` is interpreted via lex-state + oracle in this cut.
+- Regex flags (`/foo/i`, `/foo/m`, …) remain unhandled — they arrive alongside heredoc / interpolation in Phase 3.
+
 ## [0.2.0] - 2026-05-19
 
 ### Changed (BREAKING)

--- a/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
+++ b/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
@@ -73,6 +73,10 @@ name = "String"        # quoted string literal (escapes resolved by runtime)
 fields = ["value", "quote"]
 
 [[tokens]]
+name = "Regex"         # /.../  literal — Phase 2 (no flags yet)
+fields = ["value"]
+
+[[tokens]]
 name = "Op"            # generic operator token, parser disambiguates further
 fields = ["value"]
 
@@ -160,6 +164,16 @@ id = "string_d_escape"   # inside "..." after a backslash
 id = "string_s_body"     # inside '...'
 [[states]]
 id = "string_s_escape"
+
+[[states]]
+id = "regex_body"        # inside /.../ — entered manually from `data`
+                         # by the action interpreter once it has
+                         # decided (based on lex-state + oracle) that
+                         # the `/` opens a regex literal rather than
+                         # a division operator.  See SIR-style
+                         # `set_current_state` call in src/lib.rs.
+[[states]]
+id = "regex_escape"      # inside /.../ after `\\`
 
 [[states]]
 id = "comment_body"      # # to end-of-line
@@ -629,6 +643,59 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = ["parse_error(unterminated_string)", "emit(Eof)"]
+
+# ─────────────────────────────────────────────────────────────────
+# Regex body  (Phase 2)
+#
+# The action interpreter (src/lib.rs) decides when `/` in `data`
+# state opens a regex literal vs binary division.  When it picks
+# "regex", it calls `set_current_state("regex_body")` on the
+# engine, clears the text buffer, and skips re-feeding the `/`.
+# This sub-machine then accumulates chars until the closing `/`.
+#
+# Phase 2 does NOT yet parse regex flags (`i`, `m`, `x`, `o`).
+# Those land in Phase 3 alongside heredoc / interpolation work.
+# ─────────────────────────────────────────────────────────────────
+
+[[transitions]]
+from = "regex_body"
+matcher = { literal = "\\" }
+to = "regex_escape"
+
+[[transitions]]
+from = "regex_body"
+matcher = { literal = "/" }
+to = "data"
+actions = ["emit(Regex)"]
+
+[[transitions]]
+from = "regex_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_regex)", "emit(Eof)"]
+
+[[transitions]]
+from = "regex_body"
+matcher = { anything = true }
+to = "regex_body"
+actions = ["append_text(current)"]
+
+# Regex escape: any `\X` keeps both the backslash and X verbatim,
+# matching how MRI tokenises regex bodies (interpretation happens
+# in the regex engine, not the lexer).
+[[transitions]]
+from = "regex_escape"
+matcher = { anything = true }
+to = "regex_body"
+actions = ["append_text(\\\\)", "append_text(current)"]
+
+[[transitions]]
+from = "regex_escape"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_regex)", "emit(Eof)"]
 
 # ─────────────────────────────────────────────────────────────────
 # Line comment

--- a/code/packages/rust/ruby-lexer/src/lex_state.rs
+++ b/code/packages/rust/ruby-lexer/src/lex_state.rs
@@ -1,0 +1,122 @@
+//! Lex states — the bookkeeping the lexer needs to disambiguate
+//! Ruby's context-sensitive constructs.
+//!
+//! Mirrors MRI's `parse.y` enum, simplified for v0.  The key
+//! distinction is between *expression-start* positions (where `/`
+//! could begin a regex literal) and *expression-end* positions
+//! (where `/` is binary division).  After a name token we are in
+//! a third state, `ExprArg`, where the answer depends on whether
+//! the name is a local variable (consult the
+//! [`ParserOracle`](crate::ParserOracle)).
+//!
+//! See `code/specs/ruby-lexer-state-machine.md` §1 for the full
+//! state table.  Phase 2 implements the first six; the remaining
+//! states (`ExprCmdArg`, `ExprEndArg`, `ExprLabel`, `ExprLabeled`,
+//! `ExprValue`, `ExprEndFn`, `ExprClass`) are no-ops in v0 and fold
+//! into the closest neighbour.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LexState {
+    /// Beginning of expression — the initial state.  Reached at file
+    /// start, after `(`, `,`, `;`, newline, after a binary operator,
+    /// after `=`, after most keywords.
+    ///
+    /// `/` here is a **regex literal**.
+    #[default]
+    ExprBeg,
+
+    /// Mid-expression, immediately after a binary operator.  Same
+    /// disambiguation as `ExprBeg` for `/` (regex).  Tracked
+    /// separately so future versions can distinguish unary vs binary
+    /// `+` / `-`.
+    ExprMid,
+
+    /// After a value-yielding token — a literal (`Int`, `String`,
+    /// `Float`), a closing bracket (`)`, `]`, `}`), or `self` /
+    /// `nil` / `true` / `false`.
+    ///
+    /// `/` here is **division**.
+    ExprEnd,
+
+    /// After a method-shaped name (`foo`, `puts`).  The name may be
+    /// either a local variable (in which case it's a value and the
+    /// next `/` is division) or a method call (in which case the
+    /// next `/` opens a regex literal that is the call's argument).
+    ///
+    /// The lexer consults the [`ParserOracle`](crate::ParserOracle)
+    /// to decide.
+    ExprArg,
+
+    /// After `def`, `class`, or `module`.  The next identifier is a
+    /// method / class / module name being declared, not a value.
+    /// Phase 2 records this state so the parser oracle can avoid
+    /// treating the name as a local-variable introduction.
+    ExprFname,
+
+    /// After `.` or `::`.  The next identifier is a method name on
+    /// the prior receiver — never a local.
+    ExprDot,
+}
+
+impl LexState {
+    /// `true` iff `/` in this state should be lexed as a **regex
+    /// literal** (the start-of-expression interpretation).  Callers
+    /// must handle `ExprArg` separately by consulting the oracle.
+    pub fn slash_is_regex(self) -> bool {
+        matches!(self, LexState::ExprBeg | LexState::ExprMid)
+    }
+
+    /// `true` iff `/` in this state is unambiguously **binary
+    /// division**.  `ExprArg` is *not* unambiguous — see
+    /// [`slash_is_regex`].
+    pub fn slash_is_division(self) -> bool {
+        matches!(self, LexState::ExprEnd)
+    }
+
+    /// `true` iff this state is *one of the ambiguous* positions
+    /// (`ExprArg`) where the oracle must adjudicate.
+    pub fn needs_oracle_for_slash(self) -> bool {
+        matches!(self, LexState::ExprArg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slash_classification_is_total_for_non_arg_states() {
+        for state in [
+            LexState::ExprBeg,
+            LexState::ExprMid,
+            LexState::ExprEnd,
+            LexState::ExprFname,
+            LexState::ExprDot,
+        ] {
+            // Exactly one of (regex, division, needs_oracle) is true
+            // for non-Arg states.  The Fname / Dot states currently
+            // fold into "division" because a `/` immediately after
+            // `def f /pat/` would be unusual; the spec leaves room
+            // for future refinement.
+            let r = state.slash_is_regex();
+            let d = state.slash_is_division();
+            let o = state.needs_oracle_for_slash();
+            assert!(
+                (r as u8 + d as u8 + o as u8) <= 1,
+                "state {state:?} has conflicting slash classifications"
+            );
+        }
+    }
+
+    #[test]
+    fn arg_needs_oracle() {
+        assert!(LexState::ExprArg.needs_oracle_for_slash());
+        assert!(!LexState::ExprArg.slash_is_regex());
+        assert!(!LexState::ExprArg.slash_is_division());
+    }
+
+    #[test]
+    fn default_is_expr_beg() {
+        assert_eq!(LexState::default(), LexState::ExprBeg);
+    }
+}

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -32,7 +32,12 @@
 use lexer::token::{Token, TokenType};
 use state_machine::transducer::{EffectfulInput, EffectfulStateMachine};
 
+mod lex_state;
 mod machine;
+mod oracle;
+
+pub use lex_state::LexState;
+pub use oracle::{NoLocals, ParserOracle, StaticLocals};
 
 /// Non-fatal diagnostic produced by the lexer.  Stray bytes /
 /// unterminated strings / etc. are recorded here; the lexer keeps
@@ -60,12 +65,35 @@ pub struct RubyLexer {
     /// Source position where the current token started accumulating.
     token_start_line: usize,
     token_start_column: usize,
+    /// Phase 2: current lex-state, updated on every emit.  Drives
+    /// `/` disambiguation and (in later phases) other ambiguous
+    /// constructs.
+    lex_state: LexState,
+    /// Phase 2: the most recent `Name` token's lexeme.  Used by the
+    /// `/` interceptor when `lex_state == ExprArg` — the oracle
+    /// classifies this name as a local or a method.
+    last_name: String,
+    /// Phase 2: the parser-feedback contract.  Defaults to
+    /// [`NoLocals`] which treats every name as a method.
+    oracle: Box<dyn ParserOracle>,
 }
 
 impl RubyLexer {
     /// Build a fresh lexer for the given Ruby version.  Phase 1
-    /// only supports `"1.8"`.
+    /// only supports `"1.8"`.  Uses the default [`NoLocals`] oracle
+    /// — see [`RubyLexer::with_oracle`] to wire in a real parser.
     pub fn new(version: &str) -> Result<Self, String> {
+        Self::with_oracle(version, Box::new(NoLocals))
+    }
+
+    /// Build a fresh lexer with an explicit parser-feedback oracle.
+    /// The oracle is consulted (via [`ParserOracle::is_local`]) when
+    /// the lexer encounters a `/` after a name in `ExprArg` state to
+    /// decide between regex-literal and division.
+    pub fn with_oracle(
+        version: &str,
+        oracle: Box<dyn ParserOracle>,
+    ) -> Result<Self, String> {
         let definition = machine::definition_for_version(version)?;
         let machine = EffectfulStateMachine::from_definition(&definition)
             .map_err(|e| format!("failed to build ruby lexer state machine: {e}"))?;
@@ -78,7 +106,16 @@ impl RubyLexer {
             column: 1,
             token_start_line: 1,
             token_start_column: 1,
+            lex_state: LexState::default(),
+            last_name: String::new(),
+            oracle,
         })
+    }
+
+    /// Current lex-state.  Exposed for tests and tooling; the parser
+    /// is the canonical driver of state changes (Phase 2 onward).
+    pub fn lex_state(&self) -> LexState {
+        self.lex_state
     }
 
     /// Feed the whole source into the lexer.
@@ -124,6 +161,29 @@ impl RubyLexer {
     /// state (capped — a state machine that ping-pongs without
     /// consuming input is a bug).
     fn step_char(&mut self, ch: char) -> Result<(), String> {
+        // Phase 2: `/` disambiguation.  Before the state machine
+        // sees the slash, we may need to manually divert it into
+        // the `regex_body` sub-machine (which the action interpreter
+        // entered "by hand", outside the engine's transition table).
+        // This keeps the TOML state machine simple — it always
+        // emits `/` as a division operator from `data`, and the
+        // interpreter rewrites that to a regex when context says so.
+        if ch == '/' && self.machine.current_state() == "data" && self.should_open_regex() {
+            self.machine
+                .set_current_state("regex_body")
+                .map_err(|e| format!("ruby lexer: failed to enter regex_body: {e}"))?;
+            // Clear the text buffer so the regex body accumulates
+            // cleanly; record the source position so the emitted
+            // Regex token's line/column point at the opening `/`.
+            self.text_buffer.clear();
+            self.token_start_line = self.line;
+            self.token_start_column = self.column;
+            // The `/` is consumed but emits no token — it's part of
+            // the regex literal.  Advance position past it.
+            self.column += 1;
+            return Ok(());
+        }
+
         let mut buf = [0u8; 4];
         let event = ch.encode_utf8(&mut buf);
         const MAX_REENTRY: usize = 8;
@@ -147,6 +207,25 @@ impl RubyLexer {
             "ruby lexer ping-pong at {}:{} — no transition consumed input",
             self.line, self.column
         ))
+    }
+
+    /// Decide whether a `/` at the current position opens a regex
+    /// literal.  Folds the lex-state and oracle answer together:
+    ///
+    /// - `ExprBeg` / `ExprMid` / (default state at file start) → regex.
+    /// - `ExprEnd` → division (the slash follows a value).
+    /// - `ExprArg` → ask the oracle whether the preceding name is a
+    ///   local variable.  Local → division (because we're dividing
+    ///   the local's value).  Not-local → regex (the name was a
+    ///   method call and the regex is its argument).
+    fn should_open_regex(&self) -> bool {
+        if self.lex_state.slash_is_regex() {
+            return true;
+        }
+        if self.lex_state.needs_oracle_for_slash() {
+            return !self.oracle.is_local(&self.last_name);
+        }
+        false
     }
 
     fn apply_effects(&mut self, effects: &[String], current: Option<char>) -> Result<(), String> {
@@ -237,7 +316,24 @@ impl RubyLexer {
             "Name" => {
                 let text = std::mem::take(&mut self.text_buffer);
                 let kind = classify_name_token(&text);
+                // Phase 2: record this name so the `/` interceptor
+                // can ask the oracle "is this a local?".  We record
+                // it regardless of whether it's a keyword — the
+                // lex_state transition table handles the keyword case
+                // by routing past `ExprArg`.
+                self.last_name = text.clone();
                 self.push_token(kind, text);
+            }
+            "Regex" => {
+                let text = std::mem::take(&mut self.text_buffer);
+                // Encode regex literals as a String token with a
+                // recognisable prefix so the parser can disambiguate
+                // without needing a new TokenType.  Phase 3 will
+                // introduce a dedicated kind; for now the value
+                // shape `/regex-body/` round-trips cleanly through
+                // the parser layer.
+                let value = format!("/{}/", text);
+                self.push_token(TokenType::String, value);
             }
             "Op" => {
                 let text = std::mem::take(&mut self.text_buffer);
@@ -255,6 +351,11 @@ impl RubyLexer {
     }
 
     fn push_token(&mut self, type_: TokenType, value: String) {
+        // Phase 2: advance lex-state based on the token we are
+        // about to emit.  Order matters — we transition *before*
+        // pushing so the next `/` interceptor sees the up-to-date
+        // state.
+        self.lex_state = next_lex_state(self.lex_state, type_, &value);
         self.tokens.push(Token {
             type_,
             value,
@@ -268,6 +369,44 @@ impl RubyLexer {
         // source position, not the prior token's start.
         self.token_start_line = self.line;
         self.token_start_column = self.column;
+    }
+}
+
+/// Lex-state transition table.  Given the prior state, the kind of
+/// token just emitted, and its lexeme, return the new state.
+///
+/// The rules are simplified for v0:
+///   - Keywords get fine-grained transitions (e.g. `def` → `ExprFname`).
+///   - Names go to `ExprArg` (might be a call without parens).
+///   - Value-yielding atoms (`Int`, `String`, closing brackets) → `ExprEnd`.
+///   - Binary operators / `=` / opening brackets / `,` / `;` /
+///     newline / most keywords → `ExprBeg` (or `ExprMid`).
+///   - `.` → `ExprDot`.
+///   - `Eof` doesn't change state.
+fn next_lex_state(prev: LexState, kind: TokenType, value: &str) -> LexState {
+    use TokenType::*;
+    match (kind, value) {
+        (Keyword, "def") | (Keyword, "class") | (Keyword, "module") | (Keyword, "alias") | (Keyword, "undef") => {
+            LexState::ExprFname
+        }
+        (Keyword, "self") | (Keyword, "nil") | (Keyword, "true") | (Keyword, "false") => LexState::ExprEnd,
+        (Keyword, _) => LexState::ExprBeg,
+        (Name, _) => LexState::ExprArg,
+        (Number, _) | (String, _) => LexState::ExprEnd,
+        (RParen, _) | (RBracket, _) | (RBrace, _) => LexState::ExprEnd,
+        (LParen, _) | (LBracket, _) | (LBrace, _) | (Comma, _) | (Semicolon, _) | (Newline, _) => {
+            LexState::ExprBeg
+        }
+        (Plus, _) | (Minus, _) | (Star, _) | (Slash, _) | (Equals, _) | (EqualsEquals, _) | (Bang, _) => {
+            LexState::ExprMid
+        }
+        (Dot, _) => LexState::ExprDot,
+        // Colon may be a hash separator or `::` — both treat the
+        // following position as expression-start.  Symbols like
+        // `:foo` are not yet handled at the lexer level (Phase 3).
+        (Colon, _) => LexState::ExprBeg,
+        (Eof, _) => prev,
+        _ => prev,
     }
 }
 
@@ -392,6 +531,24 @@ pub fn tokenize_ruby(source: &str) -> Vec<Token> {
     tokenize_ruby_diag(source).0
 }
 
+/// Tokenize with a custom [`ParserOracle`].  Use this when the
+/// caller already has a local-variable scope to consult — most
+/// notably the parser, which collects locals as it walks the
+/// source.
+pub fn tokenize_ruby_with_oracle(
+    source: &str,
+    oracle: Box<dyn ParserOracle>,
+) -> Vec<Token> {
+    let mut lexer = RubyLexer::with_oracle("1.8", oracle).expect("ruby 1.8 lexer definition");
+    if lexer.push(source).is_err() {
+        return lexer.drain_tokens();
+    }
+    if lexer.finish().is_err() {
+        return lexer.drain_tokens();
+    }
+    lexer.drain_tokens()
+}
+
 /// Same as [`tokenize_ruby`] but also returns recorded diagnostics.
 pub fn tokenize_ruby_diag(source: &str) -> (Vec<Token>, Vec<Diagnostic>) {
     let mut lexer = RubyLexer::new("1.8").expect("ruby 1.8 lexer definition");
@@ -508,7 +665,12 @@ mod tests {
 
     #[test]
     fn binary_operators_dispatch_to_dedicated_kinds() {
-        let toks = tokenize_ruby("a + b - c * d / e");
+        // Phase 2: with the NoLocals default oracle, `d / e` would
+        // lex as a regex (because `d` is treated as a method call).
+        // To exercise binary `/` we declare the operands as locals
+        // via a `StaticLocals` oracle.
+        let oracle = Box::new(StaticLocals::with_locals(["a", "b", "c", "d", "e"]));
+        let toks = tokenize_ruby_with_oracle("a + b - c * d / e", oracle);
         let p = pairs(&toks);
         assert_eq!(
             p,
@@ -522,6 +684,161 @@ mod tests {
                 (TokenType::Name, "d"),
                 (TokenType::Slash, "/"),
                 (TokenType::Name, "e"),
+            ]
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Phase 2 — lex_state + ParserOracle wiring
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn lex_state_starts_at_expr_beg() {
+        let lexer = RubyLexer::new("1.8").expect("lexer");
+        assert_eq!(lexer.lex_state(), LexState::ExprBeg);
+    }
+
+    #[test]
+    fn lex_state_after_name_is_expr_arg() {
+        let mut lexer = RubyLexer::new("1.8").expect("lexer");
+        lexer.push("foo").unwrap();
+        lexer.finish().unwrap();
+        assert_eq!(lexer.lex_state(), LexState::ExprArg);
+    }
+
+    #[test]
+    fn lex_state_after_int_is_expr_end() {
+        let mut lexer = RubyLexer::new("1.8").expect("lexer");
+        lexer.push("42").unwrap();
+        lexer.finish().unwrap();
+        assert_eq!(lexer.lex_state(), LexState::ExprEnd);
+    }
+
+    #[test]
+    fn lex_state_after_binary_op_is_expr_mid() {
+        let mut lexer = RubyLexer::new("1.8").expect("lexer");
+        lexer.push("1 + ").unwrap();
+        lexer.finish().unwrap();
+        assert_eq!(lexer.lex_state(), LexState::ExprMid);
+    }
+
+    #[test]
+    fn lex_state_after_def_keyword_is_expr_fname() {
+        let mut lexer = RubyLexer::new("1.8").expect("lexer");
+        lexer.push("def").unwrap();
+        lexer.finish().unwrap();
+        assert_eq!(lexer.lex_state(), LexState::ExprFname);
+    }
+
+    #[test]
+    fn lex_state_after_dot_is_expr_dot() {
+        let mut lexer = RubyLexer::new("1.8").expect("lexer");
+        lexer.push("obj.").unwrap();
+        lexer.finish().unwrap();
+        assert_eq!(lexer.lex_state(), LexState::ExprDot);
+    }
+
+    #[test]
+    fn slash_at_start_of_expression_is_regex() {
+        // No preceding token → lex_state == ExprBeg → `/x/` is regex.
+        let toks = tokenize_ruby("/foo/");
+        let p = pairs(&toks);
+        // Regex literal encoded as a String token with `/.../` shape.
+        assert_eq!(p, vec![(TokenType::String, "/foo/")]);
+    }
+
+    #[test]
+    fn slash_after_binary_op_is_regex() {
+        // `1 + /foo/` — `/` follows `+`, which leaves lex_state in
+        // ExprMid → regex.
+        let toks = tokenize_ruby("1 + /foo/");
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![
+                (TokenType::Number, "1"),
+                (TokenType::Plus, "+"),
+                (TokenType::String, "/foo/"),
+            ]
+        );
+    }
+
+    #[test]
+    fn slash_after_int_is_division() {
+        // `1 / 2` — lex_state after `1` is ExprEnd → division.
+        let toks = tokenize_ruby("1 / 2");
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![
+                (TokenType::Number, "1"),
+                (TokenType::Slash, "/"),
+                (TokenType::Number, "2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn slash_after_method_name_is_regex_via_default_oracle() {
+        // With the NoLocals default (`f` is not a known local), the
+        // spec says treat every name as a method — so `f /x/` is a
+        // method call with a regex argument.
+        let toks = tokenize_ruby("f /x/");
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![(TokenType::Name, "f"), (TokenType::String, "/x/")]
+        );
+    }
+
+    #[test]
+    fn slash_after_local_name_is_division() {
+        // Oracle declares `f` as a local — `f /x/` is `f / x /`.
+        let oracle = Box::new(StaticLocals::with_locals(["f", "x"]));
+        let toks = tokenize_ruby_with_oracle("f /x/", oracle);
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![
+                (TokenType::Name, "f"),
+                (TokenType::Slash, "/"),
+                (TokenType::Name, "x"),
+                (TokenType::Slash, "/"),
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_with_backslash_escape() {
+        // `/\d+/` — body contains `\d+`; the lexer preserves both
+        // the backslash and the `d`.
+        let toks = tokenize_ruby(r"/\d+/");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, r"/\d+/")]);
+    }
+
+    #[test]
+    fn regex_with_escaped_slash() {
+        // `/a\/b/` — the body has an escaped `/`, so the literal
+        // doesn't terminate at the inner slash.
+        let toks = tokenize_ruby(r"/a\/b/");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, r"/a\/b/")]);
+    }
+
+    #[test]
+    fn static_locals_oracle_supports_dynamic_inserts() {
+        let mut locals = StaticLocals::new();
+        locals.insert("counter");
+        // Wrap in Box for the convenience entry.
+        let toks = tokenize_ruby_with_oracle("counter / 2", Box::new(locals));
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![
+                (TokenType::Name, "counter"),
+                (TokenType::Slash, "/"),
+                (TokenType::Number, "2"),
             ]
         );
     }

--- a/code/packages/rust/ruby-lexer/src/oracle.rs
+++ b/code/packages/rust/ruby-lexer/src/oracle.rs
@@ -1,0 +1,131 @@
+//! Parser-feedback contract.
+//!
+//! The lexer queries the parser via this trait to disambiguate
+//! Ruby's context-sensitive constructs.  See
+//! `code/specs/ruby-lexer-state-machine.md` §3 for the design.
+//!
+//! In Phase 2, the only query that actually wires through is
+//! [`ParserOracle::is_local`] — which the lexer uses to decide
+//! whether `/` after a name is a regex literal (method call with
+//! regex arg) or binary division (local-variable division).
+//!
+//! The other methods (`in_def`, `in_block`, `in_lambda`,
+//! `in_class_body`) are declared so future phases can plug in
+//! without breaking the public API.  Default impls all return
+//! `false` — the [`NoLocals`] oracle treats every name as a method
+//! (the conservative choice for the paren-required v0 subset).
+
+/// The lexer's view of the parser.
+///
+/// Implementors maintain whatever scope state they need to answer
+/// the queries.  The lexer holds a `Box<dyn ParserOracle>` so the
+/// concrete type can be swapped at construction.
+pub trait ParserOracle {
+    /// `true` if `name` is currently in scope as a local variable.
+    /// Used to disambiguate `f /x/` — when `f` is local, the `/` is
+    /// division; otherwise it opens a regex argument.
+    fn is_local(&self, name: &str) -> bool {
+        let _ = name;
+        false
+    }
+
+    /// `true` if the lexer is currently inside a `def` body.
+    /// Reserved for future use (some keyword behaviour differs
+    /// inside vs outside `def`).
+    fn in_def(&self) -> bool {
+        false
+    }
+
+    /// `true` if the lexer is currently inside a block body
+    /// (`do...end` or `{...}`).
+    fn in_block(&self) -> bool {
+        false
+    }
+
+    /// `true` if the lexer is currently inside a `lambda { ... }`.
+    /// Reserved — `return` semantics differ inside lambdas.
+    fn in_lambda(&self) -> bool {
+        false
+    }
+
+    /// `true` if the lexer is currently inside a class body (not a
+    /// method body within a class).
+    fn in_class_body(&self) -> bool {
+        false
+    }
+}
+
+/// The default oracle: nothing is ever a local.  Treats every name
+/// as a method.  Suitable for the paren-required v0 subset where
+/// implicit-receiver calls are rare.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoLocals;
+
+impl ParserOracle for NoLocals {}
+
+/// A trivial oracle backed by an in-memory set of local-variable
+/// names.  Useful for tests and for the parser to construct on the
+/// fly as it walks a function body.
+#[derive(Debug, Clone, Default)]
+pub struct StaticLocals {
+    locals: std::collections::HashSet<String>,
+}
+
+impl StaticLocals {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_locals<I, S>(locals: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            locals: locals.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn insert(&mut self, name: impl Into<String>) {
+        self.locals.insert(name.into());
+    }
+}
+
+impl ParserOracle for StaticLocals {
+    fn is_local(&self, name: &str) -> bool {
+        self.locals.contains(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_locals_says_no_to_everything() {
+        let oracle = NoLocals;
+        assert!(!oracle.is_local("foo"));
+        assert!(!oracle.is_local("x"));
+        assert!(!oracle.in_def());
+        assert!(!oracle.in_block());
+        assert!(!oracle.in_lambda());
+        assert!(!oracle.in_class_body());
+    }
+
+    #[test]
+    fn static_locals_round_trips() {
+        let oracle = StaticLocals::with_locals(["x", "y", "total"]);
+        assert!(oracle.is_local("x"));
+        assert!(oracle.is_local("y"));
+        assert!(oracle.is_local("total"));
+        assert!(!oracle.is_local("foo"));
+    }
+
+    #[test]
+    fn static_locals_insert_after_construction() {
+        let mut oracle = StaticLocals::new();
+        oracle.insert("counter");
+        assert!(oracle.is_local("counter"));
+        assert!(!oracle.is_local("other"));
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 2** of the multi-phase plan in [code/specs/ruby-parser.md](code/specs/ruby-parser.md).  Adds the parser-feedback contract that lets the lexer disambiguate Ruby's context-sensitive `/` operator (regex literal vs binary division).

## What's new

### Public API
- **`LexState` enum** — `ExprBeg`, `ExprMid`, `ExprEnd`, `ExprArg`, `ExprFname`, `ExprDot`. Tracked by the lexer; updated after every emitted token via a fold-style transition table.
- **`ParserOracle` trait** with `NoLocals` (the conservative default — "every name is a method") and `StaticLocals` (test helper). Future parsers maintain a real local-variable scope and pass it through.
- **`RubyLexer::with_oracle(version, oracle)`** + **`tokenize_ruby_with_oracle(source, oracle)`** entry points.

### State machine extension
- New `regex_body` / `regex_escape` sub-states in [`ruby-1.8.lexer.states.toml`](code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml).  Plus a `Regex` token kind in the declared token vocabulary.
- The action interpreter intercepts `/` in `data` state: based on the current lex-state + oracle it either lets the engine emit a division op as before, or calls `set_current_state("regex_body")` and skips re-feeding the `/`.
- Regex literals emit as `TokenType::String` with `/.../`-framed value (a dedicated `TokenType::Regex` is a later concern).

### Disambiguation table
| Lex state                | `/` is …       | Notes                                              |
|--------------------------|----------------|-----------------------------------------------------|
| `ExprBeg` / `ExprMid`    | regex          | No preceding value                                  |
| `ExprEnd`                | division       | Preceded by literal / closing bracket / `self` etc. |
| `ExprArg` + `is_local`   | division       | Local name being divided                            |
| `ExprArg` + not local    | regex          | Method call with regex arg                          |

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — **43 tests pass** (was 23 in Phase 1, +20 new)
- [x] `cargo test -p coding-adventures-ruby-parser` — 6 tests still pass against the new lexer (no parser changes needed)

### Highlight tests

- `slash_after_method_name_is_regex_via_default_oracle` — `f /x/` → `Name "f"` + `String "/x/"` (regex)
- `slash_after_local_name_is_division` — same source + `StaticLocals(["f", "x"])` → `Name` + `Slash` + `Name` + `Slash`
- `slash_at_start_of_expression_is_regex` — bare `/foo/` at file start
- `slash_after_binary_op_is_regex` — `1 + /foo/`
- `slash_after_int_is_division` — `1 / 2`
- `regex_with_backslash_escape` / `regex_with_escaped_slash` — `\d+`, `a\/b` round-trip through `regex_escape`
- Six `lex_state_after_*` tests verifying the state transitions table

## Deferred (later phases)

- `+` / `-` / `*` whitespace-sensitive disambiguation (`a + b` vs `a +b`) — Phase 2b refinement
- Regex flags (`/foo/i`, `/foo/m`, …) — Phase 3 alongside heredocs / interpolation
- Heredocs, percent literals, string interpolation — Phase 3
- Version forks (1.0 / 1.6 / 1.9.1 / 2.0 / …) — Phase 4
- `ruby-to-semantic-ir` frontend — Phase 5

## Breaking change

`tokenize_ruby(source)` default semantics now match the spec: with the `NoLocals` oracle, every name is treated as a method, so `f /x/` lexes as a method call with a regex argument.  Callers that want binary division on locals must pass a `ParserOracle` via `tokenize_ruby_with_oracle`.  One Phase 1 test (`binary_operators_dispatch_to_dedicated_kinds`) was updated to declare its operands as locals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)