### PR TITLE
Add Chief of Staff report status aliases

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this package will be documented in this file.
 - Signed replayed-minus-planned row and follow-up pressure deltas in supervisor
   drain run summaries.
 - Delta-direction helpers for supervisor drain run reports.
+- Status aliases for supervisor drain run reports.
 - Count-drift presence flags for supervisor drain run reports and summaries.
 - Stable count-drift classifications for supervisor drain run reports and
   summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -49,6 +49,8 @@ The crate keeps the boundary narrow:
   follow-up pressure deltas for host logs
 - supervisor drain reports and summaries expose delta-direction helpers for
   extra or missed replayed work and follow-up pressure
+- supervisor drain reports expose status aliases for idle runs and matched
+  follow-up pressure
 - supervisor drain run summaries expose count-drift presence flags beside
   signed deltas for host logs
 - supervisor drain run summaries expose stable count-drift classifications so

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1013,6 +1013,11 @@ impl ToolAuditSupervisorDrainRunReport {
         self.plan.follow_up_record_count() == self.drain.follow_up_record_count()
     }
 
+    /// Return whether planned and replayed follow-up pressure counts match.
+    pub fn matches_follow_up_pressure(&self) -> bool {
+        self.matches_planned_follow_up_record_count()
+    }
+
     /// Return the replayed-minus-planned row count delta.
     pub fn record_count_delta(&self) -> i128 {
         signed_count_delta(self.drain.drained_records, self.plan.planned_records)
@@ -1077,6 +1082,11 @@ impl ToolAuditSupervisorDrainRunReport {
     /// Return whether count drift should be investigated by the host.
     pub fn requires_count_drift_investigation(&self) -> bool {
         self.count_drift_kind().requires_investigation()
+    }
+
+    /// Return whether no audit rows were replayed.
+    pub fn is_idle(&self) -> bool {
+        self.drain.is_idle()
     }
 
     /// Return whether the actual run replayed at least one row.
@@ -3081,6 +3091,7 @@ mod tests {
         assert_eq!(report.drain.follow_up_record_count(), 1);
         assert!(report.matches_planned_record_count());
         assert!(report.matches_planned_follow_up_record_count());
+        assert!(report.matches_follow_up_pressure());
         assert_eq!(report.record_count_delta(), 0);
         assert_eq!(report.follow_up_record_count_delta(), 0);
         assert!(!report.replayed_extra_records());
@@ -3107,6 +3118,8 @@ mod tests {
         assert!(report.reached_end_of_log());
         assert!(!report.exhausted_tick_budget());
         assert!(!report.should_continue());
+        assert!(!report.is_idle());
+        assert!(report.made_progress());
         assert_eq!(
             report.outcome(),
             ToolAuditSupervisorDrainRunOutcome::NeedsFollowUp
@@ -3180,6 +3193,7 @@ mod tests {
         assert_eq!(report.drain.tick_count(), 1);
         assert_eq!(report.drain.drained_records, 0);
         assert!(report.matches_planned_record_count());
+        assert!(report.is_idle());
         assert!(!report.made_progress());
         assert!(!report.advanced_checkpoint());
         assert!(report.reached_end_of_log());


### PR DESCRIPTION
## Summary
- add `matches_follow_up_pressure()` as a report-level alias for follow-up count parity
- add `is_idle()` for supervisor drain run reports
- document the report status aliases in README and CHANGELOG

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD
- git diff --check