### PR TITLE
Add Chief of Staff record match helpers

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this package will be documented in this file.
   drain run summaries.
 - Delta-direction helpers for supervisor drain run reports.
 - Status aliases for supervisor drain run reports.
+- Row-count match helpers for supervisor drain run reports and summaries.
 - Count-drift presence flags for supervisor drain run reports and summaries.
 - Stable count-drift classifications for supervisor drain run reports and
   summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -51,6 +51,8 @@ The crate keeps the boundary narrow:
   extra or missed replayed work and follow-up pressure
 - supervisor drain reports expose status aliases for idle runs and matched
   follow-up pressure
+- supervisor drain reports and summaries expose row-count match helpers for
+  host scheduler checks
 - supervisor drain run summaries expose count-drift presence flags beside
   signed deltas for host logs
 - supervisor drain run summaries expose stable count-drift classifications so

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1008,6 +1008,11 @@ impl ToolAuditSupervisorDrainRunReport {
         self.plan.planned_records == self.drain.drained_records
     }
 
+    /// Return whether planned and replayed row counts match.
+    pub fn matches_record_count(&self) -> bool {
+        self.matches_planned_record_count()
+    }
+
     /// Return whether the actual run preserved the planned follow-up pressure count.
     pub fn matches_planned_follow_up_record_count(&self) -> bool {
         self.plan.follow_up_record_count() == self.drain.follow_up_record_count()
@@ -1235,6 +1240,11 @@ impl ToolAuditSupervisorDrainRunSummary {
     /// Return whether the host should investigate preflight/drain drift.
     pub fn requires_plan_drift_investigation(&self) -> bool {
         self.requires_plan_drift_investigation
+    }
+
+    /// Return whether planned and replayed row counts match.
+    pub fn matches_record_count(&self) -> bool {
+        self.matches_planned_record_count
     }
 
     /// Return whether planned and replayed follow-up pressure counts match.
@@ -3090,6 +3100,7 @@ mod tests {
         assert_eq!(report.plan.follow_up_record_count(), 1);
         assert_eq!(report.drain.follow_up_record_count(), 1);
         assert!(report.matches_planned_record_count());
+        assert!(report.matches_record_count());
         assert!(report.matches_planned_follow_up_record_count());
         assert!(report.matches_follow_up_pressure());
         assert_eq!(report.record_count_delta(), 0);
@@ -3628,6 +3639,7 @@ mod tests {
         assert!(!summary.requires_host_investigation);
         assert!(!summary.requires_host_investigation());
         assert!(summary.matches_planned_record_count);
+        assert!(summary.matches_record_count());
         assert!(summary.matches_planned_follow_up_record_count);
         assert!(summary.matches_follow_up_pressure());
         assert!(!summary.reached_end_of_log);
@@ -3733,6 +3745,7 @@ mod tests {
         let summary = report.summary();
 
         assert!(!report.matches_planned_record_count());
+        assert!(!report.matches_record_count());
         assert_eq!(report.record_count_delta(), -1);
         assert!(report.has_record_count_drift());
         assert!(!report.has_follow_up_record_count_drift());
@@ -3751,6 +3764,7 @@ mod tests {
         assert_eq!(report.host_investigation_label(), "plan_and_count_drift");
         assert!(report.requires_host_investigation());
         assert_eq!(summary.record_count_delta, -1);
+        assert!(!summary.matches_record_count());
         assert!(summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
         assert!(summary.has_count_drift());


### PR DESCRIPTION
## Summary
- add report-level `matches_record_count()` as a concise row-count parity helper
- add summary-level `matches_record_count()` so hosts can avoid field access
- document row-count match helpers in README and CHANGELOG

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD
- git diff --check