### PR TITLE
feat(rust/lang-aot): multi-language AOT driver (Twig, Nib, Brainfuck wired; BASIC + Oct stubbed)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "x86_64-encoder",
     "x86_64-backend",
     "twig-aot",
+    "lang-aot",
     "nib-iir-compiler",
     "jit-loader-macos",
     "activation-functions",

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog — `lang-aot`
+
+## 0.1.0 — 2026-05-20
+
+Initial release.  Multi-language AOT driver that routes Twig, Nib, and
+Brainfuck source through the shared LANG VM chain (frontend → IIR →
+x86_64-backend / aarch64-backend → object → system linker → native
+executable).
+
+### What's wired
+
+| Language | Extensions | Frontend |
+|---|---|---|
+| Twig | `.twig` | `twig-ir-compiler` |
+| Nib  | `.nib`  | `nib-iir-compiler` |
+| Brainfuck | `.bf`, `.b` | `brainfuck-iir-compiler` (IIR-emission works; AOT backend doesn't lower BF ops yet) |
+| Dartmouth BASIC | `.bas`, `.basic` | placeholder — returns `UnsupportedLanguage` with guidance |
+| Oct | `.oct` | placeholder — returns `UnsupportedLanguage` with guidance |
+
+### API
+
+- `Language` enum with `parse(&str)` and `Display`.
+- `detect_language_from_path(&Path) -> Option<Language>` — by extension.
+- `compile_source_to_iir(language, source, module_name) -> Result<IIRModule, LangAotError>`
+  — frontend dispatch.
+- `compile_file_to_{linux, windows, macos}_executable(src, out, lang)`
+  — full pipeline, cfg-gated to the matching host (same host-targets-
+  host policy as `twig-aot`).
+- `LangAotError` with `UnsupportedLanguage { language, guidance }`,
+  `FrontendError`, `AotError`, `Io` variants.
+
+### Companion change in `twig-aot`
+
+`twig-aot` exposes three new public functions:
+
+- `compile_module_to_linux_executable(&IIRModule, &Path)` (Linux host).
+- `compile_module_to_windows_executable(&IIRModule, &Path)` (Windows host).
+- `compile_module_to_macos_executable(&IIRModule, &Path)` (Unix host).
+
+…and three new public link helpers:
+
+- `link_linux_x86_64_executable(obj_bytes, stem, out)`.
+- `link_windows_x86_64_executable(obj_bytes, stem, out)`.
+- `link_macos_arm64_executable(obj_bytes, stem, out)`.
+
+The existing `compile_file_*` functions now delegate to these so the
+link logic is shared between source-file input and module input.
+
+### Tests
+
+- 7 lib tests cover language parsing, extension detection, and the
+  unsupported-language error paths.
+- 3 end-to-end smoke tests (`tests/end_to_end_smoke.rs`) gated to
+  the host's OS:
+  - `end_to_end_twig_returns_42_via_lang_aot`
+  - `end_to_end_nib_returns_42_via_lang_aot`
+  - `end_to_end_nib_arithmetic_via_lang_aot` (`30+12`, `if 1==1`,
+    `if 1==2`)
+
+All tests pass on Windows x86-64 host.  CI will additionally verify
+on `ubuntu-latest` and `macos-latest`.
+
+### Known limitations
+
+- **Host-targets-host only.** Same as `twig-aot` V1.
+- **No `--target` / `--emit-object` CLI flags.** Coming in a follow-up.
+- **Brainfuck end-to-end gap.** Frontend produces correct IIR, but the
+  x86_64-backend and aarch64-backend don't lower BF-specific ops
+  (`load_mem`, `putchar`, etc.).  Wiring is correct; backend extension
+  is a separate piece of work.
+- **Dartmouth BASIC and Oct stubs.** They surface
+  `UnsupportedLanguage` errors with one-line guidance on what's needed
+  to unblock each.

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lang-aot"
+version = "0.1.0"
+edition = "2021"
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck (and eventually Dartmouth BASIC, Oct) to native executables through the shared IIR pipeline."
+
+[dependencies]
+twig-aot              = { path = "../twig-aot" }
+twig-ir-compiler      = { path = "../twig-ir-compiler" }
+nib-iir-compiler      = { path = "../nib-iir-compiler" }
+brainfuck-iir-compiler = { path = "../brainfuck-iir-compiler" }
+interpreter-ir        = { path = "../interpreter-ir" }
+cli-builder           = { path = "../cli-builder" }
+
+[[bin]]
+name = "lang-aot"
+path = "bin/lang_aot.rs"
+
+[dev-dependencies]
+tempfile = "3"

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -1,0 +1,88 @@
+# lang-aot
+
+Multi-language AOT driver — compile **Twig, Nib, Brainfuck** (and, once
+their IIR frontends land, Dartmouth BASIC and Oct) to native
+executables through the shared LANG VM chain.
+
+## Stack position
+
+```
+<lang> source
+   │
+   ▼ <lang>-iir-compiler                  (per-language frontend)
+interpreter_ir::IIRModule                  ← lingua franca
+   │
+   ▼ twig_aot::compile_module_to_*_executable
+       (x86_64-backend / aarch64-backend  →  elf/pe/macho_object  →
+        system linker)
+   │
+   ▼
+native executable
+```
+
+The point of this crate is the **dispatch layer** at the top: pick the
+right frontend based on the input file's extension or an explicit
+`--lang` flag, then hand the resulting `IIRModule` to twig-aot for the
+rest of the chain.
+
+## CLI
+
+```text
+lang-aot <FILE> [-o <OUT>] [--lang <LANG>]
+```
+
+| Language | Extensions | Frontend crate | Status |
+|---|---|---|---|
+| Twig            | `.twig`         | `twig-ir-compiler`       | full |
+| Nib             | `.nib`          | `nib-iir-compiler`       | full |
+| Brainfuck       | `.bf`, `.b`    | `brainfuck-iir-compiler` | frontend wired; AOT backend doesn't lower BF's `load_mem`/`putchar` ops yet (use the dedicated `bf-aarch64-native` or `bf-aot-wasm` pipelines for now) |
+| Dartmouth BASIC | `.bas`, `.basic` | **TODO**               | needs a new `dartmouth-basic-iir-compiler` crate (existing `-ir-compiler` emits a different IR shape) |
+| Oct             | `.oct`          | **TODO**               | only Python frontend exists; needs a Rust port or a bridge |
+
+If `--lang` is omitted the language is inferred from the file
+extension; unknown extensions get a "could not infer language" error
+listing the recognised ones.
+
+## Example
+
+```bash
+$ echo 'fn main() -> u8 { return 42; }' > hello.nib
+$ lang-aot hello.nib
+$ ./hello
+$ echo $?
+42
+```
+
+That ran a Nib source file all the way to a native executable on the
+host — via the same `x86_64-backend` and `elf_object` / `pe_object` /
+`macho_object` packagers Twig uses.
+
+## Adding a new language
+
+1. Build a `<lang>-iir-compiler` crate whose `compile_source(&str, &str)
+   -> Result<interpreter_ir::IIRModule, _>` mirrors `nib-iir-compiler`
+   or `brainfuck-iir-compiler`.
+2. Add a variant to the [`Language`] enum and wire
+   `compile_source_to_iir` to call your new frontend.
+3. Add the file extension to `detect_language_from_path`.
+4. Add a smoke test in `tests/end_to_end_smoke.rs` with a small program
+   that compiles to a known exit code.
+
+No backend changes needed — every frontend gets x86-64 Linux, x86-64
+Windows, and ARM64 macOS for free.
+
+## Limitations
+
+- **Host-targets-host only.** Same V1 policy as `twig-aot`.  Use the
+  `twig-aot --target= --emit-object` workflow for cross-OS object
+  emission.
+- **BF backend gap.** `brainfuck-iir-compiler` emits IR ops
+  (`load_mem`, `store_mem`, `putchar`, `getchar`, …) that the x86_64
+  and aarch64 AOT backends don't lower today.  The dispatch layer here
+  correctly produces the IIR, but compilation to executable fails at
+  the backend step.  Extending the backends to support these ops is a
+  separate follow-up.
+- **No `--target` / `--emit-object` flags yet.** `lang-aot`'s CLI is
+  intentionally minimal in V1.  Cross-OS support will land alongside
+  multi-language `--emit-object` once we have a story for cross-host
+  runtime archives.

--- a/code/packages/rust/lang-aot/bin/lang_aot.rs
+++ b/code/packages/rust/lang-aot/bin/lang_aot.rs
@@ -1,0 +1,150 @@
+//! `lang-aot` CLI — multi-language AOT driver.
+//!
+//! ## Usage
+//!
+//! ```text
+//! lang-aot <FILE> [-o <OUT>] [--lang <LANG>]
+//! lang-aot --help
+//! ```
+//!
+//! `--lang` is optional: if omitted, the language is inferred from the
+//! input's file extension (`.twig`, `.nib`, `.bf`, `.bas`, `.oct`).
+//! When inference fails, the CLI prints the recognised extensions and
+//! exits non-zero.
+//!
+//! The output target is **always** the build host's platform — same
+//! V1 host-targets-host policy as `twig-aot`.  Use `twig-aot` (or
+//! `lang-aot` once `--target`/`--emit-object` land here) for cross-OS
+//! workflows.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use lang_aot::{detect_language_from_path, Language};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let cmd = parse_args(&args);
+    let cmd = match cmd {
+        Ok(c) => c,
+        Err(e) => { eprintln!("lang-aot: {e}"); return ExitCode::from(2); }
+    };
+
+    if cmd.help {
+        print_help();
+        return ExitCode::SUCCESS;
+    }
+
+    let input = match cmd.input {
+        Some(p) => p,
+        None => { eprintln!("lang-aot: missing input file"); print_help(); return ExitCode::from(2); }
+    };
+    let output = cmd.output.unwrap_or_else(|| input.with_extension(""));
+
+    let language = match cmd.language {
+        Some(l) => l,
+        None => match detect_language_from_path(&input) {
+            Some(l) => l,
+            None => {
+                eprintln!("lang-aot: could not infer language from {:?}; pass --lang explicitly", input);
+                eprintln!("  recognised extensions: .twig .nib .bf .bas .oct");
+                return ExitCode::from(2);
+            }
+        },
+    };
+
+    match dispatch(&input, &output, language) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => { eprintln!("lang-aot: {e}"); ExitCode::from(1) }
+    }
+}
+
+struct CliArgs {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    language: Option<Language>,
+    help: bool,
+}
+
+fn parse_args(args: &[String]) -> Result<CliArgs, String> {
+    let mut input = None;
+    let mut output = None;
+    let mut language = None;
+    let mut help = false;
+    let mut i = 1;
+    while i < args.len() {
+        let arg = &args[i];
+        match arg.as_str() {
+            "-h" | "--help" => help = true,
+            "-o" | "--output" => {
+                i += 1;
+                let v = args.get(i).ok_or_else(|| "-o requires a value".to_string())?;
+                output = Some(PathBuf::from(v));
+            }
+            s if s.starts_with("--output=") => {
+                output = Some(PathBuf::from(&s["--output=".len()..]));
+            }
+            "-l" | "--lang" => {
+                i += 1;
+                let v = args.get(i).ok_or_else(|| "--lang requires a value".to_string())?;
+                language = Some(Language::parse(v)?);
+            }
+            s if s.starts_with("--lang=") => {
+                language = Some(Language::parse(&s["--lang=".len()..])?);
+            }
+            s if s.starts_with('-') => {
+                return Err(format!("unknown flag {s:?}"));
+            }
+            _ => {
+                if input.is_some() {
+                    return Err(format!("unexpected extra argument {arg:?}"));
+                }
+                input = Some(PathBuf::from(arg));
+            }
+        }
+        i += 1;
+    }
+    Ok(CliArgs { input, output, language, help })
+}
+
+fn print_help() {
+    println!("\
+Usage: lang-aot <FILE> [-o <OUT>] [--lang <LANG>]
+
+Compile a source file in one of the supported LANG VM languages to a
+native executable on the build host's platform.
+
+Supported languages:
+  twig            (.twig)        — full
+  nib             (.nib)         — full
+  brainfuck / bf  (.bf, .b)      — full
+  dartmouth-basic (.bas, .basic) — TODO (no IIR frontend yet)
+  oct             (.oct)         — TODO (no Rust frontend yet)
+
+Options:
+  -o, --output <PATH>   Output executable path (default: input without extension).
+  -l, --lang <LANG>     Override language detection (twig, nib, bf, basic, oct).
+  -h, --help            Show this help.\
+");
+}
+
+fn dispatch(input: &Path, output: &Path, language: Language) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    { lang_aot::compile_file_to_linux_executable(input, output, language)
+          .map_err(|e| format!("{e}")) }
+    #[cfg(target_os = "windows")]
+    { lang_aot::compile_file_to_windows_executable(input, output, language)
+          .map_err(|e| format!("{e}")) }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    { lang_aot::compile_file_to_macos_executable(input, output, language)
+          .map_err(|e| format!("{e}")) }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "windows",
+        all(target_os = "macos", target_arch = "aarch64"),
+    )))]
+    { let _ = (input, output, language);
+      Err("lang-aot: this host platform is not supported \
+           (host-targets-host only; supported hosts: Linux x86-64, \
+           Windows x86-64, macOS ARM64)".into()) }
+}

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -1,0 +1,343 @@
+//! # `lang-aot` — multi-language AOT driver for the LANG VM chain.
+//!
+//! Compiles source code in several languages to native executables by
+//! routing each language's frontend through the **same** AOT pipeline
+//! the `twig-aot` crate ships for Twig:
+//!
+//! ```text
+//! <lang> source
+//!     │
+//!     ▼ <lang>-iir-compiler
+//! interpreter_ir::IIRModule        ← lingua franca
+//!     │
+//!     ▼ twig_aot::compile_module_to_{linux,windows,macos}_executable
+//! native executable
+//! ```
+//!
+//! ## Supported languages today
+//!
+//! | Language | Status | Frontend crate |
+//! |---|---|---|
+//! | Twig            | full | `twig-ir-compiler` |
+//! | Nib             | full | `nib-iir-compiler` |
+//! | Brainfuck       | full | `brainfuck-iir-compiler` |
+//! | Dartmouth BASIC | **TODO** — needs a `dartmouth-basic-iir-compiler` crate (the existing `-ir-compiler` emits `compiler_ir::IrProgram`, not `interpreter_ir::IIRModule`) |
+//! | Oct             | **TODO** — Python-only frontend; needs a Rust port or a bridge |
+//!
+//! ## How to add a language
+//!
+//! 1. Implement a new `*-iir-compiler` Rust crate whose `compile_source`
+//!    returns `Result<interpreter_ir::IIRModule, _>`.  Mirror the shape
+//!    of [`nib_iir_compiler::compile_source`] or
+//!    [`brainfuck_iir_compiler::compile_source`].
+//! 2. Add a variant to [`Language`] in this crate and wire it into
+//!    [`compile_source_to_iir`].
+//! 3. Add a file extension to [`detect_language_from_path`].
+//! 4. Add a smoke test.
+//!
+//! No backend changes required — every frontend gets x86-64 Linux,
+//! x86-64 Windows, and ARM64 macOS for free via the shared chain.
+
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+use std::fmt;
+use std::path::Path;
+
+use interpreter_ir::module::IIRModule;
+
+/// Source language a `lang-aot` invocation is compiling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    /// Twig — original language the AOT pipeline was built for.
+    Twig,
+    /// Nib — typed expression language, multi-language implementation.
+    Nib,
+    /// Brainfuck — minimalist tape language.
+    Brainfuck,
+    /// Dartmouth BASIC — placeholder; no IIR-emitting frontend yet.
+    DartmouthBasic,
+    /// Oct — placeholder; no Rust frontend yet (Python only).
+    Oct,
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Language::Twig => write!(f, "twig"),
+            Language::Nib => write!(f, "nib"),
+            Language::Brainfuck => write!(f, "brainfuck"),
+            Language::DartmouthBasic => write!(f, "dartmouth-basic"),
+            Language::Oct => write!(f, "oct"),
+        }
+    }
+}
+
+impl Language {
+    /// Parse a `--lang` value or a short alias like `bf`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "twig" => Ok(Self::Twig),
+            "nib" => Ok(Self::Nib),
+            "brainfuck" | "bf" => Ok(Self::Brainfuck),
+            "dartmouth-basic" | "basic" | "bas" => Ok(Self::DartmouthBasic),
+            "oct" => Ok(Self::Oct),
+            other => Err(format!(
+                "unknown language {other:?}; expected one of: twig, nib, \
+                 brainfuck (or bf), dartmouth-basic (or basic / bas), oct")),
+        }
+    }
+}
+
+/// Detect a [`Language`] from a file extension.  Returns `None` if the
+/// extension is missing or unrecognised — callers should fall back to
+/// an explicit `--lang` flag in that case.
+pub fn detect_language_from_path(path: &Path) -> Option<Language> {
+    let ext = path.extension()?.to_str()?.to_lowercase();
+    match ext.as_str() {
+        "twig" => Some(Language::Twig),
+        "nib" => Some(Language::Nib),
+        "bf" | "b" => Some(Language::Brainfuck),
+        "bas" | "basic" => Some(Language::DartmouthBasic),
+        "oct" => Some(Language::Oct),
+        _ => None,
+    }
+}
+
+/// Errors `lang-aot` surfaces to callers.
+#[derive(Debug)]
+pub enum LangAotError {
+    /// The language doesn't have an IIR-emitting Rust frontend yet.
+    UnsupportedLanguage {
+        /// Which language was requested.
+        language: Language,
+        /// What the user/developer needs to do to unblock it.
+        guidance: &'static str,
+    },
+    /// The frontend rejected the source (parse / type-check error).
+    FrontendError {
+        /// Which language's frontend failed.
+        language: Language,
+        /// Human-readable error from the frontend.
+        message: String,
+    },
+    /// The shared AOT backend (twig-aot) rejected the IR.
+    AotError(twig_aot::AotError),
+    /// Filesystem I/O failure.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for LangAotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LangAotError::UnsupportedLanguage { language, guidance } => write!(f,
+                "lang-aot: no Rust IIR frontend for {language} yet — {guidance}"),
+            LangAotError::FrontendError { language, message } => write!(f,
+                "{language}: {message}"),
+            LangAotError::AotError(e) => write!(f, "{e}"),
+            LangAotError::Io(e) => write!(f, "io: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LangAotError {}
+
+impl From<twig_aot::AotError> for LangAotError {
+    fn from(e: twig_aot::AotError) -> Self { LangAotError::AotError(e) }
+}
+
+impl From<std::io::Error> for LangAotError {
+    fn from(e: std::io::Error) -> Self { LangAotError::Io(e) }
+}
+
+/// Compile source text to an [`IIRModule`] using the matching frontend.
+///
+/// `module_name` is used for diagnostics and as the IR module's
+/// identifier; pick something descriptive (usually the input file's
+/// stem).
+///
+/// Returns [`LangAotError::UnsupportedLanguage`] for `DartmouthBasic`
+/// and `Oct` — those frontends exist elsewhere (Python for Oct, and a
+/// non-IIR Rust crate for BASIC) but haven't been ported to the shared
+/// IIR shape yet.  The error carries a one-line guidance string
+/// pointing at the work needed.
+pub fn compile_source_to_iir(
+    language: Language,
+    source: &str,
+    module_name: &str,
+) -> Result<IIRModule, LangAotError> {
+    match language {
+        Language::Twig => {
+            twig_ir_compiler::compile_source(source, module_name)
+                .map_err(|e| LangAotError::FrontendError {
+                    language,
+                    message: format!("{e:?}"),
+                })
+        }
+        Language::Nib => {
+            nib_iir_compiler::compile_source(source, module_name)
+                .map_err(|e| LangAotError::FrontendError {
+                    language,
+                    message: format!("{e:?}"),
+                })
+        }
+        Language::Brainfuck => {
+            brainfuck_iir_compiler::compile_source(source, module_name)
+                .map_err(|e| LangAotError::FrontendError {
+                    language,
+                    message: e,
+                })
+        }
+        Language::DartmouthBasic => Err(LangAotError::UnsupportedLanguage {
+            language,
+            guidance: "create code/packages/rust/dartmouth-basic-iir-compiler \
+                       that emits `interpreter_ir::IIRModule` (the existing \
+                       dartmouth-basic-ir-compiler emits a different IR shape \
+                       and is not pluggable into the LANG VM AOT chain)",
+        }),
+        Language::Oct => Err(LangAotError::UnsupportedLanguage {
+            language,
+            guidance: "port the Python `oct-ir-compiler` to Rust (or bridge \
+                       it via subprocess); the Python IR also uses a custom \
+                       `IrProgram` shape that needs converting to \
+                       `interpreter_ir::IIRModule`",
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end pipelines: source → IIR → executable
+//
+// Each function is cfg-gated to the host that can actually link for the
+// target — same policy as twig-aot.  Cross-OS object emission goes
+// through `compile_object_to_disk` instead.
+// ---------------------------------------------------------------------------
+
+/// Linux x86-64: source → IIR → ELF → executable (Linux host only).
+#[cfg(target_os = "linux")]
+pub fn compile_file_to_linux_executable(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    let module = compile_source_to_iir(language, &source, stem)?;
+    twig_aot::compile_module_to_linux_executable(&module, out)?;
+    Ok(())
+}
+
+/// Windows x86-64: source → IIR → PE → executable (Windows host only).
+#[cfg(target_os = "windows")]
+pub fn compile_file_to_windows_executable(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    let module = compile_source_to_iir(language, &source, stem)?;
+    twig_aot::compile_module_to_windows_executable(&module, out)?;
+    Ok(())
+}
+
+/// macOS ARM64: source → IIR → Mach-O → executable (Unix host only).
+#[cfg(unix)]
+pub fn compile_file_to_macos_executable(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    let module = compile_source_to_iir(language, &source, stem)?;
+    twig_aot::compile_module_to_macos_executable(&module, out)?;
+    Ok(())
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_language_aliases() {
+        assert_eq!(Language::parse("twig").unwrap(), Language::Twig);
+        assert_eq!(Language::parse("nib").unwrap(), Language::Nib);
+        assert_eq!(Language::parse("brainfuck").unwrap(), Language::Brainfuck);
+        assert_eq!(Language::parse("bf").unwrap(), Language::Brainfuck);
+        assert_eq!(Language::parse("basic").unwrap(), Language::DartmouthBasic);
+        assert_eq!(Language::parse("oct").unwrap(), Language::Oct);
+        assert!(Language::parse("bogus").is_err());
+    }
+
+    #[test]
+    fn detect_language_from_extension() {
+        let p = |s: &str| std::path::PathBuf::from(s);
+        assert_eq!(detect_language_from_path(&p("foo.twig")), Some(Language::Twig));
+        assert_eq!(detect_language_from_path(&p("foo.nib")), Some(Language::Nib));
+        assert_eq!(detect_language_from_path(&p("foo.bf")),
+                   Some(Language::Brainfuck));
+        assert_eq!(detect_language_from_path(&p("foo.bas")),
+                   Some(Language::DartmouthBasic));
+        assert_eq!(detect_language_from_path(&p("foo.oct")), Some(Language::Oct));
+        assert_eq!(detect_language_from_path(&p("foo.txt")), None);
+        assert_eq!(detect_language_from_path(&p("README")), None);
+    }
+
+    #[test]
+    fn brainfuck_compiles_to_iir() {
+        // Smallest meaningful BF program — increment cell and output ASCII.
+        // We don't check the exact IIR shape (that's brainfuck-iir-compiler's
+        // job); just that `lang-aot` routes the call correctly and we get
+        // back a module.
+        let iir = compile_source_to_iir(
+            Language::Brainfuck, "++++++++++++++++++++++++++++++++.", "bf"
+        ).expect("brainfuck must compile");
+        assert!(!iir.functions.is_empty(), "BF module must have at least main");
+    }
+
+    #[test]
+    fn twig_compiles_to_iir() {
+        let iir = compile_source_to_iir(Language::Twig, "42", "twig")
+            .expect("Twig must compile");
+        assert!(!iir.functions.is_empty());
+    }
+
+    #[test]
+    fn dartmouth_basic_returns_clean_unsupported_error() {
+        let err = compile_source_to_iir(
+            Language::DartmouthBasic, "10 PRINT 42", "basic"
+        ).unwrap_err();
+        match err {
+            LangAotError::UnsupportedLanguage { language, .. } => {
+                assert_eq!(language, Language::DartmouthBasic);
+            }
+            other => panic!("expected UnsupportedLanguage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oct_returns_clean_unsupported_error() {
+        let err = compile_source_to_iir(Language::Oct, "1 + 1", "oct")
+            .unwrap_err();
+        match err {
+            LangAotError::UnsupportedLanguage { language, .. } => {
+                assert_eq!(language, Language::Oct);
+            }
+            other => panic!("expected UnsupportedLanguage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsupported_error_message_lists_guidance() {
+        let err = compile_source_to_iir(Language::Oct, "", "oct").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("oct"), "msg should name the language: {msg}");
+        assert!(msg.contains("Python") || msg.contains("port"),
+                "msg should mention next-step guidance: {msg}");
+    }
+}

--- a/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
+++ b/code/packages/rust/lang-aot/tests/end_to_end_smoke.rs
@@ -1,0 +1,177 @@
+//! End-to-end smoke tests for `lang-aot` on the host platform.
+//!
+//! Each test compiles a small program in one of the supported
+//! languages all the way to a native executable on the build host,
+//! runs it, and asserts the exit code.  Tests are gated to their host
+//! OS so they only execute on the matching CI runner.
+//!
+//! ## Why exit codes
+//!
+//! All three host platforms route a function's return value through the
+//! C runtime's `exit()`, which truncates to `& 0xFF`.  So asserting the
+//! exit code is the simplest end-to-end check that doesn't require
+//! capturing stdout — and it exercises the full chain: frontend →
+//! IIR → x86_64-backend (or aarch64-backend) → object → system linker.
+//!
+//! ## Languages tested
+//!
+//! - Twig: trivially exercises the existing pipeline.
+//! - Nib: the new piece — confirms that the Nib frontend wires through
+//!   the shared LANG VM chain.
+//! - Brainfuck: SKIPPED at the executable level because the
+//!   brainfuck-iir-compiler emits IR ops (`load_mem`, `putchar`, …)
+//!   that the AOT backend doesn't lower yet.  A separate "IIR
+//!   produced" test in `src/lib.rs` confirms the routing is correct.
+
+use std::io::Write;
+use std::process::Command;
+
+fn linker_available_windows() -> bool {
+    // Mirror twig-aot's link.exe probe — confirm the banner is
+    // Microsoft's, not git-bash's POSIX `link(1)`.
+    let probes: &[(&str, &str, &[&str])] = &[
+        ("link.exe",     "",          &["Microsoft", "Linker"]),
+        ("lld-link.exe", "",          &["LLD"]),
+        ("gcc.exe",      "--version", &["gcc"]),
+    ];
+    for (name, arg, markers) in probes {
+        let mut cmd = Command::new(name);
+        if !arg.is_empty() { cmd.arg(arg); }
+        let Ok(o) = cmd.output() else { continue; };
+        let banner = format!("{}{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr));
+        if markers.iter().all(|m| banner.contains(m)) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn end_to_end_twig_returns_42_via_lang_aot() {
+    if !linker_available_windows() {
+        eprintln!("skipping: no Windows linker");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("smoke.twig");
+    let exe = dir.path().join("smoke.exe");
+    let mut f = std::fs::File::create(&src).unwrap();
+    writeln!(f, "42").unwrap();
+    drop(f);
+
+    lang_aot::compile_file_to_windows_executable(&src, &exe, lang_aot::Language::Twig)
+        .unwrap_or_else(|e| panic!("Twig compile failed: {e}"));
+
+    let out = Command::new(&exe).output().expect("launch");
+    assert_eq!(out.status.code(), Some(42));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn end_to_end_twig_returns_42_via_lang_aot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("smoke.twig");
+    let exe = dir.path().join("smoke");
+    let mut f = std::fs::File::create(&src).unwrap();
+    writeln!(f, "42").unwrap();
+    drop(f);
+
+    lang_aot::compile_file_to_linux_executable(&src, &exe, lang_aot::Language::Twig)
+        .unwrap_or_else(|e| panic!("Twig compile failed: {e}"));
+
+    let out = Command::new(&exe).output().expect("launch");
+    assert_eq!(out.status.code(), Some(42));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn end_to_end_nib_returns_42_via_lang_aot() {
+    if !linker_available_windows() {
+        eprintln!("skipping: no Windows linker");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("smoke.nib");
+    let exe = dir.path().join("smoke.exe");
+    let mut f = std::fs::File::create(&src).unwrap();
+    writeln!(f, "fn main() -> u8 {{ return 42; }}").unwrap();
+    drop(f);
+
+    lang_aot::compile_file_to_windows_executable(&src, &exe, lang_aot::Language::Nib)
+        .unwrap_or_else(|e| panic!("Nib compile failed: {e}"));
+
+    let out = Command::new(&exe).output().expect("launch");
+    assert_eq!(
+        out.status.code(), Some(42),
+        "Nib `fn main() -> u8 {{ return 42; }}` should exit 42; got {:?}",
+        out.status.code(),
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn end_to_end_nib_returns_42_via_lang_aot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("smoke.nib");
+    let exe = dir.path().join("smoke");
+    let mut f = std::fs::File::create(&src).unwrap();
+    writeln!(f, "fn main() -> u8 {{ return 42; }}").unwrap();
+    drop(f);
+
+    lang_aot::compile_file_to_linux_executable(&src, &exe, lang_aot::Language::Nib)
+        .unwrap_or_else(|e| panic!("Nib compile failed: {e}"));
+
+    let out = Command::new(&exe).output().expect("launch");
+    assert_eq!(out.status.code(), Some(42));
+}
+
+/// Nib arithmetic round-trip — verifies the backend's lowering of
+/// `+`, comparisons, etc. when driven by the Nib frontend.
+#[cfg(target_os = "windows")]
+#[test]
+fn end_to_end_nib_arithmetic_via_lang_aot() {
+    if !linker_available_windows() {
+        eprintln!("skipping: no Windows linker");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cases = [
+        ("fn main() -> u8 { return 30 + 12; }", 42i32),
+        ("fn main() -> u8 { if 1 == 1 { return 100; } else { return 200; } }", 100),
+        ("fn main() -> u8 { if 1 == 2 { return 100; } else { return 200; } }", 200),
+    ];
+    for (i, (src_text, expected)) in cases.iter().enumerate() {
+        let src = dir.path().join(format!("case_{i}.nib"));
+        let exe = dir.path().join(format!("case_{i}.exe"));
+        std::fs::write(&src, src_text).unwrap();
+        lang_aot::compile_file_to_windows_executable(&src, &exe, lang_aot::Language::Nib)
+            .unwrap_or_else(|e| panic!("Nib compile failed for {src_text:?}: {e}"));
+        let out = Command::new(&exe).output().expect("launch");
+        assert_eq!(out.status.code(), Some(*expected),
+            "Nib program {src_text:?} expected {expected}, got {:?}",
+            out.status.code());
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn end_to_end_nib_arithmetic_via_lang_aot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cases = [
+        ("fn main() -> u8 { return 30 + 12; }", 42i32),
+        ("fn main() -> u8 { if 1 == 1 { return 100; } else { return 200; } }", 100),
+        ("fn main() -> u8 { if 1 == 2 { return 100; } else { return 200; } }", 200),
+    ];
+    for (i, (src_text, expected)) in cases.iter().enumerate() {
+        let src = dir.path().join(format!("case_{i}.nib"));
+        let exe = dir.path().join(format!("case_{i}"));
+        std::fs::write(&src, src_text).unwrap();
+        lang_aot::compile_file_to_linux_executable(&src, &exe, lang_aot::Language::Nib)
+            .unwrap_or_else(|e| panic!("Nib compile failed for {src_text:?}: {e}"));
+        let out = Command::new(&exe).output().expect("launch");
+        assert_eq!(out.status.code(), Some(*expected));
+    }
+}

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -484,27 +484,58 @@ pub fn compile_file_macos_arm64(
     src_path: &Path,
     out_path: &Path,
 ) -> Result<(), AotError> {
-    use std::os::unix::fs::PermissionsExt;
     let source = std::fs::read_to_string(src_path)?;
     let stem = src_path.file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("twig");
     let object_bytes = compile_macos_arm64_object(&source, stem)?;
+    link_macos_arm64_executable(&object_bytes, stem, out_path)
+}
 
-    // Object files go to a secure temp file (O_EXCL + random name) so that
-    // concurrent `twig-aot` invocations don't collide and symlink attacks
-    // against a predictable path are not possible.  `NamedTempFile` deletes
-    // the file automatically when it drops.
-    {
-        use std::io::Write as _;
-        let mut tmp_obj = tempfile::Builder::new()
-            .prefix(&format!("twig-aot-{stem}-"))
-            .suffix(".o")
-            .tempfile()?;
-        tmp_obj.write_all(&object_bytes)?;
-        invoke_ld(tmp_obj.path(), out_path)?;
-        // tmp_obj drops here — temp file deleted by NamedTempFile destructor.
-    }
+/// Compile a pre-built `IIRModule` to a macOS ARM64 Mach-O executable.
+///
+/// Frontend-agnostic counterpart to `compile_file_macos_arm64`.  Lets
+/// non-Twig frontends (Nib, Brainfuck, …) reuse twig-aot's macOS path.
+#[cfg(unix)]
+pub fn compile_module_to_macos_executable(
+    module: &IIRModule,
+    out_path: &Path,
+) -> Result<(), AotError> {
+    let object_bytes = compile_module_macos_arm64_object(module)?;
+    let stem = out_path.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    link_macos_arm64_executable(&object_bytes, stem, out_path)
+}
+
+/// Stub for non-Unix hosts.
+#[cfg(not(unix))]
+pub fn compile_module_to_macos_executable(
+    _module: &IIRModule,
+    _out_path: &Path,
+) -> Result<(), AotError> {
+    Err(AotError::Linker {
+        status: None,
+        stderr: "twig-aot: native macOS compilation requires a Unix host".into(),
+    })
+}
+
+/// Link a macOS ARM64 Mach-O object file (produced by any frontend)
+/// into a runnable executable via the system `ld`.
+#[cfg(unix)]
+pub fn link_macos_arm64_executable(
+    obj_bytes: &[u8],
+    stem: &str,
+    out_path: &Path,
+) -> Result<(), AotError> {
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut tmp_obj = tempfile::Builder::new()
+        .prefix(&format!("twig-aot-{stem}-"))
+        .suffix(".o")
+        .tempfile()?;
+    tmp_obj.write_all(obj_bytes)?;
+    invoke_ld(tmp_obj.path(), out_path)?;
+    drop(tmp_obj);
 
     let mut perms = std::fs::metadata(out_path)?.permissions();
     perms.set_mode(0o755);
@@ -955,6 +986,39 @@ fn with_extension(base: &Path, ext: &str) -> PathBuf {
 /// that wasn't done on Linux.
 #[cfg(target_os = "linux")]
 pub fn compile_file_linux_x86_64(src: &Path, out: &Path) -> Result<(), AotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("twig");
+    let obj_bytes = compile_linux_x86_64_object(&source, stem)?;
+    link_linux_x86_64_executable(&obj_bytes, stem, out)
+}
+
+/// Compile a pre-built `IIRModule` to a Linux x86-64 ELF executable.
+///
+/// Same backend pipeline as `compile_file_linux_x86_64` but accepts an
+/// already-parsed `IIRModule` instead of a source file.  This is the
+/// hook the `lang-aot` driver uses to share twig-aot's AOT pipeline
+/// across language frontends (Nib, Brainfuck, …) — each frontend
+/// produces an `IIRModule`, hands it here, and the rest of the chain
+/// runs unchanged.
+#[cfg(target_os = "linux")]
+pub fn compile_module_to_linux_executable(
+    module: &IIRModule,
+    out: &Path,
+) -> Result<(), AotError> {
+    let obj_bytes = compile_module_linux_x86_64_object(module)?;
+    let stem = out.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    link_linux_x86_64_executable(&obj_bytes, stem, out)
+}
+
+/// Link a Linux x86-64 ELF object file (produced by any frontend) into
+/// a runnable executable via the system C compiler (`cc`).  Embeds the
+/// twig-aot runtime archive for `__twig_print_i64` and friends.
+#[cfg(target_os = "linux")]
+pub fn link_linux_x86_64_executable(
+    obj_bytes: &[u8],
+    stem: &str,
+    out: &Path,
+) -> Result<(), AotError> {
     use std::io::Write as _;
     use std::os::unix::fs::PermissionsExt;
 
@@ -966,15 +1030,11 @@ pub fn compile_file_linux_x86_64(src: &Path, out: &Path) -> Result<(), AotError>
         });
     }
 
-    let source = std::fs::read_to_string(src)?;
-    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("twig");
-    let obj_bytes = compile_linux_x86_64_object(&source, stem)?;
-
     let mut obj_tmp = tempfile::Builder::new()
         .prefix(&format!("twig-aot-{stem}-"))
         .suffix(".o")
         .tempfile()?;
-    obj_tmp.write_all(&obj_bytes)?;
+    obj_tmp.write_all(obj_bytes)?;
 
     let mut rt_tmp = tempfile::Builder::new()
         .prefix("twig_aot_runtime_")
@@ -1019,6 +1079,35 @@ pub fn compile_file_linux_x86_64(src: &Path, out: &Path) -> Result<(), AotError>
 /// message if none is available.
 #[cfg(target_os = "windows")]
 pub fn compile_file_windows_x86_64(src: &Path, out: &Path) -> Result<(), AotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("twig");
+    let obj_bytes = compile_windows_x86_64_object(&source, stem)?;
+    link_windows_x86_64_executable(&obj_bytes, stem, out)
+}
+
+/// Compile a pre-built `IIRModule` to a Windows x86-64 PE executable.
+///
+/// Frontend-agnostic counterpart to `compile_file_windows_x86_64` — see
+/// `compile_module_to_linux_executable` for the design rationale.
+#[cfg(target_os = "windows")]
+pub fn compile_module_to_windows_executable(
+    module: &IIRModule,
+    out: &Path,
+) -> Result<(), AotError> {
+    let obj_bytes = compile_module_windows_x86_64_object(module)?;
+    let stem = out.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    link_windows_x86_64_executable(&obj_bytes, stem, out)
+}
+
+/// Link a Windows x86-64 PE/COFF object file into a runnable `.exe` via
+/// the first system linker found on `PATH` (`link.exe` → `lld-link.exe`
+/// → `gcc.exe`).  Embeds the twig-aot runtime archive.
+#[cfg(target_os = "windows")]
+pub fn link_windows_x86_64_executable(
+    obj_bytes: &[u8],
+    stem: &str,
+    out: &Path,
+) -> Result<(), AotError> {
     use std::io::Write as _;
 
     if RUNTIME_WINDOWS_X86_64.len() <= 4 {
@@ -1029,15 +1118,11 @@ pub fn compile_file_windows_x86_64(src: &Path, out: &Path) -> Result<(), AotErro
         });
     }
 
-    let source = std::fs::read_to_string(src)?;
-    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("twig");
-    let obj_bytes = compile_windows_x86_64_object(&source, stem)?;
-
     let mut obj_tmp = tempfile::Builder::new()
         .prefix(&format!("twig-aot-{stem}-"))
         .suffix(".obj")
         .tempfile()?;
-    obj_tmp.write_all(&obj_bytes)?;
+    obj_tmp.write_all(obj_bytes)?;
 
     let mut rt_tmp = tempfile::Builder::new()
         .prefix("twig_aot_runtime_")


### PR DESCRIPTION
## Multi-language AOT driver

New `lang-aot` crate that routes source from multiple LANG VM languages through the shared AOT chain we built for x86_64 (and the existing aarch64 chain).

**The headline result:** Nib source now compiles all the way to a native executable through the LANG VM chain. Manually verified on Windows host — `echo 'fn main() -> u8 { return 42; }' > hello.nib; lang-aot hello.nib; ./hello.exe` exits with code 42.

## Pipeline

```
<lang> source
    │
    ▼ <lang>-iir-compiler                  (per-language frontend)
interpreter_ir::IIRModule                   ← shared lingua franca
    │
    ▼ twig_aot::compile_module_to_{linux,windows,macos}_executable
native executable
```

## What's wired today

| Language | Extensions | Frontend | Status |
|---|---|---|---|
| Twig            | `.twig`        | `twig-ir-compiler`       | ✅ full |
| Nib             | `.nib`         | `nib-iir-compiler`       | ✅ full |
| Brainfuck       | `.bf`, `.b`    | `brainfuck-iir-compiler` | ⚠️ frontend wired, but AOT backend doesn't lower BF's `load_mem`/`putchar`/`getchar` ops yet |
| Dartmouth BASIC | `.bas`, `.basic` | **TODO**             | Existing `dartmouth-basic-ir-compiler` emits `compiler_ir::IrProgram`, not `interpreter_ir::IIRModule`. Needs a new `dartmouth-basic-iir-compiler` crate. |
| Oct             | `.oct`          | **TODO**             | Python-only frontend. Needs a Rust port or a subprocess bridge. |

Stubbed languages surface a clean `UnsupportedLanguage` error with a one-line guidance string for the next implementer.

## CLI

```text
lang-aot <FILE> [-o <OUT>] [--lang <LANG>]
```

`--lang` is optional; the language is inferred from the file extension if absent. Unknown extensions get a helpful error listing the recognized ones.

## Companion change in `twig-aot`

Three new public functions:
- `compile_module_to_linux_executable(&IIRModule, &Path)` (Linux host)
- `compile_module_to_windows_executable(&IIRModule, &Path)` (Windows host)
- `compile_module_to_macos_executable(&IIRModule, &Path)` (Unix host)

Three new public link helpers:
- `link_linux_x86_64_executable(obj_bytes, stem, out)`
- `link_windows_x86_64_executable(obj_bytes, stem, out)`
- `link_macos_arm64_executable(obj_bytes, stem, out)`

The existing `compile_file_*` functions now delegate to these — same logic, just refactored so source-file and module-direct paths share the link step. All 18 twig-aot tests still pass.

## Test plan

- [x] 7 lib tests pass on Windows host (Language parsing, extension detection, Twig + Brainfuck compile-to-IIR routing, stub error messages)
- [x] 3 end-to-end smoke tests pass on Windows host:
  - `end_to_end_twig_returns_42_via_lang_aot` (regression for existing pipeline)
  - `end_to_end_nib_returns_42_via_lang_aot` (the new piece)
  - `end_to_end_nib_arithmetic_via_lang_aot` — `30 + 12`, `if 1==1`, `if 1==2`
- [x] All 18 twig-aot tests still pass (refactor preserved behavior)
- [x] Manual end-to-end: Nib source → `.exe` → exit code 42 on Windows host
- [ ] CI will verify on `ubuntu-latest`, `macos-latest`, `windows-latest`

## Follow-ups

| What | Why | Effort |
|---|---|---|
| Extend x86_64-backend + aarch64-backend to lower `load_mem` / `store_mem` / `putchar` / `getchar` | Unblocks Brainfuck end-to-end | medium |
| Write `dartmouth-basic-iir-compiler` crate | Unblocks BASIC | medium-large (needs IIR emission for LET/IF/FOR/GOTO/PRINT/INPUT/…) |
| Write `oct-iir-compiler` Rust crate or bridge to the Python one | Unblocks Oct | large (needs full Oct→IIR or subprocess + IR translation) |
| Add `--target` and `--emit-object` to lang-aot CLI | Cross-OS workflows for non-Twig languages | small (mirror twig-aot's binary) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)