### PR TITLE
feat(symbolic-vm): port Phase 36 Weierstrass log form to Rust (0.9.0)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.9.0] — 2026-05-20
+
+### Added — Phase 36: Weierstrass log form for `a² < b²`
+
+Mirrors Python `symbolic-vm` 0.61.0 (PR #3672) and TypeScript `symbolic-vm`
+0.9.0 (PR #3674).  Closes the deferred `a² < b²` branch of Phase 34 by
+emitting the explicit log-form closed solution:
+
+    ∫ c/(a + b·sin x) dx = (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
+    ∫ c/(a + b·cos x) dx = (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C
+
+where `D = √(b²−a²) > 0`.  Sin handles any nonzero rational `a`; cos
+requires `b > |a|` strictly.
+
+New free function `try_weierstrass_log_form(c, a, b, trig_head, x)` in
+`src/handlers.rs` replaces the prior `return None` in the `disc < 0`
+arm of `try_weierstrass_one_over_linear_trig`.  The log argument is
+wrapped via `apply_node("Abs", ...)` so the closed form evaluates
+numerically across the integrand's singularities.
+
+Tests: 5 new `#[test]` functions in `tests/test_vm.rs` plus one
+promoted from fallthrough (`phase36_a_less_than_b_sin_now_closes`,
+replacing `phase34_fallthrough_a_less_than_b`).
+
+Full suite: **177 passed** (172 prior + 5 net new).
+
 ## [0.8.0] — 2026-05-18
 
 ### Added — Phase 35: degenerate `a² = b²` Weierstrass cases

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1617,6 +1617,65 @@ fn try_weierstrass_degenerate(
     None
 }
 
+/// Phase 36: Weierstrass log form for `a² < b²`.  Returns the closed
+/// form with `log|·|` instead of `arctan(·)`.  Sin branch handles any
+/// nonzero `a`; cos branch requires `b > |a|` strictly (the symmetric
+/// `b < −|a|` case has the opposite sign pattern and is deferred).
+fn try_weierstrass_log_form(
+    c: RatC,
+    a: RatC,
+    b: RatC,
+    trig_head: &'static str,
+    x: &str,
+) -> Option<IRNode> {
+    // disc_sq = b² − a² > 0 (caller passed disc = a² − b² < 0).
+    let b_sq = rc_mul(b, b)?;
+    let a_sq = rc_mul(a, a)?;
+    let disc_sq = rc_sub(b_sq, a_sq)?;
+    if disc_sq.0 <= 0 {
+        return None;
+    }
+    let sqrt_disc_ir = weierstrass_sqrt_fraction_ir(disc_sq);
+    let tan_half = apply_node(
+        TAN,
+        vec![apply_node(
+            DIV,
+            vec![IRNode::Symbol(x.to_string()), IRNode::Integer(2)],
+        )],
+    );
+    if trig_head == SIN {
+        if a.0 == 0 {
+            // 1/(b·sin x) — defer to the elementary table.
+            return None;
+        }
+        // log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|
+        let a_tan = apply_node(MUL, vec![rc_to_ir(a)?, tan_half]);
+        let a_tan_plus_b = apply_node(ADD, vec![a_tan, rc_to_ir(b)?]);
+        let numer = apply_node(SUB, vec![a_tan_plus_b.clone(), sqrt_disc_ir.clone()]);
+        let denom = apply_node(ADD, vec![a_tan_plus_b, sqrt_disc_ir.clone()]);
+        let log_arg = apply_node("Abs", vec![apply_node(DIV, vec![numer, denom])]);
+        let coef_ir = apply_node(DIV, vec![rc_to_ir(c)?, sqrt_disc_ir]);
+        return Some(apply_node(MUL, vec![coef_ir, apply_node(LOG, vec![log_arg])]));
+    }
+    // COS branch: require b > |a| strictly.
+    let abs_a = (a.0.abs(), a.1);
+    let b_minus_abs_a = rc_sub(b, abs_a)?;
+    if b_minus_abs_a.0 <= 0 {
+        return None;
+    }
+    let b_minus_a = rc_sub(b, a)?;
+    if b_minus_a.0 <= 0 {
+        return None;
+    }
+    // log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
+    let bma_tan = apply_node(MUL, vec![rc_to_ir(b_minus_a)?, tan_half]);
+    let numer = apply_node(ADD, vec![sqrt_disc_ir.clone(), bma_tan.clone()]);
+    let denom = apply_node(SUB, vec![sqrt_disc_ir.clone(), bma_tan]);
+    let log_arg = apply_node("Abs", vec![apply_node(DIV, vec![numer, denom])]);
+    let coef_ir = apply_node(DIV, vec![rc_to_ir(c)?, sqrt_disc_ir]);
+    Some(apply_node(MUL, vec![coef_ir, apply_node(LOG, vec![log_arg])]))
+}
+
 /// Phase 34 entry point.  Returns the closed form when the integrand is
 /// `c / (a + b·sin/cos(x))` with rational c, a, b and a² > b² (a > 0 for cos),
 /// or `None` otherwise.
@@ -1638,7 +1697,9 @@ fn try_weierstrass_one_over_linear_trig(
         return try_weierstrass_degenerate(c_rc, a_rc, b_rc, trig_head, x);
     }
     if disc.0 < 0 {
-        return None;
+        // Phase 36: a² < b² → log form via partial fractions on the two
+        // distinct real roots of the quadratic in tan(x/2).
+        return try_weierstrass_log_form(c_rc, a_rc, b_rc, trig_head, x);
     }
     let sqrt_disc_ir = weierstrass_sqrt_fraction_ir(disc);
     let tan_half = apply_node(

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2516,8 +2516,8 @@ fn phase34_sin_operand_order_swapped() {
 }
 
 #[test]
-fn phase34_fallthrough_a_less_than_b() {
-    // ∫ 1/(1 + 2·sin x) dx — a²−b² = −3 < 0.  Log form deferred.
+fn phase36_a_less_than_b_sin_now_closes() {
+    // ∫ 1/(1 + 2·sin x) dx — Phase 36 closes the log form that Phase 34 deferred.
     let integrand = apply(
         sym(DIV),
         vec![
@@ -2528,8 +2528,14 @@ fn phase34_fallthrough_a_less_than_b() {
             ),
         ],
     );
-    let result = integrate(integrand);
-    assert!(is_unevaluated_integrate(&result));
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    // 1 + 2 sin x zero at sin x = -1/2.  Sample inside (-π/4, π/4).
+    for &x_val in &[-0.7_f64, -0.2, 0.0, 0.2, 0.7] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (1.0 + 2.0 * x_val.sin());
+        assert!((got - expected).abs() < 1e-3);
+    }
 }
 
 #[test]
@@ -2692,4 +2698,108 @@ fn phase34_regression_one_over_cos_not_misinterpreted() {
             panic!("Phase 34 incorrectly fired on ∫ 1/cos(x) dx: {result:?}");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 36 — Weierstrass log form for a² < b² (cos + edge cases)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase36_a_less_than_b_cos_now_closes() {
+    // ∫ 1/(1 + 2·cos x) dx — cos branch with b > |a|, b² > a².
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(ADD),
+                vec![int(1), apply(sym(MUL), vec![int(2), apply(sym(COS), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    // 1+2 cos x zero at x=±2π/3.  Sample inside (-π/2, π/2).
+    for &x_val in &[-1.2_f64, -0.5, 0.0, 0.5, 1.2] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (1.0 + 2.0 * x_val.cos());
+        assert!((got - expected).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn phase36_negative_a_sin() {
+    // ∫ 1/(−1 + 2·sin x) dx — sin branch with a < 0.
+    let neg_one_plus_two_sin = apply(
+        sym(ADD),
+        vec![int(-1), apply(sym(MUL), vec![int(2), apply(sym(SIN), vec![sym("x")])])],
+    );
+    let integrand = apply(sym(DIV), vec![int(1), neg_one_plus_two_sin]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    for &x_val in &[1.0_f64, 1.5, 2.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (-1.0 + 2.0 * x_val.sin());
+        assert!((got - expected).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn phase36_with_numerator_coefficient() {
+    // ∫ 3/(1 + 2·sin x) dx — c=3 scaling.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(3),
+            apply(
+                sym(ADD),
+                vec![int(1), apply(sym(MUL), vec![int(2), apply(sym(SIN), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    for &x_val in &[-0.7_f64, -0.2, 0.0, 0.2, 0.7] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 3.0 / (1.0 + 2.0 * x_val.sin());
+        assert!((got - expected).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn phase36_perfect_square_discriminant() {
+    // ∫ 1/(3 + 5·sin x) dx — disc=−16, perfect-square magnitude.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(ADD),
+                vec![int(3), apply(sym(MUL), vec![int(5), apply(sym(SIN), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    assert!(!contains_head(&phi, SQRT), "Perfect-square |disc|=16 should fold");
+    for &x_val in &[-0.3_f64, 0.0, 0.3, 0.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (3.0 + 5.0 * x_val.sin());
+        assert!((got - expected).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn phase36_cos_negative_b_still_defers() {
+    // ∫ 1/(1 − 2·cos x) dx — effective b=-2 < |a|=1; cos branch defers.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(
+                sym(SUB),
+                vec![int(1), apply(sym(MUL), vec![int(2), apply(sym(COS), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result));
 }


### PR DESCRIPTION
## Summary

Mirrors Python PR #3672 (symbolic-vm 0.61.0) and TS PR #3674 (0.9.0).
Closes the deferred `a² < b²` branch of Phase 34:

    ∫ c/(a + b·sin x) dx = (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
    ∫ c/(a + b·cos x) dx = (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C

where `D = √(b²−a²) > 0`. Sin handles any nonzero `a`; cos requires `b > |a|`.

## Test plan

- [x] 5 new `#[test]` functions + 1 promoted from fallthrough
- [x] Full Rust suite: **177 passed** (172 prior + 5 net new)
- [x] `cargo build` clean
- [x] Security review passed

## Version sequencing

Three-language Phase 36 set: Python #3672 (0.61.0), TS #3674 (0.9.0),
this PR (Rust 0.9.0). All branched off post-Phase-35 main; no inter-PR
dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)