### PR TITLE
Add summary status accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this package will be documented in this file.
 - Delta-direction helpers for supervisor drain run reports.
 - Status aliases for supervisor drain run reports.
 - Row-count match helpers for supervisor drain run reports and summaries.
+- Run-status accessors for supervisor drain run summaries.
 - Count-drift presence flags for supervisor drain run reports and summaries.
 - Stable count-drift classifications for supervisor drain run reports and
   summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -53,6 +53,8 @@ The crate keeps the boundary narrow:
   follow-up pressure
 - supervisor drain reports and summaries expose row-count match helpers for
   host scheduler checks
+- supervisor drain run summaries expose typed run-status accessors for
+  continuation, follow-up, checkpoint, and budget decisions
 - supervisor drain run summaries expose count-drift presence flags beside
   signed deltas for host logs
 - supervisor drain run summaries expose stable count-drift classifications so

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1326,6 +1326,31 @@ impl ToolAuditSupervisorDrainRunSummary {
     pub fn should_continue(&self) -> bool {
         !self.reached_end_of_log
     }
+
+    /// Return whether the actual run reached the current end of the audit log.
+    pub fn reached_end_of_log(&self) -> bool {
+        self.reached_end_of_log
+    }
+
+    /// Return whether the actual run consumed the configured tick budget.
+    pub fn exhausted_tick_budget(&self) -> bool {
+        self.exhausted_tick_budget
+    }
+
+    /// Return whether the planned or replayed rows contain follow-up pressure.
+    pub fn requires_follow_up(&self) -> bool {
+        self.requires_follow_up
+    }
+
+    /// Return whether the actual run advanced the durable checkpoint.
+    pub fn advanced_checkpoint(&self) -> bool {
+        self.advanced_checkpoint
+    }
+
+    /// Return the last replay checkpoint observed by the actual run.
+    pub fn last_checkpoint(&self) -> Option<&ToolAuditReadCheckpoint> {
+        self.last_checkpoint.as_ref()
+    }
 }
 
 /// Scheduler-facing classification for a bounded supervisor drain run.
@@ -3643,10 +3668,15 @@ mod tests {
         assert!(summary.matches_planned_follow_up_record_count);
         assert!(summary.matches_follow_up_pressure());
         assert!(!summary.reached_end_of_log);
+        assert!(!summary.reached_end_of_log());
         assert!(summary.exhausted_tick_budget);
+        assert!(summary.exhausted_tick_budget());
         assert!(!summary.requires_follow_up);
+        assert!(!summary.requires_follow_up());
         assert!(summary.advanced_checkpoint);
+        assert!(summary.advanced_checkpoint());
         assert_eq!(summary.last_checkpoint, report.last_checkpoint().cloned());
+        assert_eq!(summary.last_checkpoint(), report.last_checkpoint());
         assert!(!summary.is_idle());
         assert!(summary.made_progress());
         assert!(summary.should_continue());


### PR DESCRIPTION
## Summary
- add run-status accessors on ToolAuditSupervisorDrainRunSummary for end-of-log, tick budget, follow-up, checkpoint advancement, and last checkpoint
- cover the accessors in the flattened summary test
- document the new host-facing helper surface

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD