### PR TITLE
feat(cas-summation): Phase 39 — telescoping sums (TS 0.2.0)

### DIFF
--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.2.0 — 2026-05-20
+
+**Phase 39 — Telescoping sum recognition (TypeScript port).**
+
+Mirrors Python `cas-summation` 0.2.0 (PR #3706 ✅ merged).
+
+The `evaluateSum` dispatcher now detects structurally telescoping
+summands of the form `f = g(k+1) − g(k)` (and the antisymmetric
+`g(k) − g(k+1)`) and emits the closed form:
+
+    ∑_{k=lo}^{hi} [g(k+1) − g(k)]  =  g(hi+1) − g(lo)
+    ∑_{k=lo}^{hi} [g(k) − g(k+1)]  =  g(lo) − g(hi+1)
+
+Detection is purely structural: substitute `k → k+1` in one half of
+the `SUB` shape and compare against the other half after `evalFn`
+normalisation.  No partial-fraction expansion is attempted — the
+classic `1/(k(k+1))` example becomes telescoping only after an
+explicit `Apart` step, left for a follow-on phase.  Infinite ranges
+fall through (a future limit-aware phase will handle those).
+
+### Added
+
+- **`tryTelescoping(f, k, evalFn)`** in `src/index.ts` — returns
+  `{ gExpr, sign }` when the SUB structure matches, where `sign = 1`
+  for the standard `g(k+1) − g(k)` orientation and `-1` for the
+  antisymmetric `g(k) − g(k+1)`.
+- New dispatch step inserted between Faulhaber and classic-infinite,
+  guarded on `!infUpper`.
+
+### Added — tests
+
+`tests/cas-summation.test.ts` — new `summation: Phase 39 telescoping`
+describe block with 8 cases covering:
+
+- Standard `(k+1)² − k²` telescope at concrete bounds → 24.
+- Antisymmetric `k² − (k+1)²` orientation → −15.
+- Linear `g(k) = k` (`f ≡ 1` counts terms).
+- `g(k) = k + 5` (constant offset preserved through substitution).
+- Non-telescoping `k² − k` falls through to numeric/Faulhaber.
+- Constant-difference summand routes through step 1 (constant rule).
+- Symbolic upper bound `n` produces a non-unevaluated tree.
+- Infinite upper bound correctly stays unevaluated.
+
+All 14 tests pass (6 prior + 8 net new).
+
 ## 0.1.0
 
 - Add pure TypeScript summation and product evaluator.

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../symbolic-ir": {
       "name": "@coding-adventures/symbolic-ir",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.0.0",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -124,6 +124,25 @@ export function evaluateSum(f: IRNode, k: IRNode, lo: IRNode, hi: IRNode, evalFn
     if (raw !== undefined) return evalFn(raw);
   }
 
+  // Phase 39: telescoping sums. Detect ``f = g(k+1) − g(k)`` (or the
+  // antisymmetric ``g(k) − g(k+1)``) and emit ``g(hi+1) − g(lo)``
+  // (resp. ``g(lo) − g(hi+1)``).  Only the finite case is handled —
+  // infinite telescopes need a limit argument we leave to a future
+  // phase.  When ``α = 1, β = 0`` this is purely structural, no
+  // partial-fraction work is attempted.
+  if (!infUpper) {
+    const tele = tryTelescoping(f, k, evalFn);
+    if (tele !== undefined) {
+      const hiPlusOne = app(ADD, [hi, int(1)]);
+      const gAtHiPlusOne = substitute(tele.gExpr, k, hiPlusOne);
+      const gAtLo = substitute(tele.gExpr, k, lo);
+      if (tele.sign === 1) {
+        return evalFn(app(SUB, [gAtHiPlusOne, gAtLo]));
+      }
+      return evalFn(app(SUB, [gAtLo, gAtHiPlusOne]));
+    }
+  }
+
   if (infUpper) {
     const raw = trySpecialInfinite(f, k, lo);
     if (raw !== undefined) return evalFn(raw);
@@ -192,6 +211,48 @@ function tryGeometric(f: IRNode, k: IRNode): { coeff: IRNode; base: IRNode } | u
         return { coeff, base: pow.args[0] };
       }
     }
