### PR TITLE
feat(ruby-lexer): Phase 4a — 15-era version dispatch surface

### DIFF
--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.7.0] - 2026-05-20
+
+### Added (Phase 4a — 15-era version dispatch)
+- `ERA_VERSIONS: &[&str]` constant listing every era version modelled by [code/specs/ruby-version-evolution.md](../../../specs/ruby-version-evolution.md): `"1.0"`, `"1.6"`, `"1.8"`, `"1.9.1"`, `"1.9.3"`, `"2.0"`, `"2.1"`, `"2.3"`, `"2.5"`, `"2.6"`, `"2.7"`, `"3.0"`, `"3.1"`, `"3.2"`, `"3.3"` (chronological order).  Re-exported from the crate root.
+- `tokenize_ruby_for_version(source, version)` convenience entry point.  Validates `version` against `ERA_VERSIONS` and returns a `Result<Vec<Token>, String>`; the existing `RubyLexer::new(version)` constructor accepts the same set of strings.
+- `definition_for_version` now accepts any era string (was: only `"1.8"`) and tags the returned `StateMachineDefinition`'s `name` field with the requested era (e.g. `ruby-2.3-lexer`) so downstream tooling can identify which grammar produced the tokens.
+- Error message on unknown versions now points callers at the spec (`see code/specs/ruby-version-evolution.md`) so they know where the canonical era list lives.
+
+### Notes
+- v0 inheritance model: every era currently shares the **1.8 baseline TOML** — only the machine name differs.  This is deliberate: physically duplicating ~1100 lines of TOML 14 times would be massive churn for zero behaviour change in this PR.  Phase 4b+ will fork the era TOMLs as real syntactic deltas land (lambda `->` in 1.9.1, `%i[]` in 2.0, `&.` and `<<~` in 2.3, endless ranges in 2.6, numbered block params in 2.7, …).
+- The version-string surface is the load-bearing piece of this phase: callers that need version-gated tooling can already plumb the era string through; the underlying grammar will diverge incrementally as later phases land.
+
+### Tests (+5 new, total 82)
+- All 15 era versions parse cleanly and produce a uniquely-named `StateMachineDefinition`.
+- `ERA_VERSIONS` has no duplicates and is chronological (1.8 present, 3.3 last).
+- `tokenize_ruby_for_version` produces the expected token stream for the baseline source `"x = 1 + 2\n"` under every era.
+- Unknown version strings produce a helpful error pointing at the spec.
+
 ## [0.6.0] - 2026-05-20
 
 ### Added (Phase 3c — heredocs `<<TAG`)

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -39,6 +39,7 @@ mod machine;
 mod oracle;
 
 pub use lex_state::LexState;
+pub use machine::ERA_VERSIONS;
 pub use oracle::{NoLocals, ParserOracle, StaticLocals};
 
 /// Non-fatal diagnostic produced by the lexer.  Stray bytes /
