### PR TITLE
feat(symbolic-vm): port Phase 37 (cos b<−|a|) to Rust (0.10.0)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.10.0] — 2026-05-20
+
+### Changed — Phase 37: Weierstrass log form cos branch covers `b < −|a|`
+
+Mirrors Python `symbolic-vm` 0.62.0 (PR #3683) and TypeScript
+`symbolic-vm` 0.10.0 (PR #3685).
+
+`try_weierstrass_log_form` cos branch: removed the
+`b_minus_abs_a` and `b_minus_a` positivity guards.  The same log
+formula with `Abs` wrapping handles both `b > |a|` and `b < −|a|`.
+
+Tests: 3 new in `tests/test_vm.rs` (one promoted from
+fallthrough):
+- `phase37_cos_negative_b_now_closes` — `∫ 1/(1 − 2·cos x) dx`
+- `phase37_cos_negative_b_with_negative_a` — `∫ 1/(−1 − 3·cos x) dx`
+- `phase37_cos_negative_b_with_numerator_coefficient` — `∫ 5/(1 − 2·cos x) dx`
+
+Full suite: **179 passed** (177 prior + 3 new − 1 promoted).
+
 ## [0.9.0] — 2026-05-20
 
 ### Added — Phase 36: Weierstrass log form for `a² < b²`

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1657,16 +1657,18 @@ fn try_weierstrass_log_form(
         let coef_ir = apply_node(DIV, vec![rc_to_ir(c)?, sqrt_disc_ir]);
         return Some(apply_node(MUL, vec![coef_ir, apply_node(LOG, vec![log_arg])]));
     }
-    // COS branch: require b > |a| strictly.
-    let abs_a = (a.0.abs(), a.1);
-    let b_minus_abs_a = rc_sub(b, abs_a)?;
-    if b_minus_abs_a.0 <= 0 {
-        return None;
-    }
+    // COS branch — handles both b > |a| and b < −|a| (Phase 37 extension).
+    //
+    // The same expression log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
+    // is valid for both sign regimes because the inner rational is wrapped
+    // in Abs: when (b−a) flips sign, the numerator and denominator of the
+    // log argument swap (D − k·u and D + k·u), but |N/D'| = |D'/N| so the
+    // absolute value collapses them to the same value.
+    //
+    // Caller already ensures b² > a² (disc < 0 entry); the only additional
+    // precondition is a + b ≠ 0, which is automatic because b² > a² rules
+    // out b = −a.
     let b_minus_a = rc_sub(b, a)?;
-    if b_minus_a.0 <= 0 {
-        return None;
-    }
     // log|(D + (b−a)·tan(x/2)) / (D − (b−a)·tan(x/2))|
     let bma_tan = apply_node(MUL, vec![rc_to_ir(b_minus_a)?, tan_half]);
     let numer = apply_node(ADD, vec![sqrt_disc_ir.clone(), bma_tan.clone()]);

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2788,8 +2788,9 @@ fn phase36_perfect_square_discriminant() {
 }
 
 #[test]
-fn phase36_cos_negative_b_still_defers() {
-    // ∫ 1/(1 − 2·cos x) dx — effective b=-2 < |a|=1; cos branch defers.
+fn phase37_cos_negative_b_now_closes() {
+    // ∫ 1/(1 − 2·cos x) dx — Phase 37 (cos b<−|a|) now closes via the
+    // same log formula as Phase 36; Abs wrapping handles the sign flip.
     let integrand = apply(
         sym(DIV),
         vec![
@@ -2800,6 +2801,51 @@ fn phase36_cos_negative_b_still_defers() {
             ),
         ],
     );
-    let result = integrate(integrand);
-    assert!(is_unevaluated_integrate(&result));
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    // 1 − 2 cos x zeros at cos x = 1/2 (x = ±π/3 ≈ ±1.047).
+    // Sample on (π/3, π).
+    for &x_val in &[1.2_f64, 1.6, 2.0, 2.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (1.0 - 2.0 * x_val.cos());
+        assert!((got - expected).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn phase37_cos_negative_b_with_negative_a() {
+    // ∫ 1/(−1 − 3·cos x) dx — both a and b negative.
+    let neg_one_minus_three_cos = apply(
+        sym(SUB),
+        vec![int(-1), apply(sym(MUL), vec![int(3), apply(sym(COS), vec![sym("x")])])],
+    );
+    let integrand = apply(sym(DIV), vec![int(1), neg_one_minus_three_cos]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    for &x_val in &[0.5_f64, 1.0, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (-1.0 - 3.0 * x_val.cos());
+        assert!((got - expected).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn phase37_cos_negative_b_with_numerator_coefficient() {
+    // ∫ 5/(1 − 2·cos x) dx — numerator c=5 scales.
+    let integrand = apply(
+        sym(DIV),
+        vec![
+            int(5),
+            apply(
+                sym(SUB),
+                vec![int(1), apply(sym(MUL), vec![int(2), apply(sym(COS), vec![sym("x")])])],
+            ),
+        ],
+    );
+    let phi = integrate(integrand);
+    for &x_val in &[1.2_f64, 1.6, 2.0, 2.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 5.0 / (1.0 - 2.0 * x_val.cos());
+        assert!((got - expected).abs() < 1e-3);
+    }
 }


### PR DESCRIPTION
## Summary

Mirrors Python PR #3683 and TS PR #3685. Removes the cos-branch
guards in `try_weierstrass_log_form` that rejected `b < −|a|`. Same
log formula with `Abs` wrapping handles both sign regimes.

## Test plan

- [x] 3 new tests (1 promoted from fallthrough, 2 new variants)
- [x] Full Rust suite: **179 passed** (177 prior + 3 new − 1 promoted)
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)