+  }
+  return undefined;
+}
+
+/**
+ * Phase 39: Detect a *structurally telescoping* summand
+ * ``f = g(k+1) − g(k)`` (or its antisymmetric ``g(k) − g(k+1)``).
+ *
+ * The dispatcher then emits the closed form
+ * ``g(hi+1) − g(lo)`` (sign +1) or ``g(lo) − g(hi+1)`` (sign −1)
+ * by substituting the bounds into ``g_expr`` and subtracting.
+ *
+ * Detection is purely structural: substitute ``k → k+1`` in one half
+ * of the ``SUB`` shape and compare against the other half after
+ * normalisation via ``evalFn``.  No partial-fraction expansion is
+ * attempted — the classic ``1/(k(k+1))`` form needs an explicit
+ * ``Apart`` step first, which a follow-on phase can compose.
+ *
+ * Returns ``undefined`` when the summand is not a ``SUB`` of two
+ * shifted halves of the same ``g(k)`` expression.
+ */
+function tryTelescoping(
+  f: IRNode,
+  k: IRNode,
+  evalFn: EvalFn,
+): { gExpr: IRNode; sign: 1 | -1 } | undefined {
+  if (f.kind !== "apply" || !equals(f.head, SUB) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [left, right] = f.args;
+  const kPlusOne = app(ADD, [k, int(1)]);
+  // Standard orientation: f = g(k+1) − g(k).  We check whether
+  // substituting k → k+1 in `right` yields `left` (after normalisation).
+  const rightShifted = substitute(right, k, kPlusOne);
+  if (equals(evalFn(rightShifted), evalFn(left))) {
+    return { gExpr: right, sign: 1 };
+  }
+  // Antisymmetric: f = g(k) − g(k+1).  Check whether substituting
+  // k → k+1 in `left` yields `right`.
+  const leftShifted = substitute(left, k, kPlusOne);
+  if (equals(evalFn(leftShifted), evalFn(right))) {
+    return { gExpr: left, sign: -1 };
   }
   return undefined;
 }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -177,3 +177,80 @@ describe("summation", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 39: Telescoping sums.
+//
+// ∑_{k=lo}^{hi} [g(k+1) − g(k)] = g(hi+1) − g(lo)
+// ∑_{k=lo}^{hi} [g(k) − g(k+1)] = g(lo) − g(hi+1)
+//
+// Detection is purely structural: substitute k → k+1 in one half of the SUB
+// shape and compare to the other half after evalNode normalisation.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 39 telescoping", () => {
+  it("standard (k+1)² − k² telescope at concrete bounds", () => {
+    const k = sym("k");
+    // ∑_{k=1}^{4} [(k+1)² − k²] = 5² − 1² = 24
+    const kPlusOneSq = app(POW, [app(ADD, [k, int(1)]), int(2)]);
+    const kSq = app(POW, [k, int(2)]);
+    const f = app(SUB, [kPlusOneSq, kSq]);
+    expect(evaluateSum(f, k, int(1), int(4), evalNode)).toEqual(int(24));
+  });
+
+  it("antisymmetric k² − (k+1)² orientation", () => {
+    const k = sym("k");
+    // ∑_{k=1}^{3} [k² − (k+1)²] = 1² − 4² = −15
+    const kSq = app(POW, [k, int(2)]);
+    const kPlusOneSq = app(POW, [app(ADD, [k, int(1)]), int(2)]);
+    const f = app(SUB, [kSq, kPlusOneSq]);
+    expect(evaluateSum(f, k, int(1), int(3), evalNode)).toEqual(int(-15));
+  });
+
+  it("linear g(k) = k telescope (f ≡ 1 counts terms)", () => {
+    const k = sym("k");
+    // ∑_{k=1}^{10} [(k+1) − k] = g(11) − g(1) = 11 − 1 = 10
+    const f = app(SUB, [app(ADD, [k, int(1)]), k]);
+    expect(evaluateSum(f, k, int(1), int(10), evalNode)).toEqual(int(10));
+  });
+
+  it("g(k) = k + 5 (constant offset is preserved through substitution)", () => {
+    const k = sym("k");
+    // ∑_{k=1}^{5} [(k + 6) − (k + 5)] = g(6) − g(1) = 11 − 6 = 5
+    const gAtKPlus1 = app(ADD, [app(ADD, [k, int(1)]), int(5)]);
+    const gAtK = app(ADD, [k, int(5)]);
+    const f = app(SUB, [gAtKPlus1, gAtK]);
+    expect(evaluateSum(f, k, int(1), int(5), evalNode)).toEqual(int(5));
+  });
+
+  it("non-telescoping k² − k falls through to numeric/Faulhaber", () => {
+    const k = sym("k");
+    // ∑_{k=1}^{3} [k² − k] = (1−1)+(4−2)+(9−3) = 0+2+6 = 8
+    const f = app(SUB, [app(POW, [k, int(2)]), k]);
+    expect(evaluateSum(f, k, int(1), int(3), evalNode)).toEqual(int(8));
+  });
+
+  it("constant-difference summand routes through step 1 (constant)", () => {
+    const k = sym("k");
+    // ∑_{k=1}^{10} [5 − 3] = ∑ 2 = 20
+    const f = app(SUB, [int(5), int(3)]);
+    expect(evaluateSum(f, k, int(1), int(10), evalNode)).toEqual(int(20));
+  });
+
+  it("symbolic upper bound: result is non-unevaluated", () => {
+    const k = sym("k");
+    const n = sym("n");
+    const f = app(SUB, [app(ADD, [k, int(1)]), k]);
+    const out = evaluateSum(f, k, int(1), n, evalNode);
+    // Should not stay as a Sum(...) node.
+    expect(out.kind === "apply" && out.head === SUM).toBe(false);
+  });
+
+  it("infinite upper bound falls through (no limit-aware telescope yet)", () => {
+    const k = sym("k");
+    const f = app(SUB, [app(ADD, [k, int(1)]), k]);
+    const out = evaluateSum(f, k, int(0), sym("%inf"), evalNode);
+    expect(out.kind).toBe("apply");
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Port Phase 39 telescoping-sum recognition from Python (PR #3706 ✅ merged) to TypeScript.

`evaluateSum` now detects structurally telescoping summands `f = g(k+1) − g(k)` (and antisymmetric `g(k) − g(k+1)`) and emits `g(hi+1) − g(lo)` (resp. `g(lo) − g(hi+1)`).

## Implementation

- New `tryTelescoping(f, k, evalFn) -> { gExpr, sign } | undefined` helper.
- Inserted between Faulhaber and classic-infinite in `evaluateSum`, guarded on `!infUpper`.

## Tests

8 new cases mirroring the Python suite: standard `(k+1)² − k²`, antisymmetric, linear g, offset g, fallthroughs (non-telescoping, constant-difference, symbolic n, infinite).

All 14 tests pass (6 prior + 8 net new).

## Test plan

- [x] `npm test` passes locally.
- [x] No new external npm dependencies.
- [x] Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)