### PR TITLE
[codex] Add WHATWG ruby audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -38,6 +38,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser formatting audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser ruby audit generator
+  alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -160,6 +160,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-ruby-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_ruby_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -30,6 +30,9 @@ documented in this file.
 - Generated WHATWG formatting/implied-end-tag audit fixture over html5lib
   adoption-agency, anchor/nobr, paragraph, list/definition, ruby, heading, and
   formatting reconstruction cases, with a dedicated parser regression test.
+- Generated WHATWG ruby audit fixture over html5lib `ruby`, `rb`, `rt`,
+  `rtc`, and `rp` implied-end-tag recovery cases, including block descendants
+  and nested ruby containers, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -42,8 +45,8 @@ documented in this file.
   stray select/list end-tag cases, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
-  foreign-content, formatting, document-shell, template, and select/list audit
-  checks on the same parser and DOM dump path.
+  foreign-content, formatting, ruby, document-shell, template, and select/list
+  audit checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -167,6 +167,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting
   --check
 ```
 
+The generated `tests/fixtures/whatwg-ruby-audit.json` fixture indexes `ruby`,
+`rb`, `rt`, `rtc`, and `rp` implied-end-tag recovery, including block
+descendants and nested ruby containers:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -121,6 +121,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting
   --check
 ```
 
