### PR TITLE
fix(sql-vm,mini-sqlite): CAST uses longest numeric prefix, matches SQLite

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.66.0] - 2026-05-20
+
+### Fixed
+
+- **``CAST(text AS REAL/INTEGER)`` now matches SQLite byte-for-byte**
+  (via ``sql-vm 1.40.0``).  Python's ``int()`` / ``float()`` reject
+  any string with trailing non-numeric characters; SQLite takes the
+  longest valid numeric prefix.  Two bug classes fixed:
+
+  * ``CAST('inf' AS REAL)`` surfaced Python's infinity; SQLite returns
+    ``0.0`` because the literal keyword has no numeric prefix.  Same
+    for ``'nan'``, ``'infinity'``, etc.
+  * ``CAST('1.5abc' AS REAL)`` returned ``0.0``; SQLite returns ``1.5``.
+    ``CAST('123abc' AS INTEGER)`` returned ``0``; SQLite returns ``123``.
+
+  Subtlety: the INTEGER cast extracts only the *integer* prefix, not
+  the float prefix.  ``CAST('1.5abc' AS INTEGER)`` is ``1``, and
+  ``CAST('1e5' AS INTEGER)`` is also ``1``.
+
+  12 oracle tests in ``test_tier3_cast_numeric_prefix.py``.
+
 ## [1.65.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.65.0"
+version = "1.66.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_cast_numeric_prefix.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_cast_numeric_prefix.py
@@ -1,0 +1,69 @@
+"""Oracle tests for SQLite-compatible CAST string-to-number coercion.
+
+Companion to ``test_cast_numeric_prefix.py`` in ``sql-vm``.  Each test
+runs the same ``SELECT CAST(...)`` query against both mini-sqlite and
+the reference ``sqlite3`` module and asserts byte-for-byte equality.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+class TestCastRealOracle:
+    def test_inf_keyword_rejected(self) -> None:
+        # Was returning Python's float('inf'); SQLite returns 0.0.
+        _check("SELECT CAST('inf' AS REAL)")
+
+    def test_nan_keyword_rejected(self) -> None:
+        _check("SELECT CAST('nan' AS REAL)")
+
+    def test_infinity_keyword_rejected(self) -> None:
+        _check("SELECT CAST('infinity' AS REAL)")
+
+    def test_number_with_trailing_garbage(self) -> None:
+        # Was returning 0.0 (Python rejects the whole string); SQLite
+        # extracts the float prefix.
+        _check("SELECT CAST('1.5abc' AS REAL)")
+
+    def test_overflow_to_inf_unchanged(self) -> None:
+        # SQLite produces inf here too, so this is a regression guard.
+        _check("SELECT CAST('1e500' AS REAL)")
+
+    def test_decimal_only(self) -> None:
+        _check("SELECT CAST('.5' AS REAL)")
+
+    def test_leading_sign(self) -> None:
+        _check("SELECT CAST('+1.5' AS REAL)")
+        _check("SELECT CAST('-1.5' AS REAL)")
+
+
+class TestCastIntegerOracle:
+    def test_number_with_trailing_garbage(self) -> None:
+        # Was returning 0; SQLite extracts the integer prefix.
+        _check("SELECT CAST('123abc' AS INTEGER)")
+
+    def test_negative_with_trailing_garbage(self) -> None:
+        _check("SELECT CAST('-42abc' AS INTEGER)")
+
+    def test_float_string_takes_int_prefix(self) -> None:
+        # SQLite's INTEGER cast stops at the decimal point: result is 1.
+        _check("SELECT CAST('1.5abc' AS INTEGER)")
+        _check("SELECT CAST('1.9' AS INTEGER)")
+        _check("SELECT CAST('-1.9' AS INTEGER)")
+
+    def test_exponent_marker_stops_parsing(self) -> None:
+        _check("SELECT CAST('1e5' AS INTEGER)")
+        _check("SELECT CAST('1e5abc' AS INTEGER)")
+
+    def test_pure_garbage(self) -> None:
+        _check("SELECT CAST('abc' AS INTEGER)")
+        _check("SELECT CAST('' AS INTEGER)")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 1.40.0 — 2026-05-20
+
+### Fixed
+
+- **``CAST(text AS REAL/INTEGER)`` uses SQLite's longest-prefix rule
+  instead of Python's ``int()``/``float()`` semantics.**  Python rejects
+  any string with trailing non-numeric characters; SQLite greedily
+  takes the longest valid numeric prefix and discards the rest.
+
+  Two specific bug classes fixed:
+
+  * ``CAST('inf' AS REAL)`` (and ``'Inf'``, ``'infinity'``, ``'-inf'``,
+    ``'nan'``, ``'NaN'``) used to surface Python's ``float('inf')`` /
+    ``float('nan')`` to callers.  SQLite has no special-case for those
+    keywords — they have no leading digit so the numeric prefix is
+    empty, hence ``0.0``.
+
+  * ``CAST('1.5abc' AS REAL)`` and ``CAST('123abc' AS INTEGER)`` used to
+    return ``0.0`` / ``0`` because Python's ``float`` / ``int``
+    rejected the whole string.  SQLite returns ``1.5`` / ``123`` —
+    the valid prefix.
+
+  Subtlety: ``CAST(string AS INTEGER)`` extracts only the *integer*
+  prefix, not the float prefix.  So ``CAST('1.5abc' AS INTEGER)`` is
+  ``1``, not ``1`` from truncating ``1.5`` (it never sees the decimal).
+  ``CAST('1e5' AS INTEGER)`` is also ``1`` — the cast stops at the
+  exponent marker.
+
+  Two new helpers (``_sqlite_str_to_int``, ``_sqlite_str_to_real``)
+  encode the rule via regex prefix matching.  48 unit tests in
+  ``test_cast_numeric_prefix.py``.
+
 ## 1.39.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.39.0"
+version = "1.40.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -207,14 +207,75 @@ def _typeof(x: SqlValue) -> SqlValue:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# SQLite-compatible numeric-prefix parsers
+# ---------------------------------------------------------------------------
+#
+# SQLite's string-to-number coercion does NOT use Python's ``int()``/
+# ``float()`` semantics — instead it takes the **longest valid numeric
+# prefix** and ignores any trailing garbage.  So ``CAST('1.5abc' AS REAL)``
+# returns 1.5 (the float prefix), and ``CAST('123abc' AS INTEGER)`` returns
+# 123 (just the int prefix; SQLite's INTEGER cast specifically rejects the
+# decimal point and exponent).
+#
+# Python's ``float('inf')`` produces an infinity but SQLite rejects the
+# literal text "inf"/"nan"/"infinity" — there is no leading digit so the
+# numeric prefix is empty, hence 0.0.  Same for "abc".  These regexes
+# capture the SQLite rule directly: optional whitespace, optional sign,
+# then either digits or digits-with-decimals-and-exponent.
+
+_INT_PREFIX = re.compile(r"^\s*[+-]?\d+")
+_REAL_PREFIX = re.compile(
+    r"^\s*[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?"
+)
+
+
+def _sqlite_str_to_int(s: str) -> int:
+    """Take the longest leading integer prefix of *s*; 0 if none."""
+    m = _INT_PREFIX.match(s)
+    if not m:
+        return 0
+    try:
+        return int(m.group().strip())
+    except (ValueError, OverflowError):
+        return 0
+
+
+def _sqlite_str_to_real(s: str) -> float:
+    """Take the longest leading float prefix of *s*; 0.0 if none.
+
+    Matches SQLite's behaviour of rejecting non-numeric prefixes (so
+    ``'inf'`` → 0.0, not Python's ``float('inf')``).
+    """
+    m = _REAL_PREFIX.match(s)
+    if not m:
+        return 0.0
+    prefix = m.group().strip()
+    # A bare sign or empty match isn't a valid float — bail to 0.0.
+    if prefix in ("", "+", "-", "."):
+        return 0.0
+    try:
+        return float(prefix)
+    except (ValueError, OverflowError):
+        return 0.0
+
+
 @register("cast")
 def _cast_fn(x: SqlValue, target_type: SqlValue) -> SqlValue:
     """Cast *x* to the SQL type named by *target_type* (a TEXT string).
 
     Follows SQLite's type affinity rules:
 
-    - ``"integer"`` / ``"int"`` → Python ``int`` (truncate if float)
-    - ``"real"`` / ``"float"`` / ``"double"`` / ``"numeric"`` → Python ``float``
+    - ``"integer"`` / ``"int"`` → Python ``int`` (longest leading int
+      prefix; truncate floats toward zero).  Crucially, the *string*
+      INTEGER cast in SQLite extracts only the digit prefix — so
+      ``CAST('1.5abc' AS INTEGER)`` is ``1`` (just ``1``, not ``1.5``
+      truncated), and ``CAST('1e5' AS INTEGER)`` is also ``1``.
+    - ``"real"`` / ``"float"`` / ``"double"`` / ``"numeric"`` → Python
+      ``float`` (longest leading float prefix, including optional sign,
+      decimal point, and ``e``/``E`` exponent).  Non-numeric strings —
+      including the literal text ``"inf"`` and ``"nan"`` — coerce to
+      ``0.0`` because SQLite has no special-case for those keywords.
     - ``"text"`` / ``"varchar"`` / ``"char"`` → Python ``str``
     - ``"blob"`` / ``"none"`` → Python ``bytes``
     - ``"boolean"`` → Python ``bool`` (True if truthy)
@@ -229,18 +290,15 @@ def _cast_fn(x: SqlValue, target_type: SqlValue) -> SqlValue:
     try:
         if t in ("integer", "int", "int2", "int8", "tinyint", "smallint",
                  "mediumint", "bigint", "unsigned big int"):
+            if isinstance(x, bool):
+                return int(x)
             if isinstance(x, float):
                 return int(x)
             if isinstance(x, str):
-                # Try integer first, then float-to-int.
-                try:
-                    return int(x)
-                except ValueError:
-                    try:
-                        return int(float(x))
-                    except ValueError:
-                        return 0
-            return int(bool(x)) if isinstance(x, bool) else int(x)
+                return _sqlite_str_to_int(x)
+            if isinstance(x, bytes):
+                return _sqlite_str_to_int(x.decode("utf-8", errors="replace"))
+            return int(x)
         if t in ("real", "float", "double", "double precision",
                  "numeric", "decimal"):
             if isinstance(x, bool):
@@ -248,11 +306,8 @@ def _cast_fn(x: SqlValue, target_type: SqlValue) -> SqlValue:
             if isinstance(x, (int, float)):
                 return float(x)
             if isinstance(x, str):
-                try:
-                    return float(x)
-                except ValueError:
-                    return 0.0
-            return float(len(x))  # blob → length as float
+                return _sqlite_str_to_real(x)
+            return float(len(x))  # blob → length as float (legacy quirk)
         if t in ("text", "varchar", "nvarchar", "character", "char",
                  "varying character", "nchar", "native character",
                  "clob"):

