### PR TITLE
Add WHATWG document shell audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -38,6 +38,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser formatting audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser document-shell audit
+  generator alongside the other parser audit fixture generators.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -159,6 +159,13 @@ def default_checks() -> list[FixtureCheck]:
                 "--check",
             ),
         ),
+        FixtureCheck(
+            "whatwg-document-shell-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),
+                "--check",
+            ),
+        ),
     ]
 
 

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -30,10 +30,13 @@ documented in this file.
 - Generated WHATWG formatting/implied-end-tag audit fixture over html5lib
   adoption-agency, anchor/nobr, paragraph, list/definition, ruby, heading, and
   formatting reconstruction cases, with a dedicated parser regression test.
+- Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
+  html/head/body synthesis, frameset-boundary, and shell fragment-context
+  cases, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control, and
-  foreign-content and formatting audit checks on the same parser and DOM dump
-  path.
+  foreign-content, formatting, and document-shell audit checks on the same
+  parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -167,6 +167,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting
   --check
 ```
 
+The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
+doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
+shell fragment contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py \
+  --check
+```
+
 The broad smoke test and the focused audit fixtures use the shared
 `tests/common` html5lib parser and DOM dump helpers, so new parser conformance
 fixtures exercise the same normalization path.

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -120,3 +120,13 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting
 python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py \
   --check
 ```
+
+`whatwg-document-shell-audit.json` is a generated index over tree-construction
+cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
+boundaries, and shell fragment contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py \
+  --check
+```

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG document-shell audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-document-shell-audit.json"
+
+DOCTYPE_MARKUP = re.compile(r"<!doctype", re.I)
+COMMENT_MARKUP = re.compile(r"<!--|-->", re.I)
+HTML_MARKUP = re.compile(r"</?html(?:\s|/|>)", re.I)
+HEAD_MARKUP = re.compile(r"</?head(?:\s|/|>)", re.I)
+BODY_MARKUP = re.compile(r"</?(?:body|frameset|frame)(?:\s|/|>)", re.I)
+HEAD_CONTENT_MARKUP = re.compile(
+    r"</?(?:base|basefont|bgsound|link|meta|template)(?:\s|/|>)",
+    re.I,
+)
+SHELL_FRAGMENT_CONTEXTS = {"body", "head", "html"}
+ANCHOR_SOURCES = {
+    "comments01.dat",
+    "doctype01.dat",
+    "noscript01.dat",
+    "tests4.dat",
+    "tests6.dat",
+    "tests7.dat",
+    "tests_innerHTML_1.dat",
+}
+
+CASE_AXES = (
+    {
+        "axis": "doctype-and-quirks",
+        "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+    },
+    {
+        "axis": "html-element-boundary",
+        "reason": "explicit html start/end tags and late html-tag recovery",
+    },
+    {
+        "axis": "head-element-boundary",
+        "reason": "head insertion, head content, and noscript-in-head recovery",
+    },
+    {
+        "axis": "body-frameset-boundary",
+        "reason": "body, frameset, and frame transitions around the document shell",
+    },
+    {
+        "axis": "comment-whitespace-shell",
+        "reason": "comments and whitespace around implied html, head, and body nodes",
+    },
+    {
+        "axis": "shell-fragment-context",
+        "reason": "html, head, and body fragment parsing contexts",
+    },
+    {
+        "axis": "implicit-document-shell",
+        "reason": "implicit html/head/body shell synthesis around legacy inputs",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG document-shell audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_document_shell_case(source, case_data, fragment_context):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any document-shell audit cases")
+    return cases
+
+
+def is_document_shell_case(
+    source: str, data: str, fragment_context: str | None
+) -> bool:
+    source_file = source.split(":", 1)[0]
+    if (
+        fragment_context is not None
+        and fragment_context.lower() in SHELL_FRAGMENT_CONTEXTS
+    ):
+        return True
+    if source_file == "doctype01.dat":
+        return True
+    return (
+        source_file in ANCHOR_SOURCES
+        and (
+            DOCTYPE_MARKUP.search(data) is not None
+            or COMMENT_MARKUP.search(data) is not None
+            or HTML_MARKUP.search(data) is not None
+            or HEAD_MARKUP.search(data) is not None
+            or BODY_MARKUP.search(data) is not None
+            or HEAD_CONTENT_MARKUP.search(data) is not None
+        )
+    ) or (
+        HTML_MARKUP.search(data) is not None
+        or HEAD_MARKUP.search(data) is not None
+        or BODY_MARKUP.search(data) is not None
+    )
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-document-shell-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress doctypes, comments, html/head/body synthesis, frameset "
+            "boundaries, and shell fragment contexts."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    source_file = case.source.split(":", 1)[0]
+    fragment_context = (case.fragment_context or "").lower()
+
+    if fragment_context in SHELL_FRAGMENT_CONTEXTS:
+        return "shell-fragment-context"
+    if source_file == "doctype01.dat" or is_duplicate_doctype_case(case.data):
+        return "doctype-and-quirks"
+    if HTML_MARKUP.search(case.data):
+        return "html-element-boundary"
+    if HEAD_MARKUP.search(case.data) or HEAD_CONTENT_MARKUP.search(case.data):
+        return "head-element-boundary"
+    if BODY_MARKUP.search(case.data):
+        return "body-frameset-boundary"
+    if COMMENT_MARKUP.search(case.data):
+        return "comment-whitespace-shell"
+    return "implicit-document-shell"
+
+
+def is_duplicate_doctype_case(data: str) -> bool:
+    lower_data = data.lower()
+    return "<!doctype html><!doctype" in lower_data or "<!doctype html></doctype" in lower_data
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown document-shell audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-document-shell-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-document-shell-audit.json
@@ -1,0 +1,4403 @@
+{
+  "case_count": 731,
+  "cases": [
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-68",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:68"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-69",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:69"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-70",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:70"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-71",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:71"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-72",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:72"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-73",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:73"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-74",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:74"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-75",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:75"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-76",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:76"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-77",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:77"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-78",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:78"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "comments01-dat-82",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "comments01.dat:82"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "comments01-dat-83",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "comments01.dat:83"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-84",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:84"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-85",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:85"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-86",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:86"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-87",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:87"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-88",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:88"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-89",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:89"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-90",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:90"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-91",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:91"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-92",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:92"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-93",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:93"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-94",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:94"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-95",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:95"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-96",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:96"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-97",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:97"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-98",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:98"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-99",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:99"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-100",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:100"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-101",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:101"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-102",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:102"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-103",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:103"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-104",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:104"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-105",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:105"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-106",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:106"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-107",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:107"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-108",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:108"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-109",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:109"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-110",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:110"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-111",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:111"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-112",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:112"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-113",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:113"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-114",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:114"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-115",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:115"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-116",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:116"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-117",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:117"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-118",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:118"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-119",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:119"
+    },
+    {
+      "axis": "doctype-and-quirks",
+      "id": "doctype01-dat-120",
+      "reason": "doctype insertion, force-quirks recovery, and duplicate doctype handling",
+      "source": "doctype01.dat:120"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-148",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:148"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-149",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:149"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-150",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:150"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "domjs-unsafe-dat-151",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "domjs-unsafe.dat:151"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-156",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:156"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-159",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:159"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-160",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:160"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-161",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:161"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "domjs-unsafe-dat-162",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "domjs-unsafe.dat:162"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "domjs-unsafe-dat-163",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "domjs-unsafe.dat:163"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "menuitem-element-dat-308",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "menuitem-element.dat:308"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "menuitem-element-dat-309",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "menuitem-element.dat:309"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "menuitem-element-dat-310",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "menuitem-element.dat:310"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "menuitem-element-dat-311",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "menuitem-element.dat:311"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "menuitem-element-dat-317",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "menuitem-element.dat:317"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "menuitem-element-dat-318",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "menuitem-element.dat:318"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "menuitem-element-dat-322",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "menuitem-element.dat:322"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "menuitem-element-dat-323",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "menuitem-element.dat:323"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "namespace-sensitivity-dat-326",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "namespace-sensitivity.dat:326"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-327",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:327"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "noscript01-dat-328",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "noscript01.dat:328"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-329",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:329"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-330",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:330"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-331",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:331"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-332",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:332"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-333",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:333"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-334",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:334"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-335",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:335"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-336",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:336"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-337",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:337"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-338",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:338"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-339",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:339"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-340",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:340"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-341",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:341"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-342",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:342"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-343",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:343"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "noscript01-dat-344",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "noscript01.dat:344"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "pending-spec-changes-plain-text-unsafe-dat-345",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "pending-spec-changes-plain-text-unsafe.dat:345"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "pending-spec-changes-dat-346",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "pending-spec-changes.dat:346"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "plain-text-unsafe-dat-350",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "plain-text-unsafe.dat:350"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "plain-text-unsafe-dat-351",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "plain-text-unsafe.dat:351"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "plain-text-unsafe-dat-352",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "plain-text-unsafe.dat:352"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "plain-text-unsafe-dat-353",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "plain-text-unsafe.dat:353"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "plain-text-unsafe-dat-354",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "plain-text-unsafe.dat:354"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "plain-text-unsafe-dat-355",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "plain-text-unsafe.dat:355"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-357",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:357"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-360",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:360"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-361",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:361"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-362",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:362"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-364",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:364"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-365",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:365"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-366",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:366"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-367",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:367"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-368",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:368"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-369",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:369"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-370",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:370"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "plain-text-unsafe-dat-371",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "plain-text-unsafe.dat:371"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-386",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:386"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-387",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:387"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-388",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:388"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-389",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:389"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-390",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:390"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-391",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:391"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-392",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:392"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-393",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:393"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-394",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:394"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-395",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:395"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-396",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:396"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-397",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:397"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-398",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:398"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-399",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:399"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-400",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:400"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-401",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:401"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-402",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:402"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-403",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:403"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-404",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:404"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-405",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:405"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "ruby-dat-406",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "ruby.dat:406"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tables01-dat-439",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tables01.dat:439"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tables01-dat-441",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tables01.dat:441"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tables01-dat-446",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tables01.dat:446"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tables01-dat-449",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tables01.dat:449"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-455",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:455"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "template-dat-458",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "template.dat:458"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-459",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:459"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-483",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:483"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-491",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:491"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-492",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:492"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-494",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:494"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-495",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:495"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-496",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:496"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-497",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:497"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-498",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:498"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-499",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:499"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-500",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:500"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-501",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:501"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-502",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:502"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-503",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:503"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-504",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:504"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-505",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:505"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-506",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:506"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-507",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:507"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-508",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:508"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-509",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:509"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-510",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:510"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-511",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:511"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-512",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:512"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-513",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:513"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-514",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:514"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-515",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:515"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-516",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:516"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-517",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:517"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-518",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:518"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "template-dat-519",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "template.dat:519"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "template-dat-520",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "template.dat:520"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "template-dat-521",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "template.dat:521"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-522",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:522"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-523",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:523"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-524",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:524"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-525",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:525"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-526",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:526"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-527",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:527"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-528",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:528"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-529",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:529"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-530",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:530"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-531",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:531"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-532",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:532"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-533",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:533"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-547",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:547"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-550",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:550"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-551",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:551"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-552",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:552"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-556",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:556"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-557",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:557"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-558",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:558"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "template-dat-559",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "template.dat:559"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "template-dat-560",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "template.dat:560"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-569",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:569"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-570",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:570"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-571",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:571"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-572",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:572"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-573",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:573"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-574",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:574"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-575",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:575"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-576",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:576"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-577",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:577"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-578",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:578"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-579",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:579"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-580",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:580"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-581",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:581"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-582",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:582"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-583",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:583"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-584",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:584"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-599",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:599"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-620",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:620"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-651",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:651"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-653",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:653"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-657",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:657"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-658",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:658"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-666",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:666"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-670",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:670"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-675",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-676",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-677",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:677"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-680",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:680"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-681",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:681"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-682",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:682"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-683",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:683"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-684",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:684"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-685",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:685"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-686",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:686"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-687",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:687"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-688",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:688"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-689",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:689"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-690",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:690"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-691",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:691"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-692",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:692"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-693",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:693"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-694",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:694"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-695",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:695"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests10-dat-696",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests10.dat:696"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-697",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:697"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-698",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:698"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-699",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:699"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-700",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:700"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-701",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:701"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-702",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:702"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-703",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:703"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-732",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:732"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-733",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:733"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-734",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:734"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-735",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:735"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-736",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:736"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-737",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:737"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-738",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:738"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-739",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:739"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-740",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:740"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-741",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:741"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-742",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:742"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-743",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:743"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-744",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:744"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests12-dat-745",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests12.dat:745"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests12-dat-746",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests12.dat:746"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-747",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:747"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-748",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:748"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-749",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:749"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-750",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:750"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-751",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:751"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-752",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:752"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-753",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:753"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests15-dat-756",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests15.dat:756"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests15-dat-757",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests15.dat:757"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests15-dat-758",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests15.dat:758"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests15-dat-759",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests15.dat:759"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests15-dat-766",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests15.dat:766"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests15-dat-767",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests15.dat:767"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-843",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:843"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests16-dat-850",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests16.dat:850"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-858",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:858"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-940",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:940"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests16-dat-947",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests16.dat:947"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-955",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:955"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-980",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:980"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests18-dat-981",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests18.dat:981"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-982",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:982"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests18-dat-983",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests18.dat:983"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-984",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:984"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-994",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:994"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-995",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:995"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-996",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:996"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-997",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:997"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-998",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:998"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-1008",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:1008"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-1009",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:1009"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-1010",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:1010"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-1011",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:1011"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1015",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1015"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-1016",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:1016"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1017",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1017"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1018",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1018"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1028",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1028"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1029",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1029"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1030",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1030"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1031",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1031"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1034",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1034"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1049",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1049"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1050",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1050"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1051",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1051"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1052",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1052"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1053",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1053"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1054",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1054"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1055",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1055"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1056",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1056"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1057",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1057"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1058",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1058"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1059",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1059"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1060",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1060"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1061",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1061"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1062",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1062"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1063",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1063"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1064",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1064"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1065",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1065"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1066",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1066"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1067",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1067"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1068",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1068"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1069",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1069"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1070",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1070"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1071",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1071"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1072",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1072"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-1073",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:1073"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-1074",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:1074"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1075",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1075"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1076",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1076"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1077",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1077"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1078",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1078"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1079",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1079"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1080",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1080"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1081",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1081"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1082",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1082"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1083",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1083"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1084",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1084"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1085",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1085"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1086",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1086"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1087",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1087"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1088",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1088"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1089",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1089"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1090",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1090"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1091",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1091"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1092",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1092"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1093",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1093"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-1094",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:1094"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1097",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1097"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-1100",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:1100"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-1101",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:1101"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-1109",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:1109"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-1110",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:1110"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1222",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1222"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1223",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1223"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1224",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1224"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1225",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1225"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1226",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1226"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1227",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1227"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1228",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1228"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1229",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1229"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1230",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1230"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1231",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1231"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1232",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1232"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1233",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1233"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1234",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1234"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1235",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1235"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1239",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1239"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1240",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1240"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1241",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1241"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1242",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1242"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-1243",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:1243"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1244",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1244"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1245",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1245"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1246",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1246"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1247",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1247"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1248",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1248"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1249",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1249"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1250",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1250"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1251",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1251"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1252",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1252"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1253",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1253"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1254",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1254"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1255",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1255"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1256",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1256"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1262",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1262"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-16",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:16"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-33",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:33"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-34",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:34"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests2-dat-47",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests2.dat:47"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests2-dat-48",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests2.dat:48"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-51",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:51"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests2-dat-52",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests2.dat:52"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-53",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:53"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-54",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:54"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-55",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:55"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-56",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:56"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-57",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:57"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests2-dat-58",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests2.dat:58"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests3-dat-1",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests3.dat:1"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests3-dat-2",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests3.dat:2"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests7-dat-1",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests7.dat:1"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-2",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:2"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-10",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:10"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-11",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:11"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-12",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:12"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-13",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:13"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-14",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:14"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-15",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:15"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-16",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:16"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-17",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:17"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-18",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:18"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-19",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:19"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests9-dat-20",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests9.dat:20"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-21",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:21"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-22",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:22"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-23",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:23"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-24",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:24"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-25",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:25"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-26",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:26"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests9-dat-27",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests9.dat:27"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests3-dat-3",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests3.dat:3"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests6-dat-1",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests6.dat:1"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests3-dat-4",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests3.dat:4"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-5",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:5"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-6",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:6"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-7",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:7"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-8",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:8"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-9",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:9"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-10",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:10"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-11",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:11"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-13",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:13"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-14",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:14"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-20",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:20"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests3-dat-23",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests3.dat:23"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests6-dat-2",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests6.dat:2"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests6-dat-3",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests6.dat:3"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "tests6-dat-4",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "tests6.dat:4"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests6-dat-5",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests6.dat:5"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "tests6-dat-6",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "tests6.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-10",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:10"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-11",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:11"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-12",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:12"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-22",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:22"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-24",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:24"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-29",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:29"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-31",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:31"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-40",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:40"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-43",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:43"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-46",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:46"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-47",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:47"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-48",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:48"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-49",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:49"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-50",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:50"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests6-dat-51",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests6.dat:51"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-52",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:52"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-2",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:2"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-3",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:3"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-4",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:4"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-5",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:5"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-6",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:6"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-7",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:7"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-8",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:8"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-9",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:9"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests7-dat-10",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests7.dat:10"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests7-dat-11",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests7.dat:11"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-12",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:12"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-13",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:13"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-14",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:14"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-15",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:15"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-16",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:16"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-17",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:17"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-18",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:18"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-19",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:19"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-20",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:20"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-21",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:21"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-22",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:22"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-23",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:23"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-24",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:24"
+    },
+    {
+      "axis": "implicit-document-shell",
+      "id": "tests7-dat-25",
+      "reason": "implicit html/head/body shell synthesis around legacy inputs",
+      "source": "tests7.dat:25"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests7-dat-26",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests7.dat:26"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests7-dat-27",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests7.dat:27"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests4-dat-6",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests4.dat:6"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests4-dat-7",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests4.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests6-dat-30",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests6.dat:30"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests6-dat-32",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests6.dat:32"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests6-dat-45",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests6.dat:45"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests7-dat-28",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests7.dat:28"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-1",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:1"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-2",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:2"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests-innerhtml-1-dat-3",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests_innerHTML_1.dat:3"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-4",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:4"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-5",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:5"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-6",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests-innerhtml-1-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests_innerHTML_1.dat:7"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-8",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:8"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests-innerhtml-1-dat-28",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests_innerHTML_1.dat:28"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-79",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:79"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests-innerhtml-1-dat-80",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests_innerHTML_1.dat:80"
+    },
+    {
+      "axis": "shell-fragment-context",
+      "id": "tests-innerhtml-1-dat-81",
+      "reason": "html, head, and body fragment parsing contexts",
+      "source": "tests_innerHTML_1.dat:81"
+    },
+    {
+      "axis": "comment-whitespace-shell",
+      "id": "tests4-dat-9",
+      "reason": "comments and whitespace around implied html, head, and body nodes",
+      "source": "tests4.dat:9"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-4",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:4"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-5",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:6"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-7",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:7"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-8",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:8"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-9",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:9"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-10",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:10"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-11",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:11"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-12",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:12"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-13",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:13"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-14",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:14"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-15",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:15"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-16",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:16"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-17",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:17"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-18",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:18"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-19",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:19"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-34",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:34"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-55",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:55"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-86",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:86"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-88",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:88"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests1-dat-92",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests1.dat:92"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-93",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:93"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-101",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:101"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-105",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:105"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-110",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests1-dat-111",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests1-dat-112",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests1.dat:112"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-3",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:3"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-4",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:4"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-10",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:10"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-11",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:11"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-12",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:12"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-13",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:13"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-14",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:14"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-15",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:15"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-16",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:16"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-17",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:17"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-18",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:18"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests10-dat-19",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests10.dat:19"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-20",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:20"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-21",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:21"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-22",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:22"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-23",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:23"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-24",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:24"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-25",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:25"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests10-dat-26",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests10.dat:26"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-1",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:1"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-2",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:2"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-3",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:3"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-4",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:4"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-10",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:10"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-11",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:11"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-12",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:12"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests11-dat-13",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests11.dat:13"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests12-dat-1",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests12.dat:1"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests12-dat-2",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests12.dat:2"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-1",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:1"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-2",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:2"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-3",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:3"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-4",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:4"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-5",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:5"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-6",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:6"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests14-dat-7",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests14.dat:7"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests15-dat-3",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests15.dat:3"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests15-dat-4",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests15.dat:4"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests15-dat-5",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests15.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests15-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests15.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests15-dat-13",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests15.dat:13"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests15-dat-14",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests15.dat:14"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-76",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:76"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests16-dat-83",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests16.dat:83"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-91",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:91"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-173",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:173"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests16-dat-180",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests16.dat:180"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests16-dat-188",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests16.dat:188"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-3",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:3"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests18-dat-4",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests18.dat:4"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-5",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:5"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests18-dat-6",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests18.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-17",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:17"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-18",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:18"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-19",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:19"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-20",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:20"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-21",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:21"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-31",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:31"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests18-dat-32",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests18.dat:32"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-33",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:33"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests18-dat-34",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests18.dat:34"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-2",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:2"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-3",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:3"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-4",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:4"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:5"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-15",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:15"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-16",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:16"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-17",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:17"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-18",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:18"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-21",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:21"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-36",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:36"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-37",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:37"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-38",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:38"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-39",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:39"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-40",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:40"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-41",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:41"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-42",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:42"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-43",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:43"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-44",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:44"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-45",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:45"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-46",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:46"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-47",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:47"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-48",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:48"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-49",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:49"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-50",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:50"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-51",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:51"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-52",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:52"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-53",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:53"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-54",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:54"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-55",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:55"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-56",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:56"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-57",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:57"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-58",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:58"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-59",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:59"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-60",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:60"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-61",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:61"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-62",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:62"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-63",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:63"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-64",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:64"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-65",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:65"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-66",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:66"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-67",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:67"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-68",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:68"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-69",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:69"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-70",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:70"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-71",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:71"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-72",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:72"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-73",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:73"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-74",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:74"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-75",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:75"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-76",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:76"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-77",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:77"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-78",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:78"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-79",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:79"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-80",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:80"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests19-dat-81",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests19.dat:81"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-84",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:84"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-87",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:87"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tests19-dat-88",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tests19.dat:88"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-96",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:96"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests19-dat-97",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests19.dat:97"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-1",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:1"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-2",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:2"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-3",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:3"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-4",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:4"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-5",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-10",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:10"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-11",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:11"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-12",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:12"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-13",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:13"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-14",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:14"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-18",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:18"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-19",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:19"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-20",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:20"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-21",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:21"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "tests25-dat-22",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "tests25.dat:22"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-23",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:23"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-24",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:24"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-25",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:25"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests25-dat-26",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests25.dat:26"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-1",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:1"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-2",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:2"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-3",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:3"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-4",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:4"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "tests26-dat-15",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "tests26.dat:15"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "foreign-fragment-dat-52",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "foreign-fragment.dat:52"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "foreign-fragment-dat-53",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "foreign-fragment.dat:53"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "foreign-fragment-dat-54",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "foreign-fragment.dat:54"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "foreign-fragment-dat-55",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "foreign-fragment.dat:55"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "foreign-fragment-dat-56",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "foreign-fragment.dat:56"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "foreign-fragment-dat-57",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "foreign-fragment.dat:57"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "foreign-fragment-dat-64",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "foreign-fragment.dat:64"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tricky01-dat-2",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tricky01.dat:2"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tricky01-dat-3",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tricky01.dat:3"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tricky01-dat-4",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tricky01.dat:4"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tricky01-dat-5",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tricky01.dat:5"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "tricky01-dat-9",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "tricky01.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-17",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:17"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-18",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:18"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-19",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:19"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-20",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:20"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-21",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:21"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-22",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:22"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-23",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:23"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-24",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:24"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-25",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:25"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-26",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:26"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-27",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:27"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-28",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:28"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-29",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:29"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-30",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:30"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit01-dat-31",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit01.dat:31"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "webkit01-dat-35",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "webkit01.dat:35"
+    },
+    {
+      "axis": "head-element-boundary",
+      "id": "webkit01-dat-36",
+      "reason": "head insertion, head content, and noscript-in-head recovery",
+      "source": "webkit01.dat:36"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-51",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:51"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "webkit01-dat-52",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "webkit01.dat:52"
+    },
+    {
+      "axis": "html-element-boundary",
+      "id": "webkit02-dat-5",
+      "reason": "explicit html start/end tags and late html-tag recovery",
+      "source": "webkit02.dat:5"
+    }
+  ],
+  "counts_by_axis": {
+    "body-frameset-boundary": 310,
+    "comment-whitespace-shell": 15,
+    "doctype-and-quirks": 37,
+    "head-element-boundary": 132,
+    "html-element-boundary": 206,
+    "implicit-document-shell": 18,
+    "shell-fragment-context": 13
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress doctypes, comments, html/head/body synthesis, frameset boundaries, and shell fragment contexts.",
+  "format": "whatwg-html-document-shell-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_document_shell_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_document_shell_audit_test.rs
@@ -1,0 +1,87 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str =
+    include_str!("fixtures/whatwg-document-shell-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct DocumentShellAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<DocumentShellAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DocumentShellAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_document_shell_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-document-shell-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 700);
+    assert_axis_count(&suite, "doctype-and-quirks", 35);
+    assert_axis_count(&suite, "html-element-boundary", 200);
+    assert_axis_count(&suite, "head-element-boundary", 125);
+    assert_axis_count(&suite, "body-frameset-boundary", 300);
+    assert_axis_count(&suite, "comment-whitespace-shell", 15);
+    assert_axis_count(&suite, "shell-fragment-context", 10);
+    assert_axis_count(&suite, "implicit-document-shell", 15);
+}
+
+#[test]
+fn whatwg_document_shell_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> DocumentShellAuditSuite {
+    serde_json::from_str(WHATWG_DOCUMENT_SHELL_AUDIT)
+        .expect("WHATWG document-shell audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &DocumentShellAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG document-shell parser audit fixture covering 731 doctype, comment, html/head/body, frameset, shell fragment, and implicit-shell cases
- add a dedicated parser regression test that replays the indexed cases through the shared html5lib DOM dump path
- include the new generator in the generated HTML fixture manifest and document the stale-check path

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py --check
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser