### PR TITLE
fix(sql-vm,mini-sqlite): SUBSTR edge cases match SQLite byte-for-byte

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.64.0] - 2026-05-20
+
+### Fixed
+
+- **``SUBSTR(x, y[, z])`` edge cases now match SQLite byte-for-byte**
+  (via ``sql-vm 1.38.0``).  The previous implementation got three
+  classes of inputs wrong:
+
+  * ``y = 0`` — was treated as a sentinel for "start of string"; SQLite
+    treats it as one position *before* the first character.
+  * Negative ``z`` — was always returning empty; SQLite reads it as
+    "``|z|`` characters preceding position ``y``".
+  * Far-negative ``y`` (e.g. ``y = -100`` on a 5-char string) —
+    arithmetic overflow returned bogus partial strings.
+
+  21 oracle tests in ``test_tier3_substr_edge_cases.py`` compare each
+  interesting combination against the reference ``sqlite3`` module.
+
 ## [1.63.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.63.0"
+version = "1.64.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_substr_edge_cases.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_substr_edge_cases.py
@@ -1,0 +1,129 @@
+"""Oracle tests for ``SUBSTR(x, y[, z])`` — match SQLite byte-for-byte.
+
+Companion to ``test_substr_edge_cases.py`` in ``sql-vm``.  These tests
+go through the full mini-sqlite stack (lexer → parser → planner →
+codegen → VM → scalar registry) and assert that the answer matches
+the reference ``sqlite3`` module on the same query.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Standard usage — sanity baseline, no edge cases triggered
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrBaseline:
+    def test_basic_three_arg(self) -> None:
+        _check("SELECT substr('hello', 1, 3)")
+
+    def test_two_arg_to_end(self) -> None:
+        _check("SELECT substr('hello', 2)")
+
+    def test_zero_length(self) -> None:
+        _check("SELECT substr('hello', 2, 0)")
+
+
+# ---------------------------------------------------------------------------
+# y = 0 — one position before the string
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrZeroStart:
+    def test_zero_with_length_3(self) -> None:
+        # Was 'hel' (wrong); SQLite returns 'he'.
+        _check("SELECT substr('hello', 0, 3)")
+
+    def test_zero_with_length_1(self) -> None:
+        _check("SELECT substr('hello', 0, 1)")
+
+    def test_zero_with_length_5(self) -> None:
+        _check("SELECT substr('hello', 0, 5)")
+
+    def test_zero_with_zero_length(self) -> None:
+        _check("SELECT substr('hello', 0, 0)")
+
+
+# ---------------------------------------------------------------------------
+# Negative y — count from end
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrNegativeStart:
+    def test_minus_one(self) -> None:
+        _check("SELECT substr('hello', -1)")
+
+    def test_minus_three(self) -> None:
+        _check("SELECT substr('hello', -3)")
+
+    def test_minus_n_whole_string(self) -> None:
+        _check("SELECT substr('hello', -5)")
+
+    def test_far_negative_no_length(self) -> None:
+        # Was 'hello' (correct by accident); regression guard.
+        _check("SELECT substr('hello', -100)")
+
+
+# ---------------------------------------------------------------------------
+# Negative z — characters preceding y
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrNegativeLength:
+    def test_minus_one(self) -> None:
+        _check("SELECT substr('hello', 2, -1)")
+
+    def test_minus_three_clipped(self) -> None:
+        _check("SELECT substr('hello', 2, -3)")
+
+    def test_minus_two_at_position_three(self) -> None:
+        _check("SELECT substr('hello', 3, -2)")
+
+    def test_minus_two_at_end(self) -> None:
+        _check("SELECT substr('hello', 5, -2)")
+
+
+# ---------------------------------------------------------------------------
+# Out-of-range — far negative starts
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrOutOfRange:
+    def test_far_negative_short_length(self) -> None:
+        # Was 'hello' (wrong); SQLite returns ''.
+        _check("SELECT substr('hello', -100, 5)")
+
+    def test_far_negative_long_length(self) -> None:
+        # Was 'he' (wrong); SQLite returns 'hello'.
+        _check("SELECT substr('hello', -100, 102)")
+
+    def test_start_past_end(self) -> None:
+        _check("SELECT substr('hello', 100)")
+
+
+# ---------------------------------------------------------------------------
+# Empty input and NULL
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrEmptyAndNull:
+    def test_empty_string(self) -> None:
+        _check("SELECT substr('', 1)")
+
+    def test_empty_with_length(self) -> None:
+        _check("SELECT substr('', 1, 5)")
+
+    def test_null_input(self) -> None:
+        _check("SELECT substr(NULL, 1)")
+        _check("SELECT substr(NULL, 1, 3)")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.38.0 — 2026-05-20
+
+### Fixed
+
+- **``SUBSTR(x, y[, z])`` edge cases now match SQLite byte-for-byte.**
+  The previous implementation accumulated per-branch fixups for
+  negative ``y``, negative ``z``, and ``y = 0`` — and got several
+  combinations wrong:
+
+  * ``substr('hello', 0, 3)`` returned ``'hel'`` (wrong); SQLite
+    returns ``'he'`` because ``y = 0`` means "one position before the
+    string" so the span ``0, 1, 2`` intersects the string at
+    positions ``1, 2``.
+  * ``substr('hello', 2, -1)`` returned ``''`` (wrong); SQLite
+    returns ``'h'`` — negative ``z`` asks for ``|z|`` characters
+    *preceding* position ``y``.
+  * ``substr('hello', -100, 5)`` returned ``'hello'`` (wrong); SQLite
+    returns ``''`` because the resolved start (``-94``) plus length 5
+    is still entirely to the left of position 1.
+
+  The new algorithm models the requested character range as a closed
+  1-indexed interval ``[lo, hi]``, clips to ``[1, N]``, and converts
+  back to a Python slice — uniform handling that doesn't accumulate
+  per-branch fixups.  Blob inputs use the same algorithm on bytes.
+
+  33 unit tests in ``test_substr_edge_cases.py`` cover the full grid:
+  positive/negative/zero ``y``, positive/negative ``z``, far-negative
+  ``y``, empty strings, NULL, blob inputs, and the ``substring`` alias.
+
 ## 1.37.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.37.0"
+version = "1.38.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -999,68 +999,86 @@ def _rtrim(*args: SqlValue) -> SqlValue:
 
 @register("substr", "substring")
 def _substr(*args: SqlValue) -> SqlValue:
-    """Extract a substring.
+    """Extract a substring — full SQLite semantics, edge cases included.
 
-    ``SUBSTR(x, start)``         → from position *start* to end.
-    ``SUBSTR(x, start, length)`` → *length* characters starting at *start*.
+    ``SUBSTR(x, y)``       → from 1-indexed position *y* to end of string.
+    ``SUBSTR(x, y, z)``    → *z* characters starting at position *y*.
 
-    *start* is **1-indexed** (first character = position 1), matching SQLite.
-    Negative *start* counts from the end (position −1 = last character).
-    A *length* of 0 or negative returns an empty string.
+    The arithmetic is **1-indexed**, with three subtleties that catch
+    most implementations off-guard:
+
+    1. **Negative ``y``** counts back from the end: ``y = -1`` is the
+       last character, ``y = -2`` is the second-to-last, …, ``y = -N``
+       is the first character of an ``N``-length string.  Concretely,
+       a negative ``y`` is resolved to ``N + 1 + y``.
+
+    2. **``y = 0``** is *one position to the left* of the first
+       character — neither a valid index nor a sentinel for "beginning".
+       Combined with ``z = 3`` on ``"hello"`` (length 5), the requested
+       span is positions ``0, 1, 2`` but only positions ``1, 2`` are
+       inside the string, so the result is ``"he"`` (not ``"hel"``).
+
+    3. **Negative ``z``** means "the ``|z|`` characters *preceding*
+       position ``y``".  So ``SUBSTR("hello", 3, -2)`` asks for two
+       characters ending at position 2: positions ``1, 2`` → ``"he"``.
+
+    The implementation models the requested character range as a
+    closed 1-indexed interval ``[lo, hi]``, clips it to the string's
+    valid range ``[1, N]``, and converts back to a Python slice.  This
+    handles every overflow/underflow case uniformly — including
+    ``y = -100`` on a 5-char string (where ``y`` resolves to ``-94``
+    and the entire requested span lies to the left of the string).
+
+    Blob inputs use the same algorithm, operating on bytes.
 
     Returns NULL if *x* is NULL.
 
     Examples::
 
-        SUBSTR("hello", 2)       → "ello"
-        SUBSTR("hello", 2, 3)    → "ell"
-        SUBSTR("hello", -3)      → "llo"
-        SUBSTR("hello", 2, 0)    → ""
+        SUBSTR("hello",  2)       → "ello"
+        SUBSTR("hello",  2, 3)    → "ell"
+        SUBSTR("hello", -3)       → "llo"     ( y = 6 + (-3) = 3 )
+        SUBSTR("hello",  0, 3)    → "he"      ( positions 0,1,2 ∩ 1..5 )
+        SUBSTR("hello",  3, -2)   → "he"      ( two chars before pos 3 )
+        SUBSTR("hello", -100, 5)  → ""        ( span entirely left of string )
+        SUBSTR("hello", -100, 102)→ "hello"   ( span covers whole string )
     """
     _arity("substr", list(args), 2, 3)
     x = args[0]
     if x is None:
         return None