--- a/code/packages/python/sql-vm/tests/test_cast_numeric_prefix.py
+++ b/code/packages/python/sql-vm/tests/test_cast_numeric_prefix.py
@@ -1,0 +1,163 @@
+"""SQLite-compatible string-to-number coercion in ``CAST``.
+
+Python's ``int()`` / ``float()`` reject any string with trailing
+non-numeric characters: ``float('1.5abc')`` raises.  SQLite's CAST
+takes a different approach — it greedily matches the longest valid
+numeric prefix and discards anything that follows.  So
+``CAST('1.5abc' AS REAL)`` is ``1.5``, and ``CAST('123abc' AS INTEGER)``
+is ``123``.
+
+Two corollaries that catch most engines off-guard:
+
+1. The literal text ``"inf"`` and ``"nan"`` coerce to ``0.0`` because
+   they have no leading digit — there is no numeric prefix at all.
+   Python's ``float('inf')`` returns infinity, which mini-sqlite used
+   to surface to callers (wrong).
+
+2. The INTEGER cast extracts only the *integer* prefix, not the float
+   prefix.  ``CAST('1.5abc' AS INTEGER)`` is ``1`` (just the ``1``),
+   not ``1`` from truncating ``1.5``.  Similarly ``CAST('1e5' AS
+   INTEGER)`` is ``1`` — the cast stops at the decimal/exponent
+   marker.
+
+The new helpers ``_sqlite_str_to_int`` and ``_sqlite_str_to_real`` use
+regex prefix matching to encode SQLite's rule directly.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from sql_vm.scalar_functions import call
+
+
+def _cast(value: object, target: str) -> object:
+    return call("cast", [value, target])
+
+
+# ---------------------------------------------------------------------------
+# REAL — float prefix, no Python-style special keywords
+# ---------------------------------------------------------------------------
+
+
+class TestCastReal:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # Special-keyword strings — Python would accept these, SQLite
+            # rejects them (no leading digit → empty prefix → 0.0).
+            ("inf", 0.0),
+            ("Inf", 0.0),
+            ("infinity", 0.0),
+            ("-inf", 0.0),
+            ("nan", 0.0),
+            ("NaN", 0.0),
+            # Non-numeric prefix.
+            ("abc", 0.0),
+            ("", 0.0),
+            # Valid number followed by garbage — keep the prefix.
+            ("1.5abc", 1.5),
+            ("123abc", 123.0),
+            ("1e5abc", 100000.0),
+            # Whitespace handling.
+            ("  1.5  ", 1.5),
+            # Leading sign, decimal-only, exponent.
+            ("+1.5", 1.5),
+            ("-1.5", -1.5),
+            (".5", 0.5),
+            ("1e10", 10_000_000_000.0),
+        ],
+    )
+    def test_string_to_real(self, text: str, expected: float) -> None:
+        result = _cast(text, "REAL")
+        assert result == expected
+        assert isinstance(result, float)
+
+    def test_overflow_to_inf(self) -> None:
+        # ``1e500`` overflows IEEE 754 double → +inf; SQLite agrees.
+        result = _cast("1e500", "REAL")
+        assert math.isinf(result) and result > 0  # type: ignore[arg-type]
+
+    def test_int_input_unchanged(self) -> None:
+        assert _cast(42, "REAL") == 42.0
+
+    def test_float_input_unchanged(self) -> None:
+        assert _cast(3.14, "REAL") == 3.14
+
+    def test_bool_to_real(self) -> None:
+        assert _cast(True, "REAL") == 1.0
+        assert _cast(False, "REAL") == 0.0
+
+    def test_null(self) -> None:
+        assert _cast(None, "REAL") is None
+
+
+# ---------------------------------------------------------------------------
+# INTEGER — int prefix only (no decimal, no exponent)
+# ---------------------------------------------------------------------------
+
+
+class TestCastInteger:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # Plain integers.
+            ("0", 0),
+            ("42", 42),
+            ("-42", -42),
+            ("+42", 42),
+            # Garbage after integer prefix is discarded.
+            ("123abc", 123),
+            ("-42abc", -42),
+            # Floats become their integer prefix, NOT the truncated float.
+            # 1.5abc → integer prefix is "1" → result 1.  This is subtle:
+            # SQLite's INTEGER cast doesn't honour the decimal point at
+            # all, so the answer is the same as for 1abc.
+            ("1.5abc", 1),
+            ("1.5", 1),
+            ("1.9", 1),  # NOT 2 (no truncation; just prefix match)
+            ("-1.9", -1),
+            # Exponent markers are also not part of the int prefix.
+            ("1e5", 1),
+            ("1e5abc", 1),
+            # Empty / non-numeric.
+            ("", 0),
+            ("abc", 0),
+            # Leading whitespace.
+            ("  -7  ", -7),
+        ],
+    )
+    def test_string_to_integer(self, text: str, expected: int) -> None:
+        result = _cast(text, "INTEGER")
+        assert result == expected
+        assert isinstance(result, int)
+
+    def test_float_input_truncates(self) -> None:
+        # When the input is already a float (not a string), Python's
+        # ``int()`` truncates toward zero — same as SQLite.
+        assert _cast(1.9, "INTEGER") == 1
+        assert _cast(-1.9, "INTEGER") == -1
+
+    def test_bool_to_integer(self) -> None:
+        assert _cast(True, "INTEGER") == 1
+        assert _cast(False, "INTEGER") == 0
+
+    def test_null(self) -> None:
+        assert _cast(None, "INTEGER") is None
+
+
+# ---------------------------------------------------------------------------
+# Type-name aliases — int8, smallint, double precision, etc. — all map
+# ---------------------------------------------------------------------------
+
+
+class TestCastTypeAliases:
+    @pytest.mark.parametrize("alias", ["INT", "int8", "bigint", "smallint", "mediumint"])
+    def test_int_aliases(self, alias: str) -> None:
+        assert _cast("42abc", alias) == 42
+
+    @pytest.mark.parametrize("alias", ["FLOAT", "double", "double precision", "numeric"])
+    def test_real_aliases(self, alias: str) -> None:
+        assert _cast("3.14abc", alias) == 3.14


### PR DESCRIPTION
## Summary

Python's `int()`/`float()` reject any string with trailing non-numeric characters; SQLite greedily takes the longest valid numeric prefix. This was producing two bug classes:

1. **`CAST('inf' AS REAL)`** surfaced Python's `float('inf')` / `float('nan')`; SQLite returns `0.0` because those keywords have no leading digit. Same for `'Inf'`, `'NaN'`, `'infinity'`, `'-inf'`.

2. **`CAST('1.5abc' AS REAL)`** returned `0.0`; SQLite returns `1.5`. Same pattern for INTEGER (`CAST('123abc' AS INTEGER)` returned `0`; SQLite returns `123`).

Two new helpers `_sqlite_str_to_int` and `_sqlite_str_to_real` encode the rule via regex prefix matching.

Subtlety: the INTEGER cast extracts only the *integer* prefix, not the float prefix. `CAST('1.5abc' AS INTEGER)` is `1`, and `CAST('1e5' AS INTEGER)` is also `1` — the cast stops at the decimal point / exponent marker.

60 new tests (48 sql-vm unit + 12 mini-sqlite oracle), all comparing byte-for-byte against reference sqlite3 where applicable. Version bumps: sql-vm 1.39.0 → 1.40.0, mini-sqlite 1.65.0 → 1.66.0.

## Test plan

- [x] `pytest sql-vm/tests/test_cast_numeric_prefix.py` — 48/48
- [x] `pytest mini-sqlite/tests/test_tier3_cast_numeric_prefix.py` — 12/12
- [x] sql-vm full suite — 891 passed (843 prior + 48 new)
- [x] mini-sqlite full suite — 1671 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)