### PR TITLE
feat(lang-vm): LANG76 — byte memory ops + heap allocation

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — `aarch64-backend`
 
+## 0.4.0 — 2026-05-20 (LANG76 — byte memory ops + heap allocation)
+
+Three new CIR opcodes mirroring the LANG76 work in `x86_64-backend`
+0.6.0:
+
+- `alloc_bytes <n> -> <dest>` — sugar for `call_builtin "alloc_bytes",
+  n`.  Loads n into X0, emits `BL __twig_alloc_bytes`, stores X0 into
+  the dest slot.
+- `load_byte <ptr>, <offset> -> <dest>` — `ldr x0,[sp,ptr]; ldr
+  x1,[sp,off]; add x0,x0,x1; ldrb w0,[x0]; str x0,[sp,dest]`.  The
+  LDRB instruction zero-extends to 32 bits and AArch64 zeroes the
+  upper 32 bits of X0 automatically — exactly the 64-bit
+  zero-extension semantics LANG76 specifies.
+- `store_byte <ptr>, <offset>, <value>` — `ldr x0,[sp,ptr]; ldr
+  x1,[sp,off]; add x0,x0,x1; ldr x2,[sp,val]; strb w2,[x0]`.
+
+**Tests added (5):** alloc_bytes records `__twig_alloc_bytes` BL
+placeholder; load_byte/store_byte emit the expected ldrb/strb words
+(`0x39400000` / `0x39000002`); load_byte missing operand refusal;
+store_byte with dest refusal.
+
 ## 0.3.0 — 2026-05-20 (LANG75 — generic `call_builtin` dispatch)
 
 Adds a single CIR opcode `call_builtin "<name>", <args>` that

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -189,6 +189,8 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "print_string", n_args: 2, returns: false },
     BuiltinSig { name: "input_i64",    n_args: 0, returns: true  },
     BuiltinSig { name: "exit",         n_args: 1, returns: false },
+    // LANG76 — heap allocator.  Returns a pointer (treated as i64).
+    BuiltinSig { name: "alloc_bytes",  n_args: 1, returns: true  },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -876,6 +878,79 @@ fn emit_instr(
                 asm.str_(Reg::X0, Reg::Sp, slot)?;
             }
         }
+        return Ok(());
+    }
+
+    // ── LANG76 — byte memory ops + heap allocation ─────────────────────────────
+
+    // `alloc_bytes <n> -> <dest>` — sugar for `call_builtin "alloc_bytes", n`.
+    if op == "alloc_bytes" {
+        let dest = require_dest(instr)?;
+        let n_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("alloc_bytes: needs srcs[0]=byte_count".into())
+        })?;
+        load_operand(asm, alloc, Reg::X0, n_src)?;
+        asm.bl_external("__twig_alloc_bytes");
+        let slot = alloc.slot_of(dest);
+        asm.str_(Reg::X0, Reg::Sp, slot)?;
+        return Ok(());
+    }
+
+    // `load_byte <ptr>, <offset> -> <dest>` — read one byte from
+    // `[ptr + offset]`, zero-extend, store into `dest`.
+    //
+    // ARM64 sequence (X0/X1 are the standard scratch pair):
+    //   ldr  x0, [sp, ptr_slot]
+    //   ldr  x1, [sp, offset_slot]
+    //   add  x0, x0, x1                  ; x0 = ptr + offset
+    //   ldrb w0, [x0]                    ; load byte, zero-extend to w0
+    //   str  x0, [sp, dest_slot]         ; LDRB zeros upper 32 bits of x0
+    if op == "load_byte" {
+        let dest = require_dest(instr)?;
+        let ptr_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("load_byte: needs srcs[0]=ptr".into())
+        })?;
+        let off_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("load_byte: needs srcs[1]=offset".into())
+        })?;
+        load_operand(asm, alloc, Reg::X0, ptr_src)?;
+        load_operand(asm, alloc, Reg::X1, off_src)?;
+        asm.add(Reg::X0, Reg::X0, Reg::X1);
+        asm.ldrb(Reg::X0, Reg::X0, 0)?;
+        let slot = alloc.slot_of(dest);
+        asm.str_(Reg::X0, Reg::Sp, slot)?;
+        return Ok(());
+    }
+
+    // `store_byte <ptr>, <offset>, <value>` — write the low 8 bits of
+    // `value` to `[ptr + offset]`.  No dest.
+    //
+    // Sequence:
+    //   ldr  x0, [sp, ptr_slot]
+    //   ldr  x1, [sp, offset_slot]
+    //   add  x0, x0, x1
+    //   ldr  x2, [sp, value_slot]
+    //   strb w2, [x0]                    ; strb writes only the low byte
+    if op == "store_byte" {
+        if instr.dest.is_some() {
+            return Err(BackendError::MalformedInstr(
+                "store_byte: must not have a dest".into(),
+            ));
+        }
+        let ptr_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("store_byte: needs srcs[0]=ptr".into())
+        })?;
+        let off_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("store_byte: needs srcs[1]=offset".into())
+        })?;
+        let val_src = instr.srcs.get(2).ok_or_else(|| {
+            BackendError::MalformedInstr("store_byte: needs srcs[2]=value".into())
+        })?;
+        load_operand(asm, alloc, Reg::X0, ptr_src)?;
+        load_operand(asm, alloc, Reg::X1, off_src)?;
+        asm.add(Reg::X0, Reg::X0, Reg::X1);
+        load_operand(asm, alloc, Reg::X2, val_src)?;
+        asm.strb(Reg::X2, Reg::X0, 0)?;
         return Ok(());
     }
 
@@ -1670,6 +1745,111 @@ mod tests {
             &ctx("bad_arity", &[], "void"), &cir, &HashMap::new()
         );
         assert!(result.is_err(), "wrong arity should error");
+    }
+
+    // ── LANG76 — byte memory ops + heap allocation ────────────────────────────
+
+    #[test]
+    fn alloc_bytes_emits_bl_to_runtime() {
+        let cir = vec![
+            CIRInstr { op: "const_i64".into(), dest: Some("n".into()),
+                       srcs: vec![CIROperand::Int(16)],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "alloc_bytes".into(), dest: Some("buf".into()),
+                       srcs: vec![CIROperand::Var("n".into())],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "ret_i64".into(), dest: None,
+                       srcs: vec![CIROperand::Var("buf".into())],
+                       ty: "i64".into(), deopt_to: None },
+        ];
+        let (_bytes, ext_relocs, _) = compile_with_globals(
+            &ctx("a", &[], "i64"), &cir, &HashMap::new()
+        ).expect("alloc_bytes should compile");
+        assert_eq!(ext_relocs.iter().filter(|r| r.symbol == "__twig_alloc_bytes").count(), 1);
+    }
+
+    #[test]
+    fn load_byte_compiles() {
+        // CIR: load_byte ptr, off -> v; ret_i64 v
+        let params = vec![("ptr".into(), "i64".into()),
+                          ("off".into(), "i64".into())];
+        let cir = vec![
+            CIRInstr { op: "load_byte".into(), dest: Some("v".into()),
+                       srcs: vec![CIROperand::Var("ptr".into()),
+                                  CIROperand::Var("off".into())],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "ret_i64".into(), dest: None,
+                       srcs: vec![CIROperand::Var("v".into())],
+                       ty: "i64".into(), deopt_to: None },
+        ];
+        let bytes = compile(&ctx("lb", &params, "i64"), &cir).expect("compile ok");
+        // LDRB W0, [X0]: 0x39400000 (Rt=0, Rn=0, imm12=0).
+        let words: Vec<u32> = bytes.chunks(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert!(words.contains(&0x39400000),
+                "expected LDRB W0, [X0] (0x39400000) in {words:08X?}");
+    }
+
+    #[test]
+    fn store_byte_compiles() {
+        // CIR: store_byte ptr, off, val
+        let params = vec![("ptr".into(), "i64".into()),
+                          ("off".into(), "i64".into()),
+                          ("val".into(), "i64".into())];
+        let cir = vec![
+            CIRInstr { op: "store_byte".into(), dest: None,
+                       srcs: vec![CIROperand::Var("ptr".into()),
+                                  CIROperand::Var("off".into()),
+                                  CIROperand::Var("val".into())],
+                       ty: "void".into(), deopt_to: None },
+            CIRInstr { op: "ret_void".into(), dest: None,
+                       srcs: vec![], ty: "void".into(), deopt_to: None },
+        ];
+        let bytes = compile(&ctx("sb", &params, "void"), &cir).expect("compile ok");
+        // STRB W2, [X0]: 0x39000002 (Rt=2, Rn=0, imm12=0).
+        let words: Vec<u32> = bytes.chunks(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert!(words.contains(&0x39000002),
+                "expected STRB W2, [X0] (0x39000002) in {words:08X?}");
+    }
+
+    #[test]
+    fn load_byte_missing_offset_refuses() {
+        let params = vec![("ptr".into(), "i64".into())];
+        let cir = vec![
+            CIRInstr { op: "load_byte".into(), dest: Some("v".into()),
+                       srcs: vec![CIROperand::Var("ptr".into())],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "ret_i64".into(), dest: None,
+                       srcs: vec![CIROperand::Var("v".into())],
+                       ty: "i64".into(), deopt_to: None },
+        ];
+        assert!(compile(&ctx("bad", &params, "i64"), &cir).is_err());
+    }
+
+    #[test]
+    fn store_byte_with_dest_refuses() {
+        let cir = vec![
+            CIRInstr { op: "const_i64".into(), dest: Some("p".into()),
+                       srcs: vec![CIROperand::Int(0)],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "const_i64".into(), dest: Some("o".into()),
+                       srcs: vec![CIROperand::Int(0)],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "const_i64".into(), dest: Some("v".into()),
+                       srcs: vec![CIROperand::Int(0)],
+                       ty: "i64".into(), deopt_to: None },
+            CIRInstr { op: "store_byte".into(), dest: Some("r".into()),  // illegal!
+                       srcs: vec![CIROperand::Var("p".into()),
+                                  CIROperand::Var("o".into()),
+                                  CIROperand::Var("v".into())],
+                       ty: "void".into(), deopt_to: None },
+            CIRInstr { op: "ret_void".into(), dest: None, srcs: vec![],
+                       ty: "void".into(), deopt_to: None },
+        ];
+        assert!(compile(&ctx("bad", &[], "void"), &cir).is_err());
     }
 
     #[test]

--- a/code/packages/rust/aarch64-encoder/CHANGELOG.md
+++ b/code/packages/rust/aarch64-encoder/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — `aarch64-encoder`
 
+## 0.3.0 — 2026-05-20 (LANG76 — byte memory primitives)
+
+Adds the unsigned-offset byte load/store instructions used by
+`aarch64-backend` to lower `load_byte` / `store_byte`:
+
+- `ldrb(rt, rn, imm)` — `LDRB Wt, [Xn, #imm]`, `imm ∈ [0, 4095]`.
+  Loads one byte from `[Xn + imm]`, zero-extends to 32 bits in `Wt`
+  (which also zeros the upper 32 bits of `Xt` per AArch64 spec).
+- `strb(rt, rn, imm)` — `STRB Wt, [Xn, #imm]`, same `imm` range.
+  Writes the low byte of `Wt` to `[Xn + imm]`.
+
+Encoding base: `0x39400000` (LDRB) / `0x39000000` (STRB); imm12 in
+bits 21..10, Rn in 9..5, Rt in 4..0.  Unlike `LDR Xt` / `STR Xt` the
+byte form is **not** scaled — `imm` is interpreted as a raw byte
+offset.
+
 ## 0.2.2 — 2026-05-13 (LANG40)
 
 **Pre-indexed byte store — `STRB Wt, [Xn, #-1]!`.**

--- a/code/packages/rust/aarch64-encoder/Cargo.toml
+++ b/code/packages/rust/aarch64-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-encoder"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Pure-Rust ARM64 (AArch64) instruction encoder — covers the subset needed by jit-core / aot-core to lower CIR to native machine code."
 

--- a/code/packages/rust/aarch64-encoder/src/lib.rs
+++ b/code/packages/rust/aarch64-encoder/src/lib.rs
@@ -788,6 +788,53 @@ impl Assembler {
         Ok(())
     }
 
+    /// `LDRB Wt, [Xn, #imm]` — load one byte, zero-extend to 32 bits (LANG76).
+    ///
+    /// `imm` is a 12-bit unsigned immediate in the range `[0, 4095]` (the
+    /// byte form is **not** scaled — unlike `LDR Xt` which scales by 8 or
+    /// `LDR Wt` which scales by 4).  Wt is treated as a W-register
+    /// (32-bit) by the hardware so the upper 32 bits of Xt are zeroed
+    /// automatically — exactly the zero-extend semantics LANG76 wants.
+    ///
+    /// Encoding (LDRB unsigned offset):
+    ///
+    /// ```text
+    /// 00 111 0 01 01 imm12 Rn Rt
+    /// 0x39400000 | (imm12 << 10) | (Rn << 5) | Rt
+    /// ```
+    pub fn ldrb(&mut self, rt: Reg, rn: Reg, imm: u32) -> Result<(), EncodeError> {
+        if imm > 0xFFF {
+            return Err(EncodeError::ImmediateOutOfRange { op: "ldrb", bits: 12, value: imm as i64 });
+        }
+        let word = 0x39400000
+            | (imm << 10)
+            | (rn.idx() << 5)
+            | rt.idx();
+        self.emit(word);
+        Ok(())
+    }
+
+    /// `STRB Wt, [Xn, #imm]` — store the low byte of Wt to `[Xn + imm]`
+    /// (LANG76).  Same `imm` constraints as [`ldrb`].
+    ///
+    /// Encoding (STRB unsigned offset):
+    ///
+    /// ```text
+    /// 00 111 0 01 00 imm12 Rn Rt
+    /// 0x39000000 | (imm12 << 10) | (Rn << 5) | Rt
+    /// ```
+    pub fn strb(&mut self, rt: Reg, rn: Reg, imm: u32) -> Result<(), EncodeError> {
+        if imm > 0xFFF {
+            return Err(EncodeError::ImmediateOutOfRange { op: "strb", bits: 12, value: imm as i64 });
+        }
+        let word = 0x39000000
+            | (imm << 10)
+            | (rn.idx() << 5)
+            | rt.idx();
+        self.emit(word);
+        Ok(())
+    }
+
     /// `STRB Wt, [Xn, #-1]!` — pre-indexed byte store, always decrements Rn by 1.
     ///
     /// This is the ARM64 idiom for a "push byte" onto a downward-growing buffer:

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — `twig-aot`
 
+## 0.7.0 — 2026-05-20 (LANG76 — byte memory ops + heap allocation)
+
+Runtime archive gains one new helper:
+
+| Symbol                | Purpose                                              |
+|-----------------------|------------------------------------------------------|
+| `__twig_alloc_bytes`  | `calloc(1, n)` — zero-initialised heap allocation.   |
+
+V1 leaks (no `__twig_free`); per the LANG76 spec, that's fine for AOT'd
+command-line scripts.  Negative or zero `n` returns NULL (`0`).
+
+**End-to-end smoke tests:** `tests/{windows,linux}_x86_64_smoke.rs`
+each grow a new `end_to_end_lang76_heap_byte_io_writes_hi` test that
+hand-builds an `IIRModule` calling `alloc_bytes 4`, writes `'H','i','\n'`
+via three `store_byte` instructions, then calls `print_string` over
+the buffer.  Asserts stdout is exactly `"Hi\n"`.
+
 ## 0.6.0 — 2026-05-20 (LANG75 — runtime-archive expansion)
 
 **Runtime archive grows the V1 helper table.**

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source."
 

--- a/code/packages/rust/twig-aot/runtime/twig_runtime.c
+++ b/code/packages/rust/twig-aot/runtime/twig_runtime.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* __twig_print_i64 — print a signed 64-bit integer followed by a newline.
  *
@@ -147,4 +148,29 @@ __declspec(noreturn)
 #endif
 void __twig_exit(int32_t code) {
     exit((int)code);
+}
+
+/* __twig_alloc_bytes — allocate `n` zero-initialised bytes on the heap
+ * (LANG76).
+ *
+ * Returns a 64-bit pointer.  The pointer is valid until process exit;
+ * V1 has no `__twig_free` and intentionally leaks — fine for AOT'd
+ * command-line scripts.
+ *
+ * `calloc(1, n)` is used (rather than `malloc(n) + memset`) so the
+ * compiler/libc can take the zero-initialised-page fast path when one
+ * is available.  Negative or zero `n` returns NULL — programs that
+ * dereference the result without a null check will crash, which is
+ * acceptable per the V1 "no bounds checking, no null checking"
+ * contract.
+ *
+ * The returned `void*` is treated as `int64_t` by the frontend (the
+ * AAPCS64 / System V / MS x64 ABIs all return pointers in `x0` / `rax`
+ * regardless of pointer-vs-integer typing, so no type coercion is
+ * needed at the call site).
+ */
+int64_t __twig_alloc_bytes(int64_t n) {
+    if (n <= 0) return 0;
+    void *p = calloc(1, (size_t)n);
+    return (int64_t)(intptr_t)p;
 }

--- a/code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs
@@ -169,6 +169,76 @@ fn build_putchar_hi_module() -> interpreter_ir::module::IIRModule {
     module
 }
 
+/// LANG76 — end-to-end heap byte I/O on Linux x86-64.
+///
+/// Mirrors the Windows test: alloc 4 bytes, write `'H','i','\n'` at
+/// offsets 0/1/2, call `print_string(buf, 3)`, return 0.  Asserts
+/// stdout = `"Hi\n"`.
+#[test]
+fn end_to_end_lang76_heap_byte_io_writes_hi() {
+    let module = build_heap_byte_io_module();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let exe_path = dir.path().join("heap_byte_io");
+
+    twig_aot::compile_module_to_linux_executable(&module, &exe_path)
+        .unwrap_or_else(|e| panic!("compile failed: {e}"));
+
+    let out = Command::new(&exe_path).output()
+        .unwrap_or_else(|e| panic!("launch failed: {e}"));
+    assert_eq!(
+        out.stdout, b"Hi\n",
+        "expected stdout == \"Hi\\n\", got {:?}; stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+fn build_heap_byte_io_module() -> interpreter_ir::module::IIRModule {
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    let mut ins = Vec::new();
+    let mut con = |slot: &str, n: i64| {
+        IIRInstr::new("const", Some(slot.to_string()),
+                      vec![Operand::Int(n)], "i64")
+    };
+
+    ins.push(con("c4", 4));
+    ins.push(IIRInstr::new("alloc_bytes", Some("buf".into()),
+        vec![Operand::Var("c4".into())], "i64"));
+
+    for (slot, off, byte) in [
+        ("o0", 0_i64, 72_i64),
+        ("o1", 1,     105),
+        ("o2", 2,     10),
+    ] {
+        ins.push(con(slot, off));
+        let v = format!("v_{slot}");
+        ins.push(con(&v, byte));
+        ins.push(IIRInstr::new("store_byte", None,
+            vec![Operand::Var("buf".into()),
+                 Operand::Var(slot.into()),
+                 Operand::Var(v)], "void"));
+    }
+
+    ins.push(con("len3", 3));
+    ins.push(IIRInstr::new("call_builtin", None,
+        vec![Operand::Var("print_string".into()),
+             Operand::Var("buf".into()),
+             Operand::Var("len3".into())], "void"));
+
+    ins.push(con("r", 0));
+    ins.push(IIRInstr::new("ret", None,
+        vec![Operand::Var("r".into())], "i64"));
+
+    let main = IIRFunction::new("main", vec![], "i64", ins);
+    let mut module = IIRModule::new("heap_byte_io", "lang");
+    module.functions.push(main);
+    module.entry_point = Some("main".to_string());
+    module
+}
+
 #[test]
 fn elf_object_has_correct_machine_field() {
     // Byte-level sanity check: produce an object for `42` and assert

--- a/code/packages/rust/twig-aot/tests/windows_x86_64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/windows_x86_64_smoke.rs
@@ -218,6 +218,109 @@ fn build_putchar_hi_module() -> interpreter_ir::module::IIRModule {
     module
 }
 
+/// LANG76 — end-to-end heap byte I/O on Windows x86-64.
+///
+/// Builds a tiny `IIRModule`:
+///
+/// ```text
+/// fn main() -> i64 {
+///   const c4   = 4
+///   alloc_bytes c4 -> buf       ; calloc(1, 4)
+///   const c0   = 0
+///   const cH   = 72
+///   store_byte buf, c0, cH
+///   const c1   = 1
+///   const ci   = 105
+///   store_byte buf, c1, ci
+///   const c2_  = 2
+///   const cnl  = 10
+///   store_byte buf, c2_, cnl
+///   const c3   = 3
+///   call_builtin "print_string", buf, c3
+///   const r    = 0
+///   ret r
+/// }
+/// ```
+///
+/// Compiles, links, runs, asserts stdout = `"Hi\n"`.  This exercises
+/// the full LANG76 chain: `alloc_bytes` → `__twig_alloc_bytes`,
+/// `store_byte` (low-byte write), and `call_builtin "print_string"`
+/// reading those bytes back.
+#[test]
+fn end_to_end_lang76_heap_byte_io_writes_hi() {
+    if !linker_available() {
+        eprintln!("skipping: no Windows linker on PATH");
+        return;
+    }
+
+    let module = build_heap_byte_io_module();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let exe_path = dir.path().join("heap_byte_io.exe");
+
+    twig_aot::compile_module_to_windows_executable(&module, &exe_path)
+        .unwrap_or_else(|e| panic!("compile failed: {e}"));
+
+    let out = Command::new(&exe_path).output()
+        .unwrap_or_else(|e| panic!("launch failed: {e}"));
+    assert_eq!(
+        out.stdout, b"Hi\n",
+        "expected stdout == \"Hi\\n\", got {:?}; stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// Build a module that allocates a 4-byte buffer, writes `'H','i','\n'`
+/// at offsets 0/1/2, calls `print_string(buf, 3)`, and returns 0.
+fn build_heap_byte_io_module() -> interpreter_ir::module::IIRModule {
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    let mut ins = Vec::new();
+    let mut con = |slot: &str, n: i64| {
+        IIRInstr::new("const", Some(slot.to_string()),
+                      vec![Operand::Int(n)], "i64")
+    };
+
+    ins.push(con("c4", 4));
+    ins.push(IIRInstr::new("alloc_bytes", Some("buf".into()),
+        vec![Operand::Var("c4".into())], "i64"));
+
+    // store bytes 'H','i','\n' at offsets 0, 1, 2
+    for (slot, off, byte) in [
+        ("o0", 0_i64, 72_i64),   // 'H'
+        ("o1", 1,     105),      // 'i'
+        ("o2", 2,     10),       // '\n'
+    ] {
+        ins.push(con(slot, off));
+        let v = format!("v_{slot}");
+        ins.push(con(&v, byte));
+        ins.push(IIRInstr::new("store_byte", None,
+            vec![Operand::Var("buf".into()),
+                 Operand::Var(slot.into()),
+                 Operand::Var(v)], "void"));
+    }
+
+    // print_string(buf, 3)
+    ins.push(con("len3", 3));
+    ins.push(IIRInstr::new("call_builtin", None,
+        vec![Operand::Var("print_string".into()),
+             Operand::Var("buf".into()),
+             Operand::Var("len3".into())], "void"));
+
+    // ret 0
+    ins.push(con("r", 0));
+    ins.push(IIRInstr::new("ret", None,
+        vec![Operand::Var("r".into())], "i64"));
+
+    let main = IIRFunction::new("main", vec![], "i64", ins);
+    let mut module = IIRModule::new("heap_byte_io", "lang");
+    module.functions.push(main);
+    module.entry_point = Some("main".to_string());
+    module
+}
+
 #[test]
 fn pe_object_has_correct_machine_field() {
     // Byte-level sanity check: produce an object for `42` and assert

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — `x86_64-backend`
 
+## 0.6.0 — 2026-05-20 (LANG76 — byte memory ops + heap allocation)
+
+Three new CIR opcodes that complete the substrate for Brainfuck and
+future array work:
+
+- `alloc_bytes <n> -> <dest>` — sugar for `call_builtin "alloc_bytes",
+  n`; emits the same CALL into `__twig_alloc_bytes` and stores the
+  returned pointer (RAX) into `dest`.  Also registered in
+  `V1_BUILTINS` so `call_builtin "alloc_bytes"` works equivalently.
+- `load_byte <ptr>, <offset> -> <dest>` — reads one byte from `[ptr +
+  offset]`, zero-extends to 64 bits, stores into `dest`.  Lowers to:
+  `mov rax,ptr; mov rcx,off; add rax,rcx; movzx rax,byte [rax]; mov
+  [rbp+dest_slot],rax`.
+- `store_byte <ptr>, <offset>, <value>` — writes the low 8 bits of
+  `value` to `[ptr + offset]`.  Lowers to: `mov rax,ptr; mov rcx,off;
+  add rax,rcx; mov rdx,val; mov byte [rax], dl`.
+
+**Error handling.**  Missing operands → `MalformedInstr`; supplying a
+dest to `store_byte` → `MalformedInstr`.
+
+**Tests added (5):** alloc_bytes records `__twig_alloc_bytes` PltRel32
+reloc + RAX→dest store; load_byte byte-sequence assertion; store_byte
+byte-sequence assertion (forced empty REX); load_byte missing operand
+refusal; store_byte with dest refusal.
+
 ## 0.5.0 — 2026-05-20 (LANG75 — generic `call_builtin` dispatch)
 
 Adds a single CIR opcode `call_builtin "<name>", <args>` that dispatches

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -290,6 +290,8 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "print_string", n_args: 2, returns: false },
     BuiltinSig { name: "input_i64",    n_args: 0, returns: true  },
     BuiltinSig { name: "exit",         n_args: 1, returns: false },
+    // LANG76 — heap allocator.  Returns a pointer (treated as i64).
+    BuiltinSig { name: "alloc_bytes",  n_args: 1, returns: true  },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -780,6 +782,86 @@ fn emit_instr(
                 asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
             }
         }
+        return Ok(());
+    }
+
+    // ── LANG76 — byte memory ops + heap allocation ────────────────────────────
+
+    // `alloc_bytes <n> -> <dest>` — sugar for `call_builtin "alloc_bytes", n`.
+    //
+    // The spec exposes a separate CIR mnemonic so frontends don't have to
+    // think about V1_BUILTINS arity validation.  Internally we just emit
+    // the same CALL sequence the `call_builtin` arm above would produce,
+    // sharing the `__twig_alloc_bytes` runtime symbol and PltRel32 reloc.
+    if op == "alloc_bytes" {
+        let dest = require_dest(instr)?;
+        let n_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("alloc_bytes: needs srcs[0]=byte_count".into())
+        })?;
+        let arg0_reg = abi.arg_regs()[0];
+        load_operand(asm, alloc, arg0_reg, n_src);
+        asm.call_rel32("__twig_alloc_bytes", ExternalRelocKind::PltRel32);
+        // Return pointer in RAX → dest slot.
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        return Ok(());
+    }
+
+    // `load_byte <ptr>, <offset> -> <dest>` — read one byte from
+    // `[ptr + offset]`, zero-extend to 64 bits, store into `dest`.
+    //
+    // Sequence (uses RAX + RCX scratch; both reserved by RegAlloc):
+    //   mov  rax, [rbp + ptr_slot]      ; pointer
+    //   mov  rcx, [rbp + offset_slot]   ; offset
+    //   add  rax, rcx                    ; rax = ptr + offset
+    //   movzx rax, byte ptr [rax]        ; zero-extend load
+    //   mov  [rbp + dest_slot], rax
+    if op == "load_byte" {
+        let dest = require_dest(instr)?;
+        let ptr_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("load_byte: needs srcs[0]=ptr".into())
+        })?;
+        let off_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("load_byte: needs srcs[1]=offset".into())
+        })?;
+        load_operand(asm, alloc, Reg::Rax, ptr_src);
+        load_operand(asm, alloc, Reg::Rcx, off_src);
+        asm.add(Reg::Rax, Reg::Rcx);
+        asm.movzx_r64_byte_at(Reg::Rax, Reg::Rax);
+        let slot = alloc.slot_of(dest);
+        asm.mov_mem_r64(Reg::Rbp, RegAlloc::rbp_offset(slot), Reg::Rax);
+        return Ok(());
+    }
+
+    // `store_byte <ptr>, <offset>, <value>` — write the low 8 bits of
+    // `value` to `[ptr + offset]`.  No dest.
+    //
+    // Sequence:
+    //   mov  rax, [rbp + ptr_slot]
+    //   mov  rcx, [rbp + offset_slot]
+    //   add  rax, rcx
+    //   mov  rdx, [rbp + value_slot]
+    //   mov  byte ptr [rax], dl          ; store low 8 bits
+    if op == "store_byte" {
+        if instr.dest.is_some() {
+            return Err(BackendError::MalformedInstr(
+                "store_byte: must not have a dest".into(),
+            ));
+        }
+        let ptr_src = instr.srcs.first().ok_or_else(|| {
+            BackendError::MalformedInstr("store_byte: needs srcs[0]=ptr".into())
+        })?;
+        let off_src = instr.srcs.get(1).ok_or_else(|| {
+            BackendError::MalformedInstr("store_byte: needs srcs[1]=offset".into())
+        })?;
+        let val_src = instr.srcs.get(2).ok_or_else(|| {
+            BackendError::MalformedInstr("store_byte: needs srcs[2]=value".into())
+        })?;
+        load_operand(asm, alloc, Reg::Rax, ptr_src);
+        load_operand(asm, alloc, Reg::Rcx, off_src);
+        asm.add(Reg::Rax, Reg::Rcx);
+        load_operand(asm, alloc, Reg::Rdx, val_src);
+        asm.mov_byte_at_r8(Reg::Rax, Reg::Rdx);
         return Ok(());
     }
 
