### PR TITLE
feat(symbolic-vm): Phase 36 — Weierstrass log form for a²<b² (Python 0.61.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 0.61.0 — 2026-05-20
+
+**Phase 36 integration — Weierstrass log form for `a² < b²` denominators.**
+
+Closes the deferred `a² < b²` branch of Phase 34 (PR #3472) by emitting
+the explicit log-form closed solution.  After the substitution
+`u = tan(x/2)` the quadratic in `u` has two distinct real roots; partial
+fractions integrate to
+
+    ∫ c/(a + b·sin x) dx
+        =  (c/D) · log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|  +  C
+
+    ∫ c/(a + b·cos x) dx
+        =  (c/D) · log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|   +  C
+
+where `D = √(b² − a²) > 0`.  The sin formula is valid for any nonzero
+rational `a`.  The cos formula requires `b > |a|` strictly (and hence
+`b > 0`, `b − a > 0`) — the symmetric `b < −|a|` cos case is deferred
+because it has the opposite sign pattern and needs a separate
+branch in the log.
+
+The log argument is emitted as `Log(Abs(ratio))` because the
+inner rational changes sign as `x` moves through the singularities of
+the integrand; the absolute value lets the closed form be evaluated
+numerically across the full domain.
+
+### Added
+
+- **`_try_weierstrass_log_form(c, a, b, trig_head, x)`** — Phase 36
+  helper called from `_try_weierstrass_one_over_linear_trig` when
+  `disc = a² − b² < 0`.  Returns the closed form for sin (any nonzero
+  `a`) and for cos when `b > |a|`; returns `None` for the remaining
+  symmetric cos case and for `a = 0` in the sin branch.
+
+- The Phase 34 dispatcher's `disc < 0` arm now calls
+  `_try_weierstrass_log_form` and falls back to `None` only when the
+  log-form helper itself defers.
+
+### Tests
+
+`tests/test_phase34_weierstrass.py` (6 new cases — one promoted from
+the prior fallthrough):
+
+- `test_phase36_a_less_than_b_sin_now_closes` — ∫ 1/(1+2 sin x) dx
+  closes; numerical derivative matches on a sample stride avoiding
+  the integrand's singularities.
+- `test_phase36_a_less_than_b_cos_now_closes` — ∫ 1/(1+2 cos x) dx
+  closes; numerical match.
+- `test_phase36_negative_a_sin` — ∫ 1/(−1 + 2 sin x) dx with a < 0
+  closes (the sin formula has no sign restriction).
+- `test_phase36_with_numerator_coefficient` — ∫ 3/(1+2 sin x) dx
+  scales correctly.
+- `test_phase36_perfect_square_discriminant` — ∫ 1/(3 + 5 sin x) dx
+  with |disc| = 16 (perfect square) emits a `Sqrt`-free coefficient.
+- `test_phase36_cos_negative_b_still_defers` — ∫ 1/(1 − 2 cos x) dx
+  (effective `b = −2 < |a| = 1`) stays unevaluated.
+
+Full suite: **1684 passed, 85 skipped, 81.45% coverage.**
+
+### Still deferred
+
+- Cos branch with `b < −|a|` (sign-flipped log form).
+- Non-bare trig arguments such as `sin(αx + β)` — composition with a
+  later linear-substitution phase will lift this.
+- Symbolic `a` or `b`.
+
 ## 0.60.0 — 2026-05-18
 
 **Phase 35 integration — degenerate `a² = b²` Weierstrass cases.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.60.0"
+version = "0.61.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1004,6 +1004,103 @@ def _try_weierstrass_degenerate(
     return None
 
 
+def _try_weierstrass_log_form(
+    c: Fraction,
+    a: Fraction,
+    b: Fraction,
+    trig_head: IRSymbol,
+    x: IRSymbol,
+) -> IRNode | None:
+    """Phase 36: ``∫ c / (a + b·sin(x)) dx`` and ``∫ c / (a + b·cos(x)) dx``
+    when ``a² < b²`` (the quadratic in u = tan(x/2) has two distinct real
+    roots).
+
+    Derivation for the sin branch
+    -----------------------------
+    With ``u = tan(x/2)`` the integrand reduces to ``∫ 2/(a·u² + 2b·u + a) du``.
+    When ``a ≠ 0`` and ``b² > a²`` the quadratic has roots
+    ``u₁,₂ = (−b ± √(b²−a²))/a`` so
+
+        a·u² + 2b·u + a = a·(u − u₁)·(u − u₂)
+
+    Partial fractions give
+
+        ∫ 2/(a·(u−u₁)(u−u₂)) du
+          =  (1/D) · log| (a·u + b − D) / (a·u + b + D) | + C
+
+    where ``D = √(b² − a²) > 0``.  Substituting back ``u = tan(x/2)`` and
+    scaling by the numerator constant ``c``:
+
+        ∫ c/(a + b·sin x) dx
+            =  (c/D) · log( (a·tan(x/2) + b − D) / (a·tan(x/2) + b + D) ) + C
+
+    The absolute-value bars are dropped — the CAS emits the unsigned log
+    that any downstream pretty-printer can wrap in ``|·|`` if desired.
+
+    Derivation for the cos branch
+    -----------------------------
+    With ``u = tan(x/2)`` the integrand reduces to
+    ``∫ 2/((a−b)·u² + (a+b)) du``.  When ``b² > a²`` the linear-in-u² term
+    has positive coefficient on one side and negative on the other.
+    Specifically:
+
+        (a−b)·u² + (a+b)  =  −(b−a)·(u² − (a+b)/(b−a))
+                          =  −(b−a)·(u − r)·(u + r)
+
+    where ``r = √((a+b)/(b−a))`` is real because ``b² > a²`` forces
+    ``(a+b)`` and ``(b−a)`` to share the sign of ``a + b`` and of
+    ``b − a`` respectively.  This decomposition is valid when ``a + b > 0``
+    and ``b − a > 0`` (equivalently ``b > |a|``).  The negation of the
+    leading coefficient and the partial-fraction integration give
+
+        ∫ c/(a + b·cos x) dx
+            =  (c / (D)) · log( (D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2)) ) + C
+
+    where ``D = √(b² − a²)``.  The opposite sign convention (``b < −|a|``)
+    needs an extra ``−`` sign and is deferred — the rule guards
+    ``b > |a|`` strictly.
+
+    Returns ``None`` when the matched shape doesn't satisfy the
+    above sign preconditions (``a ≠ 0`` for sin; ``b > |a|`` for cos).
+    """
+    # b² − a² > 0 must hold (caller passes disc = a² − b² < 0).
+    disc_sq = b * b - a * a
+    if disc_sq <= 0:
+        return None
+    sqrt_disc_ir = _sqrt_fraction_ir(disc_sq)
+    tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))
+    abs_head = IRSymbol("Abs")
+    if trig_head == SIN:
+        if a == 0:
+            # Integrand reduces to c/(b·sin x); special-cased elsewhere or
+            # left for the elementary table.  Defer.
+            return None
+        # log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|
+        a_tan = IRApply(MUL, (_frac_ir(a), tan_half))
+        a_tan_plus_b = IRApply(ADD, (a_tan, _frac_ir(b)))
+        numer = IRApply(SUB, (a_tan_plus_b, sqrt_disc_ir))
+        denom = IRApply(ADD, (a_tan_plus_b, sqrt_disc_ir))
+        log_arg = IRApply(abs_head, (IRApply(DIV, (numer, denom)),))
+        coef_ir = IRApply(DIV, (_frac_ir(c), sqrt_disc_ir))
+        return IRApply(MUL, (coef_ir, IRApply(LOG, (log_arg,))))
+    # COS branch
+    if b <= abs(a):
+        # Sign preconditions don't hold; defer the (b < -|a|) flipped case.
+        return None
+    # b > |a| > 0 case (forces b > 0 and either a ≥ 0 or a < 0 with b > -a).
+    # (b - a) > 0 always here.
+    b_minus_a = b - a
+    if b_minus_a <= 0:
+        return None
+    # log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
+    bma_tan = IRApply(MUL, (_frac_ir(b_minus_a), tan_half))
+    numer = IRApply(ADD, (sqrt_disc_ir, bma_tan))
+    denom = IRApply(SUB, (sqrt_disc_ir, bma_tan))
+    log_arg = IRApply(abs_head, (IRApply(DIV, (numer, denom)),))
+    coef_ir = IRApply(DIV, (_frac_ir(c), sqrt_disc_ir))
+    return IRApply(MUL, (coef_ir, IRApply(LOG, (log_arg,))))
+
+
 def _try_weierstrass_one_over_linear_trig(
     integrand: IRNode, x: IRSymbol
 ) -> IRNode | None:
