### PR TITLE
feat(ruby-lexer): Phase 3b — string interpolation `"#{...}"`

### DIFF
--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.5.0] - 2026-05-20
+
+### Added (Phase 3b — string interpolation `"#{...}"`)
+- `string_d_hash` and `string_d_interp` states in [`ruby-1.8.lexer.states.toml`](./ruby-1.8.lexer.states.toml).  `"..."` body now branches on `#`: if followed by `{` it enters interpolation (`string_d_interp`), otherwise the `#` is treated as a literal character and the follower is re-dispatched to `string_d_body`.
+- New `interp_brace_depth: usize` field on `RubyLexer`.  Tracks nesting of `{` / `}` inside an interpolation expression so that `"#{ {a: 1} }"` correctly closes only on the outermost matching `}`.
+- The action interpreter intercepts `}` in `string_d_interp` — at depth 0 it appends the `}` to the string buffer and forces the engine back to `string_d_body` via `set_current_state`.  Same pattern as the Phase 2 `/` interceptor.
+- v0 captures interpolation **verbatim** — the `#{expr}` substring is preserved inside the `TokenType::String` value.  Recursive sub-lexing of the embedded expression is a future refinement; the parser can dispatch on the `#{` substring when it needs to evaluate.
+
+### Tests (+11 new, total 65)
+- Simple, expression, at-start, at-end, multiple-interpolation cases.
+- `#` without following `{` is literal (`"a # b"`, `"trailing #"`).
+- Nested braces inside interpolation (`"#{ {a: 1} }"`) close correctly.
+- Method call inside interpolation (`"#{arr.length}"`).
+- Single-quoted strings do **not** interpolate (`'#{name}'` stays as `#{name}`).
+- Embedded double-quotes inside `#{...}` are accepted (brace tracker is string-agnostic).
+
+### Deferred (subsequent Phase 3 follow-ups)
+- Phase 3c: heredocs (`<<X`, `<<-X`, `<<~X`) with deferred body capture and FIFO queue for multi-per-line heredocs.
+- Future refinement: recursive sub-lexing of the interpolation expression (so the parser receives individual tokens for the embedded code instead of one verbatim string).
+
 ## [0.4.0] - 2026-05-20
 
 ### Added (Phase 3a — regex flags + `%w[]` / `%q{}` percent literals)

--- a/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
+++ b/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
@@ -172,6 +172,15 @@ id = "int_body"
 id = "string_d_body"     # inside "..."
 [[states]]
 id = "string_d_escape"   # inside "..." after a backslash
+[[states]]
+id = "string_d_hash"     # inside "..." after a `#` — peeking for `{` to
+                         # decide between literal `#` and interpolation
+                         # opener `#{`.
+[[states]]
+id = "string_d_interp"   # inside "...#{...}..." — capturing the
+                         # interpolation expression verbatim until the
+                         # matching `}` (interp_brace_depth tracked by
+                         # the action interpreter for nested braces).
 
 [[states]]
 id = "string_s_body"     # inside '...'
@@ -550,13 +559,20 @@ consume = false
 actions = ["emit(Int)", "emit(Eof)"]
 
 # ─────────────────────────────────────────────────────────────────
-# Double-quoted string body (no interpolation in Phase 1)
+# Double-quoted string body (Phase 3b: with `#{...}` interpolation)
 # ─────────────────────────────────────────────────────────────────
 
 [[transitions]]
 from = "string_d_body"
 matcher = { literal = "\\" }
 to = "string_d_escape"
+
+# `#` inside `"..."` may open an interpolation (`#{...}`).  We peek
+# the next char in `string_d_hash` to decide.
+[[transitions]]
+from = "string_d_body"
+matcher = { literal = "#" }
+to = "string_d_hash"
 
 [[transitions]]
 from = "string_d_body"