@@ -799,6 +800,24 @@ fn is_ruby_keyword(s: &str) -> bool {
 /// call [`tokenize_ruby_diag`] to inspect them.
 pub fn tokenize_ruby(source: &str) -> Vec<Token> {
     tokenize_ruby_diag(source).0
+}
+
+/// Phase 4 — tokenize against a specific Ruby era.  `version` must
+/// be one of the strings in [`ERA_VERSIONS`] (or `""` for the
+/// default 1.8 baseline).  Returns an error if the version is not
+/// recognized; on success the behaviour matches [`tokenize_ruby`]
+/// for that era.
+///
+/// v0 caveat: all 15 eras currently share the 1.8 token grammar —
+/// only the underlying state-machine `name` differs.  Era-specific
+/// deltas (e.g. lambda `->` in 1.9.1, safe-nav `&.` in 2.3) arrive
+/// in subsequent phases.  Callers that need version gating today
+/// can already plumb the era string through to downstream tooling.
+pub fn tokenize_ruby_for_version(source: &str, version: &str) -> Result<Vec<Token>, String> {
+    let mut lexer = RubyLexer::new(version)?;
+    lexer.push(source)?;
+    lexer.finish()?;
+    Ok(lexer.drain_tokens())
 }
 
 /// Tokenize with a custom [`ParserOracle`].  Use this when the
@@ -1611,6 +1630,58 @@ mod tests {
             .map(|t| t.value.as_str())
             .collect();
         assert_eq!(strings, vec!["<<EOF\nbody\nEOF"]);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 4 — multi-era version dispatch.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn tokenize_ruby_for_version_accepts_all_eras() {
+        // The same baseline source lexes identically under every
+        // era version in v0 — the only difference is the
+        // state-machine identifier carried by the definition (see
+        // `machine::tests::all_15_era_versions_are_accepted`).  When
+        // Phase 4b+ forks individual era transitions, the token
+        // stream will start diverging here.
+        let src = "x = 1 + 2\n";
+        for &v in ERA_VERSIONS {
+            let toks = tokenize_ruby_for_version(src, v)
+                .unwrap_or_else(|e| panic!("version {v} failed: {e}"));
+            let kinds: Vec<TokenType> = toks
+                .iter()
+                .filter(|t| t.type_ != TokenType::Eof)
+                .map(|t| t.type_)
+                .collect();
+            assert_eq!(
+                kinds,
+                vec![
+                    TokenType::Name,
+                    TokenType::Equals,
+                    TokenType::Number,
+                    TokenType::Plus,
+                    TokenType::Number,
+                    TokenType::Newline,
+                ],
+                "version {v} produced unexpected token stream",
+            );
+        }
+    }
+
+    #[test]
+    fn tokenize_ruby_for_version_rejects_unknown() {
+        let err = tokenize_ruby_for_version("x\n", "5.0").unwrap_err();
+        assert!(err.contains("not a recognized Ruby era"));
+    }
+
+    #[test]
+    fn era_versions_includes_1_0_through_3_3() {
+        // Spot-check that the public re-export from `machine` is
+        // wired through and contains the expected end-points.
+        assert!(ERA_VERSIONS.contains(&"1.0"));
+        assert!(ERA_VERSIONS.contains(&"1.8"));
+        assert!(ERA_VERSIONS.contains(&"3.3"));
+        assert_eq!(ERA_VERSIONS.len(), 15);
     }
 
     #[test]

--- a/code/packages/rust/ruby-lexer/src/machine.rs
+++ b/code/packages/rust/ruby-lexer/src/machine.rs
@@ -1,32 +1,78 @@
 //! Version → state-machine definition lookup.
 //!
-//! The TOML state-machine source lives at the crate root (one file
-//! per Ruby version era).  We embed the bytes via `include_str!`
-//! and parse them lazily on first use through
-//! `state_machine_markup_deserializer::from_states_toml`.
+//! The Ruby 1.8 TOML at the crate root is the **canonical baseline**.
+//! Phase 4 (version evolution) introduces the 15-era version
+//! dispatch — all 15 era-version strings listed in
+//! [`code/specs/ruby-version-evolution.md`](../../../specs/ruby-version-evolution.md)
+//! are accepted by [`definition_for_version`].  Each era maps to a
+//! state-machine definition whose `name` field carries the era
+//! string (e.g. `ruby-2.3-lexer`), so downstream consumers can
+//! report which grammar they targeted.
 //!
-//! Adding a new version requires:
-//!   1. Drop a `ruby-<ver>.lexer.states.toml` at the crate root.
-//!   2. Add it to the match arm in [`definition_for_version`].
-//!   3. Update `code/specs/ruby-version-evolution.md`.
+//! v0 inheritance model: the baseline TOML is shared by every era;
+//! only the machine name differs.  This intentionally avoids
+//! duplicating ~1100 lines of TOML 14 times — era-specific deltas
+//! (lambda `->` in 1.9.1, `%i[]` in 2.0, `&.` in 2.3, `<<~` heredocs
+//! in 2.3, etc.) are deferred to Phase 4b+ where each era forks the
+//! single transitions that change.  Until then, callers asking for
+//! `"2.7"` get the same token grammar as `"1.8"` — just labelled
+//! differently so version-aware tooling can still discriminate.
+//!
+//! Adding a real era delta requires:
+//!   1. Lift the era-specific transitions into a fork in
+//!      [`era_toml`] (or split into a per-version file once the
+//!      diffs become substantial).
+//!   2. Add tests asserting the new behaviour gates on the version
+//!      string.
+//!   3. Update `code/specs/ruby-version-evolution.md` if the
+//!      behaviour diverges from the prose spec.
 
 use state_machine::definitions::StateMachineDefinition;
 use state_machine_markup_deserializer::from_states_toml;
 
 const RUBY_1_8: &str = include_str!("../ruby-1.8.lexer.states.toml");
 
+/// All era versions modelled by the spec.  Order is chronological,
+/// matching the era table in `ruby-version-evolution.md`.  `1.8` is
+/// also the **default** when callers pass `""`.
+pub const ERA_VERSIONS: &[&str] = &[
+    "1.0", "1.6", "1.8", "1.9.1", "1.9.3", "2.0", "2.1", "2.3", "2.5", "2.6",
+    "2.7", "3.0", "3.1", "3.2", "3.3",
+];
+
 pub(crate) fn definition_for_version(version: &str) -> Result<StateMachineDefinition, String> {
-    let source = match version {
-        "1.8" | "" => RUBY_1_8,
-        // Phase 1 only ships the 1.8 baseline.  Later phases add
-        // 1.0 / 1.6 (forward-derived from 1.8) and the 1.9.1 / 2.0 / ... era files.
+    let canonical = match version {
+        "" => "1.8",
+        v if ERA_VERSIONS.contains(&v) => v,
         other => {
             return Err(format!(
-                "ruby lexer: version `{other}` is not yet supported (Phase 1 ships only 1.8)"
+                "ruby lexer: version `{other}` is not a recognized Ruby era — \
+                 see code/specs/ruby-version-evolution.md for the list of 15 supported eras"
             ));
         }
     };
-    from_states_toml(source).map_err(|e| format!("ruby lexer: failed to parse TOML — {e}"))
+    let source = era_toml(canonical);
+    from_states_toml(&source).map_err(|e| format!("ruby lexer: failed to parse TOML — {e}"))
+}
+
+/// Materialize the per-era TOML.  v0: same content as the 1.8
+/// baseline with only the machine `name` retagged so downstream
+/// tooling can identify the requested era.  Phase 4b+ will fork
+/// real transitions here.
+///
+/// The `name` field appears exactly once at the top of the TOML
+/// (the inner `[[tokens]]` entries also have `name` keys, but
+/// `replacen(_, _, 1)` confines the substitution to the very first
+/// occurrence — the state-machine identifier on line 26).
+fn era_toml(version: &str) -> String {
+    if version == "1.8" {
+        // Avoid the alloc + replace when the requested era is the
+        // canonical baseline.
+        return RUBY_1_8.to_string();
+    }
+    let from = "name = \"ruby-1.8-lexer\"";
+    let to = format!("name = \"ruby-{version}-lexer\"");
+    RUBY_1_8.replacen(from, &to, 1)
 }
 
 #[cfg(test)]
@@ -38,9 +84,7 @@ mod tests {
         let def = definition_for_version("1.8").expect("definition");
         assert_eq!(def.name, "ruby-1.8-lexer");
         assert_eq!(def.profile.as_deref(), Some("lexer/v1"));
-        // Quick sanity: the dispatcher `data` state must exist.
         assert!(def.states.iter().any(|s| s.id == "data"));
-        // And so must `done`.
         assert!(def.states.iter().any(|s| s.id == "done"));
     }
 
@@ -52,7 +96,51 @@ mod tests {
 
     #[test]
     fn unknown_version_errors() {
-        let err = definition_for_version("2.0").unwrap_err();
-        assert!(err.contains("not yet supported"));
+        let err = definition_for_version("0.9").unwrap_err();
+        assert!(err.contains("not a recognized Ruby era"));
+        // Make sure the helpful pointer to the spec is in the error
+        // message — that's the path callers follow to learn what
+        // version strings *are* valid.
+        assert!(err.contains("ruby-version-evolution.md"));
+    }
+
+    #[test]
+    fn all_15_era_versions_are_accepted() {
+        // Every entry in ERA_VERSIONS must parse cleanly and tag
+        // the machine name with its era string.  This is the core
+        // Phase 4 acceptance criterion — the version dispatch
+        // surface is complete.
+        for &v in ERA_VERSIONS {
+            let def = definition_for_version(v)
+                .unwrap_or_else(|e| panic!("version {v} failed: {e}"));
+            assert_eq!(
+                def.name,
+                format!("ruby-{v}-lexer"),
+                "version {v} produced unexpected machine name {}",
+                def.name,
+            );
+            // Sanity: structural integrity is preserved across all
+            // eras — `data` and `done` are the dispatcher and final
+            // states, present in every Ruby grammar.
+            assert!(def.states.iter().any(|s| s.id == "data"));
+            assert!(def.states.iter().any(|s| s.id == "done"));
+        }
+    }
+
+    #[test]
+    fn era_versions_list_is_chronological_and_unique() {
+        // Guard against accidental ordering or duplication when
+        // future PRs append (or insert) era entries.
+        let mut seen = std::collections::HashSet::new();
+        for v in ERA_VERSIONS {
+            assert!(seen.insert(*v), "duplicate era version {v}");
+        }
+        // The 1.8 baseline must remain in the list (it is the
+        // identity era — every other era currently shares its
+        // grammar).
+        assert!(ERA_VERSIONS.contains(&"1.8"));
+        // 3.3 is the latest era per ruby-version-evolution.md and
+        // must be the last entry.
+        assert_eq!(ERA_VERSIONS.last(), Some(&"3.3"));
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 per [code/specs/ruby-parser.md](code/specs/ruby-parser.md#phasing) and [code/specs/ruby-version-evolution.md](code/specs/ruby-version-evolution.md): the Ruby lexer now recognizes all 15 era version strings catalogued in the version-evolution spec — \`1.0\` / \`1.6\` / \`1.8\` / \`1.9.1\` / \`1.9.3\` / \`2.0\` / \`2.1\` / \`2.3\` / \`2.5\` / \`2.6\` / \`2.7\` / \`3.0\` / \`3.1\` / \`3.2\` / \`3.3\` (chronological).

- New public \`ERA_VERSIONS: &[&str]\` constant exporting the canonical era list.
- New \`tokenize_ruby_for_version(source, version) -> Result<Vec<Token>, String>\` convenience entry point.
- \`definition_for_version\` accepts every era string and tags the returned machine's \`name\` field with the era (e.g. \`ruby-2.3-lexer\`) so downstream tooling can identify which grammar produced the tokens.
- Unknown version strings produce an error pointing callers at the spec.

## v0 inheritance model

Every era currently shares the 1.8 baseline TOML — only the machine name differs.  This is deliberate: physically duplicating ~1100 lines of TOML 14 times would dwarf the actual behavioural delta of this PR.  Phase 4b+ will fork the era TOMLs as real syntactic deltas land:

| Era    | First real delta to fork                                       |
|--------|-----------------------------------------------------------------|
| 1.9.1  | lambda \`->\`, hash shorthand \`{a: 1}\`                            |
| 2.0    | \`%i[]\` / \`%I[]\`, kwargs \`:\` in def args                         |
| 2.1    | numeric suffixes \`r\` and \`i\`                                    |
| 2.3    | \`&.\` operator, \`<<~\` squiggly heredoc                           |
| 2.6    | endless ranges \`(1..)\`                                          |
| 2.7    | numbered block params \`_1\`..\`_9\`                                |
| 3.0    | endless method def, rightward assign                            |

The version-string surface is the load-bearing piece of this phase: callers that need version-gated tooling can already plumb the era string through; the underlying grammar will diverge incrementally as later phases land.

## Test plan

- [x] \`cargo test -p coding-adventures-ruby-lexer\` — 82 passed (was 77 in Phase 3c; +5 new Phase 4 tests).
- [x] All 15 era versions parse cleanly and produce a uniquely-named \`StateMachineDefinition\`.
- [x] \`tokenize_ruby_for_version\` produces the expected baseline token stream under every era.
- [x] CHANGELOG entry \`0.7.0 — Phase 4a\` added.

Phases merged in this series so far: [#3464](https://github.com/adhithyan15/coding-adventures/pull/3464) (spec) · [#3661](https://github.com/adhithyan15/coding-adventures/pull/3661) (Phase 1) · [#3670](https://github.com/adhithyan15/coding-adventures/pull/3670) (Phase 2) · [#3679](https://github.com/adhithyan15/coding-adventures/pull/3679) (Phase 3a) · [#3682](https://github.com/adhithyan15/coding-adventures/pull/3682) (Phase 3b) · [#3695](https://github.com/adhithyan15/coding-adventures/pull/3695) (Phase 3c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)