### PR TITLE
fix(sql-vm,mini-sqlite): strftime %f preserves milliseconds, %W matches SQLite

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.68.0] - 2026-05-20
+
+### Fixed
+
+- **``strftime('%f', …)`` and ``strftime('%W', …)`` now match SQLite
+  byte-for-byte** (via ``sql-vm 1.42.0``):
+
+  * ``%f`` (millisecond fraction) was always emitting ``.000``
+    because ``_parse_timevalue`` truncated the input before the
+    fractional-seconds branch could run.
+  * ``%W`` (week of year) was off by one: ``strftime('%W',
+    '2024-01-15')`` returned ``'02'`` instead of ``'03'``.
+
+  15 oracle tests in ``test_tier3_strftime_fixes.py``.
+
 ## [1.67.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.67.0"
+version = "1.68.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_strftime_fixes.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_strftime_fixes.py
@@ -1,0 +1,107 @@
+"""Oracle tests for two ``strftime()`` bugs.
+
+1. ``%f`` (SQLite's millisecond format ``SS.sss``) was always emitting
+   ``.000`` for inputs that included a fractional-seconds suffix.  The
+   ISO-8601 datetime parser in ``_parse_timevalue`` had a fast path
+   that truncated the input via slice arithmetic to fit the bare
+   ``%Y-%m-%d %H:%M:%S`` strptime format — the fraction was silently
+   discarded *before* the dedicated fractional-seconds branch could
+   try to capture it.  Fix: try the fractional-seconds regex first.
+
+2. ``%W`` (week of year, Monday-based, 00–53) was off by one.  The
+   custom implementation used ``isocalendar()[1] - 1``, which produces
+   ISO-week numbering shifted — different from POSIX week-of-year.
+   Python's ``strftime('%W')`` already produces SQLite-compatible
+   output, so the fix is to remove ``%W`` from the manual substitution
+   list and let Python's strftime handle it directly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# %f — fractional seconds preserved through _parse_timevalue
+# ---------------------------------------------------------------------------
+
+
+class TestFractionalSeconds:
+    def test_full_datetime_with_milliseconds(self) -> None:
+        # Was returning '45.000'; now correctly '45.123'.
+        _check("SELECT strftime('%f', '2024-01-15 12:30:45.123')")
+
+    def test_full_datetime_isoT_with_milliseconds(self) -> None:
+        # T-separator variant.
+        _check("SELECT strftime('%f', '2024-01-15T12:30:45.123')")
+
+    def test_time_only_with_milliseconds(self) -> None:
+        # Time-only inputs were already correct; regression guard.
+        _check("SELECT strftime('%f', '12:30:45.123')")
+
+    def test_microseconds_truncated_to_milliseconds(self) -> None:
+        # SQLite outputs only 3 decimal places — the extra precision is
+        # dropped, not rounded.
+        _check("SELECT strftime('%f', '2024-01-15 12:30:45.000123')")
+
+    def test_compose_full_iso8601_with_fraction(self) -> None:
+        _check(
+            "SELECT strftime('%Y-%m-%dT%H:%M:%fZ', '2024-01-15 12:30:45.123')"
+        )
+
+    def test_partial_fraction(self) -> None:
+        # Single-digit fraction should pad correctly.
+        _check("SELECT strftime('%f', '2024-01-15 12:30:45.1')")
+
+
+# ---------------------------------------------------------------------------
+# %W — week of year (Monday-based, 00–53)
+# ---------------------------------------------------------------------------
+
+
+class TestWeekOfYear:
+    def test_week_01(self) -> None:
+        # Was returning '00' (off by one).
+        _check("SELECT strftime('%W', '2024-01-01')")
+
+    def test_week_02(self) -> None:
+        _check("SELECT strftime('%W', '2024-01-08')")
+
+    def test_week_03(self) -> None:
+        # The original probe that surfaced the bug.
+        _check("SELECT strftime('%W', '2024-01-15')")
+
+    def test_week_53(self) -> None:
+        # Last week of a 366-day leap year.
+        _check("SELECT strftime('%W', '2024-12-31')")
+
+    def test_week_00(self) -> None:
+        # Year starting on a Tuesday/.../Sunday has a partial week 00.
+        _check("SELECT strftime('%W', '2023-01-01')")
+
+
+# ---------------------------------------------------------------------------
+# Regression — other strftime specifiers still work
+# ---------------------------------------------------------------------------
+
+
+class TestStrftimeRegression:
+    def test_year_month_day(self) -> None:
+        _check("SELECT strftime('%Y-%m-%d', '2024-01-15')")
+
+    def test_unix_epoch(self) -> None:
+        _check("SELECT strftime('%s', '2024-01-01')")
+
+    def test_julian_day(self) -> None:
+        _check("SELECT strftime('%J', '2024-01-01')")
+
+    def test_day_of_year(self) -> None:
+        _check("SELECT strftime('%j', '2024-12-31')")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.42.0 — 2026-05-20
+
+### Fixed
+
+- **``strftime('%f', …)`` preserves the millisecond fraction**.  The
+  ISO-8601 datetime parser in ``_parse_timevalue`` had a fast path that
+  truncated the input via slice arithmetic to fit the bare
+  ``%Y-%m-%d %H:%M:%S`` strptime format, silently discarding the
+  fractional-seconds suffix *before* the dedicated fractional-seconds
+  branch could capture it.  Fix: try the fractional-seconds regex
+  first, then fall through to the fixed-width formats only when the
+  input has no fraction.  Result: ``strftime('%f', '2024-01-15
+  12:30:45.123')`` now returns ``'45.123'`` (was ``'45.000'``).
+
+- **``strftime('%W', …)`` matches SQLite byte-for-byte.**  The custom
+  ``%W`` substitution used ``isocalendar()[1] - 1``, which produces
+  ISO-week numbering shifted by one — different from POSIX week-of-
+  year.  Python's own ``strftime('%W')`` already produces
+  SQLite-compatible output, so the fix is to remove ``%W`` from the
+  preprocessor and route it through the default Python path.
+
 ## 1.41.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.41.0"
+version = "1.42.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -1971,7 +1971,24 @@ def _parse_timevalue(tv: SqlValue) -> datetime | None:
         s = tv.strip()
         if s.lower() == "now":
             return datetime.now(tz=UTC).replace(microsecond=0)
-        # ISO-8601 date only: YYYY-MM-DD
+        # Fractional-seconds form first: YYYY-MM-DD HH:MM:SS.sss[sss]
+        # We try this *before* the fixed-format strptime loop because the
+        # loop uses ``s[:len(fmt) + 2]`` to permit trailing garbage, which
+        # would silently truncate the fraction and discard the microsecond
+        # information.  Preserving microseconds is required for
+        # ``strftime('%f', …)`` to round-trip the input.
+        m = re.match(
+            r"^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})\.(\d+)$", s
+        )
+        if m:
+            try:
+                dt = datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M:%S")
+                # Pad/truncate the fraction to 6 digits (microseconds).
+                frac = (m.group(3) + "000000")[:6]
+                return dt.replace(microsecond=int(frac), tzinfo=UTC)
+            except ValueError:
+                pass
+        # ISO-8601 date only: YYYY-MM-DD (and variations without fractions)
         for fmt in (
             "%Y-%m-%d %H:%M:%S",
             "%Y-%m-%d %H:%M",
@@ -1984,28 +2001,25 @@ def _parse_timevalue(tv: SqlValue) -> datetime | None:
                 return dt.replace(tzinfo=UTC)
             except ValueError:
                 pass
-        # Allow fractional seconds: YYYY-MM-DD HH:MM:SS.sss
-        m = re.match(
-            r"^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})\.\d+$", s
-        )
-        if m:
-            try:
-                dt = datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M:%S")
-                return dt.replace(tzinfo=UTC)
-            except ValueError:
-                pass
         # SQLite also accepts time-only strings: 'HH:MM', 'HH:MM:SS', 'HH:MM:SS.sss'.
         # These represent the time of day on year 2000-01-01 in SQLite's internal
         # epoch, but for our purposes the date part is irrelevant — we anchor it
         # to 2000-01-01 so the time() function and strftime('%H:%M:%S', ...) work.
         # See https://www.sqlite.org/lang_datefunc.html#tmval — "time" rule.
-        m = re.match(r"^(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?$", s)
+        # The optional fractional-seconds portion is captured and converted
+        # to microseconds (same reasoning as above).
+        m = re.match(r"^(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$", s)
         if m:
             hour = int(m.group(1))
             minute = int(m.group(2))
             second = int(m.group(3)) if m.group(3) else 0
+            microsecond = (
+                int((m.group(4) + "000000")[:6]) if m.group(4) else 0
+            )
             try:
-                return datetime(2000, 1, 1, hour, minute, second, tzinfo=UTC)
+                return datetime(
+                    2000, 1, 1, hour, minute, second, microsecond, tzinfo=UTC
+                )
             except ValueError:
                 pass
         return None
@@ -2350,8 +2364,14 @@ def _unixepoch(*args: SqlValue) -> SqlValue:
 
 
 # Pre-compiled substitution map for STRFTIME's SQLite-specific specifiers.
-# Python's strftime does not support %f (SQLite = SS.SSS) or %s (epoch) or %J.
-_STRFTIME_PREPROCESS = re.compile(r"%[fJjsWP]")
+# Python's strftime does not support %f (SQLite = SS.SSS), %s (epoch),
+# %J (Julian day), or %P (lowercase am/pm on macOS libc).  We intercept
+# those and pre-substitute concrete strings, then let Python format
+# everything else.  ``%W`` (week-of-year, Monday-based, 00–53) used to be
+# intercepted here because of a misreading of the spec — Python's
+# strftime(%W) already produces SQLite-compatible output, so it's now
+# routed through the default path.
+_STRFTIME_PREPROCESS = re.compile(r"%[fJjsP]")
 
 
 def _sqlite_strftime(fmt: str, dt: datetime) -> str:
@@ -2376,9 +2396,6 @@ def _sqlite_strftime(fmt: str, dt: datetime) -> str:
             return str(2440587.5 + unix_ts / 86400.0)
         if spec == "%j":
             return f"{dt.timetuple().tm_yday:03d}"
-        if spec == "%W":
-            # Week number (Monday as first day, 00–53)
-            return f"{dt.isocalendar()[1] - 1:02d}"
         if spec == "%P":
             # Lowercase am/pm — Python's macOS libc doesn't support %P so we
             # synthesise it from %p (uppercase) and lowercase the result.


### PR DESCRIPTION
## Summary

Two strftime bugs uncovered by a gap audit:

1. **`%f` always emitted `.000`** for inputs containing fractional seconds. The ISO datetime parser in `_parse_timevalue` had a fast path that truncated the input via slice arithmetic before the dedicated fractional-seconds branch could capture it. Fix: try the fractional-seconds regex first.

2. **`%W` was off by one.** Custom `isocalendar()[1] - 1` produces ISO-week shifted from POSIX week-of-year. Python's own `strftime('%W')` already produces SQLite-compatible output, so remove `%W` from the manual preprocessor.

15 oracle tests covering %f variations (full ISO, T-separator, time-only, microseconds-truncated, composed format, partial fraction), %W (weeks 00, 01, 02, 03, 53), and regressions (%Y, %s, %J, %j). Version bumps: sql-vm 1.41.0 → 1.42.0, mini-sqlite 1.67.0 → 1.68.0.

## Test plan

- [x] `pytest mini-sqlite/tests/test_tier3_strftime_fixes.py` — 15/15
- [x] sql-vm full suite — 892 passed
- [x] mini-sqlite full suite — 1706 passed (1691 prior + 15 new)
- [x] All oracle cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)