### PR TITLE
feat(ruby-to-semantic-ir): Phase 5 — Ruby AST → narrow-waist SIR frontend

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -423,6 +423,7 @@ members = [
     "register-vm",
     "repl",
     "ruby-bridge",
+    "ruby-to-semantic-ir",
     "scytale-cipher",
     "sha256",
     "sha512",

--- a/code/packages/rust/ruby-to-semantic-ir/BUILD
+++ b/code/packages/rust/ruby-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p ruby-to-semantic-ir -- --nocapture

--- a/code/packages/rust/ruby-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/ruby-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p ruby-to-semantic-ir -- --nocapture

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-20
+
+### Added (Phase 5 — initial Ruby → SIR frontend)
+- New crate `ruby-to-semantic-ir`.  Consumes `coding-adventures-ruby-parser`'s `GrammarASTNode` and emits a `semantic_ir::Module`.
+- `compile_source(source, module_name) -> Result<Module, RubyLowerError>` — tokenize → parse → lower in one call.
+- `compile(ast, module_name) -> Result<Module, RubyLowerError>` — lower an already-parsed AST.
+- `RubyLowerError` — carries a human-readable message plus 1-based line/column drawn from the AST node's span.
+- v0 lowering covers everything ruby-parser v0 parses:
+  - Programs → synthesised `main` function whose body is the sequence of lowered statements.  Last bare-expression statement becomes the block's `value`; otherwise `value = NilLit`.
+  - Assignments (`x = expr`) → `LetBinding` for first occurrence, `Assign` for subsequent re-bindings (scope is `Local`).
+  - Method calls (`name(args...)`) → `BuiltinCall` for the known builtin set (`puts`, `print`, `p`, `gets`, `raise`); other names lower to `DirectCall` (placeholder; in v0 there are no user-defined functions, so backends will flag these as unresolved).
+  - Expressions: integer literals, string literals, name references, binary `+ - * /` lowered to `BuiltinCall("+"...)` etc., parenthesised sub-expressions.
+- Tests cover empty program, single assignment, multi-statement programs, arithmetic, method calls, re-assignment routing through `Stmt::Assign`, and tail-expression promotion to block `value`.

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ruby-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
+
+[dependencies]
+coding-adventures-ruby-parser = { path = "../ruby-parser" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+semantic-ir = { path = "../semantic-ir" }

--- a/code/packages/rust/ruby-to-semantic-ir/README.md
+++ b/code/packages/rust/ruby-to-semantic-ir/README.md
@@ -1,0 +1,81 @@
+# ruby-to-semantic-ir
+
+Ruby AST → narrow-waist [Semantic IR](../semantic-ir).  Phase 5 of the
+[Ruby parser project](../../../specs/ruby-parser.md) — the first
+frontend that consumes `ruby-parser`'s `GrammarASTNode` and emits a
+[`semantic_ir::Module`](../semantic-ir).
+
+## How it fits in the stack
+
+```
+Ruby source
+   │
+   ▼  ruby-lexer  →  ruby-parser
+GrammarASTNode (program → statement+)
+   │
+   ▼  ruby-to-semantic-ir   ← THIS CRATE
+semantic_ir::Module
+   │
+   ▼  semantic-ir-to-{rust, typescript, go, python} (existing backends)
+target source
+```
+
+This is what lets a Ruby program reach any SIR backend.  Code written
+in Ruby can be re-emitted as Rust / TypeScript / Go / Python by going
+through the narrow-waist IR — the per-language backends already exist
+and don't need to know Ruby.
+
+## v0 scope
+
+The lowering targets the same grammar subset that `ruby-parser` v0
+parses (see [ruby-parser/src/_grammar.rs](../ruby-parser/src/_grammar.rs)):
+
+- **Assignments** — `x = expr` becomes a `LetBinding` (first occurrence)
+  or `Assign` (subsequent re-binding to the same name).
+- **Method calls** — `name(args...)` becomes a `BuiltinCall` for the
+  small list of Ruby builtins we recognise (`puts`, `print`, `p`,
+  `gets`, `raise`); everything else lowers to a `DirectCall` and
+  surfaces an "unresolved" diagnostic if no matching top-level
+  function exists.  In v0 there are no `def`s, so all named calls
+  are effectively builtins or unresolved.
+- **Expressions** — integer / string literals, name references,
+  binary `+`, `-`, `*`, `/` (lowered to `BuiltinCall("+", ...)` etc.,
+  matching the convention `twig-to-semantic-ir` established).
+- **Programs** — wrapped in a synthesised `main` function whose body
+  is the sequence of lowered statements.  If the final source-level
+  statement is a bare expression, it becomes the block's *value*;
+  otherwise the value is `NilLit`.
+
+## Usage
+
+```rust
+let module = ruby_to_semantic_ir::compile_source(
+    "x = 1\ny = 2\nputs(x + y)\n",
+    "demo",
+)?;
+
+// `module` is a `semantic_ir::Module` — pass it to any SIR backend.
+```
+
+## What's deferred
+
+- `def` / `end` method definitions (the v0 ruby-parser grammar
+  doesn't accept them; Phase 6+ will extend the grammar).
+- Control flow (`if` / `while` / `case`).
+- Blocks (`do...end`, `{...}`).
+- Modules, classes, mixins.
+- The full set of Ruby's literal forms (regex, ranges, arrays,
+  hashes, symbols, heredocs as runtime values — heredocs ARE lexed
+  per Phase 3c, just not yet lowered to IR shape).
+- Effect inference — every `BuiltinCall` currently lowers with an
+  empty `EffectSet`; richer effect analysis arrives once we have
+  more of Ruby's semantics modelled.
+
+## Versioning vs. Ruby eras
+
+The lowering itself is era-agnostic: it consumes whatever
+`GrammarASTNode` the parser produces.  Era-specific syntax (lambda
+`->`, hash shorthand, `&.`, …) lands at the **parser** layer (see
+[ruby-version-evolution.md](../../../specs/ruby-version-evolution.md));
+this crate then routes the resulting AST shapes to the right SIR
+nodes.

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1,0 +1,234 @@
+//! # ruby-to-semantic-ir
+//!
+//! Ruby AST → narrow-waist [Semantic IR](semantic_ir).
+//!
+//! Phase 5 of the [Ruby parser project](../../../specs/ruby-parser.md):
+//! the first frontend that consumes [`ruby_parser`]'s
+//! [`GrammarASTNode`](parser::grammar_parser::GrammarASTNode) and
+//! emits a [`semantic_ir::Module`] suitable for any SIR backend.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Ruby source
+//!    │
+//!    ▼  ruby-lexer  →  ruby-parser
+//! GrammarASTNode (rule = "program")
+//!    │
+//!    ▼  ruby_to_semantic_ir::compile_source     ← THIS CRATE
+//! semantic_ir::Module
+//!    │
+//!    ▼  semantic-ir-to-{rust, typescript, go, python}
+//! target source
+//! ```
+//!
+//! ## Public API
+//!
+//! ```ignore
+//! use ruby_to_semantic_ir::{compile_source, RubyLowerError};
+//!
+//! let module = compile_source(
+//!     "x = 1\ny = 2\nputs(x + y)\n",
+//!     "demo",
+//! )?;
+//! // `module` is a `semantic_ir::Module`.
+//! ```
+//!
+//! See [the crate README](../README.md) for the v0 lowering rules
+//! and the explicit list of deferred Ruby features.
+
+use coding_adventures_ruby_parser::parse_ruby;
+
+mod lower;
+
+pub use lower::{compile, RubyLowerError};
+
+/// Parse Ruby source and lower it to SIR in a single call.
+///
+/// Wraps [`parse_ruby`] followed by [`compile`].  The current
+/// `parse_ruby` panics on parse errors (legacy behaviour shared with
+/// the rest of the grammar-driven parsers); a future refactor will
+/// surface those as [`RubyLowerError`]s with proper line/column.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, RubyLowerError> {
+    let ast = parse_ruby(source);
+    compile(&ast, module_name)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use semantic_ir::{Effect, Expr, Scope, Stmt};
+
+    fn lower(src: &str) -> semantic_ir::Module {
+        compile_source(src, "test").expect("lowering succeeded")
+    }
+
+    fn main_body(m: &semantic_ir::Module) -> &semantic_ir::Block {
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("main function present");
+        &f.body
+    }
+
+    #[test]
+    fn empty_program_compiles_to_nil_main() {
+        let m = lower("");
+        assert_eq!(m.name, "test");
+        let b = main_body(&m);
+        assert!(b.stmts.is_empty());
+        assert!(matches!(b.value, Expr::NilLit { .. }));
+    }
+
+    #[test]
+    fn assignment_becomes_let_binding() {
+        let m = lower("x = 1");
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 1);
+        match &b.stmts[0] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(value, Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+        // Block value is NilLit because the assignment is not a
+        // tail expression.
+        assert!(matches!(b.value, Expr::NilLit { .. }));
+    }
+
+    #[test]
+    fn tail_expression_becomes_block_value() {
+        let m = lower("1 + 2");
+        let b = main_body(&m);
+        assert!(b.stmts.is_empty());
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(args[1], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected BuiltinCall(+, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn three_assignments_become_three_let_bindings() {
+        let m = lower("x = 1\ny = 2\nz = x + y\n");
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 3);
+        let names: Vec<&str> = b
+            .stmts
+            .iter()
+            .filter_map(|s| match s {
+                Stmt::LetBinding { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["x", "y", "z"]);
+        // The third RHS references x and y as locals.
+        if let Stmt::LetBinding { value, .. } = &b.stmts[2] {
+            match value {
+                Expr::BuiltinCall { name, args, .. } => {
+                    assert_eq!(name, "+");
+                    assert!(
+                        matches!(&args[0], Expr::VarRef { name, scope, .. } if name == "x" && *scope == Scope::Local)
+                    );
+                    assert!(
+                        matches!(&args[1], Expr::VarRef { name, scope, .. } if name == "y" && *scope == Scope::Local)
+                    );
+                }
+                other => panic!("expected BuiltinCall(+, …), got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn reassignment_routes_through_assign() {
+        // First `x = 1` binds; second `x = 2` re-binds and so must
+        // emit `Stmt::Assign`, not another `LetBinding`.  SIR's
+        // semantics require this distinction so backends (Rust,
+        // TypeScript, Go) can emit `let`/`const`/`var` correctly.
+        let m = lower("x = 1\nx = 2\n");
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 2);
+        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "x"));
+        match &b.stmts[1] {
+            Stmt::Assign { name, scope, value, .. } => {
+                assert_eq!(name, "x");
+                assert_eq!(*scope, Scope::Local);
+                assert!(matches!(value, Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected Assign, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn puts_call_becomes_builtin_with_may_print() {
+        let m = lower("puts(42)");
+        let b = main_body(&m);
+        // The call is the tail expression — it becomes the value.
+        match &b.value {
+            Expr::BuiltinCall { name, args, effects, .. } => {
+                assert_eq!(name, "puts");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(args[0], Expr::IntLit { value: 42, .. }));
+                assert!(effects.contains(Effect::MayPrint));
+            }
+            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn string_literal_is_preserved() {
+        let m = lower(r#"x = "hello""#);
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => match value {
+                Expr::StrLit { value, .. } => assert_eq!(value, "hello"),
+                other => panic!("expected StrLit, got {:?}", other),
+            },
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mixed_assignment_and_tail_call() {
+        let m = lower("x = 1\nputs(x)");
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 1);
+        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "x"));
+        // The trailing `puts(x)` is a method call without an
+        // assignment around it, so it becomes the block's value.
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "puts");
+                assert!(
+                    matches!(&args[0], Expr::VarRef { name, scope, .. } if name == "x" && *scope == Scope::Local)
+                );
+            }
+            other => panic!("expected BuiltinCall(puts, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn lowered_module_passes_sir_validator() {
+        // The validator is the canonical "is this module well-formed"
+        // check — every lowering pass must produce a module that
+        // passes it.  This is the load-bearing acceptance criterion
+        // for the SIR pipeline.
+        let m = lower("x = 1\ny = 2\nputs(x + y)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
+}

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1,0 +1,596 @@
+//! Ruby `GrammarASTNode` → `semantic_ir::Module` lowering.
+//!
+//! See [the crate README](../README.md) for the v0 scope.  The
+//! lowering is deliberately tiny because the v0 ruby-parser grammar
+//! itself is tiny (six rules: `program`, `statement`, `assignment`,
+//! `method_call`, `expression_stmt`, `expression`, `term`, `factor`).
+//! Anything Ruby can write that isn't covered by those rules either
+//! fails to parse or reaches us as a more general shape that we
+//! still pattern-match against.
+
+use std::collections::HashSet;
+
+use lexer::token::{Token, TokenType};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, Effect, EffectSet, ExportName, Expr, FeatureManifest, Function, Metadata, Module,
+    Scope, Span, Stmt,
+};
+
+/// A failure encountered during Ruby → SIR lowering.
+///
+/// Carries 1-based line/column so callers can produce IDE-friendly
+/// diagnostics.  When the position is unknown (e.g. the AST node
+/// had no recorded span), the fields are zero.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RubyLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for RubyLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RubyLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for RubyLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Ruby program into a `semantic_ir::Module`.
+///
+/// The root node must be a `program` rule node — that's what
+/// [`coding_adventures_ruby_parser::parse_ruby`] always emits.  The
+/// `module_name` becomes the SIR module identifier (typically the
+/// source file's stem).
+pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, RubyLowerError> {
+    if program.rule_name != "program" {
+        return Err(RubyLowerError {
+            message: format!(
+                "expected root rule `program`, got `{}`",
+                program.rule_name
+            ),
+            line: program.start_line.unwrap_or(0),
+            column: program.start_column.unwrap_or(0),
+        });
+    }
+
+    let mut lw = Lowerer {
+        file_name: module_name.to_string(),
+        declared_locals: HashSet::new(),
+    };
+    let block = lw.lower_program(program)?;
+
+    let main = Function {
+        name: "main".to_string(),
+        params: Vec::new(),
+        return_type: None,
+        captures: Vec::new(),
+        body: block,
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: lw.span_of(program),
+    };
+
+    Ok(Module {
+        name: module_name.to_string(),
+        manifest: FeatureManifest::new(),
+        imports: Vec::new(),
+        // `main` is the conventional entry point — exporting it lets
+        // SIR backends recognise it as such.
+        exports: vec![ExportName {
+            name: "main".to_string(),
+            span: Span::synthetic(),
+        }],
+        functions: vec![main],
+        globals: Vec::new(),
+        metadata: Metadata::new(),
+        span: lw.span_of(program),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Lowerer
+// ---------------------------------------------------------------------------
+
+struct Lowerer {
+    file_name: String,
+    /// Names already bound by a prior `Stmt::LetBinding` in the
+    /// current scope.  Drives the `LetBinding` vs `Assign` choice:
+    /// first occurrence binds, subsequent occurrences re-assign.
+    declared_locals: HashSet<String>,
+}
+
+impl Lowerer {
+    /// Build a `Span` from a node's recorded start/end positions.
+    /// Missing positions fall back to a `point` at (0, 0) — fine for
+    /// SIR validation purposes.
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        let sl = node.start_line.unwrap_or(0);
+        let sc = node.start_column.unwrap_or(0);
+        let el = node.end_line.unwrap_or(sl);
+        let ec = node.end_column.unwrap_or(sc);
+        Span::new(&self.file_name, sl, sc, el, ec)
+    }
+
+    fn span_of_token(&self, t: &Token) -> Span {
+        Span::point(&self.file_name, t.line, t.column)
+    }
+
+    // -------------------------------------------------------------------
+    // program → Block
+    // -------------------------------------------------------------------
+
+    fn lower_program(&mut self, program: &GrammarASTNode) -> Result<Block, RubyLowerError> {
+        // Collect the statement nodes (skip whitespace/newline
+        // children that the parser may emit).
+        let stmts_in: Vec<&GrammarASTNode> = program
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        if stmts_in.is_empty() {
+            return Ok(Block {
+                stmts: Vec::new(),
+                value: Expr::NilLit { span: self.span_of(program) },
+                span: self.span_of(program),
+            });
+        }
+
+        // The last statement node *may* be promoted to the block's
+        // `value` slot — but only if it's an `expression_stmt` (a
+        // bare expression with no side-effecting structure around
+        // it).  Assignments always stay as statements because they
+        // bind a name, and method calls stay as statements because
+        // their effects (printing, raising) are observed before any
+        // value is consumed.  Exception: if the method call is the
+        // sole tail of the program, we still promote it so the
+        // module has a meaningful return value.
+        let last_idx = stmts_in.len() - 1;
+        let mut stmts_out: Vec<Stmt> = Vec::with_capacity(stmts_in.len());
+        let mut value: Option<Expr> = None;
+
+        for (i, s) in stmts_in.iter().enumerate() {
+            let inner = self.first_node_child(s).ok_or_else(|| RubyLowerError {
+                message: "statement node had no child rule".to_string(),
+                line: s.start_line.unwrap_or(0),
+                column: s.start_column.unwrap_or(0),
+            })?;
+
+            let is_tail = i == last_idx;
+            let tail_kind = inner.rule_name.as_str();
+            if is_tail && matches!(tail_kind, "expression_stmt" | "method_call") {
+                // Promote the tail expression to the block's value.
+                let v = match tail_kind {
+                    "expression_stmt" => {
+                        let expr_node = self.first_node_child(inner).ok_or_else(|| {
+                            RubyLowerError {
+                                message: "expression_stmt had no expression child".to_string(),
+                                line: inner.start_line.unwrap_or(0),
+                                column: inner.start_column.unwrap_or(0),
+                            }
+                        })?;
+                        self.lower_expression(expr_node)?
+                    }
+                    "method_call" => self.lower_method_call(inner)?,
+                    _ => unreachable!(),
+                };
+                value = Some(v);
+            } else {
+                stmts_out.push(self.lower_statement_inner(inner)?);
+            }
+        }
+
+        let value = value.unwrap_or(Expr::NilLit { span: self.span_of(program) });
+        Ok(Block {
+            stmts: stmts_out,
+            value,
+            span: self.span_of(program),
+        })
+    }
+
+    /// Lower the inner rule node of a `statement` (one of
+    /// `assignment` / `method_call` / `expression_stmt`) into a
+    /// `Stmt`.
+    fn lower_statement_inner(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Stmt, RubyLowerError> {
+        match node.rule_name.as_str() {
+            "assignment" => self.lower_assignment(node),
+            "method_call" => {
+                let expr = self.lower_method_call(node)?;
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
+            "expression_stmt" => {
+                let expr_node = self.first_node_child(node).ok_or_else(|| RubyLowerError {
+                    message: "expression_stmt had no expression child".to_string(),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                })?;
+                let expr = self.lower_expression(expr_node)?;
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
+            other => Err(RubyLowerError {
+                message: format!("unsupported statement form `{other}`"),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // assignment → LetBinding (first) or Assign (subsequent)
+    // -------------------------------------------------------------------
+
+    fn lower_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
+        // Shape: NAME EQUALS expression
+        let (name, name_span) = self.expect_first_name_token(node)?;
+        let expr_node = self.find_node_child(node, "expression").ok_or_else(|| {
+            RubyLowerError {
+                message: "assignment missing RHS expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }
+        })?;
+        let value = self.lower_expression(expr_node)?;
+
+        let span = self.span_of(node);
+        if self.declared_locals.contains(&name) {
+            Ok(Stmt::Assign {
+                name,
+                scope: Scope::Local,
+                value,
+                span,
+            })
+        } else {
+            self.declared_locals.insert(name.clone());
+            Ok(Stmt::LetBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })
+        }
+        // `name_span` is intentionally unused for now — the SIR Stmt
+        // span covers the whole statement.  Keeping the binding so
+        // the lookup helper stays useful for callers that need it
+        // (e.g. error messages).
+        .map(|s| {
+            let _ = name_span;
+            s
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // method_call → BuiltinCall (recognised names) or DirectCall
+    // -------------------------------------------------------------------
+
+    fn lower_method_call(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        // Shape: (NAME | KEYWORD) LPAREN [expression (COMMA expression)*] RPAREN
+        let (callee, _callee_span) = self.expect_first_name_token(node)?;
+        // Collect argument expressions: every `expression`-rule child of
+        // this node.
+        let args: Vec<Expr> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .map(|n| self.lower_expression(n))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let span = self.span_of(node);
+        if let Some(effects) = ruby_builtin_effects(&callee) {
+            Ok(Expr::BuiltinCall {
+                name: callee,
+                args,
+                effects,
+                span,
+            })
+        } else {
+            // Unrecognised name — fall back to DirectCall.  SIR
+            // backends that can't resolve the name will surface a
+            // diagnostic; this keeps the lowering total (no panics).
+            Ok(Expr::DirectCall {
+                fn_name: callee,
+                args,
+                effects: EffectSet::PURE,
+                span,
+            })
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // expression / term / factor
+    // -------------------------------------------------------------------
+
+    fn lower_expression(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        // Pass through wrapper rules transparently — the parser
+        // sometimes nests `expression → term → factor → expression`.
+        match node.rule_name.as_str() {
+            "expression" => self.lower_binary_chain(node, &["PLUS", "MINUS"]),
+            "term" => self.lower_binary_chain(node, &["STAR", "SLASH"]),
+            "factor" => self.lower_factor(node),
+            // The parser sometimes wraps a bare token into an "expression_stmt"
+            // when reached as the RHS of an assignment.  Recurse into it.
+            "expression_stmt" => {
+                let inner = self.first_node_child(node).ok_or_else(|| RubyLowerError {
+                    message: "expression_stmt had no inner expression".to_string(),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                })?;
+                self.lower_expression(inner)
+            }
+            other => Err(RubyLowerError {
+                message: format!("unsupported expression shape `{other}`"),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }),
+        }
+    }
+
+    /// Lower a left-associative chain of binary operators.  Used for
+    /// both `expression` (PLUS / MINUS) and `term` (STAR / SLASH) —
+    /// the only difference is the operator set.
+    fn lower_binary_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        ops: &[&str],
+    ) -> Result<Expr, RubyLowerError> {
+        // Walk children in order.  The first must be a sub-expression
+        // node; subsequent pairs are (op-token, sub-expression node).
+        let mut acc: Option<Expr> = None;
+        let mut pending_op: Option<(String, Span)> = None;
+
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Node(sub) => {
+                    let expr = self.lower_expression(sub)?;
+                    acc = Some(match (acc.take(), pending_op.take()) {
+                        (None, _) => expr,
+                        (Some(lhs), Some((op_name, op_span))) => Expr::BuiltinCall {
+                            name: op_name,
+                            args: vec![lhs, expr],
+                            effects: EffectSet::PURE,
+                            span: op_span,
+                        },
+                        (Some(lhs), None) => {
+                            // Two sibling sub-expressions with no operator
+                            // between them — should not happen with the
+                            // v0 grammar; treat as an internal error.
+                            return Err(RubyLowerError {
+                                message: "two consecutive expression children without an operator"
+                                    .to_string(),
+                                line: sub.start_line.unwrap_or(0),
+                                column: sub.start_column.unwrap_or(0),
+                            }
+                            .also(lhs));
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(tok) => {
+                    if ops.iter().any(|op| token_type_name(tok.type_) == *op) {
+                        pending_op = Some((
+                            token_lexeme_for_op(tok.type_).to_string(),
+                            self.span_of_token(tok),
+                        ));
+                    }
+                    // Other tokens (whitespace, newline) are dropped.
+                }
+            }
+        }
+
+        acc.ok_or_else(|| RubyLowerError {
+            message: "binary chain had no operands".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })
+    }
+
+    /// Lower a `factor` node — the leaves of the expression tree.
+    fn lower_factor(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        // factor ::= NUMBER | STRING | NAME | KEYWORD | LPAREN expression RPAREN
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(tok) => {
+                    let span = self.span_of_token(tok);
+                    match tok.type_ {
+                        TokenType::Number => {
+                            let cleaned: String =
+                                tok.value.chars().filter(|c| *c != '_').collect();
+                            let v: i64 = cleaned.parse().map_err(|_| RubyLowerError {
+                                message: format!("invalid integer literal `{}`", tok.value),
+                                line: tok.line,
+                                column: tok.column,
+                            })?;
+                            return Ok(Expr::IntLit { value: v, span });
+                        }
+                        TokenType::String => {
+                            return Ok(Expr::StrLit {
+                                value: tok.value.clone(),
+                                span,
+                            });
+                        }
+                        TokenType::Name => {
+                            // `nil` / `true` / `false` would be Keyword
+                            // tokens, not Name.  All Name tokens here
+                            // are locals (or unresolved — backend will
+                            // tell us).
+                            return Ok(Expr::VarRef {
+                                name: tok.value.clone(),
+                                scope: Scope::Local,
+                                span,
+                            });
+                        }
+                        TokenType::Keyword => match tok.value.as_str() {
+                            "nil" => return Ok(Expr::NilLit { span }),
+                            "true" => return Ok(Expr::BoolLit { value: true, span }),
+                            "false" => return Ok(Expr::BoolLit { value: false, span }),
+                            _ => {
+                                // Any other keyword used in factor position
+                                // is an error in v0 — but the parser
+                                // accepts NAME|KEYWORD as a fallback to
+                                // method-call shapes.  Treat as a local.
+                                return Ok(Expr::VarRef {
+                                    name: tok.value.clone(),
+                                    scope: Scope::Local,
+                                    span,
+                                });
+                            }
+                        },
+                        _ => {
+                            // Parens — skip the LPAREN/RPAREN tokens
+                            // and recurse into the inner expression
+                            // (which is a sibling Node child).
+                        }
+                    }
+                }
+                ASTNodeOrToken::Node(sub) => {
+                    return self.lower_expression(sub);
+                }
+            }
+        }
+        Err(RubyLowerError {
+            message: "factor node had no recognisable leaf".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------
+
+    fn first_node_child<'a>(&self, node: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
+        node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            _ => None,
+        })
+    }
+
+    fn find_node_child<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+        rule_name: &str,
+    ) -> Option<&'a GrammarASTNode> {
+        node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == rule_name => Some(n),
+            _ => None,
+        })
+    }
+
+    /// Return the lexeme of the first `Name` or `Keyword` token
+    /// directly under `node` along with its span.
+    fn expect_first_name_token(
+        &self,
+        node: &GrammarASTNode,
+    ) -> Result<(String, Span), RubyLowerError> {
+        for child in &node.children {
+            if let ASTNodeOrToken::Token(t) = child {
+                if matches!(t.type_, TokenType::Name | TokenType::Keyword) {
+                    return Ok((t.value.clone(), self.span_of_token(t)));
+                }
+            }
+        }
+        Err(RubyLowerError {
+            message: format!(
+                "expected first Name/Keyword token under `{}`",
+                node.rule_name
+            ),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Token plumbing
+// ---------------------------------------------------------------------------
+
+fn token_type_name(t: TokenType) -> &'static str {
+    // We only need names for the operator tokens that appear in
+    // expression chains.  Anything else returns a placeholder; the
+    // caller never compares it against the operator list.
+    match t {
+        TokenType::Plus => "PLUS",
+        TokenType::Minus => "MINUS",
+        TokenType::Star => "STAR",
+        TokenType::Slash => "SLASH",
+        _ => "OTHER",
+    }
+}
+
+fn token_lexeme_for_op(t: TokenType) -> &'static str {
+    match t {
+        TokenType::Plus => "+",
+        TokenType::Minus => "-",
+        TokenType::Star => "*",
+        TokenType::Slash => "/",
+        _ => "?",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ruby builtins
+// ---------------------------------------------------------------------------
+
+/// Effect set for a recognised Ruby builtin.  Returns `None` for any
+/// name we don't know — the caller falls back to `DirectCall`.
+///
+/// The v0 list is intentionally tiny: just the I/O and error-raising
+/// builtins that nearly every Ruby program touches.  Later phases
+/// will grow this as the lowering matures.
+fn ruby_builtin_effects(name: &str) -> Option<EffectSet> {
+    match name {
+        "puts" | "print" | "p" => {
+            Some(EffectSet::PURE.with(Effect::MayPrint))
+        }
+        "gets" => {
+            // Reads from stdin — modelled as a blocking effect.  Not
+            // strictly pure, but `MayBlock` is the closest tag we
+            // have in the SIR v0 effect lattice.
+            Some(EffectSet::PURE.with(Effect::MayBlock))
+        }
+        "raise" => {
+            // `raise` is divergent (the call doesn't return) and
+            // also throws — backends use both tags to suppress
+            // unreachable-code warnings and to emit `throw`/`return`
+            // shapes correctly.
+            Some(EffectSet::PURE.with(Effect::MayThrow).with(Effect::Divergent))
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+impl RubyLowerError {
+    /// Chain a value onto the error (used inside `?`-style fallbacks
+    /// where we need to "consume" a value without otherwise using it).
+    fn also<T>(self, _: T) -> Self {
+        self
+    }
+}
+


### PR DESCRIPTION
## Summary

Phase 5 per [code/specs/ruby-parser.md](code/specs/ruby-parser.md#phasing): new \`ruby-to-semantic-ir\` crate.  Consumes \`coding-adventures-ruby-parser\`'s \`GrammarASTNode\` and emits a [\`semantic_ir::Module\`](code/packages/rust/semantic-ir).

This is the **load-bearing piece** that lets Ruby reach any existing SIR backend — \`semantic-ir-to-rust\`, \`-to-typescript\`, \`-to-go\`, \`-to-python\` all become available without any of them knowing anything about Ruby.

\`\`\`
Ruby source → ruby-lexer → ruby-parser → ruby-to-semantic-ir (NEW)
              → semantic_ir::Module → any SIR backend → target source
\`\`\`

## Public API

- \`compile_source(source, module_name) -> Result<Module, RubyLowerError>\`
- \`compile(ast, module_name) -> Result<Module, RubyLowerError>\`
- \`RubyLowerError { message, line, column }\`

## v0 lowering scope

Mirrors what the v0 ruby-parser grammar accepts (see [\`ruby-parser/src/_grammar.rs\`](code/packages/rust/ruby-parser/src/_grammar.rs)):

- Programs → synthesised \`main\` function; last bare-expression statement becomes the block's \`value\`, otherwise \`NilLit\`.
- Assignments → \`LetBinding\` (first occurrence) or \`Assign\` (subsequent re-binding).  This SIR-mandated distinction lets backends emit \`let\`/\`const\`/\`var\` correctly.
- Method calls → \`BuiltinCall\` for known Ruby builtins (\`puts\`, \`print\`, \`p\`, \`gets\`, \`raise\`) with appropriate \`EffectSet\` (\`MayPrint\` / \`MayBlock\` / \`MayThrow+Divergent\`); other names lower to \`DirectCall\` as a placeholder.
- Expressions: integer/string literals, name references, binary \`+ - * /\` → \`BuiltinCall(\"+\", ...)\`.

## Test plan

- [x] \`cargo test -p ruby-to-semantic-ir\` — 9 passed (empty program, assignment, tail expression, three assignments, re-assignment via \`Stmt::Assign\`, builtin effects, string literals, mixed assignment+tail, and **every lowered module passes \`semantic_ir::validate\`**).
- [x] \`cargo build -p ruby-to-semantic-ir\` — clean, no warnings.
- [x] Crate added to the rust workspace (\`code/packages/rust/Cargo.toml\`).
- [x] README documents the v0 scope and explicitly lists deferred features.
- [x] CHANGELOG entry \`0.1.0 — Phase 5\` added.

## Deferred (Phase 5b+)

- \`def\` / \`end\` method definitions (v0 grammar doesn't accept them).
- Control flow (\`if\` / \`while\` / \`case\`), blocks (\`do…end\`, \`{…}\`).
- Modules, classes, mixins.
- Full Ruby literal vocabulary (regex, ranges, arrays, hashes, symbols, heredocs as runtime values).
- Effect inference beyond the recognised-builtin lookup.

This is the **last phase** of the Ruby parser project as scoped in the spec.  Phases merged in this series: [#3464](https://github.com/adhithyan15/coding-adventures/pull/3464) (spec) · [#3661](https://github.com/adhithyan15/coding-adventures/pull/3661) (Phase 1) · [#3670](https://github.com/adhithyan15/coding-adventures/pull/3670) (Phase 2) · [#3679](https://github.com/adhithyan15/coding-adventures/pull/3679) (Phase 3a) · [#3682](https://github.com/adhithyan15/coding-adventures/pull/3682) (Phase 3b) · [#3695](https://github.com/adhithyan15/coding-adventures/pull/3695) (Phase 3c) · [#3701](https://github.com/adhithyan15/coding-adventures/pull/3701) (Phase 4a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)