### PR TITLE
[codex] Add Nano R4 Arduino RTC metadata

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -58,8 +58,8 @@ A4/A5 Wire, D11/D12/D13 SPI with D10 as the default chip-select pin, and D0/D1
 Nano R4 mirrors that header-pin metadata for the Renesas RA4M1 Nano form
 factor: A4/A5 `Wire`, D11/D12/D13 SPI with D10 chip select, and D0/D1
 `Serial1`. It also records D4/D5 CAN metadata with the external transceiver
-requirement. Native USB, Qwiic `Wire1`, and RTC behavior remain owned by later
-board-specific adapter tranches.
+requirement plus passive RA4M1 RTC metadata. Native USB, Qwiic `Wire1`, and RTC
+bytecode behavior remain owned by later board-specific adapter tranches.
 
 Opta terminals are modeled as board-local input and relay-output pins instead
 of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -77,11 +77,12 @@ use board_vm_targets::{
     all_targets, BoardFamily, BoardTargetInfo, CanBusInfo as TargetCanBus,
     DigitalPinInfo as TargetDigitalPin, I2cBusInfo as TargetI2cBus,
     NetworkInterfaceInfo as TargetNetworkInterface, NetworkProtocol as TargetNetworkProtocol,
-    OnboardLed as TargetOnboardLed, SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus,
-    UploadAdapter as TargetUploadAdapter, UploadImageFormat as TargetUploadImageFormat,
-    UploadInfo as TargetUploadInfo, UploadPortHint as TargetUploadPortHint,
-    UploadResetMethod as TargetUploadResetMethod, UploadTransport as TargetUploadTransport,
-    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
+    OnboardLed as TargetOnboardLed, RtcInfo as TargetRtc, SpiBusInfo as TargetSpiBus,
+    UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
+    UploadImageFormat as TargetUploadImageFormat, UploadInfo as TargetUploadInfo,
+    UploadPortHint as TargetUploadPortHint, UploadResetMethod as TargetUploadResetMethod,
+    UploadTransport as TargetUploadTransport, WirelessInterfaceInfo as TargetWirelessInterface,
+    WirelessTransport as TargetWirelessTransport,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -431,6 +432,7 @@ pub struct LanguageTargetInfo {
     pub spi_buses: Vec<LanguageSpiBus>,
     pub uart_buses: Vec<LanguageUartBus>,
     pub can_buses: Vec<LanguageCanBus>,
+    pub rtc: Option<LanguageRtc>,
     pub wireless: Vec<LanguageWirelessInterface>,
     pub network_interfaces: Vec<LanguageNetworkInterface>,
     pub connection_options: Vec<LanguageConnectionOption>,
@@ -477,6 +479,14 @@ pub struct LanguageCanBus {
     pub tx_pin: u8,
     pub rx_pin: u8,
     pub controller: String,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageRtc {
+    pub instance: u8,
+    pub name: String,
+    pub peripheral: String,
     pub notes: String,
 }
 
@@ -1304,6 +1314,7 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
         spi_buses: target.spi_buses.iter().map(language_spi_bus).collect(),
         uart_buses: target.uart_buses.iter().map(language_uart_bus).collect(),
         can_buses: target.can_buses.iter().map(language_can_bus).collect(),
+        rtc: target.rtc.map(language_rtc),
         wireless: target
             .wireless
             .iter()
@@ -1387,6 +1398,15 @@ fn language_can_bus(bus: &TargetCanBus) -> LanguageCanBus {
         rx_pin: bus.rx_pin,
         controller: bus.controller.to_owned(),
         notes: bus.notes.to_owned(),
+    }
+}
+
+fn language_rtc(rtc: TargetRtc) -> LanguageRtc {
+    LanguageRtc {
+        instance: rtc.instance,
+        name: rtc.name.to_owned(),
+        peripheral: rtc.peripheral.to_owned(),
+        notes: rtc.notes.to_owned(),
     }
 }
 
@@ -4063,6 +4083,11 @@ mod tests {
         assert_eq!(board_family_name(esp32.family), "esp32");
         assert_eq!(esp32.runtime_id, "board-vm-esp32");
         assert_eq!(esp32.onboard_led, Some(LanguageOnboardLed::Gpio(2)));
+        assert_eq!(uno.rtc.as_ref().unwrap().name, "RTC");
+        assert_eq!(uno.rtc.as_ref().unwrap().peripheral, "RA4M1 RTC");
+        assert!(uno.rtc.as_ref().unwrap().notes.contains("real-time clock"));
+        assert!(uno.capabilities.contains(&"rtc.now".to_owned()));
+        assert!(uno.capabilities.contains(&"rtc.set".to_owned()));
         assert_eq!(mega.family, LanguageBoardFamily::Arduino);
         assert_eq!(board_family_name(mega.family), "arduino");
         assert_eq!(mega.runtime_id, "board-vm-arduino");
@@ -4152,12 +4177,22 @@ mod tests {
         assert_eq!(nano_r4.can_buses[0].rx_pin, 5);
         assert_eq!(nano_r4.can_buses[0].controller, "RA4M1 CAN0");
         assert!(nano_r4.can_buses[0].notes.contains("external transceiver"));
+        assert_eq!(nano_r4.rtc.as_ref().unwrap().name, "RTC");
+        assert_eq!(nano_r4.rtc.as_ref().unwrap().peripheral, "RA4M1 RTC");
+        assert!(nano_r4
+            .rtc
+            .as_ref()
+            .unwrap()
+            .notes
+            .contains("metadata only"));
         assert!(!nano_r4.capabilities.contains(&"i2c.open".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"spi.open".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"uart.open".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"can.open".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"can.write".to_owned()));
         assert!(!nano_r4.capabilities.contains(&"can.read".to_owned()));
+        assert!(!nano_r4.capabilities.contains(&"rtc.now".to_owned()));
+        assert!(!nano_r4.capabilities.contains(&"rtc.set".to_owned()));
         assert_eq!(nano_iot.family, LanguageBoardFamily::Arduino);
         assert_eq!(nano_iot.mcu, "SAMD21G18");
         assert_eq!(nano_ble.family, LanguageBoardFamily::Arduino);

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -96,6 +96,10 @@ descriptor records the RA4M1 CAN0 controller and external transceiver
 requirement, while `can.*` bytecode capabilities remain disabled for the shared
 Arduino runtime.
 
+Nano R4 RTC metadata records the RA4M1 real-time clock as a passive descriptor.
+The shared Arduino runtime still leaves `rtc.*` bytecode adapters disabled until
+a board-specific firmware path owns clock access.
+
 Host-side validation:
 
 ```sh

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -905,6 +905,13 @@ pub const ARDUINO_NANO_R4_CAN_BUSES: [CanBusInfo; 1] = [CanBusInfo {
     notes: "Arduino Nano R4 D4/D5 CAN metadata only; external transceiver required and shared Arduino runtime does not enable can.* bytecode adapters yet.",
 }];
 
+pub const ARDUINO_NANO_R4_RTC: RtcInfo = RtcInfo {
+    instance: 0,
+    name: "RTC",
+    peripheral: "RA4M1 RTC",
+    notes: "Arduino Nano R4 RA4M1 real-time clock metadata only; shared Arduino runtime does not enable rtc.* bytecode adapters yet.",
+};
+
 const fn map_arduino_digital_pins<const N: usize>(
     source: [board_vm_arduino::DigitalPinDescriptor; N],
 ) -> [DigitalPinInfo; N] {
@@ -1238,6 +1245,30 @@ const fn arduino_board_target_with_buses_and_can(
     wireless: &'static [WirelessInterfaceInfo],
     network_interfaces: &'static [NetworkInterfaceInfo],
 ) -> BoardTargetInfo {
+    arduino_board_target_with_buses_can_and_rtc(
+        target,
+        digital_pins,
+        i2c_buses,
+        spi_buses,
+        uart_buses,
+        can_buses,
+        None,
+        wireless,
+        network_interfaces,
+    )
+}
+
+const fn arduino_board_target_with_buses_can_and_rtc(
+    target: board_vm_arduino::ArduinoTargetDescriptor,
+    digital_pins: &'static [DigitalPinInfo],
+    i2c_buses: &'static [I2cBusInfo],
+    spi_buses: &'static [SpiBusInfo],
+    uart_buses: &'static [UartBusInfo],
+    can_buses: &'static [CanBusInfo],
+    rtc: Option<RtcInfo>,
+    wireless: &'static [WirelessInterfaceInfo],
+    network_interfaces: &'static [NetworkInterfaceInfo],
+) -> BoardTargetInfo {
     BoardTargetInfo {
         board_id: target.board_id,
         display_name: target.display_name,
@@ -1259,7 +1290,7 @@ const fn arduino_board_target_with_buses_and_can(
         spi_buses,
         uart_buses,
         can_buses,
-        rtc: None,
+        rtc,
         watchdog: None,
         storage_regions: &[],
         wireless,
@@ -1415,13 +1446,14 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         &[],
         &[],
     ),
-    arduino_board_target_with_buses_and_can(
+    arduino_board_target_with_buses_can_and_rtc(
         board_vm_arduino::ARDUINO_NANO_R4,
         &ARDUINO_NANO_R4_DIGITAL_PINS,
         &ARDUINO_NANO_R4_I2C_BUSES,
         &ARDUINO_NANO_R4_SPI_BUSES,
         &ARDUINO_NANO_R4_UART_BUSES,
         &ARDUINO_NANO_R4_CAN_BUSES,
+        Some(ARDUINO_NANO_R4_RTC),
         &[],
         &[],
     ),
@@ -2049,6 +2081,15 @@ mod tests {
         assert!(minima.capabilities.contains(&"rtc.set"));
         assert!(wifi.capabilities.contains(&"rtc.now"));
         assert!(wifi.capabilities.contains(&"rtc.set"));
+
+        let nano_r4 = find_target("arduino-nano-r4").unwrap();
+        assert_eq!(nano_r4.rtc, Some(ARDUINO_NANO_R4_RTC));
+        assert_eq!(nano_r4.rtc.unwrap().instance, 0);
+        assert_eq!(nano_r4.rtc.unwrap().name, "RTC");
+        assert_eq!(nano_r4.rtc.unwrap().peripheral, "RA4M1 RTC");
+        assert!(nano_r4.rtc.unwrap().notes.contains("metadata only"));
+        assert!(!nano_r4.capabilities.contains(&"rtc.now"));
+        assert!(!nano_r4.capabilities.contains(&"rtc.set"));
 
         assert_eq!(find_target("esp32-devkit-v1").unwrap().rtc, None);
         assert_eq!(find_target("raspberry-pi-pico").unwrap().rtc, None);

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -170,8 +170,11 @@ chip select, and D0/D1 `Serial1`.
 
 The Nano R4 CAN metadata tranche adds the D4/D5 CAN0 descriptor and records the
 external transceiver requirement, while leaving `can.*` capabilities disabled
-for the shared Arduino runtime. Native USB, Qwiic `Wire1`, and RTC details
-remain follow-up adapter metadata.
+for the shared Arduino runtime.
+
+The Nano R4 RTC metadata tranche records the RA4M1 real-time clock as passive
+target metadata and keeps `rtc.*` capabilities disabled for the shared Arduino
+runtime. Native USB and Qwiic `Wire1` details remain follow-up adapter metadata.
 
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino


### PR DESCRIPTION
## Summary
- add passive Arduino Nano R4 RA4M1 RTC metadata while keeping `rtc.*` bytecode capabilities disabled for the shared Arduino runtime
- surface RTC descriptors through `board-vm-language-core` target metadata so language frontends stay thin over Rust-owned board discovery
- document the Nano R4 RTC tranche in the target README, Arduino README, and Board VM target matrix while leaving Qwiic `Wire1` and bytecode RTC behavior for later slices

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-rtc-metadata cargo fmt -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-rtc-metadata cargo test -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-rtc-metadata cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core` in `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-rtc-metadata bash BUILD` in `code/packages/rust/board-vm-targets`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-rtc-metadata bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-rtc-metadata bash BUILD` in `code/packages/rust/board-vm-arduino`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.
