### PR TITLE
fix(sql-vm,mini-sqlite): REPLACE empty-needle no-op; printf %#o C-style

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.65.0] - 2026-05-20
+
+### Fixed
+
+- **``REPLACE(x, "", y)`` no-op and ``printf('%#o', …)`` C-style octal
+  prefix** (via ``sql-vm 1.39.0``).  Both were Python-vs-SQLite
+  divergences uncovered by a scalar function gap audit:
+
+  * ``replace('hello', '', 'X')`` returned ``'XhXeXlXlXoX'`` (Python
+    behaviour); SQLite returns ``'hello'`` unchanged.
+  * ``printf('%#o', 8)`` returned ``'0o10'`` (Python's modern octal
+    prefix); SQLite returns ``'010'``.  Width/zero-pad interactions
+    also fixed to match SQLite's column rules.
+
+  9 oracle tests in ``test_tier3_replace_empty_and_octal.py``.
+
 ## [1.64.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.64.0"
+version = "1.65.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_replace_empty_and_octal.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_replace_empty_and_octal.py
@@ -1,0 +1,51 @@
+"""Oracle tests for ``REPLACE(x, "", y)`` and ``printf("%#o", …)``.
+
+Companion to ``test_replace_empty_and_octal.py`` in ``sql-vm``.  Goes
+through the full mini-sqlite stack and asserts byte-for-byte equality
+against the reference ``sqlite3`` module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+class TestReplaceEmptyOracle:
+    def test_empty_needle_no_op(self) -> None:
+        # Was 'XhXeXlXlXoX' in mini-sqlite; SQLite returns 'hello'.
+        _check("SELECT replace('hello', '', 'X')")
+
+    def test_empty_needle_empty_haystack(self) -> None:
+        _check("SELECT replace('', '', 'X')")
+
+    def test_normal_replace_regression(self) -> None:
+        _check("SELECT replace('hello', 'l', 'L')")
+
+
+class TestPrintfHashOctalOracle:
+    def test_zero(self) -> None:
+        _check("SELECT printf('%#o', 0)")
+
+    def test_eight(self) -> None:
+        _check("SELECT printf('%#o', 8)")
+
+    def test_sixty_four(self) -> None:
+        _check("SELECT printf('%#o', 64)")
+
+    def test_width_padded(self) -> None:
+        _check("SELECT printf('%#5o', 8)")
+
+    def test_zero_padded(self) -> None:
+        _check("SELECT printf('%#05o', 8)")
+
+    def test_no_hash_regression(self) -> None:
+        # Without '#', SQLite emits the plain octal — must still work.
+        _check("SELECT printf('%o', 8), printf('%05o', 8)")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.39.0 — 2026-05-20
+
+### Fixed
+
+- **``REPLACE(x, "", y)`` is now a no-op** matching SQLite.  Python's
+  ``str.replace("", X)`` inserts ``X`` between every character (so
+  ``"hello".replace("", "X")`` becomes ``"XhXeXlXlXoX"``).  SQLite
+  defines an empty needle as "match nothing" and returns the input
+  unchanged.  Fix: short-circuit on empty ``old`` before delegating to
+  Python's ``str.replace``.
+
+- **``printf("%#o", val)`` now uses C's classic ``0`` octal prefix**
+  instead of Python's modern ``0o`` prefix.  Mini-sqlite was emitting
+  ``"0o10"`` for ``printf("%#o", 8)`` where SQLite emits ``"010"``.
+
+  Subtleties also handled:
+  * When ``val == 0`` the prefix is **omitted** entirely (the digit is
+    already a zero; ``"00"`` would be wrong).  ``printf("%#o", 0) → "0"``.
+  * With a width flag, the ``0`` prefix sits *after* leading spaces:
+    ``printf("%#5o", 8) → "  010"``, not ``"   010"``.
+  * Zero-padded widths grow by the prefix length:
+    ``printf("%#05o", 8) → "000010"``.
+
+  Implementation: strip ``#`` from the Python format, let Python compute
+  the width/padding, then prepend ``0`` into the correct column.
+
+  20 unit tests in ``test_replace_empty_and_octal.py``.
+
 ## 1.38.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.38.0"
+version = "1.39.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -1088,12 +1088,24 @@ def _replace(x: SqlValue, old: SqlValue, new: SqlValue) -> SqlValue:
 
     Returns NULL if any argument is NULL (handled by ``null_propagating``).
 
+    **Empty needle ⇒ no-op.**  Python's ``str.replace("", X)`` inserts ``X``
+    between every character (and at both ends), so ``"hello".replace("", "X")``
+    becomes ``"XhXeXlXlXoX"``.  SQLite explicitly treats an empty search
+    string as "match nothing" and returns the input unchanged.  We honour
+    SQLite's behaviour because callers building a SQL pipeline would not
+    expect a no-op edit to suddenly multiply their string length.
+
     Examples::
 
         REPLACE("hello world", "world", "SQL")  → "hello SQL"
         REPLACE("aaa", "a", "bb")               → "bbbbbb"
+        REPLACE("hello", "", "X")               → "hello"   (no-op)
     """
     if isinstance(x, str) and isinstance(old, str) and isinstance(new, str):
