### PR TITLE
Add WHATWG select list audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -40,6 +40,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser select/list audit
+  generator alongside the other parser audit fixture generators.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -166,6 +166,13 @@ def default_checks() -> list[FixtureCheck]:
                 "--check",
             ),
         ),
+        FixtureCheck(
+            "whatwg-select-list-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_select_list_audit_fixture.py"),
+                "--check",
+            ),
+        ),
     ]
 
 

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -33,10 +33,13 @@ documented in this file.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
+- Generated WHATWG select/list audit fixture over html5lib select shell,
+  option implied-end, optgroup-boundary, select-in-table, fragment-context, and
+  stray select/list end-tag cases, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control, and
-  foreign-content, formatting, and document-shell audit checks on the same
-  parser and DOM dump path.
+  foreign-content, formatting, document-shell, and select/list audit checks on
+  the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -176,6 +176,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_s
   --check
 ```
 
+The generated `tests/fixtures/whatwg-select-list-audit.json` fixture indexes
+select shells, option implied-end recovery, optgroup boundaries,
+select-in-table handling, select fragment contexts, and stray select/list end
+tags:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py \
+  --check
+```
+
 The broad smoke test and the focused audit fixtures use the shared
 `tests/common` html5lib parser and DOM dump helpers, so new parser conformance
 fixtures exercise the same normalization path.

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -130,3 +130,14 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_s
 python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py \
   --check
 ```
+
+`whatwg-select-list-audit.json` is a generated index over tree-construction
+cases that stress select shells, adjacent option implied-end recovery, optgroup
+boundaries, select-in-table handling, select fragment contexts, and stray
+select/list end tags:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py \
+  --check
+```

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG select/list audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-select-list-audit.json"
+
+SELECT_MARKUP = re.compile(r"</?(?:select|option|optgroup)(?:\s|/|>)", re.I)
+SELECT_FRAGMENT_CONTEXTS = {"select", "option", "optgroup"}
+
+CASE_AXES = (
+    {
+        "axis": "select-shell",
+        "reason": "select start/end tags and ordinary select insertion recovery",
+    },
+    {
+        "axis": "option-implied-end",
+        "reason": "adjacent option starts and omitted option end-tag recovery",
+    },
+    {
+        "axis": "optgroup-boundary",
+        "reason": "optgroup starts, ends, and option boundaries inside groups",
+    },
+    {
+        "axis": "select-in-table",
+        "reason": "select handling while table insertion modes are active",
+    },
+    {
+        "axis": "select-fragment-context",
+        "reason": "fragment parsing in select, option, and optgroup contexts",
+    },
+    {
+        "axis": "stray-select-end-tags",
+        "reason": "stray select, option, and optgroup end-tag recovery",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG select/list audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_select_list_case(case_data, fragment_context):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any select/list audit cases")
+    return cases
+
+
+def is_select_list_case(data: str, fragment_context: str | None) -> bool:
+    if (
+        fragment_context is not None
+        and fragment_context.lower() in SELECT_FRAGMENT_CONTEXTS
+    ):
+        return True
+    return SELECT_MARKUP.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-select-list-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress select, option, and optgroup list recovery."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data.lower()
+    fragment_context = (case.fragment_context or "").lower()
+
+    if fragment_context in SELECT_FRAGMENT_CONTEXTS:
+        return "select-fragment-context"
+    if re.search(r"</(?:select|option|optgroup)(?:\s|/|>)", data) and not re.search(
+        r"<(?:select|option|optgroup)(?:\s|/|>)", data
+    ):
+        return "stray-select-end-tags"
+    if "<table" in data or "</table" in data:
+        return "select-in-table"
+    if re.search(r"<optgroup(?:\s|/|>)", data) or re.search(
+        r"</optgroup(?:\s|/|>)", data
+    ):
+        return "optgroup-boundary"
+    if len(re.findall(r"<option(?:\s|/|>)", data)) > 1:
+        return "option-implied-end"
+    return "select-shell"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown select/list audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-select-list-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-select-list-audit.json
@@ -1,0 +1,808 @@
+{
+  "case_count": 132,
+  "cases": [
+    {
+      "axis": "select-shell",
+      "id": "domjs-unsafe-dat-153",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "domjs-unsafe.dat:153"
+    },
+    {
+      "axis": "select-shell",
+      "id": "domjs-unsafe-dat-158",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "domjs-unsafe.dat:158"
+    },
+    {
+      "axis": "select-shell",
+      "id": "domjs-unsafe-dat-159",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "domjs-unsafe.dat:159"
+    },
+    {
+      "axis": "select-shell",
+      "id": "menuitem-element-dat-319",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "menuitem-element.dat:319"
+    },
+    {
+      "axis": "select-shell",
+      "id": "menuitem-element-dat-320",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "menuitem-element.dat:320"
+    },
+    {
+      "axis": "select-shell",
+      "id": "menuitem-element-dat-321",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "menuitem-element.dat:321"
+    },
+    {
+      "axis": "select-shell",
+      "id": "plain-text-unsafe-dat-355",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "plain-text-unsafe.dat:355"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tables01-dat-442",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tables01.dat:442"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tables01-dat-443",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tables01.dat:443"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tables01-dat-444",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tables01.dat:444"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tables01-dat-445",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tables01.dat:445"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tables01-dat-453",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tables01.dat:453"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-473",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:473"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-474",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:474"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "template-dat-475",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "template.dat:475"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-476",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:476"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-477",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:477"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-478",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:478"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-479",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:479"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "template-dat-480",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "template.dat:480"
+    },
+    {
+      "axis": "select-shell",
+      "id": "template-dat-545",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "template.dat:545"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "template-dat-556",
+      "reason": "select handling while table insertion modes are active",
+      "source": "template.dat:556"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests1-dat-595",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests1.dat:595"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests1-dat-600",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests1.dat:600"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests1-dat-665",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests1.dat:665"
+    },
+    {
+      "axis": "stray-select-end-tags",
+      "id": "tests1-dat-675",
+      "reason": "stray select, option, and optgroup end-tag recovery",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "stray-select-end-tags",
+      "id": "tests1-dat-676",
+      "reason": "stray select, option, and optgroup end-tag recovery",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests10-dat-681",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests10.dat:681"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests10-dat-682",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests10.dat:682"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests10-dat-694",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests10.dat:694"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests10-dat-695",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests10.dat:695"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-965",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:965"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-966",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:966"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-967",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:967"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-968",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:968"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-969",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:969"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-970",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:970"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-971",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:971"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-972",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:972"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-973",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:973"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-974",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:974"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-975",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:975"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-976",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:976"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests18-dat-991",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests18.dat:991"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests18-dat-992",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests18.dat:992"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests18-dat-1005",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests18.dat:1005"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests18-dat-1006",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests18.dat:1006"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests18-dat-1007",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests18.dat:1007"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests19-dat-1041",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests19.dat:1041"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests19-dat-1042",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests19.dat:1042"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests19-dat-1043",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests19.dat:1043"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests19-dat-1085",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests19.dat:1085"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests20-dat-1167",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests20.dat:1167"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests20-dat-1168",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests20.dat:1168"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests2-dat-37",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests2.dat:37"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests2-dat-38",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests2.dat:38"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests2-dat-39",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests2.dat:39"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests2-dat-40",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests2.dat:40"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests2-dat-49",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests2.dat:49"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests9-dat-5",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests9.dat:5"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests9-dat-6",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests9.dat:6"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests9-dat-18",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests9.dat:18"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests9-dat-19",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests9.dat:19"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests7-dat-17",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests7.dat:17"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests7-dat-18",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests7.dat:18"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests7-dat-24",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests7.dat:24"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests7-dat-25",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests7.dat:25"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests7-dat-34",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests7.dat:34"
+    },
+    {
+      "axis": "select-fragment-context",
+      "id": "tests-innerhtml-1-dat-75",
+      "reason": "fragment parsing in select, option, and optgroup contexts",
+      "source": "tests_innerHTML_1.dat:75"
+    },
+    {
+      "axis": "select-fragment-context",
+      "id": "tests-innerhtml-1-dat-77",
+      "reason": "fragment parsing in select, option, and optgroup contexts",
+      "source": "tests_innerHTML_1.dat:77"
+    },
+    {
+      "axis": "select-fragment-context",
+      "id": "tests-innerhtml-1-dat-78",
+      "reason": "fragment parsing in select, option, and optgroup contexts",
+      "source": "tests_innerHTML_1.dat:78"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests1-dat-30",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests1.dat:30"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests1-dat-35",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests1.dat:35"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests1-dat-100",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests1.dat:100"
+    },
+    {
+      "axis": "stray-select-end-tags",
+      "id": "tests1-dat-110",
+      "reason": "stray select, option, and optgroup end-tag recovery",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "stray-select-end-tags",
+      "id": "tests1-dat-111",
+      "reason": "stray select, option, and optgroup end-tag recovery",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests10-dat-4",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests10.dat:4"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests10-dat-5",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests10.dat:5"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests10-dat-17",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests10.dat:17"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests10-dat-18",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests10.dat:18"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-1",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:1"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-2",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:2"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-3",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:3"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-4",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:4"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests17-dat-5",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests17.dat:5"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-6",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:6"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-7",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:7"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-8",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:8"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-9",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:9"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-10",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:10"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-11",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:11"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests17-dat-12",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests17.dat:12"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests18-dat-14",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests18.dat:14"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests18-dat-15",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests18.dat:15"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests18-dat-28",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests18.dat:28"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests18-dat-29",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests18.dat:29"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "tests18-dat-30",
+      "reason": "select handling while table insertion modes are active",
+      "source": "tests18.dat:30"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests19-dat-28",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests19.dat:28"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests19-dat-29",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests19.dat:29"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "tests19-dat-30",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "tests19.dat:30"
+    },
+    {
+      "axis": "select-shell",
+      "id": "tests19-dat-72",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "tests19.dat:72"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests20-dat-51",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests20.dat:51"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "tests20-dat-52",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "tests20.dat:52"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "webkit01-dat-32",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "webkit01.dat:32"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit01-dat-37",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit01.dat:37"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit01-dat-38",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit01.dat:38"
+    },
+    {
+      "axis": "select-fragment-context",
+      "id": "webkit02-dat-19",
+      "reason": "fragment parsing in select, option, and optgroup contexts",
+      "source": "webkit02.dat:19"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-26",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:26"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-27",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:27"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "webkit02-dat-28",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "webkit02.dat:28"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "webkit02-dat-29",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "webkit02.dat:29"
+    },
+    {
+      "axis": "optgroup-boundary",
+      "id": "webkit02-dat-30",
+      "reason": "optgroup starts, ends, and option boundaries inside groups",
+      "source": "webkit02.dat:30"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit02-dat-31",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit02.dat:31"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit02-dat-32",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit02.dat:32"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit02-dat-33",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit02.dat:33"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit02-dat-34",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit02.dat:34"
+    },
+    {
+      "axis": "select-in-table",
+      "id": "webkit02-dat-35",
+      "reason": "select handling while table insertion modes are active",
+      "source": "webkit02.dat:35"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-36",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:36"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-37",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:37"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-38",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:38"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-39",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:39"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-40",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:40"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-41",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:41"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-42",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:42"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-43",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:43"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-44",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:44"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-45",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:45"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-46",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:46"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "webkit02-dat-47",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "webkit02.dat:47"
+    },
+    {
+      "axis": "option-implied-end",
+      "id": "webkit02-dat-48",
+      "reason": "adjacent option starts and omitted option end-tag recovery",
+      "source": "webkit02.dat:48"
+    },
+    {
+      "axis": "select-shell",
+      "id": "webkit02-dat-49",
+      "reason": "select start/end tags and ordinary select insertion recovery",
+      "source": "webkit02.dat:49"
+    },
+    {
+      "axis": "select-fragment-context",
+      "id": "tests-innerhtml-1-dat-76",
+      "reason": "fragment parsing in select, option, and optgroup contexts",
+      "source": "tests_innerHTML_1.dat:76"
+    }
+  ],
+  "counts_by_axis": {
+    "optgroup-boundary": 13,
+    "option-implied-end": 15,
+    "select-fragment-context": 5,
+    "select-in-table": 36,
+    "select-shell": 59,
+    "stray-select-end-tags": 4
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress select, option, and optgroup list recovery.",
+  "format": "whatwg-html-select-list-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_select_list_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_select_list_audit_test.rs
@@ -1,0 +1,85 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct SelectListAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<SelectListAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SelectListAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_select_list_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-select-list-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 130);
+    assert_axis_count(&suite, "select-shell", 50);
+    assert_axis_count(&suite, "option-implied-end", 12);
+    assert_axis_count(&suite, "optgroup-boundary", 10);
+    assert_axis_count(&suite, "select-in-table", 30);
+    assert_axis_count(&suite, "select-fragment-context", 5);
+    assert_axis_count(&suite, "stray-select-end-tags", 4);
+}
+
+#[test]
+fn whatwg_select_list_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> SelectListAuditSuite {
+    serde_json::from_str(WHATWG_SELECT_LIST_AUDIT)
+        .expect("WHATWG select/list audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &SelectListAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG select/list parser audit fixture with 132 html5lib tree-construction cases across select shell, option implied-end, optgroup, select-in-table, fragment-context, and stray-end-tag axes
- add a dedicated parser regression test that replays every selected case through the shared DOM dump helper
- wire the generator into the generated HTML fixture manifest and document the new audit fixture

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser whatwg_select_list_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report