### PR TITLE
feat(ruby-lexer): Phase 3a — regex flags + `%w[]` / `%q{}` percent literals

### DIFF
--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.4.0] - 2026-05-20
+
+### Added (Phase 3a — regex flags + `%w[]` / `%q{}` percent literals)
+- Regex flag suffixes (`/foo/i`, `/foo/im`, `/foo/IM`, …) — both cases accepted, greedy slurp on `imxoeunsIMXOEUNS`.
+- `%w[...]` string-array percent literal (canonical `[` delimiter only in v0).
+- `%q{...}` non-interpolating string percent literal (canonical `{` delimiter only in v0).
+- New `regex_flags`, `after_percent`, `percent_w_open`, `percent_w_body`, `percent_q_open`, `percent_q_body` states in [`ruby-1.8.lexer.states.toml`](./ruby-1.8.lexer.states.toml).
+- New `PercentW` and `PercentQ` token kinds in the declared token vocabulary (action interpreter maps both to `TokenType::String` with the verbatim source-shape preserved as the value).
+- 11 new unit tests; total now 54 (was 43 in Phase 2).
+
+### Changed
+- The `data → %` transition now routes through `after_percent` to peek for a type letter.  When the follower is not `w` or `q`, `%` falls back to the modulo operator (matches Phase 1 behaviour).
+- The `regex_body → /` closing transition now goes to `regex_flags` (instead of `data`), appending the `/` to the text buffer.  When `regex_flags` exits, the emitted token's value has the source-shape `/body/` (no flags) or `/body/flags` (with flags).
+
+### Deferred (subsequent Phase 3 follow-ups)
+- Phase 3b: string interpolation `"a#{expr}b"` — recursive sub-lexer / sub-machine.
+- Phase 3c: heredocs (`<<X`, `<<-X`, `<<~X`) with deferred body capture and FIFO queue for multi-per-line heredocs.
+- Additional percent literals: `%W`, `%Q`, `%i`, `%I`, `%r`, `%s`, `%x` and the full set of delimiter pairs (`(...)`, `<...>`, `|...|`, any non-alphanumeric).
+
 ## [0.3.0] - 2026-05-20
 
 ### Added (Phase 2 — parser-feedback)

--- a/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
+++ b/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
@@ -53,6 +53,9 @@ alphabet = [
   # underscore — ident starter / digit separator (referenced as `literal`
   # in `data` and `ident_body` / `int_body`)
   "_",
+  # percent-literal type letters: `w` for `%w[...]`, `q` for `%q{...}`.
+  # Both are referenced as `literal` matchers in `after_percent`.
+  "w", "q",
 ]
 
 # ── Token vocabulary ──────────────────────────────────────────────
@@ -73,7 +76,17 @@ name = "String"        # quoted string literal (escapes resolved by runtime)
 fields = ["value", "quote"]
 
 [[tokens]]
-name = "Regex"         # /.../  literal — Phase 2 (no flags yet)
+name = "Regex"         # /.../[imxoeunsIMXOEUNS]*  literal
+                       # Phase 2 introduced the body; Phase 3a adds
+                       # the trailing-flag-letter suffix.
+fields = ["value"]
+
+[[tokens]]
+name = "PercentW"      # %w[a b c]  — array-of-strings percent literal
+fields = ["value"]
+
+[[tokens]]
+name = "PercentQ"      # %q{single-quoted-style string}
 fields = ["value"]
 
 [[tokens]]
@@ -174,6 +187,28 @@ id = "regex_body"        # inside /.../ — entered manually from `data`
                          # `set_current_state` call in src/lib.rs.
 [[states]]
 id = "regex_escape"      # inside /.../ after `\\`
+[[states]]
+id = "regex_flags"       # after the closing `/`, slurp trailing
+                         # flag letters (i/m/x/o/u/e/n/s, case-
+                         # insensitive).  Greedy — matches as many
+                         # flag chars as appear contiguously, then
+                         # emits the whole `/body/flags` literal.
+
+# Percent literals (Phase 3a) — `%w[a b c]` and `%q{string body}`.
+[[states]]
+id = "after_percent"     # saw `%`, peeking for type letter (w / q
+                         # / i / r / s / x / W / Q / I / R).  If the
+                         # follower isn't a known type letter, `%`
+                         # falls back to a modulo operator.
+[[states]]
+id = "percent_w_open"    # saw `%w`, peeking for opening delimiter
+                         # (`[` is the v0 canonical delimiter).
+[[states]]
+id = "percent_w_body"    # inside `%w[...]` — accumulating string-array body.
+[[states]]
+id = "percent_q_open"    # saw `%q`, peeking for `{` opening delim.
+[[states]]
+id = "percent_q_body"    # inside `%q{...}` — accumulating string body.
 
 [[states]]
 id = "comment_body"      # # to end-of-line