@@ -626,6 +642,57 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = ["parse_error(unterminated_string)", "emit(Eof)"]
+
+# ─────────────────────────────────────────────────────────────────
+# String interpolation (Phase 3b) — inside `"..."`, `#{` opens an
+# embedded expression that runs until a matching `}`.  v0 captures
+# the expression text verbatim (recursive sub-lexing is a future
+# refinement); the parser can dispatch on the `#{...}` substring
+# when it needs to evaluate.
+# ─────────────────────────────────────────────────────────────────
+
+# Saw `#` inside `"..."`: peek for `{`.
+[[transitions]]
+from = "string_d_hash"
+matcher = { literal = "{" }
+to = "string_d_interp"
+actions = ["append_text(#)", "append_text(current)"]   # append "#{"
+
+# `#` not followed by `{`: re-dispatch the char as ordinary string
+# content.  Append the leading `#` first, then let `string_d_body`
+# handle the follower via consume=false.
+[[transitions]]
+from = "string_d_hash"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["append_text(#)", "parse_error(unterminated_string)", "emit(Eof)"]
+
+[[transitions]]
+from = "string_d_hash"
+matcher = { anything = true }
+to = "string_d_body"
+consume = false
+actions = ["append_text(#)"]
+
+# Inside `#{...}`: accumulate verbatim.  The action interpreter
+# tracks `interp_brace_depth` and forces the engine back to
+# `string_d_body` when a `}` is seen at depth 0 (closing the
+# interpolation).  Until then, every char including `{` / `}` is
+# appended; the engine never observes the matching `}` because the
+# interpreter consumes it manually before feeding to the engine.
+[[transitions]]
+from = "string_d_interp"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_interpolation)", "emit(Eof)"]
+
+[[transitions]]
+from = "string_d_interp"
+matcher = { anything = true }
+to = "string_d_interp"
+actions = ["append_text(current)"]
 
 # ─────────────────────────────────────────────────────────────────
 # Single-quoted string — fewer escapes (only \' and \\).

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -76,6 +76,11 @@ pub struct RubyLexer {
     /// Phase 2: the parser-feedback contract.  Defaults to
     /// [`NoLocals`] which treats every name as a method.
     oracle: Box<dyn ParserOracle>,
+    /// Phase 3b: nesting depth of `{` / `}` inside a `#{...}`
+    /// string interpolation.  Incremented on `{`, decremented on
+    /// `}`, and `}` at depth 0 closes the interpolation (interpreter
+    /// manually transitions the engine back to `string_d_body`).
+    interp_brace_depth: usize,
 }
 
 impl RubyLexer {
@@ -109,6 +114,7 @@ impl RubyLexer {
             lex_state: LexState::default(),
             last_name: String::new(),
             oracle,
+            interp_brace_depth: 0,
         })
     }
 
@@ -182,6 +188,36 @@ impl RubyLexer {
             // the regex literal.  Advance position past it.
             self.column += 1;
             return Ok(());
+        }
+
+        // Phase 3b: `}` at brace-depth 0 inside `string_d_interp`
+        // closes the `#{...}` interpolation.  Append the `}` to the
+        // string body and force the engine back to `string_d_body`.
+        // Inner `{` / `}` increment / decrement the depth and pass
+        // through to the engine's normal `append_text(current)` arm.
+        if self.machine.current_state() == "string_d_interp" {
+            if ch == '{' {
+                self.interp_brace_depth += 1;
+            } else if ch == '}' {
+                if self.interp_brace_depth > 0 {
+                    self.interp_brace_depth -= 1;
+                } else {
+                    // Closing brace of the interpolation.  Append
+                    // `}` to the string body and pop back to
+                    // string_d_body.  Note: we DO NOT feed `}` to
+                    // the engine — the engine's `anything` arm
+                    // would re-enter string_d_interp and keep
+                    // accumulating.
+                    self.text_buffer.push('}');
+                    self.machine
+                        .set_current_state("string_d_body")
+                        .map_err(|e| {
+                            format!("ruby lexer: failed to leave string_d_interp: {e}")
+                        })?;
+                    self.column += 1;
+                    return Ok(());
+                }
+            }
         }
 
         let mut buf = [0u8; 4];
