### PR TITLE
[codex] Add Board VM Arduino wireless metadata

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -29,6 +29,13 @@ descriptor also records whether the board appears through a USB serial bridge,
 native USB bootloader, or external serial adapter, which keeps Pro Mini-style
 boards from being treated like onboard-USB Arduinos.
 
+The shared target registry also records physical wireless radios for the
+Arduino-family boards that have Wi-Fi or BLE hardware, including MKR/Nano
+NINA-based boards, Nano ESP32, GIGA, connected Portenta/Nicla variants, and Opta
+WiFi. Those descriptors do not add command or OTA capabilities by themselves;
+board-specific firmware and upload adapters still own the actual transport
+behavior.
+
 Opta terminals are modeled as board-local input and relay-output pins instead
 of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware
 is similarly registered as its own target family so follow-up capability work

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -4017,6 +4017,7 @@ mod tests {
         let uno = known_target("arduino-uno-r4-wifi").unwrap();
         let mega = known_target("arduino-mega-2560").unwrap();
         let nano_r4 = known_target("arduino-nano-r4").unwrap();
+        let nano_iot = known_target("arduino-nano-33-iot").unwrap();
         let nano_ble = known_target("arduino-nano-33-ble-rev2").unwrap();
         let nano_esp32 = known_target("arduino-nano-esp32").unwrap();
         let giga = known_target("arduino-giga-r1-wifi").unwrap();
@@ -4044,6 +4045,8 @@ mod tests {
         assert!(mega.capabilities.contains(&"program.ram_exec".to_owned()));
         assert_eq!(nano_r4.family, LanguageBoardFamily::Arduino);
         assert_eq!(nano_r4.mcu, "RA4M1");
+        assert_eq!(nano_iot.family, LanguageBoardFamily::Arduino);
+        assert_eq!(nano_iot.mcu, "SAMD21G18");
         assert_eq!(nano_ble.family, LanguageBoardFamily::Arduino);
         assert_eq!(nano_ble.mcu, "nRF52840");
         assert_eq!(nano_esp32.family, LanguageBoardFamily::Arduino);
@@ -4064,6 +4067,72 @@ mod tests {
         assert_eq!(opta_wifi.digital_pins[11].label, "O4");
         assert!(opta_wifi.digital_pins[11].supports_output);
         assert_eq!(opta_wifi.upload.as_ref().unwrap().adapter, "arduino_cli");
+        assert!(nano_iot.wireless.iter().any(|interface| interface.transport
+            == LanguageWirelessTransport::Wifi
+            && interface.chip == "u-blox NINA-W102"
+            && !interface.command_transport
+            && !interface.ota_update));
+        assert!(nano_iot.wireless.iter().any(|interface| interface.transport
+            == LanguageWirelessTransport::BluetoothLe
+            && interface.chip == "u-blox NINA-W102"
+            && !interface.command_transport
+            && !interface.ota_update));
+        assert!(!nano_iot.capabilities.contains(&"transport.wifi".to_owned()));
+        assert!(nano_iot.network_interfaces.is_empty());
+        assert!(nano_ble.wireless.iter().any(|interface| interface.transport
+            == LanguageWirelessTransport::BluetoothLe
+            && interface.chip == "nRF52840"
+            && !interface.command_transport
+            && !interface.ota_update));
+        assert!(!nano_ble
+            .capabilities
+            .contains(&"transport.bluetooth_le".to_owned()));
+        assert!(nano_esp32
+            .wireless
+            .iter()
+            .any(
+                |interface| interface.transport == LanguageWirelessTransport::Wifi
+                    && interface.chip == "ESP32-S3"
+                    && !interface.command_transport
+                    && !interface.ota_update
+            ));
+        assert!(!nano_esp32
+            .capabilities
+            .contains(&"transport.wifi".to_owned()));
+        assert!(giga.wireless.iter().any(|interface| interface.transport
+            == LanguageWirelessTransport::Wifi
+            && interface.chip == "Arduino onboard WiFi/BLE module"
+            && !interface.command_transport
+            && !interface.ota_update));
+        assert!(giga.network_interfaces.is_empty());
+        assert!(portenta_c33
+            .wireless
+            .iter()
+            .any(
+                |interface| interface.transport == LanguageWirelessTransport::Wifi
+                    && interface.chip == "ESP32-C3 module"
+                    && !interface.command_transport
+                    && !interface.ota_update
+            ));
+        assert!(nicla_vision
+            .wireless
+            .iter()
+            .any(
+                |interface| interface.transport == LanguageWirelessTransport::BluetoothLe
+                    && interface.chip == "Arduino onboard WiFi/BLE module"
+                    && !interface.command_transport
+                    && !interface.ota_update
+            ));
+        assert!(opta_wifi
+            .wireless
+            .iter()
+            .any(
+                |interface| interface.transport == LanguageWirelessTransport::Wifi
+                    && interface.chip == "Arduino onboard WiFi/BLE module"
+                    && !interface.command_transport
+                    && !interface.ota_update
+            ));
+        assert!(opta_wifi.network_interfaces.is_empty());
         assert_eq!(
             uno.led_matrix,
             Some(LanguageLedMatrix {

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -47,14 +47,20 @@ Wireless metadata separates physical support from the generic front-end sugar:
 - every current target exposes `transport.serial`
 - Arduino Uno R4 WiFi exposes Wi-Fi and Bluetooth LE through its ESP32-S3
   coprocessor
+- shared Arduino-family descriptors record physical radios for MKR WiFi 1010,
+  Nano 33 IoT, Nano 33 BLE Rev2, Nano RP2040 Connect, Nano ESP32, GIGA R1
+  WiFi, Portenta H7 Lite Connected, Portenta C33, Nicla Vision, Nicla Sense ME,
+  Nicla Voice, and Opta WiFi without claiming command or OTA transport support
+  until board-specific adapters land
 - ESP32 DevKit V1 exposes Wi-Fi, Bluetooth LE, and Bluetooth Classic natively
 - Raspberry Pi Pico exposes no wireless transports
 - Raspberry Pi Pico W exposes Wi-Fi, Bluetooth LE, and Bluetooth Classic through
   its CYW43439 radio
 
-Wi-Fi OTA is marked as a feasible Board VM update path for the wireless targets;
-Bluetooth command channels are tracked separately because OTA over Bluetooth is
-possible but not the first practical update path.
+Wi-Fi OTA is marked as a feasible Board VM update path only for targets with a
+runtime adapter that already owns that transport. Bluetooth command channels are
+tracked separately because OTA over Bluetooth is possible but not the first
+practical update path.
 
 Host-side validation:
 

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -458,6 +458,80 @@ pub const PICO_W_WIRELESS: [WirelessInterfaceInfo; 3] = [
     },
 ];
 
+pub const ARDUINO_NINA_W102_WIRELESS: [WirelessInterfaceInfo; 2] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "u-blox NINA-W102",
+        command_transport: false,
+        ota_update: false,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "u-blox NINA-W102",
+        command_transport: false,
+        ota_update: false,
+    },
+];
+
+pub const ARDUINO_NRF52840_WIRELESS: [WirelessInterfaceInfo; 1] = [WirelessInterfaceInfo {
+    transport: WirelessTransport::BluetoothLe,
+    chip: "nRF52840",
+    command_transport: false,
+    ota_update: false,
+}];
+
+pub const ARDUINO_NANO_ESP32_WIRELESS: [WirelessInterfaceInfo; 2] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "ESP32-S3",
+        command_transport: false,
+        ota_update: false,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "ESP32-S3",
+        command_transport: false,
+        ota_update: false,
+    },
+];
+
+pub const ARDUINO_WIFI_BLE_MODULE_WIRELESS: [WirelessInterfaceInfo; 2] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "Arduino onboard WiFi/BLE module",
+        command_transport: false,
+        ota_update: false,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "Arduino onboard WiFi/BLE module",
+        command_transport: false,
+        ota_update: false,
+    },
+];
+
+pub const ARDUINO_ESP32_C3_WIRELESS: [WirelessInterfaceInfo; 2] = [
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::Wifi,
+        chip: "ESP32-C3 module",
+        command_transport: false,
+        ota_update: false,
+    },
+    WirelessInterfaceInfo {
+        transport: WirelessTransport::BluetoothLe,
+        chip: "ESP32-C3 module",
+        command_transport: false,
+        ota_update: false,
+    },
+];
+
+pub const ARDUINO_NRF52832_WIRELESS: [WirelessInterfaceInfo; 1] = [WirelessInterfaceInfo {
+    transport: WirelessTransport::BluetoothLe,
+    chip: "nRF52832",
+    command_transport: false,
+    ota_update: false,
+}];
+
 const fn arduino_cli_upload(
     platform_id: &'static str,
     fqbn: &'static str,
@@ -892,6 +966,7 @@ const fn arduino_cli_port_hint(hint: board_vm_arduino::ArduinoCliPortHint) -> Up
 const fn arduino_board_target(
     target: board_vm_arduino::ArduinoTargetDescriptor,
     digital_pins: &'static [DigitalPinInfo],
+    wireless: &'static [WirelessInterfaceInfo],
 ) -> BoardTargetInfo {
     BoardTargetInfo {
         board_id: target.board_id,
@@ -917,7 +992,7 @@ const fn arduino_board_target(
         rtc: None,
         watchdog: None,
         storage_regions: &[],
-        wireless: &[],
+        wireless,
         network_interfaces: &[],
         upload: Some(arduino_cli_upload(
             target.arduino_cli.platform_id,
@@ -992,97 +1067,132 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
     arduino_board_target(
         board_vm_arduino::ARDUINO_UNO_R3,
         &ARDUINO_UNO_R3_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_CLASSIC,
         &ARDUINO_NANO_CLASSIC_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_PRO_MINI,
         &ARDUINO_PRO_MINI_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_MEGA_2560,
         &ARDUINO_MEGA_2560_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_LEONARDO,
         &ARDUINO_LEONARDO_DIGITAL_PINS,
+        &[],
     ),
-    arduino_board_target(board_vm_arduino::ARDUINO_MICRO, &ARDUINO_MICRO_DIGITAL_PINS),
-    arduino_board_target(board_vm_arduino::ARDUINO_DUE, &ARDUINO_DUE_DIGITAL_PINS),
-    arduino_board_target(board_vm_arduino::ARDUINO_ZERO, &ARDUINO_ZERO_DIGITAL_PINS),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_MICRO,
+        &ARDUINO_MICRO_DIGITAL_PINS,
+        &[],
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_DUE,
+        &ARDUINO_DUE_DIGITAL_PINS,
+        &[],
+    ),
+    arduino_board_target(
+        board_vm_arduino::ARDUINO_ZERO,
+        &ARDUINO_ZERO_DIGITAL_PINS,
+        &[],
+    ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_MKR_WIFI_1010,
         &ARDUINO_MKR_WIFI_1010_DIGITAL_PINS,
+        &ARDUINO_NINA_W102_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_EVERY,
         &ARDUINO_NANO_EVERY_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_R4,
         &ARDUINO_NANO_R4_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_33_IOT,
         &ARDUINO_NANO_33_IOT_DIGITAL_PINS,
+        &ARDUINO_NINA_W102_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_33_BLE_REV2,
         &ARDUINO_NANO_33_BLE_REV2_DIGITAL_PINS,
+        &ARDUINO_NRF52840_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_RP2040_CONNECT,
         &ARDUINO_NANO_RP2040_CONNECT_DIGITAL_PINS,
+        &ARDUINO_NINA_W102_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NANO_ESP32,
         &ARDUINO_NANO_ESP32_DIGITAL_PINS,
+        &ARDUINO_NANO_ESP32_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_GIGA_R1_WIFI,
         &ARDUINO_GIGA_R1_WIFI_DIGITAL_PINS,
+        &ARDUINO_WIFI_BLE_MODULE_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_PORTENTA_H7,
         &ARDUINO_PORTENTA_H7_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_PORTENTA_H7_LITE,
         &ARDUINO_PORTENTA_H7_LITE_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_PORTENTA_H7_LITE_CONNECTED,
         &ARDUINO_PORTENTA_H7_LITE_CONNECTED_DIGITAL_PINS,
+        &ARDUINO_WIFI_BLE_MODULE_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_PORTENTA_C33,
         &ARDUINO_PORTENTA_C33_DIGITAL_PINS,
+        &ARDUINO_ESP32_C3_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NICLA_VISION,
         &ARDUINO_NICLA_VISION_DIGITAL_PINS,
+        &ARDUINO_WIFI_BLE_MODULE_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NICLA_SENSE_ME,
         &ARDUINO_NICLA_SENSE_ME_DIGITAL_PINS,
+        &ARDUINO_NRF52832_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_NICLA_VOICE,
         &ARDUINO_NICLA_VOICE_DIGITAL_PINS,
+        &ARDUINO_NRF52832_WIRELESS,
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_OPTA_LITE,
         &ARDUINO_OPTA_LITE_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_OPTA_RS485,
         &ARDUINO_OPTA_RS485_DIGITAL_PINS,
+        &[],
     ),
     arduino_board_target(
         board_vm_arduino::ARDUINO_OPTA_WIFI,
         &ARDUINO_OPTA_WIFI_DIGITAL_PINS,
+        &ARDUINO_WIFI_BLE_MODULE_WIRELESS,
     ),
     BoardTargetInfo {
         board_id: board_vm_esp32::ESP32_DEVKIT_V1.board_id,
@@ -1632,12 +1742,32 @@ mod tests {
     fn registry_exposes_wireless_only_for_wireless_boards() {
         let uno_r4_minima = find_target("arduino-uno-r4-minima").unwrap();
         let uno_r4_wifi = find_target("arduino-uno-r4-wifi").unwrap();
+        let uno_r3 = find_target("arduino-uno-r3").unwrap();
+        let mkr_wifi = find_target("arduino-mkr-wifi-1010").unwrap();
+        let nano_r4 = find_target("arduino-nano-r4").unwrap();
+        let nano_iot = find_target("arduino-nano-33-iot").unwrap();
+        let nano_ble = find_target("arduino-nano-33-ble-rev2").unwrap();
+        let nano_rp2040 = find_target("arduino-nano-rp2040-connect").unwrap();
+        let nano_esp32 = find_target("arduino-nano-esp32").unwrap();
+        let giga = find_target("arduino-giga-r1-wifi").unwrap();
+        let portenta_h7_lite = find_target("arduino-portenta-h7-lite").unwrap();
+        let portenta_h7_lite_connected = find_target("arduino-portenta-h7-lite-connected").unwrap();
+        let portenta_c33 = find_target("arduino-portenta-c33").unwrap();
+        let nicla_vision = find_target("arduino-nicla-vision").unwrap();
+        let nicla_sense = find_target("arduino-nicla-sense-me").unwrap();
+        let nicla_voice = find_target("arduino-nicla-voice").unwrap();
+        let opta_rs485 = find_target("arduino-opta-rs485").unwrap();
+        let opta_wifi = find_target("arduino-opta-wifi").unwrap();
         let esp32 = find_target("esp32-devkit-v1").unwrap();
         let pico = find_target("raspberry-pi-pico").unwrap();
         let pico_w = find_target("raspberry-pi-pico-w").unwrap();
 
         assert!(uno_r4_minima.wireless.is_empty());
         assert!(uno_r4_minima.network_interfaces.is_empty());
+        assert!(uno_r3.wireless.is_empty());
+        assert!(nano_r4.wireless.is_empty());
+        assert!(portenta_h7_lite.wireless.is_empty());
+        assert!(opta_rs485.wireless.is_empty());
         assert!(pico.wireless.is_empty());
         assert!(uno_r4_wifi.capabilities.contains(&"transport.wifi"));
         assert!(uno_r4_wifi.capabilities.contains(&"transport.bluetooth_le"));
@@ -1654,6 +1784,42 @@ mod tests {
             .any(|interface| interface.transport == WirelessTransport::Wifi
                 && interface.command_transport
                 && interface.ota_update));
+
+        for target in [
+            mkr_wifi,
+            nano_iot,
+            nano_rp2040,
+            nano_esp32,
+            giga,
+            portenta_h7_lite_connected,
+            portenta_c33,
+            nicla_vision,
+            opta_wifi,
+        ] {
+            assert!(target
+                .wireless
+                .iter()
+                .any(|interface| interface.transport == WirelessTransport::Wifi
+                    && !interface.command_transport
+                    && !interface.ota_update));
+            assert!(!target.capabilities.contains(&"transport.wifi"));
+            assert!(target.network_interfaces.is_empty());
+        }
+
+        for target in [nano_ble, nicla_sense, nicla_voice] {
+            assert!(target.wireless.iter().any(|interface| interface.transport
+                == WirelessTransport::BluetoothLe
+                && !interface.command_transport
+                && !interface.ota_update));
+            assert!(!target.capabilities.contains(&"transport.bluetooth_le"));
+            assert!(target.network_interfaces.is_empty());
+        }
+
+        assert_eq!(nano_iot.wireless, &ARDUINO_NINA_W102_WIRELESS);
+        assert_eq!(nano_ble.wireless, &ARDUINO_NRF52840_WIRELESS);
+        assert_eq!(nano_esp32.wireless, &ARDUINO_NANO_ESP32_WIRELESS);
+        assert_eq!(portenta_c33.wireless, &ARDUINO_ESP32_C3_WIRELESS);
+        assert_eq!(nicla_sense.wireless, &ARDUINO_NRF52832_WIRELESS);
     }
 
     #[test]

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -134,6 +134,13 @@ same descriptors. Arduino CLI boards now report whether their upload path starts
 from a USB serial bridge, native USB bootloader port, or external serial
 adapter before delegating reset/programmer behavior to the board package.
 
+The Arduino wireless metadata tranche records physical Wi-Fi and Bluetooth LE
+radios for non-Uno boards such as MKR WiFi 1010, Nano 33 IoT, Nano 33 BLE Rev2,
+Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi, Portenta H7 Lite Connected,
+Portenta C33, Nicla Vision, Nicla Sense ME, Nicla Voice, and Opta WiFi. These
+entries intentionally keep command transport, OTA, and network capabilities
+disabled until a board-specific runtime adapter owns the path.
+
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino
 discovery into `board-vm-uno-r4`.


### PR DESCRIPTION
## Summary
- add Rust-owned physical wireless descriptors for broader Arduino boards beyond Uno R4
- keep command transport, OTA, and network interface support disabled for those shared Arduino descriptors until board-specific adapters own the path
- surface the metadata through language-core tests and document the descriptor-only tranche

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-wireless-metadata cargo fmt -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-wireless-metadata cargo test -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-wireless-metadata cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-wireless-metadata bash BUILD in code/packages/rust/board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-wireless-metadata bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-wireless-metadata bash BUILD in code/packages/rust/board-vm-arduino
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Generated build-plan.json and code/packages/rust/Cargo.lock were removed before committing.