### PR TITLE
feat(symbolic-vm): port Phase 37 (cos b<−|a|) to TypeScript (0.10.0)

### DIFF
--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.10.0] — 2026-05-20
+
+### Changed — Phase 37: Weierstrass log form cos branch covers `b < −|a|`
+
+Mirrors Python `symbolic-vm` 0.62.0 (PR #3683).
+
+Phase 36 (0.9.0) emitted the log-form closed solution for `a² < b²`
+but explicitly deferred the cos branch with `b < −|a|`.  A closer
+derivation shows the same formula
+
+    (c/D) · log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
+
+already handles both sign regimes correctly when wrapped in `Abs`.
+
+`tryWeierstrassLogForm` cos branch: removed the
+`subNumeric(b, absNumeric(a))` and `subNumeric(b, a)` positivity guards.
+The remaining caller-side guarantee (`disc < 0`, i.e. `b² > a²`) is
+sufficient.  `absNumeric` is retained (still referenced) for any future
+symmetric guards.
+
+Tests: 3 new in `tests/phase34-weierstrass.test.ts`:
+- Promoted: `∫ 1/(1 − 2·cos x) dx` (formerly deferred)
+- `∫ 1/(−1 − 3·cos x) dx` (negative a, negative b)
+- `∫ 5/(1 − 2·cos x) dx` (numerator scaling)
+
+Full suite: **145 tests pass** (143 prior + 3 new − 1 promoted).
+
 ## [0.9.0] — 2026-05-20
 
 ### Added — Phase 36: Weierstrass log form for `a² < b²`

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1877,10 +1877,19 @@ function tryWeierstrassLogForm(
     const coefIR = app(DIV, [fromNumeric(c), sqrtDiscIR]);
     return app(MUL, [coefIR, app(LOG, [logArg])]);
   }
-  // COS branch: require b > |a| strictly.
-  if (!isPositiveNumeric(subNumeric(b, absNumeric(a)))) return undefined;
+  // COS branch — handles both b > |a| and b < −|a| (Phase 37 extension).
+  //
+  // The same expression log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
+  // is valid for both sign regimes because the inner rational is wrapped
+  // in Abs: when (b−a) flips sign, the numerator and denominator of the
+  // log argument swap (D − k·u and D + k·u), but |N/D'| = |D'/N| so the
+  // absolute value collapses them to the same value.  The antiderivative
+  // is continuous across both sides of b = ±|a|.
+  //
+  // Caller already ensures b² > a² (disc < 0 entry); the only additional
+  // precondition is a + b ≠ 0, which is automatic because b² > a² rules
+  // out b = −a.
   const bMinusA = subNumeric(b, a);
-  if (!isPositiveNumeric(bMinusA)) return undefined;
   // log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
   const bmaTan = app(MUL, [fromNumeric(bMinusA), tanHalf]);
   const numer = app(ADD, [sqrtDiscIR, bmaTan]);

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -377,12 +377,46 @@ describe("Phase 36: log form for a² < b²", () => {
     }
   });
 
-  it("cos branch with b < |a| still defers (1 − 2·cos x)", () => {
+  it("Phase 37: cos branch with b < −|a| (∫ 1/(1 − 2·cos x) dx) now closes", () => {
     const vm = makeVM();
     const integrand = app(DIV, [int(1), app(SUB, [int(1), app(MUL, [int(2), app(COS, [X])])])]);
-    const result = vm.eval(integrate(integrand));
-    // The b = -2 < |a| = 1 branch is deferred — log argument has the
-    // opposite sign pattern.
-    expect(isUnevaluatedIntegrate(result)).toBe(true);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // 1 − 2 cos x zeros at cos x = 1/2 (x = ±π/3 ≈ ±1.047).
+    // Sample on (π/3, π) where the integrand is real and finite.
+    for (const xVal of [1.2, 1.6, 2.0, 2.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (1.0 - 2.0 * Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+});
+
+describe("Phase 37: cos branch with b < −|a|", () => {
+  it("∫ 1/(−1 − 3·cos x) dx — both a and b negative", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [
+      int(1),
+      app(SUB, [int(-1), app(MUL, [int(3), app(COS, [X])])]),
+    ]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // −1 − 3 cos x zeros at cos x = −1/3.  Sample safely.
+    for (const xVal of [0.5, 1.0, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (-1.0 - 3.0 * Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("∫ 5/(1 − 2·cos x) dx — numerator scales", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(5), app(SUB, [int(1), app(MUL, [int(2), app(COS, [X])])])]);
+    const phi = vm.eval(integrate(integrand));
+    for (const xVal of [1.2, 1.6, 2.0, 2.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 5.0 / (1.0 - 2.0 * Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Mirrors Python PR #3683. Removes the cos-branch guards in
`tryWeierstrassLogForm` that rejected `b < −|a|`. The same log formula
with `Abs` wrapping handles both sign regimes correctly.

## Test plan

- [x] 3 new tests (1 promoted from fallthrough, 2 new)
- [x] Full TS suite: **145 passed** (143 prior + 3 new − 1 promoted)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)