@@ -972,6 +1008,102 @@ mod tests {
         assert!(values.contains(&"%w[a b c]"));
         assert!(values.contains(&"."));
         assert!(values.contains(&"length"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Phase 3b — string interpolation `"#{...}"`
+    //
+    // v0 captures the interpolation expression verbatim inside the
+    // String token's value; the parser decides how to evaluate.
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn string_with_simple_interpolation() {
+        let toks = tokenize_ruby("\"hello #{name}\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "hello #{name}")]);
+    }
+
+    #[test]
+    fn string_with_expression_interpolation() {
+        let toks = tokenize_ruby("\"sum is #{1+2}\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "sum is #{1+2}")]);
+    }
+
+    #[test]
+    fn string_with_interpolation_at_start() {
+        let toks = tokenize_ruby("\"#{x}!\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "#{x}!")]);
+    }
+
+    #[test]
+    fn string_with_interpolation_at_end() {
+        let toks = tokenize_ruby("\"hi #{name}\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "hi #{name}")]);
+    }
+
+    #[test]
+    fn string_with_multiple_interpolations() {
+        let toks = tokenize_ruby("\"a #{x} b #{y} c\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "a #{x} b #{y} c")]);
+    }
+
+    #[test]
+    fn string_with_hash_but_no_brace_is_literal() {
+        // `"a # b"` — the `#` is just a literal character because
+        // it isn't followed by `{`.
+        let toks = tokenize_ruby("\"a # b\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "a # b")]);
+    }
+
+    #[test]
+    fn string_with_hash_at_end_is_literal() {
+        let toks = tokenize_ruby("\"trailing #\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "trailing #")]);
+    }
+
+    #[test]
+    fn string_interpolation_with_nested_braces() {
+        // `"#{ {a: 1} }"` — the inner `{a: 1}` is part of the
+        // interpolation expression, not a closing brace.  The brace
+        // depth tracker handles the nesting.
+        let toks = tokenize_ruby("\"#{ {a: 1} }\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "#{ {a: 1} }")]);
+    }
+
+    #[test]
+    fn string_interpolation_with_method_call() {
+        // `"#{arr.length}"` — interpolation containing a method call.
+        let toks = tokenize_ruby("\"len = #{arr.length}\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "len = #{arr.length}")]);
+    }
+
+    #[test]
+    fn single_quoted_string_does_not_interpolate() {
+        // `'#{name}'` — single-quoted strings DO NOT interpolate.
+        // The `#{...}` stays as literal text.
+        let toks = tokenize_ruby("'#{name}'");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "#{name}")]);
+    }
+
+    #[test]
+    fn string_interpolation_with_string_inside() {
+        // `"#{ "inner" }"` — the brace tracker is string-agnostic,
+        // so after `#{` we accumulate everything (including
+        // embedded `"`s) until matching `}` at depth 0.  Result:
+        // a single String with body `x #{"y"}`.
+        let toks = tokenize_ruby("\"x #{\"y\"}\"");
+        let p = pairs(&toks);
+        assert_eq!(p, vec![(TokenType::String, "x #{\"y\"}")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Phase 3b** of [ruby-parser.md](code/specs/ruby-parser.md) — adds double-quoted string interpolation.  Heredocs (Phase 3c) follow in a separate PR.

## What's new

- New `string_d_hash` and `string_d_interp` states in [`ruby-1.8.lexer.states.toml`](code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml).  `"..."` body now branches on `#`: `#{` opens an interpolation; anything else is a literal `#`.
- New `interp_brace_depth: usize` field on `RubyLexer`.  Tracks nesting of `{`/`}` inside the interpolation expression so `"#{ {a: 1} }"` correctly closes only on the outermost matching `}`.
- The action interpreter intercepts `}` at depth 0 — appends to the string buffer and forces the engine back to `string_d_body` via `set_current_state`.  Same pattern as the Phase 2 `/` regex interceptor.

## V0 capture strategy

The interpolation is captured **verbatim** — `#{expr}` is preserved inside the `TokenType::String` value.  Recursive sub-lexing of the embedded expression is a future refinement; the parser can split / re-lex when it needs to evaluate.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — **65 tests pass** (was 54 in Phase 3a, +11 new)
- [x] `cargo test -p coding-adventures-ruby-parser` — 6 tests still pass

### Highlight tests
- `string_with_simple_interpolation` — `"hello #{name}"` → verbatim string
- `string_with_expression_interpolation` — `"sum is #{1+2}"`
- `string_with_multiple_interpolations` — `"a #{x} b #{y} c"`
- `string_with_hash_but_no_brace_is_literal` — `"a # b"` (no interp)
- `string_interpolation_with_nested_braces` — `"#{ {a: 1} }"` closes correctly
- `string_interpolation_with_method_call` — `"#{arr.length}"`
- `single_quoted_string_does_not_interpolate` — `'#{name}'` stays literal
- `string_interpolation_with_string_inside` — embedded `"` doesn't confuse brace tracker

## Deferred

- **Phase 3c**: heredocs (`<<X`, `<<-X`, `<<~X`) with deferred body capture and FIFO queue
- Future refinement: recursive sub-lexing of `#{...}` so the parser receives individual tokens for the embedded code

🤖 Generated with [Claude Code](https://claude.com/claude-code)