### PR TITLE
feat(symbolic-vm): port Phase 36 Weierstrass log form to TypeScript (0.9.0)

### DIFF
--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [0.9.0] — 2026-05-20
+
+### Added — Phase 36: Weierstrass log form for `a² < b²`
+
+Ports Python `symbolic-vm` 0.61.0 (PR #3672) Phase 36 to TypeScript.
+Closes the deferred `a² < b²` branch of Phase 34 by emitting the
+explicit log-form closed solution.
+
+After the substitution `u = tan(x/2)` the quadratic in `u` has two
+distinct real roots; partial fractions give:
+
+    ∫ c/(a + b·sin x) dx = (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
+    ∫ c/(a + b·cos x) dx = (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C
+
+where `D = √(b²−a²) > 0`. The sin formula is valid for any nonzero
+rational `a`. The cos formula requires `b > |a|` strictly; the
+symmetric `b < −|a|` case is deferred.
+
+The log argument is wrapped in `Abs()` (`sym("Abs")`) because the inner
+rational changes sign across the integrand's singularities; this lets
+the closed form be evaluated numerically across the full domain.
+
+#### Added
+
+- **`tryWeierstrassLogForm(c, a, b, trigHead, x)`** — Phase 36 helper.
+  Plumbed into the existing Phase 34 dispatcher in place of the prior
+  `disc < 0 → undefined` arm.
+- **`absNumeric(v)`** — numeric absolute value helper for Int/Rat/Float.
+
+#### Tests
+
+5 new `it()` cases in `tests/phase34-weierstrass.test.ts` + 1 promoted
+from fallthrough:
+
+- ∫ 1/(1 + 2·sin x) dx — sin branch closes
+- ∫ 1/(1 + 2·cos x) dx — cos branch with `b > |a|`
+- ∫ 1/(−1 + 2·sin x) dx — sin with `a < 0`
+- ∫ 3/(1 + 2·sin x) dx — numerator scaling
+- ∫ 1/(3 + 5·sin x) dx — perfect-square `|disc|=16` folds Sqrt away
+- ∫ 1/(1 − 2·cos x) dx — `b < |a|` cos branch still deferred
+
+Full suite: **143 tests pass** (138 prior + 5 net new).
+
 ## [0.8.0] — 2026-05-18
 
 ### Added — Phase 35: degenerate `a² = b²` Weierstrass cases

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1727,11 +1727,13 @@ function tryWeierstrassOneOverLinearTrig(
   // Three-way dispatch on the discriminant:
   //   disc > 0  → Phase 34 arctan form (below)
   //   disc == 0 → Phase 35 degenerate form (four sign combinations)
-  //   disc < 0  → log form (still deferred)
+  //   disc < 0  → Phase 36 log form (this release)
   if (isZeroNumeric(disc)) {
     return tryWeierstrassDegenerate(c, a, b, trigHead, x);
   }
-  if (!isPositiveNumeric(disc)) return undefined;
+  if (!isPositiveNumeric(disc)) {
+    return tryWeierstrassLogForm(c, a, b, trigHead, x);
+  }
   const sqrtDiscIR = weierstrassSqrtFractionIR(disc);
   const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
   let atanArg: IRNode;
@@ -1832,6 +1834,60 @@ function tryWeierstrassDegenerate(
     return app(DIV, [fromNumeric(negC), denom]);
   }
   return undefined;
+}
+
+/** Numeric absolute value (Int/Rat only — float passes through). */
+function absNumeric(v: Numeric): Numeric {
+  if (v.kind === "int") return { kind: "int", value: v.value < 0n ? -v.value : v.value };
+  if (v.kind === "rat") return { kind: "rat", numer: v.numer < 0n ? -v.numer : v.numer, denom: v.denom };
+  return { kind: "float", value: Math.abs(v.value) };
+}
+
+/**
+ * Phase 36: Weierstrass log form for ``a² < b²``.
+ *
+ *   ∫ c/(a + b·sin x) dx  =  (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
+ *   ∫ c/(a + b·cos x) dx  =  (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C
+ *
+ * with ``D = √(b²−a²) > 0``.  Sin branch handles any nonzero ``a``;
+ * cos branch requires ``b > |a|`` strictly (the symmetric ``b < −|a|``
+ * case has a different sign pattern and is deferred).
+ */
+function tryWeierstrassLogForm(
+  c: Numeric,
+  a: Numeric,
+  b: Numeric,
+  trigHead: IRNode,
+  x: IRNode
+): IRNode | undefined {
+  // discSq = b² − a²; caller passes disc = a² − b² < 0, so discSq > 0.
+  const discSq = subNumeric(mulNumeric(b, b), mulNumeric(a, a));
+  if (!isPositiveNumeric(discSq)) return undefined;
+  const sqrtDiscIR = weierstrassSqrtFractionIR(discSq);
+  const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
+  const absHead = sym("Abs");
+  if (equals(trigHead, SIN)) {
+    if (isZeroNumeric(a)) return undefined; // 1/(b·sin x) deferred
+    // log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|
+    const aTan = app(MUL, [fromNumeric(a), tanHalf]);
+    const aTanPlusB = app(ADD, [aTan, fromNumeric(b)]);
+    const numer = app(SUB, [aTanPlusB, sqrtDiscIR]);
+    const denom = app(ADD, [aTanPlusB, sqrtDiscIR]);
+    const logArg = app(absHead, [app(DIV, [numer, denom])]);
+    const coefIR = app(DIV, [fromNumeric(c), sqrtDiscIR]);
+    return app(MUL, [coefIR, app(LOG, [logArg])]);
+  }
+  // COS branch: require b > |a| strictly.
+  if (!isPositiveNumeric(subNumeric(b, absNumeric(a)))) return undefined;
+  const bMinusA = subNumeric(b, a);
+  if (!isPositiveNumeric(bMinusA)) return undefined;
+  // log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
+  const bmaTan = app(MUL, [fromNumeric(bMinusA), tanHalf]);
+  const numer = app(ADD, [sqrtDiscIR, bmaTan]);
+  const denom = app(SUB, [sqrtDiscIR, bmaTan]);
+  const logArg = app(absHead, [app(DIV, [numer, denom])]);
+  const coefIR = app(DIV, [fromNumeric(c), sqrtDiscIR]);
+  return app(MUL, [coefIR, app(LOG, [logArg])]);
 }
 
 function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -186,11 +186,17 @@ describe("Phase 34: operand-order robustness", () => {
 // ---------------------------------------------------------------------------
 
 describe("Phase 34: deferred discriminant cases", () => {
-  it("a² < b² (∫ 1/(1 + 2·sin x) dx) — log form deferred", () => {
+  it("Phase 36: a² < b² (∫ 1/(1 + 2·sin x) dx) now closes via the log form", () => {
     const vm = makeVM();
     const integrand = app(DIV, [int(1), app(ADD, [int(1), app(MUL, [int(2), app(SIN, [X])])])]);
-    const result = vm.eval(integrate(integrand));
-    expect(isUnevaluatedIntegrate(result)).toBe(true);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // 1+2 sin x has poles at sin x = -1/2.  Sample x in (-π/4, π/4).
+    for (const xVal of [-0.7, -0.2, 0.0, 0.2, 0.7]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (1.0 + 2.0 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
   });
 
   it("Phase 35: a² = b² (∫ 1/(1 + sin x) dx) now closes via the degenerate form", () => {
@@ -314,5 +320,69 @@ describe("Phase 35: degenerate a² = b² cases", () => {
       const expected = 1 / (1.5 + 1.5 * Math.cos(xVal));
       expect(Math.abs(got - expected)).toBeLessThan(1e-3);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 36: log form for a² < b²
+// ---------------------------------------------------------------------------
+
+describe("Phase 36: log form for a² < b²", () => {
+  it("∫ 1/(1 + 2·cos x) dx — cos branch with b > |a|", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(1), app(MUL, [int(2), app(COS, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // 1+2 cos x zeros at x = ±2π/3.  Sample x in (-π/2, π/2).
+    for (const xVal of [-1.2, -0.5, 0.0, 0.5, 1.2]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (1 + 2 * Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("∫ 1/(−1 + 2·sin x) dx — sin branch with a < 0 still works", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(-1), app(MUL, [int(2), app(SIN, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [1.0, 1.5, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (-1 + 2 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("numerator coefficient (∫ 3/(1 + 2·sin x) dx) scales correctly", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(3), app(ADD, [int(1), app(MUL, [int(2), app(SIN, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    for (const xVal of [-0.7, -0.2, 0.0, 0.2, 0.7]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 3 / (1 + 2 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("perfect-square |disc| (∫ 1/(3 + 5·sin x) dx) folds Sqrt away", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(3), app(MUL, [int(5), app(SIN, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(containsHead(phi, SQRT)).toBe(false);
+    // 3+5 sin x zero at sin x = -3/5.  Sample safely.
+    for (const xVal of [-0.3, 0.0, 0.3, 0.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (3 + 5 * Math.sin(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("cos branch with b < |a| still defers (1 − 2·cos x)", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(SUB, [int(1), app(MUL, [int(2), app(COS, [X])])])]);
+    const result = vm.eval(integrate(integrand));
+    // The b = -2 < |a| = 1 branch is deferred — log argument has the
+    // opposite sign pattern.
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Ports Python PR #3672 (symbolic-vm 0.61.0) to TypeScript. Closes the
deferred `a² < b²` branch of Phase 34 by emitting the log-form closed
solution:

    ∫ c/(a + b·sin x) dx = (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
    ∫ c/(a + b·cos x) dx = (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C

where `D = √(b²−a²) > 0`. Sin handles any nonzero `a`; cos requires
`b > |a|`.

New helper `tryWeierstrassLogForm` plus `absNumeric()`.

## Test plan

- [x] 5 new `it()` cases + 1 promoted from fallthrough
- [x] Full TS suite: **143 passed** (138 prior + 5 net new)
- [x] `npx tsc --noEmit` clean
- [x] Security review passed

## Dependencies

Branched from main (Phase 34/35 already merged). Version 0.8.0 → 0.9.0.
**Should merge after PR #3672** (the Python equivalent at 0.61.0) for
spec/version-table consistency, though no code dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)