### PR TITLE
fix(sql-vm,mini-sqlite): date(.., '+N year') rolls Feb 29 over instead of clamping

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.69.0] - 2026-05-20
+
+### Fixed
+
+- **``date(..., '+N year')`` Feb 29 rollover matches SQLite**
+  (via ``sql-vm 1.43.0``).  Previously
+  ``date('2024-02-29', '+1 year')`` returned ``'2025-02-28'`` (clamp);
+  SQLite rolls forward to ``'2025-03-01'``.  The fix ports the
+  existing month-rollover algorithm to the year branch.
+
+  14 oracle tests in ``test_tier3_year_rollover.py`` covering forward/
+  backward rollover, leap-to-leap preservation, and ordinary
+  non-Feb-29 dates as regression guards.
+
 ## [1.68.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.68.0"
+version = "1.69.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_year_rollover.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_year_rollover.py
@@ -1,0 +1,109 @@
+"""Oracle tests for ``date(..., '+N year[s]')`` Feb 29 rollover.
+
+SQLite's ``date(timevalue, '+N year')`` follows the same overflow rule
+as its ``+N month`` counterpart: if the resulting (year, month, day)
+isn't a real date, it rolls forward into the next month rather than
+clamping the day.
+
+Concretely::
+
+    date('2024-02-29', '+1 year')
+
+The naive answer is ``2025-02-29``, which doesn't exist (2025 is not
+a leap year).  Mini-sqlite previously clamped to ``2025-02-28``.
+SQLite rolls over: the date is one day past Feb 28, so the answer is
+``2025-03-01``.
+
+The fix mirrors the existing month-rollover algorithm:
+
+* Try the literal ``(year + n, month, day)``.
+* On ``ValueError`` (e.g. Feb 29 in a non-leap year), compute the
+  overflow ``day - last_valid_day`` and add it as extra days starting
+  from the month's last valid day.
+
+The month-arithmetic path (``'+1 month'``) was already correct because
+that's where the algorithm originally lived; this PR ports the same
+logic to the year branch.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Feb 29 → next year: must roll over to Mar 1
+# ---------------------------------------------------------------------------
+
+
+class TestLeapDayForwardRollover:
+    def test_one_year(self) -> None:
+        # Was returning '2025-02-28'; SQLite returns '2025-03-01'.
+        _check("SELECT date('2024-02-29', '+1 year')")
+
+    def test_two_years(self) -> None:
+        # 2026 is also non-leap.
+        _check("SELECT date('2024-02-29', '+2 years')")
+
+    def test_three_years(self) -> None:
+        # 2027 non-leap.
+        _check("SELECT date('2024-02-29', '+3 years')")
+
+    def test_five_years(self) -> None:
+        # 2029 non-leap.
+        _check("SELECT date('2024-02-29', '+5 years')")
+
+
+class TestLeapDayBackwardRollover:
+    def test_minus_one_year(self) -> None:
+        # 2023 is non-leap; SQLite returns '2023-03-01'.
+        _check("SELECT date('2024-02-29', '-1 year')")
+
+    def test_minus_three_years(self) -> None:
+        # 2021 non-leap.
+        _check("SELECT date('2024-02-29', '-3 years')")
+
+
+class TestLeapDayToLeapYear:
+    def test_plus_four_years(self) -> None:
+        # 2028 is also a leap year — date is preserved.
+        _check("SELECT date('2024-02-29', '+4 years')")
+
+    def test_minus_four_years(self) -> None:
+        _check("SELECT date('2024-02-29', '-4 years')")
+
+    def test_plus_eight_years(self) -> None:
+        # Across multiple leap cycles.
+        _check("SELECT date('2024-02-29', '+8 years')")
+
+
+# ---------------------------------------------------------------------------
+# Regression: ordinary (non-Feb-29) dates still work
+# ---------------------------------------------------------------------------
+
+
+class TestRegularYearArithmetic:
+    def test_january_15(self) -> None:
+        _check("SELECT date('2024-01-15', '+1 year')")
+
+    def test_june_15(self) -> None:
+        _check("SELECT date('2024-06-15', '+10 years')")
+
+    def test_december_31(self) -> None:
+        # Dec 31 in any year exists; no rollover needed.
+        _check("SELECT date('2024-12-31', '+1 year')")
+
+    def test_january_1(self) -> None:
+        _check("SELECT date('2024-01-01', '+100 years')")
+
+    def test_year_with_time_component(self) -> None:
+        # Time component must be preserved.
+        _check("SELECT datetime('2024-02-29 12:34:56', '+1 year')")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.43.0 — 2026-05-20
+
+### Fixed
+
+- **``date(..., '+N year')`` no longer clamps Feb 29 — it rolls over
+  to March 1** matching SQLite.  Previously
+  ``date('2024-02-29', '+1 year')`` returned ``'2025-02-28'`` (clamp);
+  SQLite returns ``'2025-03-01'`` because the naive ``2025-02-29``
+  is invalid and the overflow day pushes into March.
+
+  The fix ports the existing month-rollover algorithm to the year
+  branch: try the literal ``(year + n, month, day)``; on ``ValueError``
+  add the overflow as extra days starting from the month's last valid
+  day.  The ``'+1 month'`` arithmetic was already correct because
+  that's where the algorithm originated.
+
 ## 1.42.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.42.0"
+version = "1.43.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -2172,9 +2172,19 @@ def _apply_modifier(dt: datetime, modifier: str) -> datetime | None:
                 return dt.replace(year=year, month=month, day=last_day) + timedelta(days=overflow)
         if unit in ("year", "years"):
             year = dt.year + n
-            # Clamp Feb 29 → Feb 28 in non-leap years.
-            day = min(dt.day, calendar.monthrange(year, dt.month)[1])
-            return dt.replace(year=year, day=day)
+            # SQLite does NOT clamp Feb 29 → Feb 28 — it lets the day roll
+            # into March.  ``date('2024-02-29', '+1 year')`` becomes
+            # ``'2025-03-01'`` (Feb 29 → Feb 28 + 1 overflow day), not
+            # ``'2025-02-28'``.  Mirror the month-rollover algorithm above:
+            # try the literal date first, then on ValueError add the
+            # overflow as extra days from the last valid day of the target
+            # month.
+            try:
+                return dt.replace(year=year, day=dt.day)
+            except ValueError:
+                last_day = calendar.monthrange(year, dt.month)[1]
+                overflow = dt.day - last_day
+                return dt.replace(year=year, day=last_day) + timedelta(days=overflow)
 
     return None  # unrecognised modifier → NULL propagation
 


### PR DESCRIPTION
## Summary

SQLite's `date(timevalue, '+N year')` rolls the date forward when the result isn't a real day. Mini-sqlite was clamping:

```
date('2024-02-29', '+1 year')
Was:    '2025-02-28'  (clamped Feb 29 → Feb 28)
SQLite: '2025-03-01'  (rolled the overflow day into March)
```

The `'+N month'` branch already had the correct rollover algorithm — this PR ports it to the year branch.

14 oracle tests covering forward/backward rollover, leap-to-leap preservation, and ordinary-date regressions. Version bumps: sql-vm 1.42.0 → 1.43.0, mini-sqlite 1.68.0 → 1.69.0.

## Test plan

- [x] `pytest mini-sqlite/tests/test_tier3_year_rollover.py` — 14/14
- [x] sql-vm full suite — 892 passed
- [x] mini-sqlite full suite — 1720 passed (1706 prior + 14 new)
- [x] All oracle cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)