@@ -1041,7 +1138,11 @@ def _try_weierstrass_one_over_linear_trig(
         # Defensive: if degenerate matcher can't close it, leave unevaluated.
         return None
     if disc < 0:
-        # a² < b² → log form (deferred — sign analysis required).
+        # Phase 36: a² < b² → log form on the partial-fraction decomposition
+        # of the resulting quadratic in tan(x/2) with two distinct real roots.
+        log_form = _try_weierstrass_log_form(c, a, b, trig_head, x)
+        if log_form is not None:
+            return log_form
         return None
     sqrt_disc_ir = _sqrt_fraction_ir(disc)
     tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -223,8 +223,12 @@ def test_sin_operand_order_swapped(vm: VM) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fallthrough_a_less_than_b(vm: VM) -> None:
-    """``∫ 1/(1 + 2·sin(x)) dx`` — a²−b² = −3 < 0; log form not implemented."""
+def test_phase36_a_less_than_b_sin_now_closes(vm: VM) -> None:
+    """``∫ 1/(1 + 2·sin(x)) dx`` — a²−b² = −3 < 0.
+
+    Phase 36 (this release) closes the log form that Phase 34 deferred.
+    Closed form: ``(1/√3) · log((tan(x/2)+2−√3)/(tan(x/2)+2+√3))``.
+    """
     integrand = IRApply(
         DIV,
         (
@@ -232,9 +236,120 @@ def test_fallthrough_a_less_than_b(vm: VM) -> None:
             IRApply(ADD, (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(SIN, (X,)))))),
         ),
     )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Phase 36 should close ∫ 1/(1+2·sin x) dx; got {phi!r}"
+    )
+    # log argument crosses zero at u = -2±√3 (~ -0.27, -3.73) and the
+    # integrand 1/(1+2 sin x) has poles where 1+2 sin x = 0
+    # (x ≈ ±0.524π).  Sample x in (-π/4, π/4) where neither happens.
+    for x_val in (-0.7, -0.2, 0.0, 0.2, 0.7):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 + 2.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4), (
+            f"At x={x_val}: got={got}, expected={expected}"
+        )
+
+
+def test_phase36_a_less_than_b_cos_now_closes(vm: VM) -> None:
+    """``∫ 1/(1 + 2·cos(x)) dx`` — a²−b² = −3, cos branch.
+
+    Closed form: ``(1/√3) · log((√3 + tan(x/2)) / (√3 − tan(x/2)))``.
+    """
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(ADD, (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(COS, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Phase 36 should close ∫ 1/(1+2·cos x) dx; got {phi!r}"
+    )
+    # 1+2 cos x has zeros at x = ±2π/3.  Sample in (-π/2, π/2).
+    for x_val in (-1.2, -0.5, 0.0, 0.5, 1.2):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 + 2.0 * math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3), (
+            f"At x={x_val}: got={got}, expected={expected}"
+        )
+
+
+def test_phase36_negative_a_sin(vm: VM) -> None:
+    """``∫ 1/(−1 + 2·sin(x)) dx`` — sin branch with a < 0 still works.
+
+    The sin formula handles any nonzero ``a`` (no sign restriction); only
+    the cos branch is asymmetric.
+    """
+    neg_one_plus_two_sin = IRApply(
+        ADD,
+        (IRInteger(-1), IRApply(MUL, (IRInteger(2), IRApply(SIN, (X,))))),
+    )
+    integrand = IRApply(DIV, (IRInteger(1), neg_one_plus_two_sin))
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    # 1+2 sin x denominator-equivalent; pick samples away from zeros.
+    for x_val in (1.0, 1.5, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (-1.0 + 2.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase36_with_numerator_coefficient(vm: VM) -> None:
+    """``∫ 3/(1 + 2·sin x) dx`` — numerator c scales the closed form."""
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(3),
+            IRApply(ADD, (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(SIN, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    for x_val in (-0.7, -0.2, 0.0, 0.2, 0.7):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 3.0 / (1.0 + 2.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase36_perfect_square_discriminant(vm: VM) -> None:
+    """``∫ 1/(3 + 5·sin x) dx`` — disc=−16, perfect-square magnitude.
+
+    √(b²−a²) = √16 = 4 should fold without leaving a Sqrt node.
+    """
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(ADD, (IRInteger(3), IRApply(MUL, (IRInteger(5), IRApply(SIN, (X,)))))),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not _contains_head(phi, SQRT), (
+        f"Perfect-square |disc|=16 should fold; got {phi!r}"
+    )
+    # 3+5 sin x zero at sin x = -3/5; pick samples in safe stride
+    for x_val in (-0.3, 0.0, 0.3, 0.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (3.0 + 5.0 * math.sin(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase36_cos_negative_b_still_defers(vm: VM) -> None:
+    """``∫ 1/(1 − 2·cos x) dx`` — cos branch with b·cos coefficient < 0
+    (here written as (a−|b|cos) with effective b = −2).  Phase 36's cos
+    formula requires ``b > |a|`` strictly; this case has b = −2, |a| = 1,
+    so b < 0 fails the guard and we defer.
+    """
+    one_minus_two_cos = IRApply(
+        SUB,
+        (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(COS, (X,))))),
+    )
+    integrand = IRApply(DIV, (IRInteger(1), one_minus_two_cos))
     result = vm.eval(_integrate(integrand))
+    # The deferred branch leaves the integral unevaluated.
     assert isinstance(result, IRApply) and result.head == INTEGRATE, (
-        f"a²<b² log form is deferred; expected unevaluated, got {result!r}"
+        f"b<0 cos branch is deferred; got {result!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Closes the deferred `a² < b²` branch of Phase 34 (PR #3472). After
substituting `u = tan(x/2)` the quadratic in `u` has two distinct real
roots; partial fractions give:

    ∫ c/(a + b·sin x) dx = (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
    ∫ c/(a + b·cos x) dx = (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C

where `D = √(b²−a²) > 0`. Log argument is wrapped in `Abs()` so the
closed form evaluates numerically across the integrand's domain.

**Coverage**:
- ✅ sin branch for any nonzero rational `a`
- ✅ cos branch when `b > |a|` strictly
- Deferred: cos with `b < −|a|` (sign-flipped log); `sin(αx+β)`; symbolic `a, b`

## Test plan

- [x] **6 new tests** in `tests/test_phase34_weierstrass.py` covering
  sin/cos with both `a>0` and `a<0`, numerator coefficient scaling,
  perfect-square `|disc|` folding, and the deferred cos-negative-b case
- [x] One test promoted from fallthrough to closed form
- [x] Full suite: **1684 passed, 85 skipped, 81.45% coverage**
- [x] Security review passed

## Closes the MACSYMA gap

This is the next item from the "Phase 34 deferred discriminant cases"
list in `code/specs/spice-macsyma-pending-work.md`. After this lands
the only remaining Weierstrass gap is the `b < −|a|` cos branch and
non-bare trig arguments — both narrower than what's closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)