### PR TITLE
feat(sql-vm,mini-sqlite): add TIMEDIFF(A, B) scalar (SQLite 3.43+)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.70.0] - 2026-05-20
+
+### Added
+
+- **``TIMEDIFF(A, B)`` scalar function** (via ``sql-vm 1.44.0``) —
+  SQLite 3.43+.  Returns ``±YYYY-MM-DD HH:MM:SS.sss`` calendar-aware
+  difference ``A − B`` matching SQLite byte-for-byte.
+
+  21 oracle tests in ``test_tier3_timediff.py`` covering basic
+  positive/negative differences, fractional seconds, calendar-field
+  borrowing across Feb's variable day count, year boundaries, NULL
+  propagation, and unparseable inputs.
+
 ## [1.69.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.69.0"
+version = "1.70.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_timediff.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_timediff.py
@@ -1,0 +1,159 @@
+"""Oracle tests for ``TIMEDIFF(A, B)`` — SQLite 3.43+ calendar diff.
+
+``TIMEDIFF`` returns the difference between two time values as a
+human-readable string of the form ``±YYYY-MM-DD HH:MM:SS.sss``.
+Crucially, the year and month components use *calendar* arithmetic,
+not simple seconds: ``timediff('2024-03-01', '2024-02-01')`` is one
+month (``'+0000-01-00 …'``), regardless of February's day count.
+
+The algorithm:
+1. Parse both inputs.  If either parse fails or is NULL → NULL.
+2. If A < B, swap and flip the sign so the magnitude is non-negative.
+3. Walk the seven fields from microseconds up (µs, s, m, h, d, mo, y)
+   borrowing one unit from the next-higher field whenever the current
+   one goes negative.  The day borrow uses ``calendar.monthrange(…)``
+   of the month preceding A's month — that's the calendar-aware part.
+4. Truncate microseconds to milliseconds (3 decimal places).
+
+Reference: https://sqlite.org/lang_datefunc.html#timediff
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Basic positive differences
+# ---------------------------------------------------------------------------
+
+
+class TestBasicPositive:
+    def test_one_day_and_one_and_a_half_hours(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-02 10:30:00', '2024-01-01 09:00:00')"
+        )
+
+    def test_zero_when_equal(self) -> None:
+        _check("SELECT timediff('2024-01-01', '2024-01-01')")
+
+    def test_fractional_seconds(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-01 12:00:00.500', "
+            "'2024-01-01 12:00:00.250')"
+        )
+
+    def test_millisecond_precision(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-01 00:00:00.001', "
+            "'2024-01-01 00:00:00.000')"
+        )
+
+    def test_iso8601_t_separator(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-01T12:00:00', '2024-01-01T11:00:00')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative differences — magnitude with leading minus sign
+# ---------------------------------------------------------------------------
+
+
+class TestNegative:
+    def test_reverse_arguments(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-01 09:00:00', '2024-01-02 10:30:00')"
+        )
+
+    def test_negative_one_year(self) -> None:
+        _check("SELECT timediff('2023-01-01', '2024-01-01')")
+
+
+# ---------------------------------------------------------------------------
+# Year and month components — calendar arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarFields:
+    def test_one_year_exactly(self) -> None:
+        _check("SELECT timediff('2025-01-01', '2024-01-01')")
+
+    def test_one_month_exactly(self) -> None:
+        _check("SELECT timediff('2024-03-01', '2024-02-01')")
+
+    def test_year_and_month(self) -> None:
+        _check(
+            "SELECT timediff('2025-02-15 10:00:00', '2024-01-10 11:30:00')"
+        )
+
+    def test_two_months_plus_days(self) -> None:
+        _check("SELECT timediff('2024-03-15', '2024-01-10')")
+
+
+# ---------------------------------------------------------------------------
+# Day-of-month borrowing — the tricky case where Feb has only 28/29 days
+# ---------------------------------------------------------------------------
+
+
+class TestDayBorrow:
+    def test_borrow_from_feb_leap(self) -> None:
+        # 15 - 20 = -5, borrow 29 (Feb 2024 leap), gives 24 days.
+        _check("SELECT timediff('2024-03-15', '2024-01-20')")
+
+    def test_borrow_from_jan(self) -> None:
+        # 29 - 31 = -2, borrow 31 (Jan), gives 29 days.
+        _check("SELECT timediff('2024-02-29', '2024-01-31')")
+
+    def test_hour_minute_day_chain_borrow(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-31 12:00:00', '2024-01-01 13:30:00')"
+        )
+
+    def test_borrow_across_year_boundary(self) -> None:
+        _check(
+            "SELECT timediff('2024-01-01 00:00:00', '2023-12-31 23:00:00')"
+        )
+
+
+# ---------------------------------------------------------------------------
+# NULL and invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestNullAndInvalid:
+    def test_null_first_argument(self) -> None:
+        _check("SELECT timediff(NULL, '2024-01-01')")
+
+    def test_null_second_argument(self) -> None:
+        _check("SELECT timediff('2024-01-01 00:00:00', NULL)")
+
+    def test_both_null(self) -> None:
+        _check("SELECT timediff(NULL, NULL)")
+
+    def test_invalid_first_argument(self) -> None:
+        _check("SELECT timediff('not-a-date', '2024-01-01')")
+
+    def test_invalid_second_argument(self) -> None:
+        _check("SELECT timediff('2024-01-01', 'also-not-a-date')")
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — 'now' arithmetic produces a non-NULL string
+# ---------------------------------------------------------------------------
+
+
+class TestNowSelf:
+    def test_now_minus_now_is_zero(self) -> None:
+        # 'now' resolves to the same instant in both arguments (we're
+        # asking a single query), so the difference must be exactly
+        # zero.  Both engines agree this is the all-zeros form.
+        _check("SELECT timediff('now', 'now')")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.44.0 — 2026-05-20
+
+### Added
+
+- **``TIMEDIFF(A, B)`` scalar function** — SQLite 3.43+.  Returns the
+  calendar-aware difference ``A − B`` as a string of the form
+  ``±YYYY-MM-DD HH:MM:SS.sss``.  When ``A < B`` the sign is ``-`` and
+  the magnitude is the time from ``A`` to ``B``.
+
+  Implementation walks the seven fields (microseconds, seconds,
+  minutes, hours, days, months, years) from low to high, borrowing
+  from the next higher field whenever the current one is negative.
+  The day-borrow step uses ``calendar.monthrange(…)`` of the month
+  *preceding* ``A``'s month — that's what makes
+  ``TIMEDIFF('2024-03-15', '2024-01-20')`` produce
+  ``'+0000-01-24 …'`` (24 days because Feb 2024 has 29 days, hence
+  ``15 + 29 − 20 = 24``).
+
+  Microseconds are truncated to milliseconds (3 decimal places) to
+  match SQLite's output precision.  NULL or unparseable inputs
+  propagate NULL.
+
 ## 1.43.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.43.0"
+version = "1.44.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -2373,6 +2373,94 @@ def _unixepoch(*args: SqlValue) -> SqlValue:
     return int(dt.timestamp())
 
 
+@register("timediff")
+def _timediff(a: SqlValue, b: SqlValue) -> SqlValue:
+    """Return the calendar-aware difference *A* − *B* as text.
+
+    ``TIMEDIFF(A, B)`` returns a string of the form
+    ``±YYYY-MM-DD HH:MM:SS.sss`` representing how much later *A* is than
+    *B*.  When *A* is earlier than *B* the sign is ``-`` and the
+    magnitude is the time from *A* to *B*.  Returns NULL if either
+    argument is NULL or fails to parse as a time value.
+
+    Available in SQLite 3.43+ (see https://sqlite.org/lang_datefunc.html).
+
+    **Calendar borrowing.**  The output components are *not* simply
+    seconds-converted: the year and month fields use calendar
+    arithmetic with monthly borrowing.  Concretely, the algorithm
+    walks the seven fields from microseconds upward and borrows from
+    the next higher field when the current one goes negative.  The
+    month-borrow step uses the day count of the month immediately
+    preceding ``A``'s month — that's what makes
+    ``timediff('2024-03-15', '2024-01-20')`` come out to
+    ``'+0000-01-24 00:00:00.000'`` (24 days because February 2024 has
+    29 days, hence ``15 + 29 − 20 = 24``).
+
+    Examples::
+
+        TIMEDIFF('2024-01-02 10:30:00', '2024-01-01 09:00:00')
+            → '+0000-00-01 01:30:00.000'
+        TIMEDIFF('2024-01-01 09:00:00', '2024-01-02 10:30:00')
+            → '-0000-00-01 01:30:00.000'
+        TIMEDIFF('2025-01-01', '2024-01-01') → '+0001-00-00 00:00:00.000'
+        TIMEDIFF('2024-02-29', '2024-01-31') → '+0000-00-29 00:00:00.000'
+        TIMEDIFF('not-a-date', '2024-01-01') → NULL
+    """
+    if a is None or b is None:
+        return None
+    dt_a = _parse_timevalue(a)
+    dt_b = _parse_timevalue(b)
+    if dt_a is None or dt_b is None:
+        return None
+    sign = "+"
+    if dt_a < dt_b:
+        sign = "-"
+        dt_a, dt_b = dt_b, dt_a
+    # Field-by-field calendar borrow.  Subtract from microseconds up;
+    # borrow from the next higher field whenever a component goes
+    # negative.  The day-borrow uses the day count of the month preceding
+    # ``dt_a``'s month, which is what gives ``timediff`` its
+    # calendar-aware (rather than seconds-only) flavour.
+    micro = dt_a.microsecond - dt_b.microsecond
+    sec = dt_a.second - dt_b.second
+    if micro < 0:
+        micro += 1_000_000
+        sec -= 1
+    minute = dt_a.minute - dt_b.minute
+    if sec < 0:
+        sec += 60
+        minute -= 1
+    hour = dt_a.hour - dt_b.hour
+    if minute < 0:
+        minute += 60
+        hour -= 1
+    day = dt_a.day - dt_b.day
+    if hour < 0:
+        hour += 24
+        day -= 1
+    month = dt_a.month - dt_b.month
+    if day < 0:
+        # Borrow one month — add the day count of the *previous* month
+        # (in dt_a's frame of reference) to the day field.
+        if dt_a.month > 1:
+            prev_month_year, prev_month = dt_a.year, dt_a.month - 1
+        else:
+            prev_month_year, prev_month = dt_a.year - 1, 12
+        day += calendar.monthrange(prev_month_year, prev_month)[1]
+        month -= 1
+    year = dt_a.year - dt_b.year
+    if month < 0:
+        month += 12
+        year -= 1
+    # Truncate microseconds to milliseconds (3 decimal places) — matches
+    # SQLite's output format.  No rounding; SQLite truncates here too.
+    millis = micro // 1000
+    return (
+        f"{sign}{year:04d}-{month:02d}-{day:02d} "
+        f"{hour:02d}:{minute:02d}:{sec:02d}.{millis:03d}"
+    )
+
+
 # Pre-compiled substitution map for STRFTIME's SQLite-specific specifiers.
 # Python's strftime does not support %f (SQLite = SS.SSS), %s (epoch),
 # %J (Julian day), or %P (lowercase am/pm on macOS libc).  We intercept


### PR DESCRIPTION
## Summary

Adds `TIMEDIFF(A, B)` — SQLite 3.43+ — which returns the calendar-aware difference `A − B` as a string `±YYYY-MM-DD HH:MM:SS.sss`.

The algorithm walks seven fields (µs, s, m, h, d, mo, y) from low to high, borrowing from the next-higher field whenever the current one is negative. The day-borrow uses `calendar.monthrange()` of the month preceding A's month — that's the calendar-aware part. Microseconds truncate to milliseconds (3 decimal places).

Example: `TIMEDIFF('2024-03-15', '2024-01-20')` produces `'+0000-01-24 00:00:00.000'` because Feb 2024 has 29 days (15 + 29 − 20 = 24).

21 oracle tests; all match `sqlite3` byte-for-byte. Version bumps: sql-vm 1.43.0 → 1.44.0, mini-sqlite 1.69.0 → 1.70.0.

## Test plan

- [x] `pytest mini-sqlite/tests/test_tier3_timediff.py` — 21/21
- [x] sql-vm full suite — 892 passed
- [x] mini-sqlite full suite — 1741 passed (1720 prior + 21 new)
- [x] All 18 smoke cases against reference `sqlite3` match byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)