### PR TITLE
Add Chief of Staff report no-action helper

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this package will be documented in this file.
 - Flattened scheduler-action labels in supervisor drain run summaries.
 - Flattened outcome labels in supervisor drain run summaries.
 - Flattened no-action scheduler flags in supervisor drain run summaries.
+- Report-level no-action scheduler helpers for supervisor drain runs.
 - Batch audit write summaries for host flush loops.
 - Replay helpers for loading queried audit rows into any `ToolAuditSink`.
 - `StorageToolAuditSink` for runtime audit emission through D18A storage with

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -70,8 +70,8 @@ The crate keeps the boundary narrow:
   the typed recommendation
 - supervisor drain run summaries flatten stable outcome labels beside the typed
   run outcome
-- supervisor drain run summaries flatten no-action scheduler flags for terminal
-  host log entries
+- supervisor drain reports and summaries expose no-action scheduler helpers for
+  terminal host log entries
 
 ## Development
 

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -916,6 +916,11 @@ impl ToolAuditSupervisorDrainRunReport {
         self.outcome().requires_scheduler_action()
     }
 
+    /// Return whether this run intentionally leaves the scheduler idle.
+    pub fn is_no_scheduler_action(&self) -> bool {
+        self.scheduler_action().is_no_action()
+    }
+
     /// Return the recommended scheduler action for this drain run.
     pub fn scheduler_action(&self) -> ToolAuditSupervisorDrainSchedulerAction {
         self.outcome().scheduler_action()
@@ -3136,6 +3141,8 @@ mod tests {
         assert!(report.reached_end_of_log());
         assert!(!report.should_continue());
         assert_eq!(report.outcome(), ToolAuditSupervisorDrainRunOutcome::Idle);
+        assert!(report.is_no_scheduler_action());
+        assert!(!report.requires_scheduler_action());
         let summary = report.summary();
         assert_eq!(summary.scheduler_action_label, "no_action");
         assert!(summary.is_no_scheduler_action);
@@ -3462,6 +3469,7 @@ mod tests {
         );
         assert_eq!(report.outcome_label(), "needs_continuation");
         assert!(report.requires_scheduler_action());
+        assert!(!report.is_no_scheduler_action());
         assert!(report.requests_continuation());
         assert!(!report.routes_follow_up());
         assert!(!report.requires_plan_drift_investigation());


### PR DESCRIPTION
## Summary
- add a report-level `is_no_scheduler_action()` helper for supervisor drain runs
- assert idle reports return no-action while continuation reports stay actionable
- document the report-level helper in README and CHANGELOG

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD
- git diff --check