### PR TITLE
[codex] Add WHATWG noscript audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -40,6 +40,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser ruby audit generator
   alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser noscript audit
+  generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -167,6 +167,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-noscript-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_noscript_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -33,6 +33,9 @@ documented in this file.
 - Generated WHATWG ruby audit fixture over html5lib `ruby`, `rb`, `rt`,
   `rtc`, and `rp` implied-end-tag recovery cases, including block descendants
   and nested ruby containers, with a dedicated parser regression test.
+- Generated WHATWG noscript audit fixture over html5lib scripting-on/off,
+  head-insertion, comment-boundary, text-mode-descendant, paragraph, and stray
+  end-tag cases, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -45,8 +48,8 @@ documented in this file.
   stray select/list end-tag cases, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
-  foreign-content, formatting, ruby, document-shell, template, and select/list
-  audit checks on the same parser and DOM dump path.
+  foreign-content, formatting, ruby, noscript, document-shell, template, and
+  select/list audit checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -176,6 +176,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit
   --check
 ```
 
+The generated `tests/fixtures/whatwg-noscript-audit.json` fixture indexes
+`noscript` behavior with scripting enabled and disabled, head insertion-mode
+boundaries, comment-looking text, RAWTEXT/PLAINTEXT descendants, paragraph
+integration, and stray noscript end tags:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -131,6 +131,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit
   --check
 ```
 
