### PR TITLE
feat(cas-summation): Phase 39 — telescoping sums (Rust 0.2.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.2.0 — 2026-05-20
+
+**Phase 39 — Telescoping sum recognition (Rust port).**
+
+Mirrors Python `cas-summation` 0.2.0 (PR #3706 ✅ merged) and the
+in-flight TypeScript port (PR #3720).
+
+`evaluate_sum` now detects structurally telescoping summands of the
+form `f = g(k+1) − g(k)` (and the antisymmetric `g(k) − g(k+1)`) and
+emits the closed form:
+
+    ∑_{k=lo}^{hi} [g(k+1) − g(k)]  =  g(hi+1) − g(lo)
+    ∑_{k=lo}^{hi} [g(k) − g(k+1)]  =  g(lo) − g(hi+1)
+
+Detection is purely structural: substitute `k → k+1` in one half of
+the `SUB` shape and compare against the other half after `eval_fn`
+normalisation.  No partial-fraction expansion is attempted (the
+classic `1/(k(k+1))` form needs an explicit `Apart` step first).
+Infinite ranges fall through (a future limit-aware phase will handle
+those).
+
+### Added
+
+- **`try_telescoping<E>(f, k, eval_fn)`** in `src/lib.rs` — generic
+  over `E: FnMut(IRNode) -> IRNode`.  Returns `Some((g_expr, sign))`
+  where `sign = 1` for the standard `g(k+1) − g(k)` orientation and
+  `-1` for the antisymmetric `g(k) − g(k+1)`.
+- New dispatch step inserted between Faulhaber and classic-infinite
+  in `evaluate_sum`, guarded on `!inf_upper`.
+
+### Added — tests
+
+`tests/tests.rs` — 8 new `#[test]` functions covering:
+
+- `phase39_standard_telescope_concrete_bounds`: `(k+1)² − k²` → 24.
+- `phase39_antisymmetric_telescope`: `k² − (k+1)²` → −15.
+- `phase39_linear_g_counts_terms`: `(k+1) − k`.
+- `phase39_constant_offset_in_g`: `(k+6) − (k+5)`.
+- `phase39_non_telescoping_falls_through`: `k² − k` (numeric path).
+- `phase39_constant_difference_routes_through_constant_rule`.
+- `phase39_symbolic_upper_bound_non_unevaluated`.
+- `phase39_infinite_upper_falls_through`.
+
+All 14 tests pass (6 prior + 8 net new).
+
 ## 0.1.0
 
 - Add symbolic summation and product evaluator for Rust.

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -268,6 +268,25 @@ where
         }
     }
 
+    // Phase 39: telescoping sums.  Detect `f = g(k+1) − g(k)` (or the
+    // antisymmetric `g(k) − g(k+1)`) and emit `g(hi+1) − g(lo)` (resp.
+    // `g(lo) − g(hi+1)`).  Pure structural detection — no partial
+    // fraction expansion; infinite case deferred to a future limit-aware
+    // phase.
+    if !inf_upper {
+        if let Some((g_expr, sign)) = try_telescoping(&f, &k, &mut eval_fn) {
+            let hi_plus_one = binary(ADD, hi.clone(), int(1));
+            let g_at_hi_plus_one = substitute(&g_expr, &k, &hi_plus_one);
+            let g_at_lo = substitute(&g_expr, &k, &lo);
+            let closed = if sign > 0 {
+                binary(SUB, g_at_hi_plus_one, g_at_lo)
+            } else {
+                binary(SUB, g_at_lo, g_at_hi_plus_one)
+            };
+            return eval_fn(closed);
+        }
+    }
+
     if inf_upper {
         if let Some(raw) = try_special_infinite(&f, &k, &lo) {
             return eval_fn(raw);
@@ -419,6 +438,42 @@ fn try_power_of_k(f: &IRNode, k: &IRNode) -> Option<(Rational, i64)> {
                 }
             }
         }
+    }
+    None
+}
+
+/// Phase 39: Detect a *structurally telescoping* summand
+/// `f = g(k+1) − g(k)` (or its antisymmetric `g(k) − g(k+1)`).
+///
+/// Returns `(g_expr, sign)` where:
+/// - `g_expr` is the expression representing `g(k)` — the "minus" half
+///   of the SUB shape.  The closed form is then `g(hi+1) − g(lo)` for
+///   `sign = +1` and `g(lo) − g(hi+1)` for `sign = -1`.
+/// - Detection is purely structural: substitute `k → k+1` in one half
+///   of the SUB and compare against the other half after `eval_fn`
+///   normalisation.  No partial-fraction expansion is attempted — the
+///   classic `1/(k(k+1))` form needs an explicit `Apart` step first.
+fn try_telescoping<E>(f: &IRNode, k: &IRNode, eval_fn: &mut E) -> Option<(IRNode, i32)>
+where
+    E: FnMut(IRNode) -> IRNode,
+{
+    let node = match f {
+        IRNode::Apply(node) if head_is(&node.head, SUB) && node.args.len() == 2 => node,
+        _ => return None,
+    };
+    let left = &node.args[0];
+    let right = &node.args[1];
+    let k_plus_one = binary(ADD, k.clone(), int(1));
+    // Standard orientation: f = g(k+1) − g(k).  Check whether
+    // substituting k → k+1 in `right` yields `left` (after normalisation).
+    let right_shifted = substitute(right, k, &k_plus_one);
+    if eval_fn(right_shifted) == eval_fn(left.clone()) {
+        return Some((right.clone(), 1));
+    }
+    // Antisymmetric: f = g(k) − g(k+1).
+    let left_shifted = substitute(left, k, &k_plus_one);
+    if eval_fn(left_shifted) == eval_fn(right.clone()) {
+        return Some((left.clone(), -1));
     }
     None
 }

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -200,3 +200,109 @@ fn unknown_sum_falls_back_to_sum_node() {
     let out = evaluate_sum(f, k, int(1), sym("n"), eval);
     assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 39: Telescoping sums.
+//
+// ∑_{k=lo}^{hi} [g(k+1) − g(k)] = g(hi+1) − g(lo)
+// ∑_{k=lo}^{hi} [g(k) − g(k+1)] = g(lo) − g(hi+1)
+//
+// Detection is purely structural: substitute k → k+1 in one half of the SUB
+// shape and compare to the other half after eval normalisation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase39_standard_telescope_concrete_bounds() {
+    // ∑_{k=1}^{4} [(k+1)² − k²] = 5² − 1² = 24.
+    let k = sym("k");
+    let k_plus_one_sq = apply(
+        sym(POW),
+        vec![apply(sym(ADD), vec![k.clone(), int(1)]), int(2)],
+    );
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let f = apply(sym(SUB), vec![k_plus_one_sq, k_sq]);
+    assert_eq!(evaluate_sum(f, k, int(1), int(4), eval), int(24));
+}
+
+#[test]
+fn phase39_antisymmetric_telescope() {
+    // ∑_{k=1}^{3} [k² − (k+1)²] = 1² − 4² = −15.
+    let k = sym("k");
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let k_plus_one_sq = apply(
+        sym(POW),
+        vec![apply(sym(ADD), vec![k.clone(), int(1)]), int(2)],
+    );
+    let f = apply(sym(SUB), vec![k_sq, k_plus_one_sq]);
+    assert_eq!(evaluate_sum(f, k, int(1), int(3), eval), int(-15));
+}
+
+#[test]
+fn phase39_linear_g_counts_terms() {
+    // ∑_{k=1}^{10} [(k+1) − k] = g(11) − g(1) = 11 − 1 = 10.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(ADD), vec![k.clone(), int(1)]), k.clone()],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), int(10), eval), int(10));
+}
+
+#[test]
+fn phase39_constant_offset_in_g() {
+    // ∑_{k=1}^{5} [(k + 6) − (k + 5)] = g(6) − g(1) = 11 − 6 = 5.
+    let k = sym("k");
+    let g_at_k_plus_1 = apply(
+        sym(ADD),
+        vec![apply(sym(ADD), vec![k.clone(), int(1)]), int(5)],
+    );
+    let g_at_k = apply(sym(ADD), vec![k.clone(), int(5)]);
+    let f = apply(sym(SUB), vec![g_at_k_plus_1, g_at_k]);
+    assert_eq!(evaluate_sum(f, k, int(1), int(5), eval), int(5));
+}
+
+#[test]
+fn phase39_non_telescoping_falls_through() {
+    // ∑_{k=1}^{3} [k² − k] = (1−1)+(4−2)+(9−3) = 8 (numeric fallback).
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(POW), vec![k.clone(), int(2)]), k.clone()],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), int(3), eval), int(8));
+}
+
+#[test]
+fn phase39_constant_difference_routes_through_constant_rule() {
+    // ∑_{k=1}^{10} [5 − 3] = ∑ 2 = 20 (step 1 fires first; telescope never runs).
+    let k = sym("k");
+    let f = apply(sym(SUB), vec![int(5), int(3)]);
+    assert_eq!(evaluate_sum(f, k, int(1), int(10), eval), int(20));
+}
+
+#[test]
+fn phase39_symbolic_upper_bound_non_unevaluated() {
+    let k = sym("k");
+    let n = sym("n");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(ADD), vec![k.clone(), int(1)]), k.clone()],
+    );
+    let out = evaluate_sum(f, k, int(1), n, eval);
+    // Must not stay as a SUM(...) node.
+    assert!(
+        !matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)),
+        "expected non-unevaluated form, got {out:?}"
+    );
+}
+
+#[test]
+fn phase39_infinite_upper_falls_through() {
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![apply(sym(ADD), vec![k.clone(), int(1)]), k.clone()],
+    );
+    let out = evaluate_sum(f, k, int(0), sym("%inf"), eval);
+    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}