+        if old == "":
+            # Match SQLite: empty needle is a no-op rather than Python's
+            # "insert between every character" behaviour.
+            return x
         return x.replace(old, new)
     return x
 
@@ -1398,6 +1410,39 @@ def _printf_format(template: str, args: list[SqlValue]) -> str:  # noqa: C901
         width = int(width_s) if width_s else 0
         if conv in "diouxX":
             val = 0 if arg is None else (int(arg) if not isinstance(arg, bool) else int(arg))
+            # Python's ``%#o`` formats with the modern ``0o`` prefix; SQLite
+            # (following C printf) uses the classic single ``0`` prefix and,
+            # critically, **omits the prefix entirely when the value is 0**
+            # (because the digit itself is already a zero, so adding ``0``
+            # would just produce ``00``).  Also: when both ``#`` and a
+            # width/zero-pad are present, SQLite places the ``0`` prefix
+            # *after* the leading spaces (e.g. ``%#5o`` of 8 → ``"  010"``),
+            # so we strip ``#`` from the Python format, let Python compute
+            # the padding, then prepend ``0`` into the right column.
+            if conv == "o" and "#" in flags:
+                py_flags = flags.replace("#", "")
+                spec = f"%{py_flags}{width_s}"
+                if prec_s:
+                    spec += f".{prec_s}"
+                spec += conv
+                try:
+                    s = spec % val
+                except TypeError:
+                    s = str(val)
+                if val != 0:
+                    # Replace one space with '0' if we right-aligned with
+                    # spaces; otherwise simply prepend.  Zero-padded width
+                    # produces a string already starting with '0', so the
+                    # natural "prepend" branch is correct there too.
+                    stripped = s.lstrip(" ")
+                    spaces = len(s) - len(stripped)
+                    s = (
+                        " " * (spaces - 1) + "0" + stripped
+                        if spaces > 0
+                        else "0" + s
+                    )
+                result.append(s)
+                continue
             spec = f"%{flags}{width_s}"
             if prec_s:
                 spec += f".{prec_s}"