-    if not isinstance(x, str):
-        if isinstance(x, (bytes, bytearray)):
-            # Blob substr — operate on bytes.
-            s = bytes(x)
-            start = int(args[1]) if args[1] is not None else 1  # type: ignore[arg-type]
-            if start > 0:
-                start -= 1  # Convert to 0-indexed.
-            # negative start: count from end
-            idx = start if start < 0 else start
-            if len(args) == 3 and args[2] is not None:
-                length = int(args[2])  # type: ignore[arg-type]
-                if length <= 0:
-                    return b""
-                return s[idx: idx + length]
-            return s[idx:]
+    is_blob = isinstance(x, (bytes, bytearray))
+    if not is_blob and not isinstance(x, str):
         return x
-    start = int(args[1]) if args[1] is not None else 1  # type: ignore[arg-type]
-    if start > 0:
-        start -= 1  # Convert to 0-indexed.
-    # Negative start: SQLite counts from end (−1 = last char).
+    s: bytes | str = bytes(x) if is_blob else x
+    empty: bytes | str = b"" if is_blob else ""
+    n = len(s)
+    y_raw = args[1]
+    y = int(y_raw) if y_raw is not None else 1  # type: ignore[arg-type]
+    # Resolve 1-indexed start position.  Negative y counts from the end;
+    # y == 0 stays as 0 (one position before the first character — a
+    # legitimate SQLite-ism that callers occasionally rely on).
+    if y < 0:
+        y = n + 1 + y
+    # Determine the requested closed interval [lo, hi] in 1-indexed
+    # positions.  Both bounds may be outside [1, n] before clipping.
     if len(args) == 3 and args[2] is not None:
-        length = int(args[2])  # type: ignore[arg-type]
-        if length <= 0:
-            return ""
-        if start < 0:
-            end = start + length
-            if end <= 0:
-                # Entire span is before the start of the string.
-                start_pos = len(x) + start
-                if start_pos < 0:
-                    start_pos = 0
-                return x[start_pos: start_pos + length]
-            if end < 0:
-                return x[start:end]
-            stop = None if start + length > len(x) else start + length
-            return x[start:stop]
-        return x[start: start + length]
-    if start < 0:
-        return x[start:]
-    return x[start:]
+        z = int(args[2])  # type: ignore[arg-type]
+        if z >= 0:
+            lo, hi = y, y + z - 1
+        else:
+            # Negative length: |z| characters *preceding* position y.
+            lo, hi = y + z, y - 1
+    else:
+        lo, hi = y, n
+    # Clip to the valid range; if the clipped interval is empty, return
+    # the empty string/blob without going through the slice (which would
+    # do the right thing anyway, but we want a clean unified exit).
+    lo = max(lo, 1)
+    hi = min(hi, n)
+    if lo > hi:
+        return empty
+    return s[lo - 1: hi]
 
 
 @register("replace")

--- a/code/packages/python/sql-vm/tests/test_substr_edge_cases.py
+++ b/code/packages/python/sql-vm/tests/test_substr_edge_cases.py
@@ -1,0 +1,207 @@
+"""Exhaustive edge-case tests for ``SUBSTR(x, y[, z])``.
+
+SQLite's substr has three corners that catch most implementations:
+
+1. ``y = 0`` is one position *to the left* of the first character — not
+   a sentinel for "start of string".  Combined with positive ``z``, the
+   request span includes position 0 (invalid) so the returned string is
+   one character shorter than ``z``.
+
+2. **Negative ``y``** counts from the end: ``y = -1`` is the last
+   character.  Concretely ``y`` resolves to ``N + 1 + y`` (so on an
+   empty string, ``y = -1`` resolves to 0 — same as the previous
+   corner).
+
+3. **Negative ``z``** asks for ``|z|`` characters *preceding* position
+   ``y`` — useful for "take everything up to but not including this
+   point".
+
+Before this PR mini-sqlite got every one of those wrong (e.g.
+``substr('hello', 0, 3)`` returned ``'hel'`` instead of ``'he'``).  The
+new implementation models the requested character range as a closed
+1-indexed interval ``[lo, hi]``, clips to ``[1, N]``, and converts to a
+Python slice — uniform handling that doesn't accumulate per-branch
+fixups.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sql_vm.scalar_functions import call
+
+
+def _s(*args: object) -> object:
+    return call("substr", list(args))
+
+
+# ---------------------------------------------------------------------------
+# Standard positive-y, positive-z — sanity baseline
+# ---------------------------------------------------------------------------
+
+
+class TestSubstrBaseline:
+    def test_basic(self) -> None:
+        assert _s("hello", 1, 3) == "hel"
+
+    def test_from_middle(self) -> None:
+        assert _s("hello", 2, 3) == "ell"
+
+    def test_to_end(self) -> None:
+        assert _s("hello", 2) == "ello"
+
+    def test_overshoot_length(self) -> None:
+        assert _s("hello", 2, 100) == "ello"
+
+    def test_zero_length(self) -> None:
+        assert _s("hello", 2, 0) == ""
+
+
+# ---------------------------------------------------------------------------
+# Negative ``y`` — count from end (resolved as N + 1 + y)
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeStart:
+    def test_minus_one_is_last_char(self) -> None:
+        assert _s("hello", -1) == "o"
+
+    def test_minus_three_from_end(self) -> None:
+        assert _s("hello", -3) == "llo"
+
+    def test_minus_n_is_whole_string(self) -> None:
+        assert _s("hello", -5) == "hello"
+
+    def test_negative_overshoot_no_length(self) -> None:
+        # y = -100 → resolved y = -94; from -94 to end means clipped to
+        # [1, 5] which is the whole string.
+        assert _s("hello", -100) == "hello"
+
+
+# ---------------------------------------------------------------------------
+# ``y = 0`` — one position before the string
+# ---------------------------------------------------------------------------
+
+
+class TestZeroStart:
+    def test_zero_with_length_3(self) -> None:
+        # Span: positions 0,1,2 → ∩ [1,5] = positions 1,2 → 'he'.
+        assert _s("hello", 0, 3) == "he"
+
+    def test_zero_with_length_1(self) -> None:
+        # Span: position 0 → ∩ [1,5] = empty.
+        assert _s("hello", 0, 1) == ""
+
+    def test_zero_with_length_5(self) -> None:
+        # Span: positions 0..4 → ∩ [1,5] = positions 1..4 → 'hell'.
+        assert _s("hello", 0, 5) == "hell"
+
+    def test_zero_with_zero_length(self) -> None:
+        assert _s("hello", 0, 0) == ""
+
+    def test_zero_no_length(self) -> None:
+        # y=0, no length → from 0 to end → clipped to [1, 5] → 'hello'.
+        assert _s("hello", 0) == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Negative ``z`` — characters preceding position y
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeLength:
+    def test_minus_one_takes_one_before(self) -> None:
+        # 1 char before position 2 = position 1 = 'h'.
+        assert _s("hello", 2, -1) == "h"
+
+    def test_minus_three_clipped(self) -> None:
+        # 3 chars before position 2 = positions -1, 0, 1 → only 1 valid → 'h'.
+        assert _s("hello", 2, -3) == "h"
+
+    def test_minus_two_at_position_three(self) -> None:
+        # 2 chars before position 3 = positions 1, 2 = 'he'.
+        assert _s("hello", 3, -2) == "he"
+
+    def test_negative_length_from_end(self) -> None:
+        # y=5 is last char; -2 means positions 3, 4 = 'll'.
+        assert _s("hello", 5, -2) == "ll"
+
+    def test_negative_length_negative_start(self) -> None:
+        # y=-2 → position 4. z=-2 → positions 2, 3 = 'el'.
+        assert _s("hello", -2, -2) == "el"
+
+
+# ---------------------------------------------------------------------------
+# Out-of-range — start way before or way after the string
+# ---------------------------------------------------------------------------
+
+
+class TestOutOfRange:
+    def test_far_negative_short_length(self) -> None:
+        # y=-100 → resolved -94. z=5. Span [-94, -90] entirely left of [1, 5].
+        assert _s("hello", -100, 5) == ""
+
+    def test_far_negative_long_length(self) -> None:
+        # y=-94, z=102. Span [-94, 7] ∩ [1, 5] = [1, 5] → 'hello'.
+        assert _s("hello", -100, 102) == "hello"
+
+    def test_start_past_end(self) -> None:
+        assert _s("hello", 6) == ""
+        assert _s("hello", 100) == ""
+
+    def test_start_past_end_with_length(self) -> None:
+        assert _s("hello", 100, 5) == ""
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    def test_empty_string(self) -> None:
+        assert _s("", 1) == ""
+        assert _s("", 1, 5) == ""
+        assert _s("", -1) == ""
+
+    def test_null_input(self) -> None:
+        assert _s(None, 1) is None
+        assert _s(None, 1, 3) is None
+
+
+# ---------------------------------------------------------------------------
+# Blob inputs — operate on bytes with the same algorithm
+# ---------------------------------------------------------------------------
+
+
+class TestBlobSubstr:
+    def test_blob_basic(self) -> None:
+        assert _s(b"hello", 1, 3) == b"hel"
+
+    def test_blob_zero_start(self) -> None:
+        assert _s(b"hello", 0, 3) == b"he"
+
+    def test_blob_negative_start(self) -> None:
+        assert _s(b"hello", -3) == b"llo"
+
+    def test_blob_negative_length(self) -> None:
+        assert _s(b"hello", 3, -2) == b"he"
+
+
+# ---------------------------------------------------------------------------
+# substring alias (SQL-standard spelling)
+# ---------------------------------------------------------------------------
+
+
+class TestSubstringAlias:
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        [
+            (("hello", 1, 3), "hel"),
+            (("hello", 0, 3), "he"),
+            (("hello", -3), "llo"),
+            (("hello", 3, -2), "he"),
+        ],
+    )
+    def test_substring_matches_substr(self, args: tuple, expected: str) -> None:
+        assert call("substring", list(args)) == expected


### PR DESCRIPTION
## Summary

The `SUBSTR(x, y[, z])` implementation had three categories of bugs:
- **`y = 0`**: was treated as "start of string"; SQLite treats it as one position *before* the first character. `substr('hello', 0, 3)` returned `'hel'` instead of `'he'`.
- **Negative `z`**: was returning empty; SQLite reads it as "`|z|` characters preceding position `y`". `substr('hello', 2, -1)` returned `''` instead of `'h'`.
- **Far-negative `y`**: arithmetic overflow returned bogus partial strings. `substr('hello', -100, 5)` returned `'hello'` instead of `''`.

New algorithm models the requested range as a closed 1-indexed interval `[lo, hi]`, clips to `[1, N]`, and converts to a Python slice. Uniform handling, no per-branch fixups. Blob inputs use the same algorithm on bytes.

54 tests added: 33 sql-vm unit + 21 mini-sqlite oracle. Version bumps: sql-vm 1.37.0 → 1.38.0, mini-sqlite 1.63.0 → 1.64.0.

## Test plan

- [x] `pytest sql-vm/tests/test_substr_edge_cases.py` — 33/33
- [x] `pytest mini-sqlite/tests/test_tier3_substr_edge_cases.py` — 21/21
- [x] sql-vm full suite — 790 passed (plus 33 new = 823)
- [x] mini-sqlite full suite — 1629 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)