### PR TITLE
[codex] Add Nano R4 Arduino CAN metadata

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -57,8 +57,9 @@ A4/A5 Wire, D11/D12/D13 SPI with D10 as the default chip-select pin, and D0/D1
 
 Nano R4 mirrors that header-pin metadata for the Renesas RA4M1 Nano form
 factor: A4/A5 `Wire`, D11/D12/D13 SPI with D10 chip select, and D0/D1
-`Serial1`. Native USB, Qwiic `Wire1`, CAN, and RTC behavior remain owned by
-later board-specific adapter tranches.
+`Serial1`. It also records D4/D5 CAN metadata with the external transceiver
+requirement. Native USB, Qwiic `Wire1`, and RTC behavior remain owned by later
+board-specific adapter tranches.
 
 Opta terminals are modeled as board-local input and relay-output pins instead
 of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -74,14 +74,14 @@ use board_vm_protocol::{
     CAP_FLAG_PROTOCOL_FEATURE, FLAG_IS_ERROR_RESPONSE, FLAG_IS_RESPONSE,
 };
 use board_vm_targets::{
-    all_targets, BoardFamily, BoardTargetInfo, DigitalPinInfo as TargetDigitalPin,
-    I2cBusInfo as TargetI2cBus, NetworkInterfaceInfo as TargetNetworkInterface,
-    NetworkProtocol as TargetNetworkProtocol, OnboardLed as TargetOnboardLed,
-    SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
-    UploadImageFormat as TargetUploadImageFormat, UploadInfo as TargetUploadInfo,
-    UploadPortHint as TargetUploadPortHint, UploadResetMethod as TargetUploadResetMethod,
-    UploadTransport as TargetUploadTransport, WirelessInterfaceInfo as TargetWirelessInterface,
-    WirelessTransport as TargetWirelessTransport,
+    all_targets, BoardFamily, BoardTargetInfo, CanBusInfo as TargetCanBus,
+    DigitalPinInfo as TargetDigitalPin, I2cBusInfo as TargetI2cBus,
+    NetworkInterfaceInfo as TargetNetworkInterface, NetworkProtocol as TargetNetworkProtocol,
+    OnboardLed as TargetOnboardLed, SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus,
+    UploadAdapter as TargetUploadAdapter, UploadImageFormat as TargetUploadImageFormat,
+    UploadInfo as TargetUploadInfo, UploadPortHint as TargetUploadPortHint,
+    UploadResetMethod as TargetUploadResetMethod, UploadTransport as TargetUploadTransport,
+    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -430,6 +430,7 @@ pub struct LanguageTargetInfo {
     pub i2c_buses: Vec<LanguageI2cBus>,
     pub spi_buses: Vec<LanguageSpiBus>,
     pub uart_buses: Vec<LanguageUartBus>,
+    pub can_buses: Vec<LanguageCanBus>,
     pub wireless: Vec<LanguageWirelessInterface>,
     pub network_interfaces: Vec<LanguageNetworkInterface>,
     pub connection_options: Vec<LanguageConnectionOption>,
@@ -466,6 +467,16 @@ pub struct LanguageUartBus {
     pub rx_pin: u8,
     pub arduino_uart: u8,
     pub internal: bool,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageCanBus {
+    pub bus: u8,
+    pub name: String,
+    pub tx_pin: u8,
+    pub rx_pin: u8,
+    pub controller: String,
     pub notes: String,
 }
 
@@ -1292,6 +1303,7 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
         i2c_buses: target.i2c_buses.iter().map(language_i2c_bus).collect(),
         spi_buses: target.spi_buses.iter().map(language_spi_bus).collect(),
         uart_buses: target.uart_buses.iter().map(language_uart_bus).collect(),
+        can_buses: target.can_buses.iter().map(language_can_bus).collect(),
         wireless: target
             .wireless
             .iter()
@@ -1363,6 +1375,17 @@ fn language_uart_bus(bus: &TargetUartBus) -> LanguageUartBus {
         rx_pin: bus.rx_pin,
         arduino_uart: bus.arduino_uart,
         internal: bus.internal,
+        notes: bus.notes.to_owned(),
+    }
+}
+
+fn language_can_bus(bus: &TargetCanBus) -> LanguageCanBus {
+    LanguageCanBus {
+        bus: bus.bus,
+        name: bus.name.to_owned(),
+        tx_pin: bus.tx_pin,
+        rx_pin: bus.rx_pin,
+        controller: bus.controller.to_owned(),
         notes: bus.notes.to_owned(),
     }
 }
@@ -4123,9 +4146,18 @@ mod tests {
         assert_eq!(nano_r4.uart_buses[0].tx_pin, 1);
         assert_eq!(nano_r4.uart_buses[0].rx_pin, 0);
         assert!(nano_r4.uart_buses[0].notes.contains("native USB"));
+        assert_eq!(nano_r4.can_buses.len(), 1);
+        assert_eq!(nano_r4.can_buses[0].name, "CAN0");
+        assert_eq!(nano_r4.can_buses[0].tx_pin, 4);
+        assert_eq!(nano_r4.can_buses[0].rx_pin, 5);
+        assert_eq!(nano_r4.can_buses[0].controller, "RA4M1 CAN0");
+        assert!(nano_r4.can_buses[0].notes.contains("external transceiver"));
         assert!(!nano_r4.capabilities.contains(&"i2c.open".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"spi.open".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"uart.open".to_owned()));
+        assert!(!nano_r4.capabilities.contains(&"can.open".to_owned()));
+        assert!(!nano_r4.capabilities.contains(&"can.write".to_owned()));
+        assert!(!nano_r4.capabilities.contains(&"can.read".to_owned()));
         assert_eq!(nano_iot.family, LanguageBoardFamily::Arduino);
         assert_eq!(nano_iot.mcu, "SAMD21G18");
         assert_eq!(nano_ble.family, LanguageBoardFamily::Arduino);

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -91,6 +91,11 @@ form factor: A4/A5 `Wire`, D11/D12/D13 SPI with D10 chip select, and D0/D1
 `Serial1`. The native USB path remains upload/transport metadata, and the
 separate Qwiic `Wire1` connector stays out of this header-pin tranche.
 
+Nano R4 also exposes passive CAN metadata for its D4/D5 header pins. The
+descriptor records the RA4M1 CAN0 controller and external transceiver
+requirement, while `can.*` bytecode capabilities remain disabled for the shared
+Arduino runtime.
+
 Host-side validation:
 
 ```sh

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -896,6 +896,15 @@ pub const ARDUINO_NANO_R4_UART_BUSES: [UartBusInfo; 1] = [UartBusInfo {
     notes: "Arduino Nano R4 D1/D0 serial metadata only; native USB remains upload/transport metadata, not a separate GPIO UART.",
 }];
 
+pub const ARDUINO_NANO_R4_CAN_BUSES: [CanBusInfo; 1] = [CanBusInfo {
+    bus: 0,
+    name: "CAN0",
+    tx_pin: 4,
+    rx_pin: 5,
+    controller: "RA4M1 CAN0",
+    notes: "Arduino Nano R4 D4/D5 CAN metadata only; external transceiver required and shared Arduino runtime does not enable can.* bytecode adapters yet.",
+}];
+
 const fn map_arduino_digital_pins<const N: usize>(
     source: [board_vm_arduino::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -1207,6 +1216,28 @@ const fn arduino_board_target_with_buses(
     wireless: &'static [WirelessInterfaceInfo],
     network_interfaces: &'static [NetworkInterfaceInfo],
 ) -> BoardTargetInfo {
+    arduino_board_target_with_buses_and_can(
+        target,
+        digital_pins,
+        i2c_buses,
+        spi_buses,
+        uart_buses,
+        &[],
+        wireless,
+        network_interfaces,
+    )
+}
+
+const fn arduino_board_target_with_buses_and_can(
+    target: board_vm_arduino::ArduinoTargetDescriptor,
+    digital_pins: &'static [DigitalPinInfo],
+    i2c_buses: &'static [I2cBusInfo],
+    spi_buses: &'static [SpiBusInfo],
+    uart_buses: &'static [UartBusInfo],
+    can_buses: &'static [CanBusInfo],
+    wireless: &'static [WirelessInterfaceInfo],
+    network_interfaces: &'static [NetworkInterfaceInfo],
+) -> BoardTargetInfo {
     BoardTargetInfo {
         board_id: target.board_id,
         display_name: target.display_name,
@@ -1227,7 +1258,7 @@ const fn arduino_board_target_with_buses(
         i2c_buses,
         spi_buses,
         uart_buses,
-        can_buses: &[],
+        can_buses,
         rtc: None,
         watchdog: None,
         storage_regions: &[],
@@ -1384,12 +1415,13 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         &[],
         &[],
     ),
-    arduino_board_target_with_buses(
+    arduino_board_target_with_buses_and_can(
         board_vm_arduino::ARDUINO_NANO_R4,
         &ARDUINO_NANO_R4_DIGITAL_PINS,
         &ARDUINO_NANO_R4_I2C_BUSES,
         &ARDUINO_NANO_R4_SPI_BUSES,
         &ARDUINO_NANO_R4_UART_BUSES,
+        &ARDUINO_NANO_R4_CAN_BUSES,
         &[],
         &[],
     ),
@@ -1978,6 +2010,18 @@ mod tests {
         let wifi = find_target("arduino-uno-r4-wifi").unwrap();
         assert_eq!(wifi.can_buses, minima.can_buses);
         assert!(wifi.can_buses[0].notes.contains("SPI"));
+
+        let nano_r4 = find_target("arduino-nano-r4").unwrap();
+        assert_eq!(nano_r4.can_buses, &ARDUINO_NANO_R4_CAN_BUSES);
+        assert_eq!(nano_r4.can_buses[0].name, "CAN0");
+        assert_eq!(nano_r4.can_buses[0].tx_pin, 4);
+        assert_eq!(nano_r4.can_buses[0].rx_pin, 5);
+        assert_eq!(nano_r4.can_buses[0].controller, "RA4M1 CAN0");
+        assert!(nano_r4.can_buses[0].notes.contains("external transceiver"));
+        assert!(nano_r4.can_buses[0].notes.contains("metadata only"));
+        assert!(!nano_r4.capabilities.contains(&"can.open"));
+        assert!(!nano_r4.capabilities.contains(&"can.write"));
+        assert!(!nano_r4.capabilities.contains(&"can.read"));
 
         assert!(find_target("esp32-devkit-v1").unwrap().can_buses.is_empty());
         assert!(find_target("raspberry-pi-pico")

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -166,8 +166,12 @@ modeled as upload/transport metadata.
 
 The Nano R4 bus metadata tranche applies that same header-pin descriptor shape
 to the RA4M1 Nano target. It reports A4/A5 `Wire`, D11/D12/D13 SPI with D10 as
-chip select, and D0/D1 `Serial1`; native USB, Qwiic `Wire1`, CAN, and RTC
-details remain follow-up adapter metadata.
+chip select, and D0/D1 `Serial1`.
+
+The Nano R4 CAN metadata tranche adds the D4/D5 CAN0 descriptor and records the
+external transceiver requirement, while leaving `can.*` capabilities disabled
+for the shared Arduino runtime. Native USB, Qwiic `Wire1`, and RTC details
+remain follow-up adapter metadata.
 
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino


### PR DESCRIPTION
## Summary
- add passive Arduino Nano R4 CAN0 metadata for the D4/D5 header pins, including the RA4M1 CAN0 controller and external transceiver requirement
- surface CAN bus descriptors through `board-vm-language-core` target metadata while keeping `can.*` bytecode capabilities disabled for the shared Arduino runtime
- document the Nano R4 CAN tranche in the target README, Arduino README, and Board VM target matrix while leaving Qwiic `Wire1` and RTC details for later slices

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-can-metadata cargo fmt -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-can-metadata cargo test -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-can-metadata cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-can-metadata bash BUILD` in `code/packages/rust/board-vm-targets`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-can-metadata bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-can-metadata bash BUILD` in `code/packages/rust/board-vm-arduino`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.