+`whatwg-ruby-audit.json` is a generated index over tree-construction cases
+that stress `ruby`, `rb`, `rt`, `rtc`, and `rp` implied-end-tag recovery,
+including block descendants and nested ruby containers:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG ruby audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-ruby-audit.json"
+
+RUBY_MARKUP = re.compile(r"</?(?:ruby|rb|rtc|rt|rp)(?:\s|/|>)", re.I)
+BLOCK_IN_RUBY_MARKUP = re.compile(
+    r"</?(?:div|p|span|table|tbody|tr|td)(?:\s|/|>)",
+    re.I,
+)
+
+CASE_AXES = (
+    {
+        "axis": "rb-boundary",
+        "reason": "rb implied end tags before following ruby annotation groups",
+    },
+    {
+        "axis": "rt-boundary",
+        "reason": "rt implied end tags before sibling ruby annotations",
+    },
+    {
+        "axis": "rtc-boundary",
+        "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+    },
+    {
+        "axis": "rp-boundary",
+        "reason": "rp implied end tags before sibling ruby annotations",
+    },
+    {
+        "axis": "block-in-ruby",
+        "reason": "ruby annotation recovery around block and phrasing descendants",
+    },
+    {
+        "axis": "nested-ruby",
+        "reason": "nested ruby containers inside rtc and ruby descendants",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG ruby audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_ruby_case(case_data):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any ruby audit cases")
+    return cases
+
+
+def is_ruby_case(data: str) -> bool:
+    return RUBY_MARKUP.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-ruby-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress ruby, rb, rt, rtc, and rp implied-end-tag recovery, "
+            "including nested ruby and block-descendant boundaries."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data.lower()
+    ruby_starts = len(re.findall(r"<ruby(?:\s|/|>)", data))
+
+    if ruby_starts > 1:
+        return "nested-ruby"
+    if BLOCK_IN_RUBY_MARKUP.search(data) is not None:
+        return "block-in-ruby"
+    if re.search(r"<rtc(?:\s|/|>)", data) is not None:
+        return "rtc-boundary"
+    if re.search(r"<rp(?:\s|/|>)", data) is not None:
+        return "rp-boundary"
+    if re.search(r"<rt(?:\s|/|>)", data) is not None:
+        return "rt-boundary"
+    if re.search(r"<rb(?:\s|/|>)", data) is not None:
+        return "rb-boundary"
+    return "rb-boundary"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown ruby audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-ruby-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-ruby-audit.json
@@ -1,0 +1,274 @@
+{
+  "case_count": 43,
+  "cases": [
+    {
+      "axis": "rb-boundary",
+      "id": "ruby-dat-386",
+      "reason": "rb implied end tags before following ruby annotation groups",
+      "source": "ruby.dat:386"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "ruby-dat-387",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:387"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-388",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:388"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "ruby-dat-389",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:389"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "ruby-dat-390",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "ruby.dat:390"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "ruby-dat-391",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:391"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "ruby-dat-392",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:392"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-393",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:393"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "ruby-dat-394",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:394"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "ruby-dat-395",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "ruby.dat:395"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-396",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:396"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-397",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:397"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-398",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:398"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-399",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:399"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "ruby-dat-400",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "ruby.dat:400"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "ruby-dat-401",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:401"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "ruby-dat-402",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:402"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "ruby-dat-403",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "ruby.dat:403"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "ruby-dat-404",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "ruby.dat:404"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "ruby-dat-405",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "ruby.dat:405"
+    },
+    {
+      "axis": "nested-ruby",
+      "id": "ruby-dat-406",
+      "reason": "nested ruby containers inside rtc and ruby descendants",
+      "source": "ruby.dat:406"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-1022",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:1022"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-1023",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:1023"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-1024",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:1024"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-1025",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:1025"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-1026",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:1026"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-1027",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:1027"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "tests19-dat-1028",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "tests19.dat:1028"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "tests19-dat-1029",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "tests19.dat:1029"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "tests19-dat-1030",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "tests19.dat:1030"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "tests19-dat-1031",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "tests19.dat:1031"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-9",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:9"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-10",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:10"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-11",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:11"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-12",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:12"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-13",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:13"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "tests19-dat-14",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "tests19.dat:14"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "tests19-dat-15",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "tests19.dat:15"
+    },
+    {
+      "axis": "rp-boundary",
+      "id": "tests19-dat-16",
+      "reason": "rp implied end tags before sibling ruby annotations",
+      "source": "tests19.dat:16"
+    },
+    {
+      "axis": "rt-boundary",
+      "id": "tests19-dat-17",
+      "reason": "rt implied end tags before sibling ruby annotations",
+      "source": "tests19.dat:17"
+    },
+    {
+      "axis": "rtc-boundary",
+      "id": "tests19-dat-18",
+      "reason": "rtc scope handling around nested rt, rb, rp, and rtc boundaries",
+      "source": "tests19.dat:18"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "webkit01-dat-29",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "webkit01.dat:29"
+    },
+    {
+      "axis": "block-in-ruby",
+      "id": "webkit01-dat-30",
+      "reason": "ruby annotation recovery around block and phrasing descendants",
+      "source": "webkit01.dat:30"
+    }
+  ],
+  "counts_by_axis": {
+    "block-in-ruby": 18,
+    "nested-ruby": 1,
+    "rb-boundary": 1,
+    "rp-boundary": 7,
+    "rt-boundary": 7,
+    "rtc-boundary": 9
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress ruby, rb, rt, rtc, and rp implied-end-tag recovery, including nested ruby and block-descendant boundaries.",
+  "format": "whatwg-html-ruby-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_ruby_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_ruby_audit_test.rs
@@ -1,0 +1,84 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_RUBY_AUDIT: &str = include_str!("fixtures/whatwg-ruby-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct RubyAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<RubyAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RubyAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_ruby_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-ruby-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 35);
+    assert_axis_count(&suite, "rb-boundary", 1);
+    assert_axis_count(&suite, "rt-boundary", 4);
+    assert_axis_count(&suite, "rtc-boundary", 6);
+    assert_axis_count(&suite, "rp-boundary", 4);
+    assert_axis_count(&suite, "block-in-ruby", 8);
+    assert_axis_count(&suite, "nested-ruby", 1);
+}
+
+#[test]
+fn whatwg_ruby_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> RubyAuditSuite {
+    serde_json::from_str(WHATWG_RUBY_AUDIT).expect("WHATWG ruby audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &RubyAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG ruby audit fixture over 43 html5lib tree-construction cases
- split ruby coverage into rb, rt, rtc, rp, block-in-ruby, and nested-ruby axes
- wire the new generator into the generated HTML fixture manifest and docs/changelogs

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- cargo test -p coding-adventures-html-parser whatwg_ruby_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py