### PR TITLE
feat(symbolic-vm): Phase 38 — Weierstrass for non-bare trig arguments (Python 0.63.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## 0.63.0 — 2026-05-20
+
+**Phase 38 — Weierstrass closed forms lifted to linear trig arguments
+`sin(α·x + β)` and `cos(α·x + β)`.**
+
+The previous Phases 34–37 closed Weierstrass for `∫ c / (a + b·trig(x)) dx`
+in all discriminant regimes (`a² > b²` arctan, `a² = b²` degenerate,
+`a² < b²` log) but only when the trig argument was the bare variable
+`x`.  Phase 38 generalises every branch to accept any linear-in-`x`
+rational argument `α·x + β` (with `α, β ∈ Q`, `α ≠ 0`).
+
+The mathematics is a single inner change of variable: with `u = α·x + β`
+we have `du = α · dx`, so
+
+    ∫ c/(a + b·sin(α·x + β)) dx
+        =  (1/α) · ∫ c/(a + b·sin u) du   (Phase 34/36/37 closed form in `u`)
+
+The closed form is the existing one with `tan((α·x + β)/2)` substituted
+for `tan(x/2)` and the outer constant scaled by `1/α`.  When `α = 1` and
+`β = 0`, the new code path is bit-for-bit identical to the old Phases
+34–37 — full backwards compatibility.
+
+### Added
+
+- **`_parse_linear_in_x(node, x)`** in `integrate.py` — parses a node
+  into a `(α, β)` rational pair when it represents `α·x + β`.  Handles
+  bare `x`, scalar multiples, ADD/SUB with any operand ordering, and
+  leading `Neg` wrappers.  Rejects nonlinear (`x²`) and pure-constant
+  shapes by returning `None`.  `α = 0` is filtered out so callers may
+  rely on `α ≠ 0` throughout.
+- **`_build_linear_arg_ir(α, β, x)`** — converts the parsed `(α, β)`
+  back into IR, collapsing trivial cases (`α=1, β=0 → x`, etc.) so the
+  emitted `tan(arg/2)` carries the simplest equivalent argument.
+- **`_parse_const_times_trig_linear(node, x)`** — supersedes the
+  Phase 34 bare-`x` predecessor.  Returns `(c, head, α, β)` for any
+  shape matching `c·sin(α·x+β)` or `c·cos(α·x+β)` (plus all the
+  scalar / Neg / order variants the old code handled).
+
+### Changed
+
+- **`_parse_a_plus_b_sincos`** — now returns `(a, b, head, α, β)`
+  instead of `(a, b, head)`.  All four signs/orderings of the parent
+  ADD/SUB pattern continue to work; the extra `α, β` carry the inner
+  trig argument's linear coefficients through to the dispatcher.
+- **`_try_weierstrass_degenerate`, `_try_weierstrass_log_form`,
+  `_try_weierstrass_one_over_linear_trig`** — accept an `arg_node`
+  IR parameter representing `α·x + β` and substitute it into the
+  `tan(arg/2)` construction.  The outer `c ← c/α` scaling is applied
+  once at the dispatcher entry, so each branch's closed form is
+  otherwise unchanged.
+
+### Added — tests
+
+`tests/test_phase34_weierstrass.py` (10 new cases, including one
+promoted from the prior fallthrough):
+
+- `test_phase38_sin_two_x_closes` — `∫ 1/(2 + sin(2x)) dx` closes; the
+  derivative numerically matches `1/(2 + sin 2x)` on `(−π/2, π/2)`.
+- `test_phase38_cos_three_x` — `α = 3` cos variant.
+- `test_phase38_sin_x_plus_constant_phase` — `α = 1, β = 1` isolates
+  the phase shift.
+- `test_phase38_sin_two_x_plus_phase` — full `α = 2, β = 1` general case.
+- `test_phase38_rational_alpha` — `α = 1/2` rational coefficient.
+- `test_phase38_negative_alpha` — `α = −2` sign-flipped case.
+- `test_phase38_degenerate_branch_under_substitution` — `∫ 1/(1+cos 2x) dx`
+  exercises the Phase 35 degenerate path with α=2.
+- `test_phase38_log_form_under_substitution` — `∫ 1/(1+2·sin 2x) dx`
+  exercises the Phase 36 log path with α=2.
+- `test_phase38_fallthrough_nonlinear_argument` — `sin(x²)` is correctly
+  left unevaluated.
+- `test_phase38_fallthrough_symbolic_alpha` — `sin(α·x)` with symbolic
+  α defers gracefully.
+
+### Still deferred
+
+- Symbolic coefficients (`a`, `b`, `α`, or `β` non-numeric) — needs an
+  assumption context to decide discriminant sign.
+- Trig argument involving `x²` or other nonlinear forms — out of scope
+  for Weierstrass; a future substitution phase would compose with these.
+
 ## 0.62.0 — 2026-05-20
 
 **Phase 37 — Weierstrass log form extended to `b < −|a|` cos branch.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.62.0"
+version = "0.63.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -806,21 +806,39 @@ def _rational_to_ir(
 
 
 # ----------------------------------------------------------------------
-# Phase 34 — Weierstrass substitution for ∫ c/(a + b·sin(x)) dx and
-# ∫ c/(a + b·cos(x)) dx with numeric a, b satisfying a² > b².
+# Phase 34/35/36/37/38 — Weierstrass substitution for
+# ∫ c / (a + b·trig(α·x + β)) dx with numeric (rational) `c, a, b, α, β`
+# and `α ≠ 0`.
 #
-# The substitution u = tan(x/2) gives sin(x) = 2u/(1+u²),
-# cos(x) = (1-u²)/(1+u²), dx = 2/(1+u²) du.  Applying it to the two
-# canonical integrands reduces both to a single rational function of u
-# that integrates to an arctan (when the resulting quadratic in u has
-# negative discriminant, i.e. a² > b²).  Direct closed forms:
+# The substitution `u = tan(arg/2)` with `arg = α·x + β` gives
+# `sin(arg) = 2u/(1+u²)`, `cos(arg) = (1−u²)/(1+u²)`,
+# `darg = α·dx = 2/(1+u²) du`.  Reducing both canonical integrands to a
+# rational function of `u` yields, depending on the discriminant
+# `disc = a² − b²`:
 #
-#     ∫ 1/(a + b·sin x) dx  =  (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
-#     ∫ 1/(a + b·cos x) dx  =  (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
+#   Phase 34 (disc > 0 — arctan):
+#     ∫ 1/(a + b·sin arg) dx
+#         =  (2/(α·√(a²−b²))) · arctan((a·tan(arg/2) + b)/√(a²−b²))
+#     ∫ 1/(a + b·cos arg) dx                (a > 0 required for this form)
+#         =  (2/(α·√(a²−b²))) · arctan(√((a−b)/(a+b)) · tan(arg/2))
 #
-# Cases a² < b² (log form) and a² = b² (rational-in-tan form) are
-# intentionally deferred — they need a sign-determination on the
-# argument inside log, and are less common in practice.
+#   Phase 35 (disc = 0 — degenerate, no outer arctan):
+#     Four sign combinations on (a, b, head) ⇒ tan(arg/2) / cot(arg/2)
+#     closed forms.
+#
+#   Phase 36/37 (disc < 0 — log form):
+#     ∫ 1/(a + b·sin arg) dx
+#         =  (1/(α·D)) · log|(a·tan(arg/2) + b − D)/(a·tan(arg/2) + b + D)|
+#     ∫ 1/(a + b·cos arg) dx
+#         =  (1/(α·D)) · log|(D + (b−a)·tan(arg/2))/(D − (b−a)·tan(arg/2))|
+#     where D = √(b² − a²).  The Abs wrapping covers both `b > |a|` and
+#     `b < −|a|` regimes simultaneously (Phase 37).
+#
+# Phase 38 lifts the entire family from the bare-`x` argument to any
+# linear rational ``α·x + β``.  The single change of variable
+# `u = α·x + β` (with `du = α·dx`) scales the antiderivative by `1/α`,
+# which we fold into the numerator constant `c ← c/α` at the dispatcher
+# entry — so each branch's closed form remains unchanged structurally.
 # ----------------------------------------------------------------------
 
 
@@ -845,19 +863,136 @@ def _sqrt_fraction_ir(f: Fraction) -> IRNode:
     return IRApply(SQRT, (_frac_ir(f),))
 
 
-def _parse_const_times_trig_x(
+def _parse_linear_in_x(
     node: IRNode, x: IRSymbol
-) -> tuple[Fraction, IRSymbol] | None:
-    """Match ``c·sin(x)`` / ``c·cos(x)`` / ``sin(x)`` / ``cos(x)`` and return
-    ``(c, head)``.
+) -> tuple[Fraction, Fraction] | None:
+    """Parse ``α·x + β`` (with α, β ∈ Q, α ≠ 0) and return ``(α, β)``.
+
+    Recognised shapes (any operand ordering within commutative heads):
+
+    +----------------------+----------+
+    | Shape                | Returns  |
+    +======================+==========+
+    | ``x``                | (1, 0)   |
+    | ``α·x``              | (α, 0)   |
+    | ``α·x + β``          | (α, β)   |
+    | ``β + α·x``          | (α, β)   |
+    | ``α·x − β``          | (α, −β)  |
+    | ``β − α·x``          | (−α, β)  |
+    | ``−(α·x + β)``       | (−α, −β) |
+    +----------------------+----------+
+
+    Returns ``None`` when ``node`` is not a linear-in-``x`` rational
+    combination (e.g. ``x²``, ``sin(x)``, pure constants free of ``x``,
+    or a nested nonlinear form).  This is the Phase 38 generalisation
+    of the bare-``x`` predecessor: ``α = 1, β = 0`` recovers the old
+    behaviour exactly.
+    """
+    # Bare variable shortcut.
+    if node == x:
+        return Fraction(1), Fraction(0)
+    # Constants free of ``x`` are not linear-in-``x`` (no x term).
+    if not _depends_on(node, x):
+        return None
+    # ``α·x`` — Mul of constant and ``x`` (either order).  Reject α = 0
+    # so callers can rely on α ≠ 0 throughout.
+    if isinstance(node, IRApply) and node.head == MUL and len(node.args) == 2:
+        left, right = node.args
+        c_left = _node_to_frac(left)
+        if c_left is not None and right == x and c_left != 0:
+            return c_left, Fraction(0)
+        c_right = _node_to_frac(right)
+        if c_right is not None and left == x and c_right != 0:
+            return c_right, Fraction(0)
+        return None
+    # ``−(linear)`` — unwrap and negate both coefficients.
+    if isinstance(node, IRApply) and node.head == NEG and len(node.args) == 1:
+        inner = _parse_linear_in_x(node.args[0], x)
+        if inner is None:
+            return None
+        a, b = inner
+        return -a, -b
+    # ``ADD(const, linear)`` or ``ADD(linear, const)``.
+    if isinstance(node, IRApply) and node.head == ADD and len(node.args) == 2:
+        left, right = node.args
+        for const_side, lin_side in ((left, right), (right, left)):
+            c = _node_to_frac(const_side)
+            if c is None:
+                continue
+            lin = _parse_linear_in_x(lin_side, x)
+            if lin is None:
+                continue
+            a, b = lin
+            return a, b + c
+        return None
+    # ``SUB(left, right)`` — two distinct cases depending on which side
+    # carries the ``x`` dependence.
+    if isinstance(node, IRApply) and node.head == SUB and len(node.args) == 2:
+        left, right = node.args
+        # Case A: ``linear − constant`` → (α, β − c).
+        c_right = _node_to_frac(right)
+        if c_right is not None:
+            lin = _parse_linear_in_x(left, x)
+            if lin is not None:
+                a, b = lin
+                return a, b - c_right
+        # Case B: ``constant − linear`` → (−α, c − β).
+        c_left = _node_to_frac(left)
+        if c_left is not None:
+            lin = _parse_linear_in_x(right, x)
+            if lin is not None:
+                a, b = lin
+                return -a, c_left - b
+        return None
+    return None
+
+
+def _build_linear_arg_ir(
+    alpha: Fraction, beta: Fraction, x: IRSymbol
+) -> IRNode:
+    """Build an IR node for ``α·x + β`` collapsing the trivial cases.
+
+    The output is used inside ``tan(arg/2)`` in every Weierstrass closed
+    form, so we prefer the simplest equivalent shape:
+
+    - ``α = 1, β = 0`` → ``x``      (the historical bare path)
+    - ``α = 1, β ≠ 0`` → ``x + β``
+    - ``β = 0, α ≠ 1`` → ``α·x``
+    - otherwise         → ``(α·x) + β``
+    """
+    if alpha == 1 and beta == 0:
+        return x
+    if beta == 0:
+        return IRApply(MUL, (_frac_ir(alpha), x))
+    if alpha == 1:
+        return IRApply(ADD, (x, _frac_ir(beta)))
+    a_x = IRApply(MUL, (_frac_ir(alpha), x))
+    return IRApply(ADD, (a_x, _frac_ir(beta)))
+
+
+def _parse_const_times_trig_linear(
+    node: IRNode, x: IRSymbol
+) -> tuple[Fraction, IRSymbol, Fraction, Fraction] | None:
+    """Match ``c·sin(α·x + β)`` / ``c·cos(α·x + β)`` (and the c=1 / α=1 /
+    β=0 degenerate variants) and return ``(c, head, α, β)``.
 
     Accepts both argument orders within ``Mul`` and unwraps a leading
-    ``Neg``.  Argument inside trig must be the bare variable ``x``.
-    Returns ``None`` if the shape doesn't match.
+    ``Neg``.  The argument inside the trig must be linear in ``x`` per
+    :func:`_parse_linear_in_x`.  Returns ``None`` when the shape doesn't
+    fit (e.g. ``sin(x²)`` or ``sin(x)·cos(x)``).
+
+    Phase 38 generalises the predecessor :func:`_parse_const_times_trig_x`
+    which only accepted the bare-``x`` argument.
     """
-    if isinstance(node, IRApply) and node.head in (SIN, COS):
-        if len(node.args) == 1 and node.args[0] == x:
-            return Fraction(1), node.head
+    if (
+        isinstance(node, IRApply)
+        and node.head in (SIN, COS)
+        and len(node.args) == 1
+    ):
+        lin = _parse_linear_in_x(node.args[0], x)
+        if lin is not None:
+            alpha, beta = lin
+            return Fraction(1), node.head, alpha, beta
     if isinstance(node, IRApply) and node.head == MUL and len(node.args) == 2:
         left, right = node.args
         for const_side, trig_side in ((left, right), (right, left)):
@@ -868,50 +1003,53 @@ def _parse_const_times_trig_x(
                 isinstance(trig_side, IRApply)
                 and trig_side.head in (SIN, COS)
                 and len(trig_side.args) == 1
-                and trig_side.args[0] == x
             ):
-                return c, trig_side.head
+                lin = _parse_linear_in_x(trig_side.args[0], x)
+                if lin is not None:
+                    alpha, beta = lin
+                    return c, trig_side.head, alpha, beta
     if isinstance(node, IRApply) and node.head == NEG and len(node.args) == 1:
-        inner = _parse_const_times_trig_x(node.args[0], x)
+        inner = _parse_const_times_trig_linear(node.args[0], x)
         if inner is not None:
-            c, head = inner
-            return -c, head
+            c, head, alpha, beta = inner
+            return -c, head, alpha, beta
     return None
 
 
 def _parse_a_plus_b_sincos(
     node: IRNode, x: IRSymbol
-) -> tuple[Fraction, Fraction, IRSymbol] | None:
-    """Parse ``a + b·sin(x)`` / ``a + b·cos(x)`` (any operand order) into
-    ``(a, b, head)`` with ``a, b ∈ Q``.
+) -> tuple[Fraction, Fraction, IRSymbol, Fraction, Fraction] | None:
+    """Parse ``a + b·sin(α·x+β)`` / ``a + b·cos(α·x+β)`` (any operand
+    order) into ``(a, b, head, α, β)`` with ``a, b, α, β ∈ Q`` and
+    ``α ≠ 0``.
 
-    Accepts the SUB shape too (``a − b·sin(x)`` becomes ``(a, −b, sin)``).
-    Returns ``None`` if the shape isn't a binary linear combination of a
-    constant and a constant-multiple-of-trig-x.
+    Accepts the SUB shape too (``a − b·trig(αx+β)`` becomes
+    ``(a, −b, head, α, β)``).  Returns ``None`` if the shape isn't a
+    binary linear combination of a constant and a constant-multiple of a
+    trig function of a linear-in-``x`` argument.  Phase 38 supersedes
+    the bare-``x``-only predecessor.
     """
     if not isinstance(node, IRApply) or len(node.args) != 2:
         return None
     if node.head == ADD:
         left, right = node.args
     elif node.head == SUB:
-        # Treat ``a − b·trig(x)`` as ``a + (−b)·trig(x)``: parse the
-        # right side and negate.  Symmetric ``b·trig(x) − a`` is rarely
+        # Treat ``a − b·trig(...)`` as ``a + (−b)·trig(...)``: parse the
+        # right side and negate.  Symmetric ``b·trig(...) − a`` is rarely
         # the canonical form but we cover it via the swap branch below.
         left, right_raw = node.args
-        # Wrap right_raw in Neg synthetically — but we can't mutate; we'll
-        # just try both arrangements directly.
         a_left = _node_to_frac(left)
         if a_left is not None:
-            trig_parse = _parse_const_times_trig_x(right_raw, x)
+            trig_parse = _parse_const_times_trig_linear(right_raw, x)
             if trig_parse is not None:
-                b, head = trig_parse
-                return a_left, -b, head
-        # Try ``b·trig(x) − a`` = (−a) + b·trig(x)
-        b_trig_left = _parse_const_times_trig_x(left, x)
+                b, head, alpha, beta = trig_parse
+                return a_left, -b, head, alpha, beta
+        # Try ``b·trig(...) − a`` = (−a) + b·trig(...)
+        b_trig_left = _parse_const_times_trig_linear(left, x)
         a_right = _node_to_frac(right_raw)
         if b_trig_left is not None and a_right is not None:
-            b, head = b_trig_left
-            return -a_right, b, head
+            b, head, alpha, beta = b_trig_left
+            return -a_right, b, head, alpha, beta
         return None
     else:
         return None
@@ -920,11 +1058,11 @@ def _parse_a_plus_b_sincos(
         a = _node_to_frac(const_side)
         if a is None:
             continue
-        trig_parse = _parse_const_times_trig_x(trig_side, x)
+        trig_parse = _parse_const_times_trig_linear(trig_side, x)
         if trig_parse is None:
             continue
-        b, head = trig_parse
-        return a, b, head
+        b, head, alpha, beta = trig_parse
+        return a, b, head, alpha, beta
     return None
 
 
@@ -933,9 +1071,16 @@ def _try_weierstrass_degenerate(
     a: Fraction,
     b: Fraction,
     trig_head: IRSymbol,
-    x: IRSymbol,
+    arg_node: IRNode,
 ) -> IRNode | None:
     """Phase 35: degenerate ``a² = b²`` Weierstrass cases.
+
+    Phase 38 generalisation: ``arg_node`` is the IR for the trig
+    argument ``α·x + β``.  The substitution ``u = tan(arg/2)`` carries
+    through unchanged because the inner factor ``α`` has already been
+    absorbed into ``c`` by the caller (``c ← c/α``); see
+    :func:`_try_weierstrass_one_over_linear_trig`.
+
 
     Four sign combinations on ``(a, b, trig_head)``:
 
@@ -973,7 +1118,7 @@ def _try_weierstrass_degenerate(
         # disc = 0 and a = 0 implies b = 0 too — degenerate denominator
         # ``0 + 0·sin x = 0``; integrating 1/0 is undefined.  Punt.
         return None
-    tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))
+    tan_half = IRApply(TAN, (IRApply(DIV, (arg_node, TWO)),))
     if trig_head == SIN:
         if b == a:
             # ∫ c/(a + a·sin x) dx = -2c / (a · (tan(x/2) + 1))
@@ -1009,11 +1154,16 @@ def _try_weierstrass_log_form(
     a: Fraction,
     b: Fraction,
     trig_head: IRSymbol,
-    x: IRSymbol,
+    arg_node: IRNode,
 ) -> IRNode | None:
     """Phase 36: ``∫ c / (a + b·sin(x)) dx`` and ``∫ c / (a + b·cos(x)) dx``
     when ``a² < b²`` (the quadratic in u = tan(x/2) has two distinct real
     roots).
+
+    Phase 38 generalisation: ``arg_node`` is the IR for the trig
+    argument ``α·x + β``; the inner factor ``α`` has been pre-absorbed
+    into ``c`` by the caller.  The same closed forms apply with
+    ``tan(arg/2)`` in place of ``tan(x/2)``.
 
     Derivation for the sin branch
     -----------------------------
@@ -1068,7 +1218,7 @@ def _try_weierstrass_log_form(
     if disc_sq <= 0:
         return None
     sqrt_disc_ir = _sqrt_fraction_ir(disc_sq)
-    tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))
+    tan_half = IRApply(TAN, (IRApply(DIV, (arg_node, TWO)),))
     abs_head = IRSymbol("Abs")
     if trig_head == SIN:
         if a == 0:
@@ -1109,13 +1259,18 @@ def _try_weierstrass_log_form(
 def _try_weierstrass_one_over_linear_trig(
     integrand: IRNode, x: IRSymbol
 ) -> IRNode | None:
-    """Phase 34: ``∫ c / (a + b·sin(x)) dx`` and ``∫ c / (a + b·cos(x)) dx``
-    via the Weierstrass substitution ``u = tan(x/2)``.
+    """Phase 34 + 38: ``∫ c / (a + b·sin(α·x+β)) dx`` and
+    ``∫ c / (a + b·cos(α·x+β)) dx`` via the Weierstrass substitution
+    ``u = tan((α·x+β)/2)``.
 
-    Both ``c`` (numerator) and the coefficients ``a, b`` must be numeric
-    (Integer or Rational); a closed form is only emitted when
-    ``a² > b²`` (denominator never zero on ℝ).  Returns ``None``
-    otherwise — log-form and linear-in-tan cases remain unevaluated.
+    Both ``c`` (numerator) and the coefficients ``a, b, α, β`` must be
+    numeric (Integer or Rational) with ``α ≠ 0``.  When ``α = 1`` and
+    ``β = 0`` this recovers the original bare-``x`` Phase 34/35/36/37
+    behaviour exactly; otherwise the inner change of variable
+    ``u = α·x + β`` (with ``du = α·dx``) divides the antiderivative by
+    ``α``, which we fold into the numerator constant ``c ← c/α`` so the
+    same closed forms apply with ``tan((α·x+β)/2)`` in place of
+    ``tan(x/2)``.
     """
     if not isinstance(integrand, IRApply) or integrand.head != DIV:
         return None
@@ -1130,27 +1285,36 @@ def _try_weierstrass_one_over_linear_trig(
     parsed = _parse_a_plus_b_sincos(den, x)
     if parsed is None:
         return None
-    a, b, trig_head = parsed
+    a, b, trig_head, alpha, beta = parsed
+    # ``α ≠ 0`` is guaranteed by _parse_linear_in_x; the assert documents
+    # the invariant for future readers and triggers in debug builds if a
+    # caller ever weakens that contract.
+    assert alpha != 0
+    # Apply ``u = α·x + β`` change of variable upfront by folding 1/α
+    # into the numerator scaling.
+    c = c / alpha
+    arg_node = _build_linear_arg_ir(alpha, beta, x)
     disc = a * a - b * b
     if disc == 0:
-        # Phase 35: degenerate a² = b² cases — closed forms in tan(x/2)
+        # Phase 35: degenerate a² = b² cases — closed forms in tan(arg/2)
         # without an outer arctan.  Four sign combinations are handled
         # below; cases where a + b = 0 (sin/cos coefficient cancel) are
         # picked up via the `b == -a` / `b == a` checks.
-        degen = _try_weierstrass_degenerate(c, a, b, trig_head, x)
+        degen = _try_weierstrass_degenerate(c, a, b, trig_head, arg_node)
         if degen is not None:
             return degen
         # Defensive: if degenerate matcher can't close it, leave unevaluated.
         return None
     if disc < 0:
         # Phase 36: a² < b² → log form on the partial-fraction decomposition
-        # of the resulting quadratic in tan(x/2) with two distinct real roots.
-        log_form = _try_weierstrass_log_form(c, a, b, trig_head, x)
+        # of the resulting quadratic in tan(arg/2) with two distinct real
+        # roots.
+        log_form = _try_weierstrass_log_form(c, a, b, trig_head, arg_node)
         if log_form is not None:
             return log_form
         return None
     sqrt_disc_ir = _sqrt_fraction_ir(disc)
-    tan_half = IRApply(TAN, (IRApply(DIV, (x, TWO)),))
+    tan_half = IRApply(TAN, (IRApply(DIV, (arg_node, TWO)),))
     if trig_head == SIN:
         # arctan argument: (a·tan(x/2) + b) / √(a²−b²)
         atan_arg_top = IRApply(

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -494,16 +494,205 @@ def test_phase35_rational_coefficients(vm: VM) -> None:
         assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
 
 
-def test_fallthrough_non_bare_argument(vm: VM) -> None:
-    """``∫ 1/(2 + sin(2x)) dx`` — argument inside Sin is not bare x.
+# ---------------------------------------------------------------------------
+# Phase 38: linear substitution lifts Weierstrass to ``trig(α·x + β)``
+# ---------------------------------------------------------------------------
+#
+# When the trig argument is ``α·x + β`` rather than the bare ``x``, the
+# substitution ``u = α·x + β`` (with ``du = α·dx``) divides the antiderivative
+# by ``α`` and replaces ``tan(x/2)`` with ``tan((α·x+β)/2)``.  The same closed
+# forms then apply unchanged.  These tests cover all three regimes
+# (a² > b² arctan, a² = b² degenerate, a² < b² log) under non-bare arguments
+# and verify the closed form by numerical differentiation against the original
+# integrand.
+# ---------------------------------------------------------------------------
 
-    Phase 34 only handles the canonical bare-variable form.  A future
-    Phase could compose with substitution to handle linear arguments;
-    for now the integral remains unevaluated.
+
+def test_phase38_sin_two_x_closes(vm: VM) -> None:
+    """``∫ 1/(2 + sin(2x)) dx`` — Phase 38 lifts to ``tan((2x)/2) = tan(x)``.
+
+    With ``α = 2, β = 0`` the antiderivative is
+    ``(1/2)·(2/√3)·arctan((2·tan(x) + 1)/√3)``.  Verified by numerical
+    differentiation against ``1/(2 + sin(2x))``.
     """
     two_x = IRApply(MUL, (IRInteger(2), X))
     integrand = IRApply(
         DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (two_x,)))))
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Phase 38 should close ∫ 1/(2+sin 2x) dx; got {phi!r}"
+    )
+    assert _contains_head(phi, ATAN)
+    # Sample on (−π/2, π/2) avoiding singularities of tan(x).
+    for x_val in (-1.0, -0.3, 0.0, 0.3, 1.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.sin(2.0 * x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4), (
+            f"At x={x_val}: derivative={got}, expected={expected}"
+        )
+
+
+def test_phase38_cos_three_x(vm: VM) -> None:
+    """``∫ 1/(2 + cos(3x)) dx`` — Phase 38 with ``α = 3, β = 0``."""
+    three_x = IRApply(MUL, (IRInteger(3), X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(COS, (three_x,)))))
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    # Sample on a window where tan(3x/2) is finite.
+    for x_val in (-0.5, -0.2, 0.0, 0.2, 0.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.cos(3.0 * x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_phase38_sin_x_plus_constant_phase(vm: VM) -> None:
+    """``∫ 1/(2 + sin(x + 1)) dx`` — Phase 38 with ``α = 1, β = 1``.
+
+    The ``1/α`` scaling is trivial (α=1) so this isolates the β shift in the
+    argument; ``tan(x/2)`` is replaced by ``tan((x+1)/2)``.
+    """
+    x_plus_one = IRApply(ADD, (X, IRInteger(1)))
+    integrand = IRApply(
+        DIV,
+        (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (x_plus_one,))))),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.sin(x_val + 1.0))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_phase38_sin_two_x_plus_phase(vm: VM) -> None:
+    """``∫ 1/(2 + sin(2x + 1)) dx`` — full Phase 38 with α=2, β=1.
+
+    Both the inner ``1/α = 1/2`` scaling and the constant phase shift β=1
+    are exercised.  The substitution ``u = 2x + 1`` yields
+    ``(1/2)·∫ 1/(2 + sin u) du`` whose closed form Weierstrass-derives.
+    """
+    two_x_plus_one = IRApply(ADD, (IRApply(MUL, (IRInteger(2), X)), IRInteger(1)))
+    integrand = IRApply(
+        DIV,
+        (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (two_x_plus_one,))))),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-0.8, -0.3, 0.0, 0.3, 0.8):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.sin(2.0 * x_val + 1.0))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_phase38_rational_alpha(vm: VM) -> None:
+    """``∫ 1/(2 + sin(x/2)) dx`` — Phase 38 with rational ``α = 1/2``.
+
+    The 1/α = 2 scaling makes the outer coefficient ``2·(2/√3) = 4/√3``.
+    Verified numerically.
+    """
+    half_x = IRApply(MUL, (IRRational(1, 2), X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (half_x,)))))
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-2.0, -1.0, -0.3, 0.5, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.sin(0.5 * x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_phase38_negative_alpha(vm: VM) -> None:
+    """``∫ 1/(2 + sin(−2x)) dx`` — Phase 38 with ``α = −2``.
+
+    The negative ``α`` introduces a ``1/α = −1/2`` factor in the closed form;
+    structurally this just flips the sign of the outer coefficient.  The
+    derivative check confirms the sign is correct.
+    """
+    neg_two_x = IRApply(MUL, (IRInteger(-2), X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (neg_two_x,)))))
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-1.0, -0.3, 0.0, 0.3, 1.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (2.0 + math.sin(-2.0 * x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
+
+
+def test_phase38_degenerate_branch_under_substitution(vm: VM) -> None:
+    """Degenerate ``a² = b²`` case under Phase 38: ``∫ 1/(1 + cos(2x)) dx``.
+
+    Bare ``x``: ``1 + cos x = 2·cos²(x/2)`` → antiderivative ``tan(x/2)``.
+    With ``α = 2``: antiderivative scales to ``(1/2)·tan(x)``, derivative
+    ``(1/2)·sec²(x) = 1/(1 + cos(2x))`` since ``1 + cos(2x) = 2·cos²(x)``.
+    """
+    two_x = IRApply(MUL, (IRInteger(2), X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(1), IRApply(COS, (two_x,)))))
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    for x_val in (-1.0, -0.3, 0.3, 1.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 + math.cos(2.0 * x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase38_log_form_under_substitution(vm: VM) -> None:
+    """Log-form ``a² < b²`` case under Phase 38: ``∫ 1/(1 + 2·sin(2x)) dx``.
+
+    Same closed form as Phase 36 with ``tan(x)`` instead of ``tan(x/2)`` and
+    an extra ``1/2`` outer factor from ``α = 2``.
+    """
+    two_x = IRApply(MUL, (IRInteger(2), X))
+    integrand = IRApply(
+        DIV,
+        (
+            IRInteger(1),
+            IRApply(
+                ADD,
+                (IRInteger(1), IRApply(MUL, (IRInteger(2), IRApply(SIN, (two_x,))))),
+            ),
+        ),
+    )
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE)
+    # Sample at points where 1 + 2·sin(2x) ≠ 0 and away from log
+    # singularities.  sin(2x) = −1/2 at 2x ∈ {−π/6, 7π/6, ...} so we
+    # stay clear of x ≈ ±π/12 (~ ±0.26).
+    for x_val in (-1.0, -0.5, 0.0, 0.5, 1.0):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (1.0 + 2.0 * math.sin(2.0 * x_val))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase38_fallthrough_nonlinear_argument(vm: VM) -> None:
+    """``∫ 1/(2 + sin(x²)) dx`` — argument is not linear in x.
+
+    Phase 38 only covers linear ``α·x + β`` arguments.  A quadratic argument
+    falls through and the integral is left unevaluated.
+    """
+    x_sq = IRApply(MUL, (X, X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (x_sq,)))))
+    )
+    result = vm.eval(_integrate(integrand))
+    assert isinstance(result, IRApply) and result.head == INTEGRATE
+
+
+def test_phase38_fallthrough_symbolic_alpha(vm: VM) -> None:
+    """``∫ 1/(2 + sin(α·x)) dx`` with symbolic ``α`` — sign of α undecidable,
+    so the linear-argument parser refuses.  Stays unevaluated.
+    """
+    alpha = IRSymbol("alpha")
+    alpha_x = IRApply(MUL, (alpha, X))
+    integrand = IRApply(
+        DIV, (IRInteger(1), IRApply(ADD, (IRInteger(2), IRApply(SIN, (alpha_x,)))))
     )
     result = vm.eval(_integrate(integrand))
     assert isinstance(result, IRApply) and result.head == INTEGRATE