@@ -349,11 +384,13 @@ matcher = { literal = "/" }
 to = "data"
 actions = ["set_text(/)", "emit(Op)"]
 
+# `%` enters `after_percent` to disambiguate modulo operator vs
+# percent literal start.  See after_percent transitions below.
 [[transitions]]
 from = "data"
 matcher = { literal = "%" }
-to = "data"
-actions = ["set_text(%)", "emit(Op)"]
+to = "after_percent"
+actions = ["clear_text", "append_text(%)"]
 
 [[transitions]]
 from = "data"
@@ -662,11 +699,16 @@ from = "regex_body"
 matcher = { literal = "\\" }
 to = "regex_escape"
 
+# Closing `/` of a regex body: append it to the text buffer (as a
+# separator between body and flags) and transition into the flag-
+# slurp state.  The emit(Regex) interpreter then wraps the buffer
+# with a single leading `/`, yielding `/body/` (no flags) or
+# `/body/flags` (with flags).
 [[transitions]]
 from = "regex_body"
 matcher = { literal = "/" }
-to = "data"
-actions = ["emit(Regex)"]
+to = "regex_flags"
+actions = ["append_text(/)"]
 
 [[transitions]]
 from = "regex_body"
@@ -696,6 +738,153 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = ["parse_error(unterminated_regex)", "emit(Eof)"]
+
+# Regex flag slurp (Phase 3a).  After the closing `/`, accept any
+# of the standard MRI flag letters in either case.  Greedy — stays
+# in this state as long as flag-letter chars appear contiguously.
+# Any other character ends the literal and re-dispatches the char
+# to `data` (consume=false).
+[[transitions]]
+from = "regex_flags"
+matcher = { one_of = "imxoeunsIMXOEUNS" }
+to = "regex_flags"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "regex_flags"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["emit(Regex)", "emit(Eof)"]
+
+[[transitions]]
+from = "regex_flags"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["emit(Regex)"]
+
+# ─────────────────────────────────────────────────────────────────
+# Percent literals (Phase 3a) — `%w[a b c]` and `%q{string body}`.
+#
+# `%` already entered `after_percent` (data → after_percent earlier
+# in this file).  The text buffer contains `%` at that point.
+# ─────────────────────────────────────────────────────────────────
+
+# `%w` — string-array literal.
+[[transitions]]
+from = "after_percent"
+matcher = { literal = "w" }
+to = "percent_w_open"
+actions = ["append_text(current)"]
+
+# `%q` — single-quoted-style string.
+[[transitions]]
+from = "after_percent"
+matcher = { literal = "q" }
+to = "percent_q_open"
+actions = ["append_text(current)"]
+
+# Any other follower: `%` is a modulo operator.  Re-dispatch the
+# next char to `data` so it lexes normally.
+[[transitions]]
+from = "after_percent"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["set_text(%)", "emit(Op)"]
+
+[[transitions]]
+from = "after_percent"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["set_text(%)", "emit(Op)", "emit(Eof)"]
+
+# After `%w`, the next char must be the opening delimiter.  v0
+# supports `[` as the canonical delimiter; other delimiters fall
+# back to "% is modulo, w is a name" — emit the percent as Op and
+# re-dispatch the `w` to data.
+[[transitions]]
+from = "percent_w_open"
+matcher = { literal = "[" }
+to = "percent_w_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "percent_w_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(percent_w_no_delim)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_w_open"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["parse_error(percent_w_no_delim)", "set_text(%)", "emit(Op)"]
+
+# Inside `%w[...]` — slurp characters until matching `]`.
+[[transitions]]
+from = "percent_w_body"
+matcher = { literal = "]" }
+to = "data"
+actions = ["append_text(current)", "emit(PercentW)"]
+
+[[transitions]]
+from = "percent_w_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_percent_w)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_w_body"
+matcher = { anything = true }
+to = "percent_w_body"
+actions = ["append_text(current)"]
+
+# After `%q`, the next char must be the opening `{` delimiter.
+[[transitions]]
+from = "percent_q_open"
+matcher = { literal = "{" }
+to = "percent_q_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "percent_q_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(percent_q_no_delim)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_q_open"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["parse_error(percent_q_no_delim)", "set_text(%)", "emit(Op)"]
+
+# Inside `%q{...}` — slurp characters until matching `}`.
+[[transitions]]
+from = "percent_q_body"
+matcher = { literal = "}" }
+to = "data"
+actions = ["append_text(current)", "emit(PercentQ)"]
+
+[[transitions]]
+from = "percent_q_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_percent_q)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_q_body"
+matcher = { anything = true }
+to = "percent_q_body"
+actions = ["append_text(current)"]
 
 # ─────────────────────────────────────────────────────────────────
 # Line comment

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -325,15 +325,33 @@ impl RubyLexer {
                 self.push_token(kind, text);
             }
             "Regex" => {
+                // Phase 3a shape: the text buffer holds `body/`
+                // (when no flags follow) or `body/flags` (when one
+                // or more flag letters were slurped in
+                // `regex_flags`).  The closing `/` is appended to
+                // the buffer by the `regex_body → regex_flags`
+                // transition, so we only need to prepend the
+                // leading `/` here to get the verbatim source-shape
+                // of the literal.
                 let text = std::mem::take(&mut self.text_buffer);
-                // Encode regex literals as a String token with a
-                // recognisable prefix so the parser can disambiguate
-                // without needing a new TokenType.  Phase 3 will
-                // introduce a dedicated kind; for now the value
-                // shape `/regex-body/` round-trips cleanly through
-                // the parser layer.
-                let value = format!("/{}/", text);
+                let value = format!("/{}", text);
                 self.push_token(TokenType::String, value);
+            }
+            "PercentW" => {
+                // %w[a b c] — string-array literal.  The text buffer
+                // contains the verbatim source `%w[a b c]` (including
+                // the `%w[` opener and `]` closer).  Encode as
+                // TokenType::String with the verbatim value; the
+                // parser inspects the lexeme prefix to know it's a
+                // string array.
+                let text = std::mem::take(&mut self.text_buffer);
+                self.push_token(TokenType::String, text);
+            }
+            "PercentQ" => {
+                // %q{single-quoted-style body} — non-interpolating
+                // string.  Same encoding strategy as PercentW.
+                let text = std::mem::take(&mut self.text_buffer);
+                self.push_token(TokenType::String, text);
             }
             "Op" => {
                 let text = std::mem::take(&mut self.text_buffer);
@@ -841,6 +859,119 @@ mod tests {
                 (TokenType::Number, "2"),
             ]
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Phase 3a — regex flags + `%w[]` / `%q{}` percent literals
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn regex_with_single_flag() {
+        let toks = tokenize_ruby("/foo/i");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "/foo/i")]);
+    }
+
+    #[test]
+    fn regex_with_multiple_flags() {
+        let toks = tokenize_ruby("/foo/imx");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "/foo/imx")]);
+    }
+
+    #[test]
+    fn regex_with_uppercase_flag() {
+        // Uppercase `I`, `M`, etc. are also recognised flag letters.
+        let toks = tokenize_ruby("/foo/IM");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "/foo/IM")]);
+    }
+
+    #[test]
+    fn regex_flag_slurp_is_greedy_then_splits() {
+        // `/foo/i puts` → regex with `i` flag, then a separate `puts`
+        // Name token.  Greedy flag matching exits on the space.
+        let toks = tokenize_ruby("/foo/i puts");
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![
+                (TokenType::String, "/foo/i"),
+                (TokenType::Name, "puts"),
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_without_flags_preserves_phase_2_behaviour() {
+        // /\d+/ — no flag letter follows; emit `/\d+/`.
+        let toks = tokenize_ruby(r"/\d+/");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, r"/\d+/")]);
+    }
+
+    #[test]
+    fn percent_w_array_basic() {
+        let toks = tokenize_ruby("%w[a b c]");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "%w[a b c]")]);
+    }
+
+    #[test]
+    fn percent_w_array_with_newlines_inside_body() {
+        let toks = tokenize_ruby("%w[a\n  b\n  c]");
+        // The token preserves the verbatim body including the
+        // newlines — the parser splits on whitespace later.
+        let strings: Vec<&str> = toks
+            .iter()
+            .filter(|t| t.type_ == TokenType::String)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(strings, vec!["%w[a\n  b\n  c]"]);
+    }
+
+    #[test]
+    fn percent_q_string_basic() {
+        let toks = tokenize_ruby("%q{hello world}");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "%q{hello world}")]);
+    }
+
+    #[test]
+    fn percent_q_string_with_quotes_inside() {
+        // `%q{...}` preserves embedded `"` and `'` literally.
+        let toks = tokenize_ruby(r#"%q{he said "hi"}"#);
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, r#"%q{he said "hi"}"#)]);
+    }
+
+    #[test]
+    fn modulo_operator_still_works() {
+        // `%` not followed by `w` / `q` is still the modulo operator.
+        // `1 % 2` — there's no special letter following `%`, so it
+        // falls back to Op.
+        let toks = tokenize_ruby("1 % 2");
+        let p = pairs(&toks);
+        assert_eq!(
+            p,
+            vec![
+                (TokenType::Number, "1"),
+                (TokenType::Name, "%"),
+                (TokenType::Number, "2"),
+            ]
+        );
+        // (`%` lands on TokenType::Name with value "%" because the
+        // existing op-classifier doesn't have a dedicated kind for
+        // modulo.  Match Phase 1 behaviour.)
+    }
+
+    #[test]
+    fn percent_w_then_method_call() {
+        let toks = tokenize_ruby("%w[a b c].length");
+        let values: Vec<&str> = toks.iter().map(|t| t.value.as_str()).collect();
+        assert!(values.contains(&"%w[a b c]"));
+        assert!(values.contains(&"."));
+        assert!(values.contains(&"length"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Phase 3a** — partial implementation of Phase 3 per [code/specs/ruby-parser.md](code/specs/ruby-parser.md) §"Phasing".  Covers the simpler additive parts; string interpolation (3b) and heredocs (3c) follow as separate PRs.

## What's new

### Regex flag suffixes (`/foo/i`, `/foo/IM`, …)
- New `regex_flags` state in [`ruby-1.8.lexer.states.toml`](code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml)
- `regex_body → /` now transitions to `regex_flags` and appends the `/` to the buffer
- Greedy slurp on `imxoeunsIMXOEUNS` (case-insensitive)
- Non-flag char emits the full literal and re-dispatches via `consume = false`
- `emit(Regex)` interpreter wraps the buffer with a single leading `/` so the value has source-shape `/body/` (no flags) or `/body/flags` (with flags)

### `%w[...]` string-array literal
- New `after_percent`, `percent_w_open`, `percent_w_body` states
- `data → %` routes through `after_percent` to peek for a type letter
- `%` not followed by `w`/`q` falls back to modulo operator (Phase 1 behaviour preserved)
- Emits the verbatim source-shape (`%w[a b c]`) as a single `TokenType::String` token

### `%q{...}` non-interpolating string
- New `percent_q_open`, `percent_q_body` states
- Canonical `{` delimiter only in v0

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — **54 tests pass** (was 43 in Phase 2, +11 new)
- [x] `cargo test -p coding-adventures-ruby-parser` — 6 tests still pass against the new lexer

### Highlight tests
- `regex_with_single_flag`, `regex_with_multiple_flags`, `regex_with_uppercase_flag`
- `regex_flag_slurp_is_greedy_then_splits` — `/foo/i puts` splits correctly on the space
- `regex_without_flags_preserves_phase_2_behaviour` — `/\d+/` still emits `/\d+/`
- `percent_w_array_basic`, `percent_w_array_with_newlines_inside_body`, `percent_w_then_method_call`
- `percent_q_string_basic`, `percent_q_string_with_quotes_inside`
- `modulo_operator_still_works` — `1 % 2` still lexes as Op (Phase 1 fallback)

## Deferred to next PRs

- **Phase 3b**: string interpolation `"a#{expr}b"` — recursive sub-lexer
- **Phase 3c**: heredocs (`<<X`, `<<-X`, `<<~X`) with deferred body capture and FIFO queue for multi-per-line heredocs
- Additional percent literals (`%W`, `%Q`, `%i`, `%I`, `%r`, `%s`, `%x`) and the full set of delimiter pairs (`(...)`, `<...>`, `|...|`, any non-alphanumeric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)