### PR TITLE
Flatten Chief of Staff summary outcome labels

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this package will be documented in this file.
   plan-drift investigation branches.
 - Flattened scheduler-action intent flags in supervisor drain run summaries.
 - Flattened scheduler-action labels in supervisor drain run summaries.
+- Flattened outcome labels in supervisor drain run summaries.
 - Batch audit write summaries for host flush loops.
 - Replay helpers for loading queried audit rows into any `ToolAuditSink`.
 - `StorageToolAuditSink` for runtime audit emission through D18A storage with

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -68,6 +68,8 @@ The crate keeps the boundary narrow:
   host logs and scheduling dashboards
 - supervisor drain run summaries flatten stable scheduler-action labels beside
   the typed recommendation
+- supervisor drain run summaries flatten stable outcome labels beside the typed
+  run outcome
 
 ## Development
 

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -964,6 +964,7 @@ impl ToolAuditSupervisorDrainRunReport {
         ToolAuditSupervisorDrainRunSummary {
             checkpoint_name: self.plan.checkpoint_name.clone(),
             outcome: self.outcome(),
+            outcome_label: self.outcome_label(),
             scheduler_action: self.scheduler_action(),
             scheduler_action_label: self.scheduler_action_label(),
             requires_scheduler_action: self.requires_scheduler_action(),
@@ -1095,6 +1096,8 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub checkpoint_name: String,
     /// Scheduler-facing classification for this run.
     pub outcome: ToolAuditSupervisorDrainRunOutcome,
+    /// Stable scheduler-facing outcome label for host logs.
+    pub outcome_label: &'static str,
     /// Recommended host scheduler action for this run.
     pub scheduler_action: ToolAuditSupervisorDrainSchedulerAction,
     /// Stable scheduler action label for host logs.
@@ -1158,7 +1161,7 @@ pub struct ToolAuditSupervisorDrainRunSummary {
 impl ToolAuditSupervisorDrainRunSummary {
     /// Return the stable scheduler-facing label for this run outcome.
     pub fn outcome_label(&self) -> &'static str {
-        self.outcome.as_str()
+        self.outcome_label
     }
 
     /// Return whether this run outcome asks the scheduler to take action.
@@ -3052,6 +3055,8 @@ mod tests {
             ToolAuditSupervisorDrainRunOutcome::NeedsFollowUp
         );
         let summary = report.summary();
+        assert_eq!(summary.outcome_label, "needs_follow_up");
+        assert_eq!(summary.outcome_label(), "needs_follow_up");
         assert_eq!(summary.scheduler_action_label, "route_follow_up");
         assert_eq!(summary.scheduler_action_label(), "route_follow_up");
         assert!(summary.requires_scheduler_action);
@@ -3479,6 +3484,7 @@ mod tests {
             summary.outcome,
             ToolAuditSupervisorDrainRunOutcome::NeedsContinuation
         );
+        assert_eq!(summary.outcome_label, "needs_continuation");
         assert_eq!(summary.outcome_label(), "needs_continuation");
         assert_eq!(
             summary.scheduler_action,
@@ -3552,6 +3558,7 @@ mod tests {
             summary.outcome,
             ToolAuditSupervisorDrainRunOutcome::PlanDiverged
         );
+        assert_eq!(summary.outcome_label, "plan_diverged");
         assert_eq!(summary.outcome_label(), "plan_diverged");
         assert_eq!(
             summary.scheduler_action,


### PR DESCRIPTION
## Summary
- add a stable outcome label field to supervisor drain run summaries
- have the summary outcome label helper read the flattened field
- document the summary-level outcome label in README and changelog

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD