### PR TITLE
fix(sql-vm,mini-sqlite): date()/datetime()/time() 'unixepoch' modifier

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.67.0] - 2026-05-20
+
+### Fixed
+
+- **``date()/datetime()/time()`` with ``'unixepoch'`` modifier now
+  matches SQLite byte-for-byte** (via ``sql-vm 1.41.0``).  The
+  modifier was previously a no-op:
+
+  * ``date('2024-01-01', 'unixepoch')`` returned ``'2024-01-01'``
+    (ignoring the modifier); SQLite returns NULL because the input
+    is not a numeric Unix-epoch value.
+  * ``date('1704067200', 'unixepoch')`` returned NULL (ISO parse
+    failed); SQLite returns ``'2024-01-01'`` after parsing the
+    numeric string as Unix-epoch seconds.
+
+  Now strings are accepted *only* if the entire value (modulo
+  whitespace) is a valid number — ISO dates and numeric prefixes
+  followed by garbage both produce NULL.  20 oracle tests in
+  ``test_tier3_date_unixepoch.py``.
+
 ## [1.66.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.66.0"
+version = "1.67.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_date_unixepoch.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_date_unixepoch.py
@@ -1,0 +1,134 @@
+"""Oracle tests for ``date()/datetime()/time()`` with the ``'unixepoch'`` modifier.
+
+SQLite's ``unixepoch`` modifier forces the time value to be read as
+a Unix-epoch number — fundamentally different from the modifier's
+SQLite docs framing as a post-processing step.  Concretely:
+
+* Numeric time values (int or float) are read as seconds since
+  1970-01-01 UTC.
+* String time values are accepted **only** if the whole string is a
+  valid number (optionally signed, optionally fractional, optionally
+  whitespace-padded).  Strings that contain non-numeric characters
+  — including ISO-8601 dates like ``'2024-01-15'`` — produce NULL,
+  because SQLite refuses to interpret them as numeric Unix epochs.
+
+Before this PR mini-sqlite ignored the modifier entirely: it would
+still parse ``date('2024-01-15', 'unixepoch')`` as the ISO date
+``'2024-01-15'``, and would reject pure numeric strings like
+``date('1704067200', 'unixepoch')`` outright (because
+``_parse_timevalue`` ran first and ISO-parsing failed).
+
+The fix centralises ``unixepoch`` handling in ``_resolve_datetime``:
+when the modifier appears in the chain, we coerce the time value to
+a number ourselves (rejecting non-numeric strings via ``fullmatch``),
+then strip the modifier from the chain so the downstream handler
+doesn't re-process it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# unixepoch modifier rejects non-numeric strings
+# ---------------------------------------------------------------------------
+
+
+class TestUnixepochRejectsNonNumeric:
+    def test_iso_date_string_rejected(self) -> None:
+        # Was returning '2024-01-01' (modifier ignored); SQLite returns NULL.
+        _check("SELECT date('2024-01-01', 'unixepoch')")
+
+    def test_iso_datetime_string_rejected(self) -> None:
+        _check("SELECT date('2024-01-01 00:00:00', 'unixepoch')")
+
+    def test_partial_number_rejected(self) -> None:
+        # Has '-' inside; SQLite treats whole string as non-numeric → NULL.
+        _check("SELECT date('2024-01-15', 'unixepoch')")
+
+    def test_number_with_trailing_garbage_rejected(self) -> None:
+        # Different from CAST: unixepoch requires the *whole* string to
+        # be numeric, not a prefix match.
+        _check("SELECT date('2024abc', 'unixepoch')")
+
+    def test_pure_garbage(self) -> None:
+        _check("SELECT date('abc', 'unixepoch')")
+
+    def test_null_input(self) -> None:
+        _check("SELECT date(NULL, 'unixepoch')")
+
+
+# ---------------------------------------------------------------------------
+# unixepoch modifier accepts pure numeric strings
+# ---------------------------------------------------------------------------
+
+
+class TestUnixepochAcceptsNumeric:
+    def test_int_string(self) -> None:
+        # Was returning NULL (parse failed); SQLite returns '2024-01-01'.
+        _check("SELECT date('1704067200', 'unixepoch')")
+
+    def test_float_string(self) -> None:
+        _check("SELECT date('1704067200.5', 'unixepoch')")
+
+    def test_negative_string(self) -> None:
+        # Pre-epoch dates work too.
+        _check("SELECT date('-1234567890', 'unixepoch')")
+
+    def test_explicit_plus_sign(self) -> None:
+        _check("SELECT date('+1704067200', 'unixepoch')")
+
+    def test_whitespace_padding(self) -> None:
+        # SQLite tolerates surrounding whitespace.
+        _check("SELECT date('  1704067200  ', 'unixepoch')")
+
+    def test_raw_integer(self) -> None:
+        # Already-numeric input continues to work.
+        _check("SELECT date(1704067200, 'unixepoch')")
+
+    def test_zero_is_epoch(self) -> None:
+        _check("SELECT date(0, 'unixepoch')")
+
+
+# ---------------------------------------------------------------------------
+# datetime() and time() inherit the same rule
+# ---------------------------------------------------------------------------
+
+
+class TestUnixepochOtherFunctions:
+    def test_datetime_numeric_string(self) -> None:
+        _check("SELECT datetime('1704067200', 'unixepoch')")
+
+    def test_datetime_iso_string_rejected(self) -> None:
+        _check("SELECT datetime('2024-01-01', 'unixepoch')")
+
+    def test_time_numeric_string(self) -> None:
+        _check("SELECT time('1704067200', 'unixepoch')")
+
+    def test_time_iso_string_rejected(self) -> None:
+        _check("SELECT time('2024-01-01', 'unixepoch')")
+
+
+# ---------------------------------------------------------------------------
+# Regression: no modifier still works as before
+# ---------------------------------------------------------------------------
+
+
+class TestNoModifierRegression:
+    def test_iso_date_string(self) -> None:
+        _check("SELECT date('2024-01-01')")
+
+    def test_iso_datetime_string(self) -> None:
+        _check("SELECT date('2024-01-01 12:30:45')")
+
+    def test_julian_day_float(self) -> None:
+        _check("SELECT date(2460311.5)")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.41.0 — 2026-05-20
+
+### Fixed
+
+- **``date()/datetime()/time()`` with the ``'unixepoch'`` modifier now
+  forces numeric interpretation of the time value** — matching SQLite.
+
+  Previously the modifier was a no-op: ``date('2024-01-15', 'unixepoch')``
+  returned ``'2024-01-15'`` (SQLite returns NULL), and pure numeric
+  strings like ``date('1704067200', 'unixepoch')`` returned NULL
+  (SQLite returns ``'2024-01-01'``).
+
+  The fix centralises ``unixepoch`` handling in ``_resolve_datetime``:
+  when the modifier appears in the chain we coerce the time value to
+  a number directly (via a ``re.fullmatch`` that requires the entire
+  string be numeric — strings containing ``-`` like ISO dates have
+  internal punctuation and fail the match), then strip the modifier
+  from the chain so the downstream handler doesn't re-process it.
+
+  Two existing test cases in ``test_scalar_functions.py`` were
+  updated — they had pinned the previous no-op behaviour.
+
 ## 1.40.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.40.0"
+version = "1.41.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -2166,14 +2166,70 @@ def _apply_modifier(dt: datetime, modifier: str) -> datetime | None:
 
 
 def _resolve_datetime(args: list[SqlValue], skip_first: bool = False) -> datetime | None:
-    """Parse time value from args[0] (or args[1] if skip_first), apply modifiers."""
+    """Parse time value from args[0] (or args[1] if skip_first), apply modifiers.
+
+    The ``unixepoch`` modifier is special: it changes how the *time value
+    itself* is interpreted (not a post-processing step on an already-parsed
+    datetime).  Specifically, when ``unixepoch`` appears anywhere in the
+    modifier list:
+
+    - A numeric time value (int or float) is read as Unix-epoch seconds.
+    - A string time value is parsed via SQLite's longest-numeric-prefix
+      rule and read as Unix-epoch seconds.  Strings that lack a numeric
+      prefix — including ISO-8601 date strings like ``'2024-01-01'`` —
+      return NULL.
+
+    Without the ``unixepoch`` modifier, mini-sqlite still accepts bare
+    integer time values as Unix epoch (more lenient than real SQLite,
+    which returns NULL); changing that is a behavioural break held back
+    for a future PR.
+    """
     offset = 1 if skip_first else 0
     if len(args) <= offset:
         return None
-    dt = _parse_timevalue(args[offset])
-    if dt is None:
-        return None
-    for mod in args[offset + 1:]:
+    raw_tv = args[offset]
+    modifiers = list(args[offset + 1:])
+
+    force_unixepoch = any(
+        isinstance(m, str) and m.strip().lower() == "unixepoch"
+        for m in modifiers
+    )
+    if force_unixepoch:
+        if raw_tv is None:
+            return None
+        # SQLite requires the *entire* string (modulo surrounding
+        # whitespace) to be a valid number — ``'2024-01-15'`` does not
+        # count as ``2024`` followed by garbage, it counts as not-a-number
+        # and produces NULL.  We enforce the whole-string match via
+        # ``fullmatch`` rather than the longest-prefix rule used by CAST.
+        if isinstance(raw_tv, str):
+            num_m = re.fullmatch(r"\s*[+-]?\d+(?:\.\d+)?\s*", raw_tv)
+            if not num_m:
+                return None
+            text = raw_tv.strip()
+            try:
+                raw_tv = float(text) if "." in text else int(text)
+            except (ValueError, OverflowError):
+                return None
+        elif isinstance(raw_tv, bool) or not isinstance(raw_tv, (int, float)):
+            return None
+        try:
+            dt = datetime.fromtimestamp(float(raw_tv), tz=UTC).replace(microsecond=0)
+        except (ValueError, OSError, OverflowError):
+            return None
+        # Strip ``unixepoch`` from the remaining modifier chain so the
+        # downstream handler doesn't see it twice (it's currently a no-op
+        # there, but we want the modifier semantics centralised here).
+        modifiers = [
+            m for m in modifiers
+            if not (isinstance(m, str) and m.strip().lower() == "unixepoch")
+        ]
+    else:
+        dt = _parse_timevalue(raw_tv)
+        if dt is None:
+            return None
+
+    for mod in modifiers:
         if mod is None:
             return None
         if not isinstance(mod, str):

--- a/code/packages/python/sql-vm/tests/test_scalar_functions.py
+++ b/code/packages/python/sql-vm/tests/test_scalar_functions.py
@@ -1361,12 +1361,20 @@ class TestDateTimeFunctions:
         assert fn("date", "2024-01-15", "weekday 0") == "2024-01-21"
 
     # ------------------------------------------------------------------
-    # unixepoch modifier (no-op — we already store as datetime)
+    # unixepoch modifier — forces numeric interpretation of the time value
     # ------------------------------------------------------------------
 
-    def test_date_unixepoch_modifier(self) -> None:
-        # 'unixepoch' as a modifier is a no-op in our model.
-        assert fn("date", "2024-01-15", "unixepoch") == "2024-01-15"
+    def test_date_unixepoch_modifier_rejects_date_string(self) -> None:
+        # SQLite returns NULL when the unixepoch modifier is applied to a
+        # date-formatted string (it has no numeric prefix).  Mini-sqlite
+        # previously ignored the modifier and returned the date as-is;
+        # the corrected behaviour matches sqlite3.
+        assert fn("date", "2024-01-15", "unixepoch") is None
+
+    def test_date_unixepoch_modifier_numeric_string(self) -> None:
+        # Numeric string IS valid input for the unixepoch modifier — it
+        # is parsed as an integer count of seconds since the epoch.
+        assert fn("date", "1704067200", "unixepoch") == "2024-01-01"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

The `'unixepoch'` modifier was a no-op:
- `date('2024-01-01', 'unixepoch')` returned `'2024-01-01'`; SQLite returns NULL (input isn't numeric).
- `date('1704067200', 'unixepoch')` returned NULL (ISO parse failed first); SQLite returns `'2024-01-01'`.

The fix centralises `unixepoch` handling in `_resolve_datetime`. When the modifier appears in the chain, the time value is coerced to a number directly via `re.fullmatch(r"\s*[+-]?\d+(?:\.\d+)?\s*", text)` — the whole string must be numeric, so ISO dates with internal `-` fail the match. After parsing as `datetime.fromtimestamp()` the modifier is stripped from the chain.

22 tests: 2 sql-vm updates (had pinned the no-op behaviour) + 20 mini-sqlite oracle tests covering rejection of ISO dates/partial numbers/garbage, acceptance of int/float/negative/signed/whitespace-padded strings, `datetime()` and `time()` inheriting the rule, and a regression guard for unmodified inputs.

Version bumps: sql-vm 1.40.0 → 1.41.0, mini-sqlite 1.66.0 → 1.67.0.

## Test plan

- [x] `pytest mini-sqlite/tests/test_tier3_date_unixepoch.py` — 20/20
- [x] sql-vm full suite — 892 passed
- [x] mini-sqlite full suite — 1691 passed (1671 prior + 20 new)
- [x] All oracle cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)