@@ -1848,6 +1930,105 @@ mod tests {
         ];
         let result = compile_function(&ctx, &ir, X86_64Abi::SysV);
         assert!(result.is_err());
+    }
+
+    // ── LANG76 — byte memory ops + heap allocation ────────────────────────────
+
+    #[test]
+    fn alloc_bytes_calls_runtime_helper_and_stores_rax() {
+        // alloc_bytes 16 -> buf
+        let ctx = fn_ctx("a", &[], "i64");
+        let ir = vec![
+            instr("const_i64", Some("n"), vec![Op::Int(16)]),
+            instr("alloc_bytes", Some("buf"),
+                  vec![Op::Var("n".into())]),
+            instr("ret_i64", None, vec![Op::Var("buf".into())]),
+        ];
+        let (bytes, relocs) = compile_function_with_relocs(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // Arg goes into RDI (SysV).
+        assert!(body_contains(&bytes, &[0x48, 0x8B, 0xBD]),
+                "expected `mov rdi, [rbp+disp]` for n");
+        // CALL E8 followed by 4 zero placeholder bytes.
+        assert!(body_contains(&bytes, &[0xE8]),
+                "expected CALL opcode E8");
+        // Store RAX to dest slot: 48 89 85 ...
+        assert!(body_contains(&bytes, &[0x48, 0x89, 0x85]),
+                "expected `mov [rbp+disp], rax` for buf");
+        let plt: Vec<_> = relocs.iter()
+            .filter(|r| r.symbol == "__twig_alloc_bytes").collect();
+        assert_eq!(plt.len(), 1);
+    }
+
+    #[test]
+    fn load_byte_emits_add_then_movzx() {
+        // load_byte ptr, off -> dest
+        let params = vec![("ptr".into(), "i64".into()),
+                          ("off".into(), "i64".into())];
+        let ctx = fn_ctx("lb", &params, "i64");
+        let ir = vec![
+            instr("load_byte", Some("v"),
+                  vec![Op::Var("ptr".into()), Op::Var("off".into())]),
+            instr("ret_i64", None, vec![Op::Var("v".into())]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // `add rax, rcx` = 48 01 C8
+        assert!(body_contains(&bytes, &[0x48, 0x01, 0xC8]),
+                "expected `add rax, rcx` to combine ptr + offset");
+        // `movzx rax, byte ptr [rax]` = 48 0F B6 00
+        assert!(body_contains(&bytes, &[0x48, 0x0F, 0xB6, 0x00]),
+                "expected `movzx rax, byte [rax]`");
+    }
+
+    #[test]
+    fn store_byte_emits_mov_byte_at_dl() {
+        // store_byte ptr, off, val
+        let params = vec![("ptr".into(), "i64".into()),
+                          ("off".into(), "i64".into()),
+                          ("val".into(), "i64".into())];
+        let ctx = fn_ctx("sb", &params, "void");
+        let ir = vec![
+            instr("store_byte", None,
+                  vec![Op::Var("ptr".into()),
+                       Op::Var("off".into()),
+                       Op::Var("val".into())]),
+            instr("ret_void", None, vec![]),
+        ];
+        let bytes = compile_function(&ctx, &ir, X86_64Abi::SysV).unwrap();
+        // After `add rax, rcx` (48 01 C8), load val into rdx, then `mov [rax], dl`
+        // which with forced REX prefix is `40 88 10` (REX with all bits 0, opcode 88,
+        // ModRM mod=00 reg=010(DL) rm=000(RAX)).
+        assert!(body_contains(&bytes, &[0x48, 0x01, 0xC8]),
+                "expected `add rax, rcx`");
+        assert!(body_contains(&bytes, &[0x40, 0x88, 0x10]),
+                "expected `mov byte ptr [rax], dl` with empty REX prefix");
+    }
+
+    #[test]
+    fn load_byte_missing_offset_refuses() {
+        let params = vec![("ptr".into(), "i64".into())];
+        let ctx = fn_ctx("bad", &params, "i64");
+        let ir = vec![
+            instr("load_byte", Some("v"),
+                  vec![Op::Var("ptr".into())]),
+            instr("ret_i64", None, vec![Op::Var("v".into())]),
+        ];
+        assert!(compile_function(&ctx, &ir, X86_64Abi::SysV).is_err());
+    }
+
+    #[test]
+    fn store_byte_with_dest_refuses() {
+        let ctx = fn_ctx("bad", &[], "void");
+        let ir = vec![
+            instr("const_i64", Some("p"), vec![Op::Int(0)]),
+            instr("const_i64", Some("o"), vec![Op::Int(0)]),
+            instr("const_i64", Some("v"), vec![Op::Int(0)]),
+            instr("store_byte", Some("r"),  // illegal!
+                  vec![Op::Var("p".into()),
+                       Op::Var("o".into()),
+                       Op::Var("v".into())]),
+            instr("ret_void", None, vec![]),
+        ];
+        assert!(compile_function(&ctx, &ir, X86_64Abi::SysV).is_err());
     }
 
     #[test]

--- a/code/packages/rust/x86_64-encoder/CHANGELOG.md
+++ b/code/packages/rust/x86_64-encoder/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — `x86_64-encoder`
 
+## 0.3.0 — 2026-05-20 (LANG76 — byte memory primitives)
+
+Two new instruction emitters for `load_byte` / `store_byte` lowering
+in `x86_64-backend`:
+
+- `movzx_r64_byte_at(dst, base)` — `MOVZX r64, BYTE PTR [base]` (4
+  bytes: `REX.W 0F B6 ModRM`).  Loads one byte from `[base]`,
+  zero-extends to 64 bits, writes into `dst`.
+- `mov_byte_at_r8(base, src)` — `MOV BYTE PTR [base], src.low8` (3
+  bytes: `REX 88 ModRM`).  Always emits a REX prefix (even when
+  empty) so the byte-register encoding is unambiguous for any GPR.
+
+Both helpers assert `base.low3() ∉ {4, 5}` (no RSP/R12 SIB; no
+RBP/R13 RIP-relative).  Callers always pre-compute the effective
+address into RAX/RCX/RDX before invoking these helpers, matching the
+LANG76 spec.
+
 ## 0.2.0 — 2026-05-14 (LANG43 phase 5 — calls)
 
 Added `call_label(LabelId)` — `CALL rel32` to an internal label,

--- a/code/packages/rust/x86_64-encoder/Cargo.toml
+++ b/code/packages/rust/x86_64-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-encoder"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Pure-Rust x86-64 (AMD64 / Intel 64) instruction encoder — covers the subset needed by jit-core / aot-core to lower CIR to native machine code on Linux and Windows."
 

--- a/code/packages/rust/x86_64-encoder/src/lib.rs
+++ b/code/packages/rust/x86_64-encoder/src/lib.rs
@@ -654,6 +654,46 @@ impl Assembler {
         self.emit_u8(modrm(0b11, dst.low3(), src.low3()));
     }
 
+    /// `MOVZX r64, byte ptr [base]` — load one byte from `[base]`, zero-extend
+    /// to 64 bits, store into `dst` (LANG76).
+    ///
+    /// Opcode `REX.W 0F B6 /r ModRM(mod=00, reg=dst, rm=base)`, 4 bytes.
+    ///
+    /// **Constraints on `base`:** must not be `RSP`/`R12` (low3 == 4, which
+    /// would require an SIB byte) and must not be `RBP`/`R13` (low3 == 5,
+    /// which `mod=00` reinterprets as RIP-relative addressing).  Callers
+    /// should always pre-compute the effective address into `RAX` / `RCX`
+    /// / `RDX` (low3 ∈ {0, 1, 2}) before invoking this helper.  Violating
+    /// this contract is a programmer error and the function panics.
+    pub fn movzx_r64_byte_at(&mut self, dst: Reg, base: Reg) {
+        assert_ne!(base.low3(), 4, "movzx_r64_byte_at: RSP/R12 needs SIB — use a different base register");
+        assert_ne!(base.low3(), 5, "movzx_r64_byte_at: RBP/R13 with mod=00 means RIP-relative — use a different base register");
+        self.emit_u8(rex(true, dst.high1(), false, base.high1()));
+        self.emit_u8(0x0F);
+        self.emit_u8(0xB6);
+        self.emit_u8(modrm(0b00, dst.low3(), base.low3()));
+    }
+
+    /// `MOV byte ptr [base], r8` — store the low 8 bits of `src` to `[base]`
+    /// (LANG76).
+    ///
+    /// Opcode `REX 88 /r ModRM(mod=00, reg=src, rm=base)`, 3 bytes.  An
+    /// "empty" REX prefix (`0x40`) is always emitted so the byte-register
+    /// encoding is unambiguous for *any* `src` (without REX the
+    /// `src.low3 ∈ {4,5,6,7}` slots map to legacy `AH`/`CH`/`DH`/`BH`
+    /// instead of `SPL`/`BPL`/`SIL`/`DIL`, which we don't want).
+    ///
+    /// **Constraints on `base`:** same as [`movzx_r64_byte_at`] — must not
+    /// be RSP/R12 (SIB) or RBP/R13 (RIP-relative).
+    pub fn mov_byte_at_r8(&mut self, base: Reg, src: Reg) {
+        assert_ne!(base.low3(), 4, "mov_byte_at_r8: RSP/R12 needs SIB — use a different base register");
+        assert_ne!(base.low3(), 5, "mov_byte_at_r8: RBP/R13 with mod=00 means RIP-relative — use a different base register");
+        // Force REX prefix so byte-reg encoding is unambiguous.
+        self.emit_u8(rex(false, src.high1(), false, base.high1()));
+        self.emit_u8(0x88);
+        self.emit_u8(modrm(0b00, src.low3(), base.low3()));
+    }
+
     // -----------------------------------------------------------------------
     // Stack
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

LANG76 completes the substrate Brainfuck (BF07), BASIC arrays (PL05 V2), and Oct byte arrays (OCT02 V2) need.  Builds on LANG75 (#3705, now merged) — `alloc_bytes` is registered in the V1 helper table alongside `print_i64`/`putchar`/`getchar`/etc.

### New CIR opcodes (both backends)

- `alloc_bytes <n> -> <dest>` — sugar for `call_builtin "alloc_bytes", n`.  Returns the pointer (treated as `i64`) from `__twig_alloc_bytes`.
- `load_byte <ptr>, <offset> -> <dest>` — reads one byte from `[ptr + offset]`, zero-extends to 64 bits.
- `store_byte <ptr>, <offset>, <value>` — writes the low 8 bits of `value` to `[ptr + offset]`.

### Encoder additions

- `x86_64-encoder` 0.3.0: `movzx_r64_byte_at`, `mov_byte_at_r8`.
- `aarch64-encoder` 0.3.0: `ldrb`, `strb` (unsigned-offset; `imm ∈ [0, 4095]`, **not** scaled).

### Runtime archive

`__twig_alloc_bytes(int64_t n)` — `calloc(1, n)` wrapper; returns `0` on `n <= 0`.  V1 leaks.

### End-to-end smoke test

Hand-built `IIRModule` on both Windows + Linux: alloc 4 bytes, write `'H','i','\n'` via three `store_byte` instructions, then `print_string(buf, 3)`.  Verified locally on Windows — stdout is exactly `"Hi\n"`.

## Version bumps

- `x86_64-encoder`: 0.2.0 → 0.3.0
- `aarch64-encoder`: 0.2.2 → 0.3.0
- `x86_64-backend`: 0.5.0 → 0.6.0
- `aarch64-backend`: 0.3.0 → 0.4.0
- `twig-aot`: 0.6.0 → 0.7.0

## Test plan

- [x] `cargo test -p x86_64-backend` — 47 unit tests pass (5 new for LANG76)
- [x] `cargo test -p aarch64-backend` — 40 unit tests pass (5 new for LANG76)
- [x] Windows e2e LANG76 test passes locally
- [x] Security review: cleared — encoder asserts only panic on programmer bugs (callers always pass RAX/X0); `__twig_alloc_bytes` handles negative/zero/huge `n` safely; pointer-to-int cast goes through `intptr_t`
- [ ] CI: Linux + Windows + macOS

Spec: [code/specs/LANG76-byte-memory-ops-and-heap.md](code/specs/LANG76-byte-memory-ops-and-heap.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)