### PR TITLE
[codex] Add WHATWG head/body audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -42,6 +42,8 @@ documented in this file.
   alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser noscript audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser head/body audit
+  generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -174,6 +174,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-head-body-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_head_body_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -36,6 +36,9 @@ documented in this file.
 - Generated WHATWG noscript audit fixture over html5lib scripting-on/off,
   head-insertion, comment-boundary, text-mode-descendant, paragraph, and stray
   end-tag cases, with a dedicated parser regression test.
+- Generated WHATWG head/body audit fixture over html5lib shell transitions,
+  head metadata relocation, head text-mode handoff, frameset/body
+  compatibility, and late shell tags, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -48,8 +51,8 @@ documented in this file.
   stray select/list end-tag cases, with a dedicated parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
-  foreign-content, formatting, ruby, noscript, document-shell, template, and
-  select/list audit checks on the same parser and DOM dump path.
+  foreign-content, formatting, ruby, noscript, head/body, document-shell,
+  template, and select/list audit checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -186,6 +186,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_a
   --check
 ```
 
+The generated `tests/fixtures/whatwg-head-body-audit.json` fixture indexes
+`html`/`head`/`body` shell transitions, head metadata relocation, title/style/
+script handoff, frameset/body compatibility, and late shell tags:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -142,6 +142,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_a
   --check
 ```
 