+`whatwg-noscript-audit.json` is a generated index over tree-construction cases
+that stress `noscript` behavior with scripting enabled and disabled, head
+insertion-mode boundaries, comment-looking text, RAWTEXT/PLAINTEXT
+descendants, paragraph integration, and stray noscript end tags:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG noscript audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-noscript-audit.json"
+
+NOSCRIPT_START = re.compile(r"<noscript(?:\s|/|>)", re.I)
+NOSCRIPT_END = re.compile(r"</noscript(?:\s|/|>)", re.I)
+TEXTMODE_DESCENDANT = re.compile(r"<(?:iframe|noframes|plaintext|style)(?:\s|/|>)", re.I)
+
+CASE_AXES = (
+    {
+        "axis": "head-noscript-disabled",
+        "reason": "head insertion-mode noscript handling with scripting disabled",
+    },
+    {
+        "axis": "comment-boundary",
+        "reason": "noscript text/comment-looking boundaries under both scripting modes",
+    },
+    {
+        "axis": "textmode-descendant",
+        "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+    },
+    {
+        "axis": "stray-noscript-end-tag",
+        "reason": "stray noscript end tags in body and table insertion contexts",
+    },
+    {
+        "axis": "paragraph-noscript",
+        "reason": "noscript inside paragraph phrasing flow with sibling content",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+    scripting: str
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG noscript audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        scripting = "enabled"
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+            elif metadata_line == "#script-on":
+                scripting = "enabled"
+            elif metadata_line == "#script-off":
+                scripting = "disabled"
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_noscript_case(case_data):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                    scripting=scripting,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any noscript audit cases")
+    return cases
+
+
+def is_noscript_case(data: str) -> bool:
+    return NOSCRIPT_START.search(data) is not None or NOSCRIPT_END.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "scripting": case.scripting,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-noscript-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress noscript insertion-mode boundaries, scripting-on/off "
+            "tokenization, comment-looking text, RAWTEXT/PLAINTEXT descendants, "
+            "stray end tags, and paragraph integration."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data.lower()
+    source_file = case.source.split(":", 1)[0]
+
+    if source_file == "noscript01.dat":
+        return "head-noscript-disabled"
+    if source_file == "webkit02.dat":
+        return "paragraph-noscript"
+    if NOSCRIPT_START.search(data) is None and NOSCRIPT_END.search(data) is not None:
+        return "stray-noscript-end-tag"
+    if TEXTMODE_DESCENDANT.search(data) is not None:
+        return "textmode-descendant"
+    if "<!--" in data and ("</noscript" in data or "<noscript" in data):
+        return "comment-boundary"
+    raise SystemExit(f"unclassified noscript audit case: {case.source}")
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown noscript audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-noscript-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-noscript-audit.json
@@ -1,0 +1,379 @@
+{
+  "case_count": 52,
+  "cases": [
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-327",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:327"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-328",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:328"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-329",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:329"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-330",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:330"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-331",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:331"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-332",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:332"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-333",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:333"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-334",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:334"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-335",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:335"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-336",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:336"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-337",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:337"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-338",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:338"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-339",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:339"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-340",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:340"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-341",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:341"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-342",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:342"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-343",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:343"
+    },
+    {
+      "axis": "head-noscript-disabled",
+      "id": "noscript01-dat-344",
+      "reason": "head insertion-mode noscript handling with scripting disabled",
+      "scripting": "disabled",
+      "source": "noscript01.dat:344"
+    },
+    {
+      "axis": "stray-noscript-end-tag",
+      "id": "tests1-dat-675",
+      "reason": "stray noscript end tags in body and table insertion contexts",
+      "scripting": "enabled",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "stray-noscript-end-tag",
+      "id": "tests1-dat-676",
+      "reason": "stray noscript end tags in body and table insertion contexts",
+      "scripting": "enabled",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-851",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:851"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-852",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:852"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-853",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:853"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-854",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:854"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-855",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "enabled",
+      "source": "tests16.dat:855"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-856",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "disabled",
+      "source": "tests16.dat:856"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-948",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:948"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-949",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:949"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-950",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:950"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-951",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:951"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-952",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "enabled",
+      "source": "tests16.dat:952"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-953",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "disabled",
+      "source": "tests16.dat:953"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests18-dat-982",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "disabled",
+      "source": "tests18.dat:982"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests5-dat-16",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests5.dat:16"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests5-dat-17",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests5.dat:17"
+    },
+    {
+      "axis": "stray-noscript-end-tag",
+      "id": "tests1-dat-110",
+      "reason": "stray noscript end tags in body and table insertion contexts",
+      "scripting": "enabled",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "stray-noscript-end-tag",
+      "id": "tests1-dat-111",
+      "reason": "stray noscript end tags in body and table insertion contexts",
+      "scripting": "enabled",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-84",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:84"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-85",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:85"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-86",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:86"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-87",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:87"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-88",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "enabled",
+      "source": "tests16.dat:88"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-89",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "disabled",
+      "source": "tests16.dat:89"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-181",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:181"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-182",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:182"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-183",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "enabled",
+      "source": "tests16.dat:183"
+    },
+    {
+      "axis": "comment-boundary",
+      "id": "tests16-dat-184",
+      "reason": "noscript text/comment-looking boundaries under both scripting modes",
+      "scripting": "disabled",
+      "source": "tests16.dat:184"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-185",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "enabled",
+      "source": "tests16.dat:185"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests16-dat-186",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "disabled",
+      "source": "tests16.dat:186"
+    },
+    {
+      "axis": "textmode-descendant",
+      "id": "tests18-dat-5",
+      "reason": "noscript interaction with RAWTEXT and PLAINTEXT descendants",
+      "scripting": "disabled",
+      "source": "tests18.dat:5"
+    },
+    {
+      "axis": "paragraph-noscript",
+      "id": "webkit02-dat-2",
+      "reason": "noscript inside paragraph phrasing flow with sibling content",
+      "scripting": "enabled",
+      "source": "webkit02.dat:2"
+    },
+    {
+      "axis": "paragraph-noscript",
+      "id": "webkit02-dat-3",
+      "reason": "noscript inside paragraph phrasing flow with sibling content",
+      "scripting": "disabled",
+      "source": "webkit02.dat:3"
+    }
+  ],
+  "counts_by_axis": {
+    "comment-boundary": 18,
+    "head-noscript-disabled": 18,
+    "paragraph-noscript": 2,
+    "stray-noscript-end-tag": 4,
+    "textmode-descendant": 10
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress noscript insertion-mode boundaries, scripting-on/off tokenization, comment-looking text, RAWTEXT/PLAINTEXT descendants, stray end tags, and paragraph integration.",
+  "format": "whatwg-html-noscript-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_noscript_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_noscript_audit_test.rs
@@ -1,0 +1,87 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_NOSCRIPT_AUDIT: &str = include_str!("fixtures/whatwg-noscript-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct NoscriptAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<NoscriptAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NoscriptAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    scripting: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_noscript_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-noscript-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 45);
+    assert_axis_count(&suite, "head-noscript-disabled", 15);
+    assert_axis_count(&suite, "comment-boundary", 18);
+    assert_axis_count(&suite, "textmode-descendant", 10);
+    assert_axis_count(&suite, "stray-noscript-end-tag", 4);
+    assert_axis_count(&suite, "paragraph-noscript", 2);
+}
+
+#[test]
+fn whatwg_noscript_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty()
+                && !case.axis.is_empty()
+                && !case.reason.is_empty()
+                && !case.scripting.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> NoscriptAuditSuite {
+    serde_json::from_str(WHATWG_NOSCRIPT_AUDIT).expect("WHATWG noscript audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &NoscriptAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG noscript audit fixture over html5lib tree-construction smoke cases
- cover scripting enabled/disabled metadata, head noscript, comment-like text, text-mode descendants, stray end tags, and paragraph integration
- wire the generator into the shared generated HTML fixture manifest and parser docs

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_noscript_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
