### PR TITLE
feat(symbolic-vm): Phase 37 — Weierstrass log form cos b<−|a| (Python 0.62.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.62.0 — 2026-05-20
+
+**Phase 37 — Weierstrass log form extended to `b < −|a|` cos branch.**
+
+Phase 36 closed the `a² < b²` log form for the `b > |a|` case but
+explicitly deferred the symmetric `b < −|a|` case under the
+(incorrect) assumption that a separate sign-flipped formula was
+needed.  A more careful derivation shows that the existing
+``log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|`` formula already
+handles both sign regimes correctly when the `Abs` wrapping is in
+place — the numerator and denominator swap as `b−a` changes sign, and
+``|N/D'| = |D'/N|`` collapses them to the same value.
+
+### Changed
+
+- **`_try_weierstrass_log_form` cos branch** (`integrate.py`): removed
+  the ``if b <= abs(a): return None`` and ``if b_minus_a <= 0: return None``
+  guards.  The remaining caller-side guarantee (``b² > a²``, from the
+  Phase 34 dispatcher's ``disc < 0`` entry condition) is sufficient for
+  the formula to produce the correct antiderivative across all sign
+  combinations of `a` and `b` with `|b| > |a|`.
+
+### Added — tests
+
+`tests/test_phase34_weierstrass.py` (3 new cases — one promoted from
+the prior fallthrough):
+
+- `test_phase37_cos_negative_b_now_closes` — `∫ 1/(1 − 2·cos x) dx`
+  closes; numerical derivative matches across the open interval where
+  the integrand is finite (avoiding the zeros at `cos x = 1/2`).
+- `test_phase37_cos_negative_b_with_negative_a` — `∫ 1/(−1 − 3·cos x) dx`
+  with both `a` and `b` negative.
+- `test_phase37_cos_negative_b_with_numerator_coefficient` —
+  `∫ 5/(1 − 2·cos x) dx` confirms the coefficient passes through.
+
+Full suite: **1686 passed, 85 skipped, 81.44% coverage.**
+
+### Still deferred
+
+- Non-bare trig arguments (e.g. `sin(αx + β)`) — needs composition with
+  a linear-substitution phase.
+- Symbolic `a` or `b`.
+- `a = 0` sin branch (would reduce to `∫ c/(b·sin x) dx` — falls back
+  to the elementary table).
+
 ## 0.61.0 — 2026-05-20
 
 **Phase 36 integration — Weierstrass log form for `a² < b²` denominators.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.61.0"
+version = "0.62.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1083,15 +1083,20 @@ def _try_weierstrass_log_form(
         log_arg = IRApply(abs_head, (IRApply(DIV, (numer, denom)),))
         coef_ir = IRApply(DIV, (_frac_ir(c), sqrt_disc_ir))
         return IRApply(MUL, (coef_ir, IRApply(LOG, (log_arg,))))
-    # COS branch
-    if b <= abs(a):
-        # Sign preconditions don't hold; defer the (b < -|a|) flipped case.
-        return None
-    # b > |a| > 0 case (forces b > 0 and either a ≥ 0 or a < 0 with b > -a).
-    # (b - a) > 0 always here.
+    # COS branch — handles both b > |a| and b < −|a| (Phase 37 extension).
+    #
+    # The same expression ``log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|``
+    # is valid for both sign regimes because the inner rational is
+    # wrapped in ``Abs``: when ``b−a`` flips sign across the two cases,
+    # the numerator and denominator of the log argument swap (one goes to
+    # ``D − k·u``, the other to ``D + k·u``), but ``|N/D'| = |D'/N|`` so
+    # the absolute value collapses them to the same value.  The
+    # antiderivative is then continuous on both sides of ``b = ±|a|``.
+    #
+    # Caller already ensures ``b² > a²`` (disc < 0 entry); the only
+    # additional precondition is ``a + b ≠ 0``, which is automatic
+    # because ``b² > a²`` rules out ``b = −a``.
     b_minus_a = b - a
-    if b_minus_a <= 0:
-        return None
     # log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
     bma_tan = IRApply(MUL, (_frac_ir(b_minus_a), tan_half))
     numer = IRApply(ADD, (sqrt_disc_ir, bma_tan))

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -335,22 +335,64 @@ def test_phase36_perfect_square_discriminant(vm: VM) -> None:
         assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
 
 
-def test_phase36_cos_negative_b_still_defers(vm: VM) -> None:
-    """``∫ 1/(1 − 2·cos x) dx`` — cos branch with b·cos coefficient < 0
-    (here written as (a−|b|cos) with effective b = −2).  Phase 36's cos
-    formula requires ``b > |a|`` strictly; this case has b = −2, |a| = 1,
-    so b < 0 fails the guard and we defer.
+def test_phase37_cos_negative_b_now_closes(vm: VM) -> None:
+    """``∫ 1/(1 − 2·cos x) dx`` — cos branch with effective b = −2 < |a| = 1.
+
+    Phase 37 (this release) extends Phase 36's cos branch to cover the
+    symmetric ``b < −|a|`` case.  The closed form is the same
+    ``log|(D + (b−a)·tan(x/2))/(D − (b−a)·tan(x/2))|`` formula — the
+    Abs wrapping handles the sign flip automatically.
     """
     one_minus_two_cos = IRApply(
         SUB,
         (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(COS, (X,))))),
     )
     integrand = IRApply(DIV, (IRInteger(1), one_minus_two_cos))
-    result = vm.eval(_integrate(integrand))
-    # The deferred branch leaves the integral unevaluated.
-    assert isinstance(result, IRApply) and result.head == INTEGRATE, (
-        f"b<0 cos branch is deferred; got {result!r}"
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Phase 37 should close ∫ 1/(1−2·cos x) dx; got {phi!r}"
     )
+    # 1 − 2 cos x has zeros at cos x = 1/2 (x = ±π/3).  Sample on
+    # (π/3, π) where the integrand is real and finite.
+    for x_val in (1.2, 1.6, 2.0, 2.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 - 2.0 * math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3), (
+            f"At x={x_val}: got={got}, expected={expected}"
+        )
+
+
+def test_phase37_cos_negative_b_with_negative_a(vm: VM) -> None:
+    """``∫ 1/(−1 − 3·cos x) dx`` — both a and b negative.  ``b = −3 < −|a| = −1``.
+
+    Closed form derived from same formula; the Abs wrapping handles signs.
+    """
+    neg_one_minus_three_cos = IRApply(
+        SUB,
+        (IRInteger(-1), IRApply(MUL, (IRInteger(3), IRApply(COS, (X,))))),
+    )
+    integrand = IRApply(DIV, (IRInteger(1), neg_one_minus_three_cos))
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    # −1 − 3 cos x has zeros at cos x = −1/3.  Sample safely.
+    for x_val in (0.5, 1.0, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (-1.0 - 3.0 * math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase37_cos_negative_b_with_numerator_coefficient(vm: VM) -> None:
+    """``∫ 5/(1 − 2·cos x) dx`` — numerator c=5 scales the closed form."""
+    one_minus_two_cos = IRApply(
+        SUB,
+        (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(COS, (X,))))),
+    )
+    integrand = IRApply(DIV, (IRInteger(5), one_minus_two_cos))
+    phi = vm.eval(_integrate(integrand))
+    for x_val in (1.2, 1.6, 2.0, 2.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 5.0 / (1.0 - 2.0 * math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
 
 
 def test_phase35_a_equals_b_now_closes(vm: VM) -> None:


### PR DESCRIPTION
## Summary

Closes the last documented Weierstrass deferral other than non-bare trig
arguments and symbolic coefficients.

Phase 36 (PR #3672) emitted the log-form closed solution for
`a² < b²` but explicitly deferred the cos branch with `b < −|a|`
under the (incorrect) assumption that a separate sign-flipped formula
was needed.  A closer derivation shows the same formula

    (c/D) · log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|

already handles both sign regimes correctly: when `b−a` changes sign,
the numerator and denominator of the inner ratio swap, and the `Abs`
wrapping collapses them to the same value via `|N/D'| = |D'/N|`.

## Change

`_try_weierstrass_log_form` cos branch: removed two overly
conservative guards (`b <= abs(a)` and `b_minus_a <= 0`). The remaining
caller-side guarantee (`disc < 0`, i.e. `b² > a²`) is sufficient.

## Test plan

- [x] 3 new tests in `tests/test_phase34_weierstrass.py`:
  - `test_phase37_cos_negative_b_now_closes` (promoted from
    fallthrough; `∫ 1/(1 − 2·cos x) dx`)
  - `test_phase37_cos_negative_b_with_negative_a`
    (`∫ 1/(−1 − 3·cos x) dx`)
  - `test_phase37_cos_negative_b_with_numerator_coefficient`
    (`∫ 5/(1 − 2·cos x) dx`)
- [x] Full suite: **1686 passed, 85 skipped, 81.44% coverage**
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)