### PR DESCRIPTION
## Summary

- Lifts the Weierstrass closed forms (Phases 34–37) from `∫ c/(a + b·trig(x)) dx` to the general `∫ c/(a + b·trig(α·x + β)) dx` form.
- One inner change of variable `u = α·x + β` carries through: `tan(x/2) → tan((α·x+β)/2)` and the outer coefficient gains a `1/α` factor, with both folded into the existing closed forms.
- All three discriminant regimes (Phase 34 arctan, Phase 35 degenerate, Phase 36/37 log) covered; backwards-compatible for α=1, β=0.

## Stacked on

This PR is built on top of #3683 (Phase 37 — Weierstrass cos `b < −|a|` Python 0.62.0). Merging order: #3683 first, then this one.

## Implementation

- New `_parse_linear_in_x(node, x)` recognises `α·x + β` shapes (with α, β ∈ ℚ, α ≠ 0).
- New `_build_linear_arg_ir(α, β, x)` constructs the substituted IR while collapsing trivial cases.
- `_parse_const_times_trig_x` → `_parse_const_times_trig_linear` returns `(c, head, α, β)`.
- `_parse_a_plus_b_sincos` returns `(a, b, head, α, β)`.
- Each branch function (degenerate / log / arctan) now takes `arg_node: IRNode` and uses `tan(arg/2)` instead of `tan(x/2)`.
- Dispatcher absorbs `1/α` into `c` once at entry.

## Tests

10 new cases in `test_phase34_weierstrass.py`:
- `sin(2x)`, `cos(3x)`, `sin(x + 1)`, `sin(2x + 1)` — full arctan branch coverage with various α, β.
- Rational α=1/2, negative α=−2.
- Degenerate `(1 + cos 2x)` and log-form `(1 + 2·sin 2x)` under substitution.
- Fallthrough: nonlinear x² argument, symbolic α — both stay unevaluated.

The pre-existing `test_fallthrough_non_bare_argument` is promoted to a success test (`test_phase38_sin_two_x_closes`).

## Verification

- 35/35 Phase 34 test cases pass.
- 1482 tests pass in the wider suite (the 59 pre-existing failures are environment-only `lang_parser` ImportErrors unrelated to this change).
- Security review passed (read-only math, no I/O / network / eval / pickle / subprocess).

## Test plan

- [x] Existing Phase 34/35/36/37 tests still pass (bit-for-bit identical when α=1, β=0).
- [x] New Phase 38 tests numerically verify the closed form's derivative matches the integrand.
- [x] Nonlinear and symbolic-argument fallthrough cases stay unevaluated.
- [ ] CI: ruff / mypy / pytest in the symbolic-vm package and any downstream consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)