### PR TITLE
feat(symbolic-vm): Phase 38 — Weierstrass for non-bare trig arguments (TS 0.11.0)

### DIFF
--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## [0.11.0] — 2026-05-20
+
+### Added — Phase 38: Weierstrass closed forms lifted to linear trig arguments
+
+Mirrors Python `symbolic-vm` 0.63.0 (PR #3690).
+
+The previous Phases 34–37 closed Weierstrass for
+`∫ c / (a + b·trig(x)) dx` in all discriminant regimes (`a² > b²` arctan,
+`a² = b²` degenerate, `a² < b²` log) but only when the trig argument was
+the bare variable `x`.  Phase 38 generalises every branch to accept any
+linear-in-`x` rational argument `α·x + β` (with `α, β ∈ ℚ`, `α ≠ 0`).
+
+The mathematics is a single inner change of variable: with
+`u = α·x + β` we have `du = α · dx`, so
+
+    ∫ c / (a + b·sin(α·x + β)) dx
+        = (1/α) · ∫ c / (a + b·sin u) du  (Phase 34/36/37 closed form in u)
+
+The closed form is the existing one with `tan((α·x + β)/2)` substituted
+for `tan(x/2)` and the outer constant scaled by `1/α`.  When `α = 1`
+and `β = 0`, the new code path is bit-for-bit identical to the Phase
+34–37 behaviour — full backwards compatibility.
+
+### Added
+
+- **`weierstrassParseLinearInX(node, x)`** in `src/index.ts` — parses a
+  node into `{ alpha, beta }` Numeric pair (Int/Rat) when it represents
+  `α·x + β`.  Handles bare `x`, scalar multiples, ADD/SUB with any
+  operand ordering, and leading `Neg` wrappers.  Rejects nonlinear
+  (`x²`) and pure-constant shapes by returning `undefined`.  `α = 0`
+  is filtered out so callers may rely on `α ≠ 0` throughout.
+- **`weierstrassBuildLinearArgIR(α, β, x)`** — builds the IR for
+  `α·x + β`, collapsing trivial cases (`α=1, β=0 → x`, etc.) so the
+  emitted `tan(arg/2)` carries the simplest equivalent argument.
+- **`weierstrassParseConstTimesTrigLinear`** — supersedes the Phase 34
+  bare-`x` predecessor.  Returns `{ c, head, alpha, beta }` for any
+  shape matching `c·sin(α·x + β)` or `c·cos(α·x + β)`.
+
+### Changed
+
+- **`weierstrassParseAPlusBSincos`** — now returns
+  `{ a, b, trigHead, alpha, beta }` instead of `{ a, b, trigHead }`.
+- **`tryWeierstrassDegenerate`, `tryWeierstrassLogForm`,
+  `tryWeierstrassOneOverLinearTrig`** — accept an `argNode: IRNode`
+  parameter representing `α·x + β` and substitute it into the
+  `tan(arg/2)` construction.  The outer `c ← c/α` scaling is applied
+  once at the dispatcher entry, so each branch's closed form is
+  otherwise unchanged.
+
+### Added — tests
+
+`tests/phase34-weierstrass.test.ts` — 10 new cases:
+
+- `∫ 1/(2 + sin 2x) dx` (promoted from the prior Phase 34 deferral).
+- `∫ 1/(2 + cos 3x) dx` — α = 3 cos variant.
+- `∫ 1/(2 + sin(x + 1)) dx` — pure phase shift.
+- `∫ 1/(2 + sin(2x + 1)) dx` — full α = 2, β = 1 case.
+- Rational α = 1/2 and negative α = −2.
+- Degenerate `(1 + cos 2x)` and log-form `(1 + 2·sin 2x)` under
+  substitution.
+- Fallthrough tests for nonlinear `sin(x²)` and symbolic `sin(α·x)`.
+
+All 154 tests pass.
+
+### Still deferred
+
+- Symbolic coefficients (`a`, `b`, `α`, or `β` non-numeric) — needs an
+  assumption context to decide discriminant sign.
+- Trig argument involving `x²` or other nonlinear forms — out of scope
+  for Weierstrass.
+
 ## [0.10.0] — 2026-05-20
 
 ### Changed — Phase 37: Weierstrass log form cos branch covers `b < −|a|`

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1624,15 +1624,139 @@ function weierstrassSqrtFractionIR(f: Numeric): IRNode {
   return app(SQRT, [fromNumeric(f)]);
 }
 
-/** Match `c·sin(x)`, `c·cos(x)`, `sin(x)`, `cos(x)`, or their Neg-wrappings.
- *  Returns ``{ c, head }`` (head is SIN or COS) or undefined. */
-function weierstrassParseConstTimesTrigX(
+/**
+ * Phase 38: Parse a linear-in-``x`` rational expression ``α·x + β`` and
+ * return ``{ alpha, beta }`` with ``α, β`` exact Numeric (Int/Rat) and
+ * ``α ≠ 0``.  Recognised shapes:
+ *
+ *   x              → (1, 0)
+ *   α·x            → (α, 0)
+ *   α·x + β        → (α, β)
+ *   β + α·x        → (α, β)
+ *   α·x − β        → (α, −β)
+ *   β − α·x        → (−α, β)
+ *   −(α·x + β)     → (−α, −β)
+ *
+ * Returns ``undefined`` when the expression is not linear in ``x`` (e.g.
+ * ``x²``, ``sin(x)``, pure constants free of x, or a nested nonlinear
+ * form).  ``α = 0`` is filtered out so callers may rely on ``α ≠ 0``.
+ */
+function weierstrassParseLinearInX(
   node: IRNode,
   x: IRNode
-): { readonly c: Numeric; readonly head: IRNode } | undefined {
-  if (node.kind === "apply" && (equals(node.head, SIN) || equals(node.head, COS))) {
-    if (node.args.length === 1 && equals(node.args[0], x)) {
-      return { c: { kind: "int", value: 1n }, head: node.head };
+): { readonly alpha: Numeric; readonly beta: Numeric } | undefined {
+  if (equals(node, x)) {
+    return { alpha: { kind: "int", value: 1n }, beta: { kind: "int", value: 0n } };
+  }
+  if (!dependsOn(node, x)) {
+    return undefined; // pure constant — no x term
+  }
+  if (node.kind === "apply" && equals(node.head, MUL) && node.args.length === 2) {
+    const [left, right] = node.args;
+    const cLeft = toNumeric(left);
+    if (cLeft !== undefined && cLeft.kind !== "float" && equals(right, x) && !isZeroNumeric(cLeft)) {
+      return { alpha: cLeft, beta: { kind: "int", value: 0n } };
+    }
+    const cRight = toNumeric(right);
+    if (cRight !== undefined && cRight.kind !== "float" && equals(left, x) && !isZeroNumeric(cRight)) {
+      return { alpha: cRight, beta: { kind: "int", value: 0n } };
+    }
+    return undefined;
+  }
+  if (node.kind === "apply" && equals(node.head, NEG) && node.args.length === 1) {
+    const inner = weierstrassParseLinearInX(node.args[0], x);
+    if (inner === undefined) return undefined;
+    return { alpha: negNumeric(inner.alpha), beta: negNumeric(inner.beta) };
+  }
+  if (node.kind === "apply" && equals(node.head, ADD) && node.args.length === 2) {
+    const [left, right] = node.args;
+    for (const [constSide, linSide] of [
+      [left, right],
+      [right, left],
+    ] as const) {
+      const c = toNumeric(constSide);
+      if (c === undefined || c.kind === "float") continue;
+      const lin = weierstrassParseLinearInX(linSide, x);
+      if (lin === undefined) continue;
+      return { alpha: lin.alpha, beta: addNumeric(lin.beta, c) };
+    }
+    return undefined;
+  }
+  if (node.kind === "apply" && equals(node.head, SUB) && node.args.length === 2) {
+    const [left, right] = node.args;
+    // Case A: linear − constant → (α, β − c)
+    const cRight = toNumeric(right);
+    if (cRight !== undefined && cRight.kind !== "float") {
+      const lin = weierstrassParseLinearInX(left, x);
+      if (lin !== undefined) {
+        return { alpha: lin.alpha, beta: subNumeric(lin.beta, cRight) };
+      }
+    }
+    // Case B: constant − linear → (−α, c − β)
+    const cLeft = toNumeric(left);
+    if (cLeft !== undefined && cLeft.kind !== "float") {
+      const lin = weierstrassParseLinearInX(right, x);
+      if (lin !== undefined) {
+        return {
+          alpha: negNumeric(lin.alpha),
+          beta: subNumeric(cLeft, lin.beta),
+        };
+      }
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Phase 38: Build the IR node for ``α·x + β`` collapsing trivial cases so the
+ * downstream ``tan(arg/2)`` constructions emit the simplest equivalent form.
+ *   α=1, β=0 → x          (the historical bare-x path; bit-for-bit identical)
+ *   α=1, β≠0 → x + β
+ *   β=0, α≠1 → α·x
+ *   otherwise → α·x + β
+ */
+function weierstrassBuildLinearArgIR(
+  alpha: Numeric,
+  beta: Numeric,
+  x: IRNode
+): IRNode {
+  const alphaIsOne =
+    (alpha.kind === "int" && alpha.value === 1n) ||
+    (alpha.kind === "rat" && alpha.numer === 1n && alpha.denom === 1n);
+  const betaIsZero = isZeroNumeric(beta);
+  if (alphaIsOne && betaIsZero) return x;
+  if (betaIsZero) return app(MUL, [fromNumeric(alpha), x]);
+  if (alphaIsOne) return app(ADD, [x, fromNumeric(beta)]);
+  return app(ADD, [app(MUL, [fromNumeric(alpha), x]), fromNumeric(beta)]);
+}
+
+/** Phase 38: match ``c·sin(α·x+β)`` / ``c·cos(α·x+β)`` (and the c=1 / α=1 /
+ *  β=0 degenerate variants) and return ``{ c, head, alpha, beta }``.
+ *
+ *  Accepts both argument orders within ``Mul`` and unwraps a leading
+ *  ``Neg``.  The trig argument must be linear in ``x`` per
+ *  :func:`weierstrassParseLinearInX`.  Supersedes the Phase 34 bare-``x``
+ *  predecessor `weierstrassParseConstTimesTrigX`. */
+function weierstrassParseConstTimesTrigLinear(
+  node: IRNode,
+  x: IRNode
+):
+  | { readonly c: Numeric; readonly head: IRNode; readonly alpha: Numeric; readonly beta: Numeric }
+  | undefined {
+  if (
+    node.kind === "apply" &&
+    (equals(node.head, SIN) || equals(node.head, COS)) &&
+    node.args.length === 1
+  ) {
+    const lin = weierstrassParseLinearInX(node.args[0], x);
+    if (lin !== undefined) {
+      return {
+        c: { kind: "int", value: 1n },
+        head: node.head,
+        alpha: lin.alpha,
+        beta: lin.beta,
+      };
     }
   }
   if (node.kind === "apply" && equals(node.head, MUL) && node.args.length === 2) {
@@ -1646,28 +1770,44 @@ function weierstrassParseConstTimesTrigX(
       if (
         trigSide.kind === "apply" &&
         (equals(trigSide.head, SIN) || equals(trigSide.head, COS)) &&
-        trigSide.args.length === 1 &&
-        equals(trigSide.args[0], x)
+        trigSide.args.length === 1
       ) {
-        return { c, head: trigSide.head };
+        const lin = weierstrassParseLinearInX(trigSide.args[0], x);
+        if (lin !== undefined) {
+          return { c, head: trigSide.head, alpha: lin.alpha, beta: lin.beta };
+        }
       }
     }
   }
   if (node.kind === "apply" && equals(node.head, NEG) && node.args.length === 1) {
-    const inner = weierstrassParseConstTimesTrigX(node.args[0], x);
+    const inner = weierstrassParseConstTimesTrigLinear(node.args[0], x);
     if (inner !== undefined) {
-      return { c: negNumeric(inner.c), head: inner.head };
+      return {
+        c: negNumeric(inner.c),
+        head: inner.head,
+        alpha: inner.alpha,
+        beta: inner.beta,
+      };
     }
   }
   return undefined;
 }
 
-/** Parse ``a + b·sin(x)`` or ``a + b·cos(x)`` (any operand ordering, plus the
- *  SUB head variant).  Returns ``{ a, b, trigHead }`` or undefined. */
+/** Parse ``a + b·sin(α·x+β)`` or ``a + b·cos(α·x+β)`` (any operand ordering,
+ *  plus the SUB head variant).  Returns ``{ a, b, trigHead, alpha, beta }``
+ *  or undefined.  Phase 38 generalises the Phase 34 bare-``x`` predecessor. */
 function weierstrassParseAPlusBSincos(
   node: IRNode,
   x: IRNode
-): { readonly a: Numeric; readonly b: Numeric; readonly trigHead: IRNode } | undefined {
+):
+  | {
+      readonly a: Numeric;
+      readonly b: Numeric;
+      readonly trigHead: IRNode;
+      readonly alpha: Numeric;
+      readonly beta: Numeric;
+    }
+  | undefined {
   if (node.kind !== "apply" || node.args.length !== 2) return undefined;
   if (equals(node.head, ADD)) {
     const [left, right] = node.args;
@@ -1677,29 +1817,43 @@ function weierstrassParseAPlusBSincos(
     ] as const) {
       const a = toNumeric(constSide);
       if (a === undefined || a.kind === "float") continue;
-      const trigParse = weierstrassParseConstTimesTrigX(trigSide, x);
+      const trigParse = weierstrassParseConstTimesTrigLinear(trigSide, x);
       if (trigParse === undefined) continue;
-      return { a, b: trigParse.c, trigHead: trigParse.head };
+      return {
+        a,
+        b: trigParse.c,
+        trigHead: trigParse.head,
+        alpha: trigParse.alpha,
+        beta: trigParse.beta,
+      };
     }
     return undefined;
   }
   if (equals(node.head, SUB)) {
-    // `a − b·trig(x)` = `a + (−b)·trig(x)` and the symmetric reversal.
+    // `a − b·trig(...)` = `a + (−b)·trig(...)` and the symmetric reversal.
     const [left, right] = node.args;
     const aLeft = toNumeric(left);
     if (aLeft !== undefined && aLeft.kind !== "float") {
-      const trigParse = weierstrassParseConstTimesTrigX(right, x);
+      const trigParse = weierstrassParseConstTimesTrigLinear(right, x);
       if (trigParse !== undefined) {
-        return { a: aLeft, b: negNumeric(trigParse.c), trigHead: trigParse.head };
+        return {
+          a: aLeft,
+          b: negNumeric(trigParse.c),
+          trigHead: trigParse.head,
+          alpha: trigParse.alpha,
+          beta: trigParse.beta,
+        };
       }
     }
-    const bTrigLeft = weierstrassParseConstTimesTrigX(left, x);
+    const bTrigLeft = weierstrassParseConstTimesTrigLinear(left, x);
     const aRight = toNumeric(right);
     if (bTrigLeft !== undefined && aRight !== undefined && aRight.kind !== "float") {
       return {
         a: negNumeric(aRight),
         b: bTrigLeft.c,
         trigHead: bTrigLeft.head,
+        alpha: bTrigLeft.alpha,
+        beta: bTrigLeft.beta,
       };
     }
     return undefined;
@@ -1707,8 +1861,11 @@ function weierstrassParseAPlusBSincos(
   return undefined;
 }
 
-/** Phase 34 entry point. Returns the closed form, or undefined when the
- *  shape doesn't match or the discriminant fails the a² > b² / a > 0 guards. */
+/** Phase 34 + 38 entry point.  Returns the closed form for
+ *  ``∫ c / (a + b·trig(α·x + β)) dx`` (with `a, b, α, β ∈ ℚ`, `α ≠ 0`), or
+ *  undefined when the shape doesn't match or the discriminant fails the
+ *  branch-specific guards.  When `α = 1, β = 0` this is bit-for-bit
+ *  identical to the original Phase 34/35/36/37 behaviour. */
 function tryWeierstrassOneOverLinearTrig(
   integrand: IRNode,
   x: IRNode
@@ -1717,28 +1874,34 @@ function tryWeierstrassOneOverLinearTrig(
   if (integrand.args.length !== 2) return undefined;
   const [num, den] = integrand.args;
   if (dependsOn(num, x)) return undefined;
-  const c = toNumeric(num);
-  if (c === undefined || c.kind === "float") return undefined;
+  const cIn = toNumeric(num);
+  if (cIn === undefined || cIn.kind === "float") return undefined;
   const parsed = weierstrassParseAPlusBSincos(den, x);
   if (parsed === undefined) return undefined;
-  const { a, b, trigHead } = parsed;
+  const { a, b, trigHead, alpha, beta } = parsed;
+  // Phase 38: fold the inner substitution u = α·x + β (du = α·dx) into
+  // the numerator constant once at entry: c ← c/α.  Every branch below
+  // can then use the original closed-form formulas with `tan(arg/2)`
+  // in place of `tan(x/2)`.  α=0 is excluded by `parseLinearInX`.
+  const c = divNumeric(cIn, alpha);
+  const argNode = weierstrassBuildLinearArgIR(alpha, beta, x);
   // disc = a² − b² (exact Numeric arithmetic — both a, b are Int/Rat).
   const disc = subNumeric(mulNumeric(a, a), mulNumeric(b, b));
   // Three-way dispatch on the discriminant:
   //   disc > 0  → Phase 34 arctan form (below)
   //   disc == 0 → Phase 35 degenerate form (four sign combinations)
-  //   disc < 0  → Phase 36 log form (this release)
+  //   disc < 0  → Phase 36/37 log form
   if (isZeroNumeric(disc)) {
-    return tryWeierstrassDegenerate(c, a, b, trigHead, x);
+    return tryWeierstrassDegenerate(c, a, b, trigHead, argNode);
   }
   if (!isPositiveNumeric(disc)) {
-    return tryWeierstrassLogForm(c, a, b, trigHead, x);
+    return tryWeierstrassLogForm(c, a, b, trigHead, argNode);
   }
   const sqrtDiscIR = weierstrassSqrtFractionIR(disc);
-  const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
+  const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
   let atanArg: IRNode;
   if (equals(trigHead, SIN)) {
-    // (a·tan(x/2) + b) / √(a²−b²)
+    // (a·tan(arg/2) + b) / √(a²−b²)
     const top = app(ADD, [app(MUL, [fromNumeric(a), tanHalf]), fromNumeric(b)]);
     atanArg = app(DIV, [top, sqrtDiscIR]);
   } else {
@@ -1801,10 +1964,12 @@ function tryWeierstrassDegenerate(
   a: Numeric,
   b: Numeric,
   trigHead: IRNode,
-  x: IRNode
+  argNode: IRNode
 ): IRNode | undefined {
   if (isZeroNumeric(a)) return undefined;
-  const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
+  // Phase 38 generalisation: `argNode` is the IR for ``α·x + β``; the
+  // inner factor ``α`` has been pre-absorbed into ``c`` by the caller.
+  const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
   const negA = negNumeric(a);
   if (equals(trigHead, SIN)) {
     if (eqNumeric(b, a)) {
@@ -1858,13 +2023,15 @@ function tryWeierstrassLogForm(
   a: Numeric,
   b: Numeric,
   trigHead: IRNode,
-  x: IRNode
+  argNode: IRNode
 ): IRNode | undefined {
+  // Phase 38 generalisation: `argNode` is the IR for ``α·x + β``; the
+  // inner factor ``α`` has been pre-absorbed into ``c`` by the caller.
   // discSq = b² − a²; caller passes disc = a² − b² < 0, so discSq > 0.
   const discSq = subNumeric(mulNumeric(b, b), mulNumeric(a, a));
   if (!isPositiveNumeric(discSq)) return undefined;
   const sqrtDiscIR = weierstrassSqrtFractionIR(discSq);
-  const tanHalf = app(TAN, [app(DIV, [x, int(2)])]);
+  const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
   const absHead = sym("Abs");
   if (equals(trigHead, SIN)) {
     if (isZeroNumeric(a)) return undefined; // 1/(b·sin x) deferred

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -211,13 +211,9 @@ describe("Phase 34: deferred discriminant cases", () => {
     }
   });
 
-  it("non-bare argument (∫ 1/(2 + sin 2x) dx) — Phase 34 doesn't compose with subs", () => {
-    const vm = makeVM();
-    const twoX = app(MUL, [int(2), X]);
-    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [twoX])])]);
-    const result = vm.eval(integrate(integrand));
-    expect(isUnevaluatedIntegrate(result)).toBe(true);
-  });
+  // (The non-bare-argument deferral previously asserted here has been
+  // promoted to a Phase 38 success test in the dedicated Phase 38 block
+  // below — Phase 38 closes those integrals via linear substitution.)
 
   it("symbolic coefficient (∫ 1/(a + sin x) dx) — discriminant sign undecidable", () => {
     const vm = makeVM();
@@ -418,5 +414,145 @@ describe("Phase 37: cos branch with b < −|a|", () => {
       const expected = 5.0 / (1.0 - 2.0 * Math.cos(xVal));
       expect(Math.abs(got - expected)).toBeLessThan(1e-3);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 38: linear substitution lifts Weierstrass to ``trig(α·x + β)``.
+//
+// With ``u = α·x + β`` (``du = α·dx``), every Phase 34/35/36/37 closed form
+// applies unchanged with ``tan((α·x+β)/2)`` in place of ``tan(x/2)`` and the
+// outer coefficient scaled by ``1/α``.  Each case is verified by central
+// differencing the closed form against the original integrand at sample
+// points avoiding the integrand's singularities.
+// ---------------------------------------------------------------------------
+
+describe("Phase 38: linear-argument substitution lifts Weierstrass", () => {
+  it("∫ 1/(2 + sin 2x) dx closes (promoted from Phase 34 deferral)", () => {
+    const vm = makeVM();
+    const twoX = app(MUL, [int(2), X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [twoX])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    expect(containsHead(phi, ATAN)).toBe(true);
+    for (const xVal of [-1.0, -0.3, 0.0, 0.3, 1.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (2.0 + Math.sin(2.0 * xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(2 + cos 3x) dx — α = 3 cos variant", () => {
+    const vm = makeVM();
+    const threeX = app(MUL, [int(3), X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(COS, [threeX])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-0.5, -0.2, 0.0, 0.2, 0.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (2.0 + Math.cos(3.0 * xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(2 + sin(x + 1)) dx — pure phase shift α = 1, β = 1", () => {
+    const vm = makeVM();
+    const xPlusOne = app(ADD, [X, int(1)]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [xPlusOne])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-2.0, -1.0, 0.0, 1.0, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (2.0 + Math.sin(xVal + 1.0));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(2 + sin(2x + 1)) dx — full α = 2, β = 1 case", () => {
+    const vm = makeVM();
+    const twoXPlusOne = app(ADD, [app(MUL, [int(2), X]), int(1)]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [twoXPlusOne])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-0.8, -0.3, 0.0, 0.3, 0.8]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (2.0 + Math.sin(2.0 * xVal + 1.0));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(2 + sin(x/2)) dx — rational α = 1/2", () => {
+    const vm = makeVM();
+    const halfX = app(MUL, [rational(1, 2), X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [halfX])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-2.0, -1.0, 0.5, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (2.0 + Math.sin(0.5 * xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(2 + sin(−2x)) dx — negative α = −2", () => {
+    const vm = makeVM();
+    const negTwoX = app(MUL, [int(-2), X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [negTwoX])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    for (const xVal of [-1.0, -0.3, 0.0, 0.3, 1.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (2.0 + Math.sin(-2.0 * xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("∫ 1/(1 + cos 2x) dx — degenerate Phase 35 branch under α = 2", () => {
+    const vm = makeVM();
+    const twoX = app(MUL, [int(2), X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(1), app(COS, [twoX])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // 1 + cos 2x = 2 cos²(x); singularities at x = ±π/2 ≈ ±1.57.
+    for (const xVal of [-1.0, -0.3, 0.3, 1.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (1.0 + Math.cos(2.0 * xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("∫ 1/(1 + 2·sin 2x) dx — log-form Phase 36 branch under α = 2", () => {
+    const vm = makeVM();
+    const twoX = app(MUL, [int(2), X]);
+    const integrand = app(DIV, [
+      int(1),
+      app(ADD, [int(1), app(MUL, [int(2), app(SIN, [twoX])])]),
+    ]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    // 1 + 2·sin 2x zeros at sin 2x = −1/2, so 2x ∈ {−π/6, 7π/6,...}; staying
+    // clear of x ≈ ±π/12 ≈ ±0.26 by sampling outside that window.
+    for (const xVal of [-1.0, -0.5, 0.0, 0.5, 1.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1.0 / (1.0 + 2.0 * Math.sin(2.0 * xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
+  it("∫ 1/(2 + sin(x²)) dx falls through — argument is not linear in x", () => {
+    const vm = makeVM();
+    const xSq = app(MUL, [X, X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [xSq])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
+  });
+
+  it("∫ 1/(2 + sin(α·x)) dx falls through — symbolic α", () => {
+    const vm = makeVM();
+    const alpha = sym("alpha");
+    const alphaX = app(MUL, [alpha, X]);
+    const integrand = app(DIV, [int(1), app(ADD, [int(2), app(SIN, [alphaX])])]);
+    const result = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(result)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Ports Phase 38 from Python (PR #3690) to TypeScript: lifts the Weierstrass closed forms from `∫ c/(a + b·trig(x)) dx` to the general `∫ c/(a + b·trig(α·x + β)) dx` form.
- All three discriminant regimes (Phase 34 arctan, Phase 35 degenerate, Phase 36/37 log) covered; backwards-compatible for α=1, β=0.

## Stacked on

This PR is built on top of #3685 (Phase 37 TS). Merge #3685 first.

## Implementation

- New `weierstrassParseLinearInX(node, x)` parses `α·x + β` with α, β ∈ ℚ, α ≠ 0.
- New `weierstrassBuildLinearArgIR(α, β, x)` builds the IR collapsing trivial cases.
- `weierstrassParseConstTimesTrigX` → `weierstrassParseConstTimesTrigLinear` returns the `(c, head, α, β)` tuple.
- `weierstrassParseAPlusBSincos` returns `{ a, b, trigHead, alpha, beta }`.
- The three closed-form constructors take `argNode: IRNode` and use `tan(arg/2)`. The dispatcher absorbs `1/α` into `c` once at entry.

## Tests

10 new cases in `tests/phase34-weierstrass.test.ts` mirroring the Python suite:

- `sin(2x)`, `cos(3x)`, `sin(x+1)`, `sin(2x+1)` — arctan branch.
- Rational α=1/2, negative α=−2.
- Degenerate `(1 + cos 2x)` and log-form `(1 + 2·sin 2x)` under substitution.
- Fallthrough: nonlinear x² argument, symbolic α.

All 154 tests pass. The pre-existing "non-bare argument deferred" Phase 34 test is removed (replaced by the Phase 38 success test).

## Test plan

- [x] All existing Phase 34/35/36/37 tests still pass (bit-for-bit identical when α=1, β=0).
- [x] New Phase 38 tests numerically verify the closed form's derivative matches the integrand.
- [x] Nonlinear and symbolic-argument fallthrough cases stay unevaluated.
- [x] `npx tsc --noEmit` passes.
- [x] Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)