### PR DESCRIPTION
## Summary

Port Phase 39 telescoping-sum recognition from Python (PR #3706 ✅ merged) and TypeScript (PR #3720 in review) to Rust.

`evaluate_sum` now detects structurally telescoping summands `f = g(k+1) − g(k)` (and antisymmetric `g(k) − g(k+1)`) and emits `g(hi+1) − g(lo)` (resp. `g(lo) − g(hi+1)`).

## Implementation

- New `try_telescoping<E>(f, k, eval_fn) -> Option<(IRNode, i32)>` helper, generic over `E: FnMut(IRNode) -> IRNode`.
- Inserted between Faulhaber and classic-infinite in `evaluate_sum`, guarded on `!inf_upper`.

## Tests

8 new `#[test]` functions mirroring the Python/TS suites:

- Standard `(k+1)² − k²` telescope (concrete bounds, → 24).
- Antisymmetric `k² − (k+1)²` (→ −15).
- Linear `g(k) = k`, offset `g(k) = k + 5`.
- Fallthroughs: non-telescoping `k² − k`, constant-difference, symbolic n, infinite range.

All 14 tests pass (6 prior + 8 net new).

## Test plan

- [x] `cargo build` passes, `cargo test` 14/14 passes.
- [x] No `unsafe`, no new external dependencies.
- [x] Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)