+`whatwg-head-body-audit.json` is a generated index over tree-construction
+cases that stress `html`/`head`/`body` shell transitions, head metadata
+relocation, title/style/script handoff, frameset/body compatibility, and late
+shell tags:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG head/body audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-head-body-audit.json"
+
+HEAD_BODY_MARKUP = re.compile(
+    r"</?(?:html|head|body|frameset|base|basefont|bgsound|link|meta|title|style|script)(?:\s|/|>)",
+    re.I,
+)
+HEAD_TEXT_MODE_MARKUP = re.compile(r"</?(?:title|style|script)(?:\s|/|>)", re.I)
+HEAD_METADATA_MARKUP = re.compile(
+    r"</?(?:base|basefont|bgsound|link|meta)(?:\s|/|>)",
+    re.I,
+)
+
+CASE_AXES = (
+    {
+        "axis": "head-text-mode",
+        "reason": "title, style, and script handoff around document shell boundaries",
+    },
+    {
+        "axis": "head-metadata-boundary",
+        "reason": "metadata elements moving through head, body, and table contexts",
+    },
+    {
+        "axis": "body-frameset-transition",
+        "reason": "frameset/body compatibility and frameset-ok transitions",
+    },
+    {
+        "axis": "body-boundary",
+        "reason": "explicit body start/end tags and late body handling",
+    },
+    {
+        "axis": "head-boundary",
+        "reason": "explicit head start/end tags and misplaced head content",
+    },
+    {
+        "axis": "html-boundary",
+        "reason": "html start/end tag merging and stray html boundary recovery",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG head/body audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if fragment_context is None and is_head_body_case(case_data):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any head/body audit cases")
+    return cases
+
+
+def is_head_body_case(data: str) -> bool:
+    return HEAD_BODY_MARKUP.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-head-body-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress html/head/body shell transitions, metadata relocation, "
+            "head text-mode handoff, frameset/body compatibility, and late shell tags."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data.lower()
+
+    if HEAD_TEXT_MODE_MARKUP.search(data) is not None:
+        return "head-text-mode"
+    if HEAD_METADATA_MARKUP.search(data) is not None:
+        return "head-metadata-boundary"
+    if "<frameset" in data or "</frameset" in data:
+        return "body-frameset-transition"
+    if "<body" in data or "</body" in data:
+        return "body-boundary"
+    if "<head" in data or "</head" in data:
+        return "head-boundary"
+    if "<html" in data or "</html" in data:
+        return "html-boundary"
+    raise SystemExit(f"unclassified head/body audit case: {case.source}")
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown head/body audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-head-body-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-head-body-audit.json
@@ -1,0 +1,6532 @@
+{
+  "case_count": 1086,
+  "cases": [
+    {
+      "axis": "head-text-mode",
+      "id": "adoption02-dat-19",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "adoption02.dat:19"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "comments01-dat-83",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "comments01.dat:83"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "doctype01-dat-116",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "doctype01.dat:116"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-124",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:124"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-125",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:125"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-126",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:126"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-127",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:127"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-128",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:128"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-129",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:129"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-130",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:130"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-131",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:131"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-132",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:132"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-133",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:133"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-134",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:134"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-135",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:135"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-136",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:136"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-137",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:137"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-138",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:138"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-139",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:139"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-140",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:140"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-141",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:141"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-142",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:142"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-143",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:143"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-144",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:144"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-145",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:145"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "domjs-unsafe-dat-146",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "domjs-unsafe.dat:146"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "domjs-unsafe-dat-148",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "domjs-unsafe.dat:148"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "domjs-unsafe-dat-149",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "domjs-unsafe.dat:149"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "domjs-unsafe-dat-150",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "domjs-unsafe.dat:150"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "domjs-unsafe-dat-151",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "domjs-unsafe.dat:151"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "domjs-unsafe-dat-156",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "domjs-unsafe.dat:156"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "domjs-unsafe-dat-159",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "domjs-unsafe.dat:159"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "domjs-unsafe-dat-160",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "domjs-unsafe.dat:160"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "domjs-unsafe-dat-161",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "domjs-unsafe.dat:161"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "domjs-unsafe-dat-162",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "domjs-unsafe.dat:162"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "domjs-unsafe-dat-163",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "domjs-unsafe.dat:163"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "html5test-com-dat-287",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "html5test-com.dat:287"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "html5test-com-dat-288",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "html5test-com.dat:288"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "menuitem-element-dat-308",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "menuitem-element.dat:308"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "menuitem-element-dat-309",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "menuitem-element.dat:309"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "menuitem-element-dat-310",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "menuitem-element.dat:310"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "menuitem-element-dat-311",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "menuitem-element.dat:311"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "menuitem-element-dat-317",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "menuitem-element.dat:317"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "menuitem-element-dat-318",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "menuitem-element.dat:318"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "menuitem-element-dat-322",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "menuitem-element.dat:322"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "menuitem-element-dat-323",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "menuitem-element.dat:323"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "namespace-sensitivity-dat-326",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "namespace-sensitivity.dat:326"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-327",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:327"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-328",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:328"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-329",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:329"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-330",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:330"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-331",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:331"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "noscript01-dat-332",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "noscript01.dat:332"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "noscript01-dat-333",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "noscript01.dat:333"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "noscript01-dat-334",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "noscript01.dat:334"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "noscript01-dat-335",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "noscript01.dat:335"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-336",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:336"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "noscript01-dat-337",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "noscript01.dat:337"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-338",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:338"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-339",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:339"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-340",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:340"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-341",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:341"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-342",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:342"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-343",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:343"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "noscript01-dat-344",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "noscript01.dat:344"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "pending-spec-changes-plain-text-unsafe-dat-345",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "pending-spec-changes-plain-text-unsafe.dat:345"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "pending-spec-changes-dat-346",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "pending-spec-changes.dat:346"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-350",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:350"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-351",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:351"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-352",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:352"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-353",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:353"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-354",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:354"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "plain-text-unsafe-dat-355",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "plain-text-unsafe.dat:355"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "plain-text-unsafe-dat-357",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "plain-text-unsafe.dat:357"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "plain-text-unsafe-dat-360",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "plain-text-unsafe.dat:360"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "plain-text-unsafe-dat-361",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "plain-text-unsafe.dat:361"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "plain-text-unsafe-dat-362",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "plain-text-unsafe.dat:362"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-364",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:364"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-365",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:365"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-366",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:366"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-367",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:367"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-368",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:368"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-369",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:369"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-370",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:370"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "plain-text-unsafe-dat-371",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "plain-text-unsafe.dat:371"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-386",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:386"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-387",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:387"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-388",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:388"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-389",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:389"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-390",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:390"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-391",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:391"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-392",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:392"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-393",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:393"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-394",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:394"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-395",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:395"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-396",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:396"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-397",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:397"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-398",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:398"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-399",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:399"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-400",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:400"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-401",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:401"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-402",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:402"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-403",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:403"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-404",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:404"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-405",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:405"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "ruby-dat-406",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "ruby.dat:406"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-407",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:407"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-408",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:408"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-409",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:409"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-410",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:410"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-411",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:411"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-412",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:412"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-413",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:413"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-414",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:414"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-415",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:415"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-416",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:416"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-417",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:417"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-418",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:418"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-419",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:419"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-420",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:420"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-421",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:421"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-422",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:422"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-423",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:423"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-424",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:424"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-425",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:425"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-426",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:426"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-427",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:427"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-428",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:428"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-429",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:429"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-430",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:430"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-431",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:431"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scriptdata01-dat-432",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scriptdata01.dat:432"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tables01-dat-439",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tables01.dat:439"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tables01-dat-441",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tables01.dat:441"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tables01-dat-446",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tables01.dat:446"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tables01-dat-449",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tables01.dat:449"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-455",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:455"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "template-dat-458",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "template.dat:458"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "template-dat-459",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "template.dat:459"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-483",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:483"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-491",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:491"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-492",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:492"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "template-dat-494",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "template.dat:494"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "template-dat-495",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "template.dat:495"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "template-dat-496",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "template.dat:496"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "template-dat-497",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "template.dat:497"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "template-dat-498",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "template.dat:498"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-499",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:499"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-500",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:500"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-501",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:501"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-502",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:502"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-503",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:503"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-504",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:504"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-505",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:505"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-506",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:506"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-507",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:507"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-508",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:508"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-509",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:509"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-510",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:510"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-511",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:511"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-512",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:512"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-513",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:513"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "template-dat-514",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "template.dat:514"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "template-dat-515",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "template.dat:515"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "template-dat-516",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "template.dat:516"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-517",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:517"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-518",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:518"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "template-dat-519",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "template.dat:519"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "template-dat-520",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "template.dat:520"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "template-dat-521",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "template.dat:521"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-522",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:522"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-523",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:523"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-524",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:524"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-525",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:525"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-526",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:526"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-527",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:527"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-528",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:528"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-529",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:529"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-530",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:530"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-531",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:531"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-532",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:532"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-533",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:533"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "template-dat-548",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "template.dat:548"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "template-dat-549",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "template.dat:549"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-550",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:550"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-551",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:551"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-552",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:552"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-556",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:556"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "template-dat-557",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "template.dat:557"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "template-dat-558",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "template.dat:558"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "template-dat-559",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "template.dat:559"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "template-dat-560",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "template.dat:560"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "template-dat-561",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "template.dat:561"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests1-dat-569",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests1.dat:569"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-570",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:570"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-571",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:571"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-572",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:572"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-573",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:573"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-574",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:574"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-575",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:575"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-576",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:576"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-577",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:577"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-578",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:578"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-579",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:579"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-580",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:580"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-581",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:581"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-582",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:582"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-583",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:583"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests1-dat-584",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests1.dat:584"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-592",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:592"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-599",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:599"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-615",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:615"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-616",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:616"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-620",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:620"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-649",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:649"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-650",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:650"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests1-dat-651",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests1.dat:651"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-653",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:653"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests1-dat-657",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests1.dat:657"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests1-dat-658",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests1.dat:658"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-664",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:664"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-666",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:666"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests1-dat-670",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests1.dat:670"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-675",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-676",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests1-dat-677",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests1.dat:677"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-680",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:680"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-681",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:681"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-682",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:682"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-683",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:683"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-684",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:684"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-685",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:685"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-686",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:686"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-687",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:687"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-688",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:688"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-689",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:689"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-690",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:690"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-691",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:691"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-692",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:692"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-693",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:693"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-694",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:694"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-695",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:695"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-696",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:696"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-697",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:697"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests10-dat-698",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests10.dat:698"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests10-dat-699",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests10.dat:699"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-700",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:700"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-701",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:701"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-702",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:702"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-703",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:703"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests10-dat-713",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests10.dat:713"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests10-dat-717",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests10.dat:717"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-732",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:732"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-733",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:733"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-734",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:734"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-735",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:735"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-736",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:736"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-737",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:737"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-738",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:738"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-739",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:739"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-740",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:740"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-741",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:741"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-742",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:742"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-743",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:743"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-744",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:744"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests12-dat-745",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests12.dat:745"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests12-dat-746",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests12.dat:746"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests14-dat-747",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests14.dat:747"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests14-dat-748",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests14.dat:748"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-749",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:749"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-750",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:750"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-751",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:751"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-752",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:752"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests14-dat-753",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests14.dat:753"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests15-dat-756",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests15.dat:756"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests15-dat-757",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests15.dat:757"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests15-dat-758",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests15.dat:758"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests15-dat-759",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests15.dat:759"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests15-dat-760",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests15.dat:760"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests15-dat-764",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests15.dat:764"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests15-dat-766",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests15.dat:766"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests15-dat-767",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests15.dat:767"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-768",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:768"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-769",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:769"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-770",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:770"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-771",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:771"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-772",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:772"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-773",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:773"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-774",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:774"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-775",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:775"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-776",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:776"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-777",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:777"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-778",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:778"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-779",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:779"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-780",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:780"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-781",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:781"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-782",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:782"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-783",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:783"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-784",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:784"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-785",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:785"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-786",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:786"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-787",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:787"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-788",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:788"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-789",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:789"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-790",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:790"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-791",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:791"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-792",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:792"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-793",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:793"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-794",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:794"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-795",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:795"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-796",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:796"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-797",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:797"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-798",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:798"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-799",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:799"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-800",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:800"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-801",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:801"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-802",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:802"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-803",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:803"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-804",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:804"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-805",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:805"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-806",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:806"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-807",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:807"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-808",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:808"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-809",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:809"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-810",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:810"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-811",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:811"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-812",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:812"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-813",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:813"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-814",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:814"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-815",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:815"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-816",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:816"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-817",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:817"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-818",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:818"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-819",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:819"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-820",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:820"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-821",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:821"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-822",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:822"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-823",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:823"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-824",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:824"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-825",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:825"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-826",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:826"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-827",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:827"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-828",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:828"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-829",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:829"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-830",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:830"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-831",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:831"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-832",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:832"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-833",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:833"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-834",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:834"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-835",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:835"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-836",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:836"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-837",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:837"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-838",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:838"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-839",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:839"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-840",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:840"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-841",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:841"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-842",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:842"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-843",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:843"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-844",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:844"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-845",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:845"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-846",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:846"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-847",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:847"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-848",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:848"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-849",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:849"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-850",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:850"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-858",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:858"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-867",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:867"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-868",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:868"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-869",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:869"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-870",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:870"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-871",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:871"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-872",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:872"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-873",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:873"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-874",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:874"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-875",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:875"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-876",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:876"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-877",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:877"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-878",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:878"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-879",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:879"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-880",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:880"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-881",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:881"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-882",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:882"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-883",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:883"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-884",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:884"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-885",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:885"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-886",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:886"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-887",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:887"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-888",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:888"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-889",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:889"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-890",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:890"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-891",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:891"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-892",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:892"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-893",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:893"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-894",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:894"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-895",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:895"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-896",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:896"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-897",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:897"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-898",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:898"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-899",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:899"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-900",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:900"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-901",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:901"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-902",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:902"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-903",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:903"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-904",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:904"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-905",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:905"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-906",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:906"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-907",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:907"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-908",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:908"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-909",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:909"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-910",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:910"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-911",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:911"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-912",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:912"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-913",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:913"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-914",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:914"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-915",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:915"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-916",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:916"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-917",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:917"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-918",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:918"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-919",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:919"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-920",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:920"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-921",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:921"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-922",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:922"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-923",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:923"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-924",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:924"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-925",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:925"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-926",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:926"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-927",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:927"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-928",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:928"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-929",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:929"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-930",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:930"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-931",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:931"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-932",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:932"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-933",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:933"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-934",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:934"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-935",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:935"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-936",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:936"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-937",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:937"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-938",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:938"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-939",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:939"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-940",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:940"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-941",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:941"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-942",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:942"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-943",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:943"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-944",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:944"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-945",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:945"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-946",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:946"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-947",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:947"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-955",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:955"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests18-dat-980",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests18.dat:980"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests18-dat-981",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests18.dat:981"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests18-dat-982",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests18.dat:982"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests18-dat-983",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests18.dat:983"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests18-dat-984",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests18.dat:984"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests18-dat-994",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests18.dat:994"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-995",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:995"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-996",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:996"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests18-dat-997",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests18.dat:997"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-998",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:998"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1000",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1000"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1001",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1001"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1002",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1002"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1003",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1003"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1004",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1004"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1005",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1005"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1006",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1006"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-1007",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:1007"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-1008",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:1008"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-1009",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:1009"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-1010",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:1010"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-1011",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:1011"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-1015",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:1015"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests19-dat-1016",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests19.dat:1016"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-1017",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:1017"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-1018",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:1018"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-1028",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:1028"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-1029",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:1029"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-1030",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:1030"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-1031",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:1031"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-1034",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:1034"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1049",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1049"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-1050",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:1050"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1051",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1051"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1052",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1052"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1053",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1053"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1054",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1054"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1055",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1055"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1056",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1056"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1057",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1057"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1058",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1058"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1059",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1059"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1060",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1060"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1061",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1061"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1062",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1062"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1063",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1063"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1064",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1064"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1065",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1065"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1066",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1066"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1067",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1067"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1068",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1068"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1069",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1069"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1070",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1070"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1071",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1071"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1072",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1072"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1073",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1073"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1074",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1074"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1075",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1075"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1076",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1076"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1077",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1077"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1078",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1078"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1079",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1079"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1080",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1080"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1081",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1081"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1082",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1082"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1083",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1083"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1084",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1084"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1085",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1085"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1086",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1086"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1087",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1087"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1088",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1088"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1089",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1089"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1090",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1090"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1091",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1091"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1092",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1092"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1093",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1093"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-1094",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:1094"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-1097",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:1097"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1098",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1098"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1099",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1099"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1100",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1100"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests19-dat-1101",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests19.dat:1101"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1109",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1109"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1110",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1110"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1111",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1111"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-1112",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:1112"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests20-dat-1166",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests20.dat:1166"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1222",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1222"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1223",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1223"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-1224",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:1224"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-1225",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:1225"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-1226",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:1226"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1227",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1227"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1228",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1228"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1229",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1229"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1230",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1230"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1231",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1231"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1232",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1232"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1233",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1233"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1234",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1234"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1235",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1235"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests25-dat-1239",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests25.dat:1239"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests25-dat-1240",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests25.dat:1240"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1241",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1241"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-1242",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:1242"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-1243",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:1243"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1244",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1244"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1245",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1245"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1246",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1246"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1247",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1247"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1248",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1248"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1249",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1249"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1250",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1250"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1251",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1251"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1252",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1252"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1253",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1253"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1254",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1254"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1255",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1255"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1256",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1256"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1262",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1262"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests2-dat-6",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests2.dat:6"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests2-dat-7",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests2.dat:7"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests2-dat-8",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests2.dat:8"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests2-dat-9",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests2.dat:9"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests2-dat-12",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests2.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests2-dat-16",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests2.dat:16"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests2-dat-19",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests2.dat:19"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests2-dat-33",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests2.dat:33"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests2-dat-34",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests2.dat:34"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests2-dat-47",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests2.dat:47"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests2-dat-48",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests2.dat:48"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests2-dat-51",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests2.dat:51"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests2-dat-52",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests2.dat:52"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests2-dat-53",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests2.dat:53"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests2-dat-54",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests2.dat:54"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests2-dat-55",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests2.dat:55"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests2-dat-56",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests2.dat:56"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests2-dat-57",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests2.dat:57"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests2-dat-58",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests2.dat:58"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests3-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests3.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests3-dat-2",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests3.dat:2"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-2",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:2"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-3",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:3"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-4",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:4"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-7",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:7"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-8",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:8"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-10",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:10"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-13",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:13"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-14",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:14"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests5-dat-15",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests5.dat:15"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests7-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests7.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:2"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:11"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-12",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-13",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:13"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-14",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:14"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-15",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:15"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-16",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:16"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-17",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:17"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-18",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:18"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-19",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:19"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-20",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:20"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-21",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:21"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests9-dat-22",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests9.dat:22"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests9-dat-23",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests9.dat:23"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-24",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:24"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-25",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:25"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-26",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:26"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests9-dat-27",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests9.dat:27"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests3-dat-3",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests3.dat:3"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests6-dat-1",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests6.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests3-dat-4",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests3.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:11"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests3-dat-13",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests3.dat:13"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests3-dat-14",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests3.dat:14"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests3-dat-16",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests3.dat:16"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-20",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:20"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests3-dat-23",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests3.dat:23"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests6-dat-3",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests6.dat:3"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests6-dat-4",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests6.dat:4"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-8",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:8"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-9",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:9"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-10",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:10"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-11",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:11"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-12",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests6-dat-22",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests6.dat:22"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests6-dat-24",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests6.dat:24"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-29",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:29"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-31",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:31"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests6-dat-40",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests6.dat:40"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests6-dat-43",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests6.dat:43"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-46",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:46"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests6-dat-47",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests6.dat:47"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-48",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:48"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-49",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:49"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-50",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:50"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-51",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:51"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests6-dat-52",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests6.dat:52"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests7-dat-2",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests7.dat:2"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests7-dat-3",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests7.dat:3"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests7-dat-4",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests7.dat:4"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests7-dat-5",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests7.dat:5"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests7-dat-6",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests7.dat:6"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests7-dat-7",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests7.dat:7"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests7-dat-8",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests7.dat:8"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests7-dat-9",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests7.dat:9"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests7-dat-10",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests7.dat:10"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests7-dat-11",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests7.dat:11"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests7-dat-12",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests7.dat:12"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests7-dat-13",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests7.dat:13"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests7-dat-26",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests7.dat:26"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests7-dat-27",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests7.dat:27"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests1-dat-4",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests1.dat:4"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-5",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:6"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-7",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:7"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-8",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:11"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-12",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-13",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:13"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-14",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:14"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-15",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:15"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-16",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:16"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests1-dat-17",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests1.dat:17"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-18",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:18"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests1-dat-19",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests1.dat:19"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-27",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:27"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests1-dat-34",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests1.dat:34"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-50",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:50"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-51",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:51"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-55",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:55"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-84",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:84"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-85",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:85"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests1-dat-86",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests1.dat:86"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-88",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:88"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests1-dat-92",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests1.dat:92"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests1-dat-93",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests1.dat:93"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-99",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:99"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-101",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:101"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests1-dat-105",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests1.dat:105"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-110",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests1-dat-111",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests1-dat-112",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests1.dat:112"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-3",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:3"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-4",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:11"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-12",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-13",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:13"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-14",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:14"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-15",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:15"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-16",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:16"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-17",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:17"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-18",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:18"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-19",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:19"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-20",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:20"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests10-dat-21",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests10.dat:21"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests10-dat-22",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests10.dat:22"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-23",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:23"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-24",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:24"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-25",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:25"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests10-dat-26",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests10.dat:26"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests10-dat-36",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests10.dat:36"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests10-dat-40",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests10.dat:40"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-1",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:2"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-3",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:3"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-4",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:11"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-12",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests11-dat-13",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests11.dat:13"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests12-dat-1",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests12.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests12-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests12.dat:2"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests14-dat-1",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests14.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests14-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests14.dat:2"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-3",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:3"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-4",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:4"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-5",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:5"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests14-dat-6",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests14.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests14-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests14.dat:7"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests15-dat-3",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests15.dat:3"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests15-dat-4",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests15.dat:4"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests15-dat-5",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests15.dat:5"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests15-dat-6",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests15.dat:6"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests15-dat-7",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests15.dat:7"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests15-dat-11",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests15.dat:11"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests15-dat-13",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests15.dat:13"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests15-dat-14",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests15.dat:14"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-2",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:2"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-3",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:3"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-4",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:4"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-5",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:5"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-6",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:6"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-7",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:7"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-8",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:8"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-9",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:9"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-10",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:10"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-11",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:11"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-12",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:12"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-13",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:13"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-14",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:14"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-15",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:15"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-16",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:16"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-17",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:17"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-18",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:18"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-19",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:19"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-20",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:20"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-21",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:21"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-22",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:22"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-23",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:23"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-24",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:24"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-25",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:25"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-26",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:26"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-27",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:27"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-28",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:28"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-29",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:29"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-30",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:30"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-31",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:31"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-32",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:32"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-33",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:33"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-34",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:34"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-35",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:35"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-36",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:36"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-37",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:37"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-38",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:38"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-39",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:39"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-40",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:40"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-41",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:41"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-42",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:42"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-43",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:43"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-44",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:44"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-45",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:45"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-46",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:46"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-47",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:47"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-48",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:48"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-49",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:49"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-50",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:50"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-51",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:51"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-52",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:52"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-53",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:53"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-54",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:54"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-55",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:55"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-56",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:56"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-57",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:57"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-58",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:58"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-59",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:59"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-60",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:60"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-61",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:61"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-62",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:62"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-63",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:63"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-64",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:64"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-65",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:65"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-66",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:66"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-67",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:67"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-68",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:68"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-69",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:69"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-70",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:70"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-71",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:71"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-72",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:72"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-73",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:73"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-74",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:74"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-75",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:75"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-76",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:76"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-77",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:77"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-78",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:78"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-79",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:79"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-80",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:80"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-81",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:81"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-82",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:82"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-83",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:83"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-91",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:91"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-100",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:100"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-101",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:101"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-102",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:102"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-103",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:103"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-104",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:104"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-105",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:105"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-106",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:106"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-107",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:107"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-108",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:108"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-109",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:109"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-110",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:110"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-111",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:111"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-112",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:112"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-113",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:113"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-114",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:114"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-115",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:115"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-116",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:116"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-117",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:117"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-118",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:118"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-119",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:119"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-120",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:120"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-121",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:121"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-122",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:122"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-123",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:123"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-124",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:124"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-125",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:125"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-126",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:126"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-127",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:127"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-128",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:128"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-129",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:129"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-130",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:130"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-131",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:131"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-132",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:132"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-133",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:133"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-134",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:134"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-135",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:135"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-136",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:136"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-137",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:137"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-138",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:138"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-139",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:139"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-140",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:140"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-141",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:141"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-142",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:142"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-143",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:143"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-144",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:144"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-145",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:145"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-146",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:146"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-147",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:147"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-148",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:148"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-149",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:149"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-150",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:150"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-151",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:151"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-152",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:152"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-153",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:153"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-154",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:154"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-155",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:155"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-156",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:156"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-157",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:157"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-158",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:158"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-159",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:159"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-160",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:160"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-161",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:161"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-162",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:162"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-163",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:163"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-164",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:164"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-165",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:165"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-166",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:166"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-167",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:167"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-168",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:168"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-169",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:169"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-170",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:170"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-171",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:171"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-172",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:172"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-173",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:173"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-174",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:174"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-175",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:175"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-176",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:176"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-177",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:177"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-178",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:178"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-179",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:179"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-180",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:180"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests16-dat-188",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests16.dat:188"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests18-dat-3",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests18.dat:3"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests18-dat-4",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests18.dat:4"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests18-dat-5",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests18.dat:5"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests18-dat-6",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests18.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests18-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests18.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests18-dat-17",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests18.dat:17"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-18",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:18"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-19",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:19"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests18-dat-20",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests18.dat:20"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-21",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:21"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-23",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:23"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-24",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:24"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-25",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:25"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-26",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:26"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-27",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:27"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-28",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:28"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-29",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:29"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests18-dat-30",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests18.dat:30"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-31",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:31"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-32",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:32"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-33",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:33"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests18-dat-34",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests18.dat:34"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-2",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:2"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests19-dat-3",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests19.dat:3"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-4",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:5"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-15",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:15"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-16",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:16"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-17",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:17"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-18",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:18"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-21",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:21"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-36",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:36"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests19-dat-37",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests19.dat:37"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-38",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:38"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-39",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:39"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-40",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:40"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-41",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:41"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-42",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:42"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-43",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:43"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-44",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:44"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-45",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:45"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-46",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:46"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-47",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:47"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-48",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:48"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-49",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:49"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-50",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:50"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-51",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:51"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-52",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:52"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-53",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:53"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-54",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:54"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-55",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:55"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-56",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:56"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-57",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:57"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-58",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:58"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-59",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:59"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-60",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:60"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-61",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:61"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-62",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:62"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-63",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:63"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-64",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:64"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-65",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:65"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-66",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:66"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-67",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:67"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-68",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:68"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-69",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:69"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-70",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:70"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-71",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:71"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-72",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:72"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-73",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:73"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-74",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:74"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-75",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:75"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-76",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:76"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-77",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:77"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-78",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:78"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-79",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:79"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-80",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:80"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "tests19-dat-81",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "tests19.dat:81"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tests19-dat-84",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tests19.dat:84"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-85",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:85"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-86",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:86"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-87",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:87"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests19-dat-88",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests19.dat:88"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-96",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:96"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-97",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:97"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-98",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:98"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests19-dat-99",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests19.dat:99"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "tests20-dat-50",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "tests20.dat:50"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-1",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:2"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-3",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:3"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-4",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:4"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-5",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:11"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-12",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-13",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:13"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-14",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:14"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests25-dat-18",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests25.dat:18"
+    },
+    {
+      "axis": "head-boundary",
+      "id": "tests25-dat-19",
+      "reason": "explicit head start/end tags and misplaced head content",
+      "source": "tests25.dat:19"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-20",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:20"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-21",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:21"
+    },
+    {
+      "axis": "head-metadata-boundary",
+      "id": "tests25-dat-22",
+      "reason": "metadata elements moving through head, body, and table contexts",
+      "source": "tests25.dat:22"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-23",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:23"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-24",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:24"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-25",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:25"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests25-dat-26",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests25.dat:26"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-1",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:2"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-3",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:3"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-4",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tests26-dat-15",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tests26.dat:15"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scripted-adoption01-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scripted/adoption01.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scripted-ark-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scripted/ark.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scripted-webkit01-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scripted/webkit01.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scripted-webkit01-dat-2",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scripted/webkit01.dat:2"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tricky01-dat-2",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tricky01.dat:2"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tricky01-dat-3",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tricky01.dat:3"
+    },
+    {
+      "axis": "html-boundary",
+      "id": "tricky01-dat-4",
+      "reason": "html start/end tag merging and stray html boundary recovery",
+      "source": "tricky01.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tricky01-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tricky01.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "tricky01-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "tricky01.dat:9"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-5",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:5"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-7",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-17",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:17"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-18",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:18"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-19",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:19"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-20",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:20"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-21",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:21"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-22",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:22"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-23",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:23"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-24",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:24"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-25",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:25"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-26",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:26"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-27",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:27"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-28",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:28"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-29",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:29"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-30",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:30"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "webkit01-dat-31",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "webkit01.dat:31"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit01-dat-35",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit01.dat:35"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-36",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:36"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-39",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:39"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-40",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:40"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-41",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:41"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-42",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:42"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-43",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:43"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit01-dat-44",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit01.dat:44"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "webkit01-dat-51",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "webkit01.dat:51"
+    },
+    {
+      "axis": "body-frameset-transition",
+      "id": "webkit01-dat-52",
+      "reason": "frameset/body compatibility and frameset-ok transitions",
+      "source": "webkit01.dat:52"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "webkit02-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "webkit02.dat:5"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "webkit02-dat-21",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "webkit02.dat:21"
+    }
+  ],
+  "counts_by_axis": {
+    "body-boundary": 280,
+    "body-frameset-transition": 153,
+    "head-boundary": 49,
+    "head-metadata-boundary": 50,
+    "head-text-mode": 481,
+    "html-boundary": 73
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress html/head/body shell transitions, metadata relocation, head text-mode handoff, frameset/body compatibility, and late shell tags.",
+  "format": "whatwg-html-head-body-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
@@ -1,0 +1,85 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct HeadBodyAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<HeadBodyAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HeadBodyAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_head_body_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-head-body-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 1000);
+    assert_axis_count(&suite, "head-text-mode", 475);
+    assert_axis_count(&suite, "head-metadata-boundary", 50);
+    assert_axis_count(&suite, "body-frameset-transition", 150);
+    assert_axis_count(&suite, "body-boundary", 275);
+    assert_axis_count(&suite, "head-boundary", 45);
+    assert_axis_count(&suite, "html-boundary", 70);
+}
+
+#[test]
+fn whatwg_head_body_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> HeadBodyAuditSuite {
+    serde_json::from_str(WHATWG_HEAD_BODY_AUDIT)
+        .expect("WHATWG head/body audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &HeadBodyAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG head/body audit fixture over 1,086 html5lib tree-construction smoke cases
- split coverage across head text-mode handoff, head metadata relocation, frameset/body transitions, body boundaries, head boundaries, and html boundaries
- wire the generator into the shared generated HTML fixture manifest and parser docs

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_head_body_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
