### PR TITLE
[codex] Add WHATWG template audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -40,6 +40,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser template audit
+  generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser select/list audit
   generator alongside the other parser audit fixture generators.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -167,6 +167,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-template-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_template_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-select-list-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_select_list_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -33,13 +33,17 @@ documented in this file.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
+- Generated WHATWG template audit fixture over html5lib template shell,
+  table/select/frameset interactions, nested-template, EOF, document-shell,
+  text-mode, foreign-content, and fragment-context cases, with a dedicated
+  parser regression test.
 - Generated WHATWG select/list audit fixture over html5lib select shell,
   option implied-end, optgroup-boundary, select-in-table, fragment-context, and
   stray select/list end-tag cases, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
-  tree-insertion, frameset, table, form/interactive, text-control, and
-  foreign-content, formatting, document-shell, and select/list audit checks on
-  the same parser and DOM dump path.
+  tree-insertion, frameset, table, form/interactive, text-control,
+  foreign-content, formatting, document-shell, template, and select/list audit
+  checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -176,6 +176,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_s
   --check
 ```
 
+The generated `tests/fixtures/whatwg-template-audit.json` fixture indexes
+template insertion modes, nested template stacks, EOF recovery,
+table/select/frameset interactions, document-shell placement, text-mode
+content, foreign content, and template fragment contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-select-list-audit.json` fixture indexes
 select shells, option implied-end recovery, optgroup boundaries,
 select-in-table handling, select fragment contexts, and stray select/list end

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -131,6 +131,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_s
   --check
 ```
 
+`whatwg-template-audit.json` is a generated index over tree-construction cases
+that stress template insertion modes, nested template stacks, EOF recovery,
+and template interactions with tables, selects, framesets, document shells,
+text modes, foreign content, and template fragment contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py \
+  --check
+```
+
 `whatwg-select-list-audit.json` is a generated index over tree-construction
 cases that stress select shells, adjacent option implied-end recovery, optgroup
 boundaries, select-in-table handling, select fragment contexts, and stray

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG template audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-template-audit.json"
+
+TEMPLATE_MARKUP = re.compile(r"</?template(?:\s|/|>)", re.I)
+TEMPLATE_FRAGMENT_CONTEXTS = {"template"}
+TABLE_MARKUP = re.compile(
+    r"</?(?:table|tbody|thead|tfoot|tr|td|th|caption|colgroup|col)(?:\s|/|>)",
+    re.I,
+)
+SELECT_MARKUP = re.compile(r"</?(?:select|option|optgroup)(?:\s|/|>)", re.I)
+FRAMESET_MARKUP = re.compile(r"</?(?:frameset|frame)(?:\s|/|>)", re.I)
+RAWTEXT_MARKUP = re.compile(r"</?(?:script|style|plaintext|xmp)(?:\s|/|>)", re.I)
+FOREIGN_MARKUP = re.compile(r"</?(?:svg|math|foreignobject)(?:\s|/|>)", re.I)
+SHELL_MARKUP = re.compile(r"</?(?:html|head|body)(?:\s|/|>)", re.I)
+
+CASE_AXES = (
+    {
+        "axis": "template-shell",
+        "reason": "ordinary template start/end tags and content model boundaries",
+    },
+    {
+        "axis": "table-template",
+        "reason": "template insertion while table insertion modes are active",
+    },
+    {
+        "axis": "select-template",
+        "reason": "template insertion inside select, option, and optgroup contexts",
+    },
+    {
+        "axis": "frameset-template",
+        "reason": "template insertion around frameset and frame recovery",
+    },
+    {
+        "axis": "nested-template",
+        "reason": "nested template stacks and template-stack unwinding",
+    },
+    {
+        "axis": "eof-template",
+        "reason": "unclosed template EOF recovery across insertion modes",
+    },
+    {
+        "axis": "head-body-template",
+        "reason": "template placement around html, head, body, and late shell tags",
+    },
+    {
+        "axis": "rawtext-template",
+        "reason": "script, style, plaintext, and other text-mode content in templates",
+    },
+    {
+        "axis": "foreign-content-template",
+        "reason": "template-like markup inside SVG, MathML, and integration points",
+    },
+    {
+        "axis": "template-fragment-context",
+        "reason": "fragment parsing with template as the context element",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG template audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_template_case(source, case_data, fragment_context):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any template audit cases")
+    return cases
+
+
+def is_template_case(
+    source: str, data: str, fragment_context: str | None
+) -> bool:
+    source_file = source.split(":", 1)[0]
+    if (
+        fragment_context is not None
+        and fragment_context.lower() in TEMPLATE_FRAGMENT_CONTEXTS
+    ):
+        return True
+    return source_file == "template.dat" or TEMPLATE_MARKUP.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-template-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress template insertion modes, nested template stacks, EOF "
+            "recovery, and template interactions with tables, selects, framesets, "
+            "document shells, text modes, foreign content, and fragment contexts."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data.lower()
+    fragment_context = (case.fragment_context or "").lower()
+    start_templates = len(re.findall(r"<template(?:\s|/|>)", data))
+    end_templates = len(re.findall(r"</template(?:\s|/|>)", data))
+
+    if fragment_context in TEMPLATE_FRAGMENT_CONTEXTS:
+        return "template-fragment-context"
+    if FOREIGN_MARKUP.search(data) is not None:
+        return "foreign-content-template"
+    if start_templates > 1:
+        return "nested-template"
+    if start_templates > end_templates:
+        return "eof-template"
+    if RAWTEXT_MARKUP.search(data) is not None:
+        return "rawtext-template"
+    if SELECT_MARKUP.search(data) is not None:
+        return "select-template"
+    if FRAMESET_MARKUP.search(data) is not None:
+        return "frameset-template"
+    if TABLE_MARKUP.search(data) is not None:
+        return "table-template"
+    if SHELL_MARKUP.search(data) is not None:
+        return "head-body-template"
+    return "template-shell"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown template audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-template-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-template-audit.json
@@ -1,0 +1,710 @@
+{
+  "case_count": 115,
+  "cases": [
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-455",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:455"
+    },
+    {
+      "axis": "template-shell",
+      "id": "template-dat-456",
+      "reason": "ordinary template start/end tags and content model boundaries",
+      "source": "template.dat:456"
+    },
+    {
+      "axis": "template-shell",
+      "id": "template-dat-457",
+      "reason": "ordinary template start/end tags and content model boundaries",
+      "source": "template.dat:457"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-458",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:458"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-459",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:459"
+    },
+    {
+      "axis": "template-shell",
+      "id": "template-dat-460",
+      "reason": "ordinary template start/end tags and content model boundaries",
+      "source": "template.dat:460"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-461",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:461"
+    },
+    {
+      "axis": "template-shell",
+      "id": "template-dat-462",
+      "reason": "ordinary template start/end tags and content model boundaries",
+      "source": "template.dat:462"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-463",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:463"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-464",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:464"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-465",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:465"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-466",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:466"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-467",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:467"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-468",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:468"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-469",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:469"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-470",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:470"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-471",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:471"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-472",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:472"
+    },
+    {
+      "axis": "select-template",
+      "id": "template-dat-473",
+      "reason": "template insertion inside select, option, and optgroup contexts",
+      "source": "template.dat:473"
+    },
+    {
+      "axis": "select-template",
+      "id": "template-dat-474",
+      "reason": "template insertion inside select, option, and optgroup contexts",
+      "source": "template.dat:474"
+    },
+    {
+      "axis": "select-template",
+      "id": "template-dat-475",
+      "reason": "template insertion inside select, option, and optgroup contexts",
+      "source": "template.dat:475"
+    },
+    {
+      "axis": "select-template",
+      "id": "template-dat-476",
+      "reason": "template insertion inside select, option, and optgroup contexts",
+      "source": "template.dat:476"
+    },
+    {
+      "axis": "select-template",
+      "id": "template-dat-477",
+      "reason": "template insertion inside select, option, and optgroup contexts",
+      "source": "template.dat:477"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-478",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:478"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-479",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:479"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-480",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:480"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-481",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:481"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-482",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:482"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-483",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:483"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-484",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:484"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-485",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:485"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-486",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:486"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-487",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:487"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-488",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:488"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-489",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:489"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-490",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:490"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-491",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:491"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-492",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:492"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-493",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:493"
+    },
+    {
+      "axis": "frameset-template",
+      "id": "template-dat-494",
+      "reason": "template insertion around frameset and frame recovery",
+      "source": "template.dat:494"
+    },
+    {
+      "axis": "frameset-template",
+      "id": "template-dat-495",
+      "reason": "template insertion around frameset and frame recovery",
+      "source": "template.dat:495"
+    },
+    {
+      "axis": "frameset-template",
+      "id": "template-dat-496",
+      "reason": "template insertion around frameset and frame recovery",
+      "source": "template.dat:496"
+    },
+    {
+      "axis": "frameset-template",
+      "id": "template-dat-497",
+      "reason": "template insertion around frameset and frame recovery",
+      "source": "template.dat:497"
+    },
+    {
+      "axis": "rawtext-template",
+      "id": "template-dat-498",
+      "reason": "script, style, plaintext, and other text-mode content in templates",
+      "source": "template.dat:498"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-499",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:499"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-500",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:500"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-501",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:501"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-502",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:502"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-503",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:503"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-504",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:504"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-505",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:505"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-506",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:506"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-507",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:507"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-508",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:508"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-509",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:509"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-510",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:510"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-511",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:511"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-512",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:512"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-513",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:513"
+    },
+    {
+      "axis": "rawtext-template",
+      "id": "template-dat-514",
+      "reason": "script, style, plaintext, and other text-mode content in templates",
+      "source": "template.dat:514"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-515",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:515"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-516",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:516"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-517",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:517"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-518",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:518"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-519",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:519"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-520",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:520"
+    },
+    {
+      "axis": "frameset-template",
+      "id": "template-dat-521",
+      "reason": "template insertion around frameset and frame recovery",
+      "source": "template.dat:521"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-522",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:522"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-523",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:523"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-524",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:524"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-525",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:525"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-526",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:526"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-527",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:527"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-528",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:528"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-529",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:529"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-530",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:530"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-531",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:531"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-532",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:532"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-533",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:533"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-534",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:534"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-535",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:535"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-536",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:536"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-537",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:537"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-538",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:538"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-539",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:539"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-540",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:540"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-541",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:541"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-542",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:542"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-543",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:543"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-544",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:544"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-545",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:545"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-546",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:546"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-547",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:547"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-548",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:548"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-549",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:549"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-550",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:550"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-551",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:551"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-552",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:552"
+    },
+    {
+      "axis": "foreign-content-template",
+      "id": "template-dat-553",
+      "reason": "template-like markup inside SVG, MathML, and integration points",
+      "source": "template.dat:553"
+    },
+    {
+      "axis": "foreign-content-template",
+      "id": "template-dat-554",
+      "reason": "template-like markup inside SVG, MathML, and integration points",
+      "source": "template.dat:554"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-555",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:555"
+    },
+    {
+      "axis": "select-template",
+      "id": "template-dat-556",
+      "reason": "template insertion inside select, option, and optgroup contexts",
+      "source": "template.dat:556"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-557",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:557"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-558",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:558"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-559",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:559"
+    },
+    {
+      "axis": "head-body-template",
+      "id": "template-dat-560",
+      "reason": "template placement around html, head, body, and late shell tags",
+      "source": "template.dat:560"
+    },
+    {
+      "axis": "nested-template",
+      "id": "template-dat-561",
+      "reason": "nested template stacks and template-stack unwinding",
+      "source": "template.dat:561"
+    },
+    {
+      "axis": "eof-template",
+      "id": "template-dat-562",
+      "reason": "unclosed template EOF recovery across insertion modes",
+      "source": "template.dat:562"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-563",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:563"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-564",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:564"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-565",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:565"
+    },
+    {
+      "axis": "rawtext-template",
+      "id": "tests18-dat-993",
+      "reason": "script, style, plaintext, and other text-mode content in templates",
+      "source": "tests18.dat:993"
+    },
+    {
+      "axis": "rawtext-template",
+      "id": "tests18-dat-16",
+      "reason": "script, style, plaintext, and other text-mode content in templates",
+      "source": "tests18.dat:16"
+    },
+    {
+      "axis": "table-template",
+      "id": "template-dat-112",
+      "reason": "template insertion while table insertion modes are active",
+      "source": "template.dat:112"
+    },
+    {
+      "axis": "template-fragment-context",
+      "id": "template-dat-109",
+      "reason": "fragment parsing with template as the context element",
+      "source": "template.dat:109"
+    }
+  ],
+  "counts_by_axis": {
+    "eof-template": 18,
+    "foreign-content-template": 2,
+    "frameset-template": 5,
+    "head-body-template": 10,
+    "nested-template": 22,
+    "rawtext-template": 4,
+    "select-template": 6,
+    "table-template": 43,
+    "template-fragment-context": 1,
+    "template-shell": 4
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress template insertion modes, nested template stacks, EOF recovery, and template interactions with tables, selects, framesets, document shells, text modes, foreign content, and fragment contexts.",
+  "format": "whatwg-html-template-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_template_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_template_audit_test.rs
@@ -1,0 +1,89 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_TEMPLATE_AUDIT: &str = include_str!("fixtures/whatwg-template-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct TemplateAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<TemplateAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TemplateAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_template_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-template-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 115);
+    assert_axis_count(&suite, "template-shell", 4);
+    assert_axis_count(&suite, "table-template", 15);
+    assert_axis_count(&suite, "select-template", 5);
+    assert_axis_count(&suite, "frameset-template", 3);
+    assert_axis_count(&suite, "nested-template", 20);
+    assert_axis_count(&suite, "eof-template", 15);
+    assert_axis_count(&suite, "head-body-template", 8);
+    assert_axis_count(&suite, "rawtext-template", 4);
+    assert_axis_count(&suite, "foreign-content-template", 2);
+    assert_axis_count(&suite, "template-fragment-context", 1);
+}
+
+#[test]
+fn whatwg_template_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> TemplateAuditSuite {
+    serde_json::from_str(WHATWG_TEMPLATE_AUDIT)
+        .expect("WHATWG template audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &TemplateAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG template audit fixture over 115 html5lib tree-construction cases
- split template coverage into shell, table, select, frameset, nested, EOF, head/body, text-mode, foreign-content, and fragment-context axes
- wire the new generator into the generated HTML fixture manifest and docs/changelogs

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- cargo test -p coding-adventures-html-parser whatwg_template_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py