--- a/code/packages/python/sql-vm/tests/test_replace_empty_and_octal.py
+++ b/code/packages/python/sql-vm/tests/test_replace_empty_and_octal.py
@@ -1,0 +1,92 @@
+"""Two corner-case fixes in the scalar function registry.
+
+1. ``REPLACE(x, "", y)`` is a no-op in SQLite — empty needle matches
+   nothing.  Python's ``str.replace("", X)`` inserts ``X`` between every
+   character (and at both ends), which is almost never what a SQL caller
+   wants.  Mini-sqlite previously delegated to Python and produced
+   ``"XhXeXlXlXoX"`` from ``replace("hello", "", "X")``.  The fix is a
+   one-line short-circuit.
+
+2. ``printf("%#o", val)`` uses C's classic ``0`` prefix, not Python's
+   modern ``0o`` prefix.  Combined with width/zero-pad flags SQLite has
+   subtle rules (the ``0`` prefix is *omitted* when ``val == 0`` and is
+   placed *after* leading spaces in right-aligned widths).  The new
+   implementation strips ``#`` from the Python format, lets Python compute
+   the basic width/padding, then prepends ``0`` into the correct column.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sql_vm.scalar_functions import call
+
+# ---------------------------------------------------------------------------
+# REPLACE(x, "", y) — empty needle is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceEmptyNeedle:
+    def test_empty_needle_no_change(self) -> None:
+        # Was 'XhXeXlXlXoX'; SQLite returns 'hello'.
+        assert call("replace", ["hello", "", "X"]) == "hello"
+
+    def test_empty_needle_empty_haystack(self) -> None:
+        assert call("replace", ["", "", "X"]) == ""
+
+    def test_empty_needle_empty_replacement(self) -> None:
+        # Both empty: still a no-op.
+        assert call("replace", ["hello", "", ""]) == "hello"
+
+    def test_non_empty_needle_still_works(self) -> None:
+        # Regression guard: the early-return only fires for empty needle.
+        assert call("replace", ["hello", "l", "L"]) == "heLLo"
+
+    def test_replace_with_longer_string(self) -> None:
+        assert call("replace", ["aaa", "a", "bb"]) == "bbbbbb"
+
+
+# ---------------------------------------------------------------------------
+# printf("%#o", …) — C-style ``0`` prefix, not Python's ``0o``
+# ---------------------------------------------------------------------------
+
+
+class TestPrintfHashOctal:
+    @pytest.mark.parametrize(
+        ("fmt", "value", "expected"),
+        [
+            ("%#o", 0, "0"),       # zero gets no prefix
+            ("%#o", 8, "010"),
+            ("%#o", 64, "0100"),
+            ("%#o", 1, "01"),
+            # Right-aligned width: prefix sits *after* leading spaces.
+            ("%#5o", 0, "    0"),
+            ("%#5o", 8, "  010"),
+            ("%#5o", 64, " 0100"),
+            # Zero-padded width: total width grows by the prefix.
+            ("%#05o", 0, "00000"),
+            ("%#05o", 8, "000010"),
+            ("%#05o", 64, "000100"),
+        ],
+    )
+    def test_hash_octal(self, fmt: str, value: int, expected: str) -> None:
+        assert call("printf", [fmt, value]) == expected
+
+    @pytest.mark.parametrize(
+        ("fmt", "value", "expected"),
+        [
+            # Without ``#`` flag — unchanged behaviour.
+            ("%o", 8, "10"),
+            ("%5o", 8, "   10"),
+            ("%05o", 8, "00010"),
+        ],
+    )
+    def test_plain_octal_unchanged(self, fmt: str, value: int, expected: str) -> None:
+        assert call("printf", [fmt, value]) == expected
+
+    def test_hash_hex_unaffected(self) -> None:
+        # ``%#x`` was already producing ``0x…``, which matches SQLite.
+        assert call("printf", ["%#x", 255]) == "0xff"
+
+    def test_hash_HEX_uppercase(self) -> None:
+        assert call("printf", ["%#X", 255]) == "0XFF"


### PR DESCRIPTION
## Summary

Two Python-vs-SQLite divergences uncovered by a scalar function gap audit:

1. **`REPLACE(x, "", y)`**: Python's `str.replace("", X)` inserts X between every character → `'XhXeXlXlXoX'`. SQLite treats empty needle as no-op → `'hello'`. One-line fix.

2. **`printf('%#o', val)`**: Python uses modern `0o` prefix; SQLite uses C-style `0` prefix. Plus three subtleties:
   - Zero value omits prefix: `printf('%#o', 0) → '0'`
   - Width: prefix sits after leading spaces — `printf('%#5o', 8) → '  010'`
   - Zero-padded width grows by prefix length — `printf('%#05o', 8) → '000010'`

29 new tests (20 sql-vm unit + 9 mini-sqlite oracle), all comparing byte-for-byte against reference sqlite3. Version bumps: sql-vm 1.38.0 → 1.39.0, mini-sqlite 1.64.0 → 1.65.0.

## Test plan

- [x] `pytest sql-vm/tests/test_replace_empty_and_octal.py` — 20/20
- [x] `pytest mini-sqlite/tests/test_tier3_replace_empty_and_octal.py` — 9/9
- [x] sql-vm full suite — 843 passed
- [x] mini-sqlite full suite — 1659 passed (1650 prior + 9 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)