### PR TITLE
Add WHATWG list item audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -46,6 +46,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser void-element audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser list-item audit
+  generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -188,6 +188,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-list-item-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_list_item_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -43,6 +43,10 @@ documented in this file.
   stray void end tags, table/select contexts, fragment contexts, foreign
   boundaries, and legacy void-like element cases, with a dedicated parser
   regression test.
+- Generated WHATWG list-item audit fixture over html5lib `li`, `dt`, and `dd`
+  implied-end-tag recovery, nested list boundaries, paragraph/list
+  interactions, formatting reconstruction, and list-in-table recovery cases,
+  with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -56,8 +60,8 @@ documented in this file.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
   foreign-content, formatting, ruby, noscript, head/body, document-shell,
-  void-element, template, and select/list audit checks on the same parser and
-  DOM dump path.
+  void-element, list-item, template, and select/list audit checks on the same
+  parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -204,6 +204,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_eleme
   --check
 ```
 
+The generated `tests/fixtures/whatwg-list-item-audit.json` fixture indexes
+`li`, `dt`, and `dd` implied-end-tag recovery, nested list boundaries,
+paragraph/list interactions, formatting reconstruction, and list-in-table
+recovery:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -164,6 +164,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_eleme
   --check
 ```
 
+`whatwg-list-item-audit.json` is a generated index over tree-construction
+cases that stress `li`, `dt`, and `dd` implied-end-tag recovery, nested list
+boundaries, paragraph/list interactions, formatting reconstruction, and
+list-in-table recovery:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG list-item audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-list-item-audit.json"
+
+LIST_MARKUP = re.compile(r"</?(?:li|dd|dt|ul|ol|dl)(?:\s|/|>)", re.I)
+LI_MARKUP = re.compile(r"<li(?:\s|/|>)", re.I)
+DT_DD_MARKUP = re.compile(r"<(?:dt|dd)(?:\s|/|>)", re.I)
+NESTED_LIST_MARKUP = re.compile(r"<(?:ul|ol)(?:\s|/|>)", re.I)
+DEFINITION_LIST_MARKUP = re.compile(r"<dl(?:\s|/|>)", re.I)
+PARAGRAPH_MARKUP = re.compile(r"</?p(?:\s|/|>)", re.I)
+FORMATTING_MARKUP = re.compile(
+    r"</?(?:a|b|big|code|em|font|i|nobr|s|small|strike|strong|tt|u)(?:\s|/|>)",
+    re.I,
+)
+TABLE_MARKUP = re.compile(
+    r"<(?:table|tbody|tfoot|thead|tr|td|th|caption)(?:\s|/|>)",
+    re.I,
+)
+
+CASE_AXES = (
+    {
+        "axis": "list-with-paragraph",
+        "reason": "list and definition tags that implicitly close open paragraphs",
+    },
+    {
+        "axis": "nested-list-boundary",
+        "reason": "nested ul and ol boundaries around list item insertion",
+    },
+    {
+        "axis": "dt-dd-implied-end-tag",
+        "reason": "definition term and description implied end-tag recovery",
+    },
+    {
+        "axis": "list-with-formatting",
+        "reason": "list item implied end tags with active formatting elements",
+    },
+    {
+        "axis": "li-implied-end-tag",
+        "reason": "adjacent li start tags and stray li recovery",
+    },
+    {
+        "axis": "list-in-table",
+        "reason": "list item recovery while table insertion modes are active",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG list-item audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_list_case(case_data):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any list-item audit cases")
+    return cases
+
+
+def is_list_case(data: str) -> bool:
+    return LIST_MARKUP.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-list-item-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress li, dt, and dd implied end-tag recovery, nested list "
+            "boundaries, paragraph/list interactions, formatting reconstruction, "
+            "and list recovery in table insertion modes."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data
+
+    if TABLE_MARKUP.search(data):
+        return "list-in-table"
+    if FORMATTING_MARKUP.search(data):
+        return "list-with-formatting"
+    if PARAGRAPH_MARKUP.search(data):
+        return "list-with-paragraph"
+    if DT_DD_MARKUP.search(data):
+        return "dt-dd-implied-end-tag"
+    if NESTED_LIST_MARKUP.search(data):
+        return "nested-list-boundary"
+    if DEFINITION_LIST_MARKUP.search(data):
+        return "dt-dd-implied-end-tag"
+    if LI_MARKUP.search(data):
+        return "li-implied-end-tag"
+    raise SystemExit(f"unclassified list-item audit case: {case.source}")
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown list-item audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-list-item-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-list-item-audit.json
@@ -1,0 +1,358 @@
+{
+  "case_count": 57,
+  "cases": [
+    {
+      "axis": "list-with-paragraph",
+      "id": "blocks-dat-38",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "blocks.dat:38"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "blocks-dat-39",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "blocks.dat:39"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "blocks-dat-58",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "blocks.dat:58"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "blocks-dat-59",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "blocks.dat:59"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "blocks-dat-66",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "blocks.dat:66"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "blocks-dat-67",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "blocks.dat:67"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "html5test-com-dat-289",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "html5test-com.dat:289"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "inbody01-dat-297",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "inbody01.dat:297"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "inbody01-dat-298",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "inbody01.dat:298"
+    },
+    {
+      "axis": "li-implied-end-tag",
+      "id": "menuitem-element-dat-312",
+      "reason": "adjacent li start tags and stray li recovery",
+      "source": "menuitem-element.dat:312"
+    },
+    {
+      "axis": "li-implied-end-tag",
+      "id": "menuitem-element-dat-325",
+      "reason": "adjacent li start tags and stray li recovery",
+      "source": "menuitem-element.dat:325"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests1-dat-599",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests1.dat:599"
+    },
+    {
+      "axis": "list-with-formatting",
+      "id": "tests1-dat-668",
+      "reason": "list item implied end tags with active formatting elements",
+      "source": "tests1.dat:668"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests1-dat-669",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests1.dat:669"
+    },
+    {
+      "axis": "list-with-formatting",
+      "id": "tests1-dat-675",
+      "reason": "list item implied end tags with active formatting elements",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "list-in-table",
+      "id": "tests1-dat-676",
+      "reason": "list item recovery while table insertion modes are active",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests10-dat-710",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests10.dat:710"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests10-dat-711",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests10.dat:711"
+    },
+    {
+      "axis": "li-implied-end-tag",
+      "id": "tests19-dat-1037",
+      "reason": "adjacent li start tags and stray li recovery",
+      "source": "tests19.dat:1037"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests19-dat-1043",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests19.dat:1043"
+    },
+    {
+      "axis": "li-implied-end-tag",
+      "id": "tests19-dat-1064",
+      "reason": "adjacent li start tags and stray li recovery",
+      "source": "tests19.dat:1064"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests19-dat-1065",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests19.dat:1065"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests19-dat-1066",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests19.dat:1066"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-1127",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:1127"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-1137",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:1137"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-1142",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:1142"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-1148",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:1148"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-1149",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:1149"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-1150",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:1150"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests2-dat-11",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests2.dat:11"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests2-dat-26",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests2.dat:26"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests2-dat-27",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests2.dat:27"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests2-dat-28",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests2.dat:28"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests3-dat-20",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests3.dat:20"
+    },
+    {
+      "axis": "list-in-table",
+      "id": "tests8-dat-6",
+      "reason": "list item recovery while table insertion modes are active",
+      "source": "tests8.dat:6"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests1-dat-34",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests1.dat:34"
+    },
+    {
+      "axis": "list-with-formatting",
+      "id": "tests1-dat-103",
+      "reason": "list item implied end tags with active formatting elements",
+      "source": "tests1.dat:103"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests1-dat-104",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests1.dat:104"
+    },
+    {
+      "axis": "list-with-formatting",
+      "id": "tests1-dat-110",
+      "reason": "list item implied end tags with active formatting elements",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "list-in-table",
+      "id": "tests1-dat-111",
+      "reason": "list item recovery while table insertion modes are active",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests10-dat-33",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests10.dat:33"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "tests10-dat-34",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "tests10.dat:34"
+    },
+    {
+      "axis": "li-implied-end-tag",
+      "id": "tests19-dat-24",
+      "reason": "adjacent li start tags and stray li recovery",
+      "source": "tests19.dat:24"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests19-dat-30",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests19.dat:30"
+    },
+    {
+      "axis": "li-implied-end-tag",
+      "id": "tests19-dat-51",
+      "reason": "adjacent li start tags and stray li recovery",
+      "source": "tests19.dat:51"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests19-dat-52",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests19.dat:52"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "tests19-dat-53",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "tests19.dat:53"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-11",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:11"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-21",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:21"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-26",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:26"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-32",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:32"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-33",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:33"
+    },
+    {
+      "axis": "list-with-paragraph",
+      "id": "tests20-dat-34",
+      "reason": "list and definition tags that implicitly close open paragraphs",
+      "source": "tests20.dat:34"
+    },
+    {
+      "axis": "list-with-formatting",
+      "id": "tricky01-dat-4",
+      "reason": "list item implied end tags with active formatting elements",
+      "source": "tricky01.dat:4"
+    },
+    {
+      "axis": "dt-dd-implied-end-tag",
+      "id": "webkit01-dat-33",
+      "reason": "definition term and description implied end-tag recovery",
+      "source": "webkit01.dat:33"
+    },
+    {
+      "axis": "list-with-formatting",
+      "id": "webkit01-dat-39",
+      "reason": "list item implied end tags with active formatting elements",
+      "source": "webkit01.dat:39"
+    },
+    {
+      "axis": "nested-list-boundary",
+      "id": "webkit01-dat-46",
+      "reason": "nested ul and ol boundaries around list item insertion",
+      "source": "webkit01.dat:46"
+    }
+  ],
+  "counts_by_axis": {
+    "dt-dd-implied-end-tag": 10,
+    "li-implied-end-tag": 6,
+    "list-in-table": 3,
+    "list-with-formatting": 6,
+    "list-with-paragraph": 22,
+    "nested-list-boundary": 10
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress li, dt, and dd implied end-tag recovery, nested list boundaries, paragraph/list interactions, formatting reconstruction, and list recovery in table insertion modes.",
+  "format": "whatwg-html-list-item-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_list_item_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_list_item_audit_test.rs
@@ -1,0 +1,85 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_LIST_ITEM_AUDIT: &str = include_str!("fixtures/whatwg-list-item-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct ListItemAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<ListItemAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListItemAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_list_item_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-list-item-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 55);
+    assert_axis_count(&suite, "list-with-paragraph", 20);
+    assert_axis_count(&suite, "nested-list-boundary", 10);
+    assert_axis_count(&suite, "dt-dd-implied-end-tag", 10);
+    assert_axis_count(&suite, "list-with-formatting", 6);
+    assert_axis_count(&suite, "li-implied-end-tag", 6);
+    assert_axis_count(&suite, "list-in-table", 1);
+}
+
+#[test]
+fn whatwg_list_item_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> ListItemAuditSuite {
+    serde_json::from_str(WHATWG_LIST_ITEM_AUDIT)
+        .expect("WHATWG list-item audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &ListItemAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG list-item audit fixture over li/dt/dd implied end-tag and nested list recovery cases
- add a parser regression test that replays the selected html5lib tree-construction cases through the shared DOM dump path
- wire the new generator into the generated fixture manifest check and docs/changelogs

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_list_item_audit
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser