### PR TITLE
fix(sql-optimizer,sql-vm,mini-sqlite): AND/OR coerce integers to truth

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.71.0] - 2026-05-20
+
+### Fixed
+
+- **``SELECT 1 AND 0`` and similar integer-literal boolean expressions
+  now return the correct value** (via ``sql-optimizer 0.13.0`` and
+  ``sql-vm 1.45.0``).  Previously the optimizer folded every literal
+  combination that wasn't already a Python ``bool`` to ``NULL``,
+  including ``1 AND 0`` (should be ``0``), ``1 OR 0`` (should be ``1``),
+  and ``NULL AND 0`` (should be ``0`` — FALSE dominates).
+
+  Column-driven AND/OR (e.g. ``WHERE a AND b`` where both columns are
+  ``INTEGER``) was also broken at the VM level because
+  ``apply_binary(AND, 1, 0)`` raised ``TypeMismatch``.  Both code paths
+  now use SQLite's numeric truthiness rule: zero is FALSE, any other
+  numeric is TRUE, NULL is unknown.
+
+  23 oracle tests in ``test_tier3_and_or_truthiness.py`` covering
+  integer literals, 3-valued logic with NULL, negative / large /
+  float numerics, column-driven AND/OR, and a regression guard for
+  the boolean-comparison path that previously worked by accident.
+
 ## [1.70.0] - 2026-05-20
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.70.0"
+version = "1.71.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_and_or_truthiness.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_and_or_truthiness.py
@@ -1,0 +1,186 @@
+"""SQLite-compatible boolean coercion for ``AND`` / ``OR``.
+
+SQLite has no separate BOOLEAN storage class: integers and floats
+double as booleans.  Zero is FALSE; any other numeric value is TRUE.
+The ``AND`` / ``OR`` operators must therefore coerce numeric operands
+to truth values, not require Python ``bool`` instances.
+
+Before this PR mini-sqlite silently produced NULL for ``SELECT 1 AND 0``:
+
+* The constant-folding optimizer compared each operand to the Python
+  ``True`` / ``False`` singletons with the ``is`` operator.  Integer
+  literals like ``1`` and ``0`` failed all four identity checks, so
+  the fold fell through to "both are literals but neither is TRUE/
+  FALSE — must be NULL" and produced ``Literal(None)``.
+
+* The VM-level ``apply_binary(AND, 1, 0)`` raised ``TypeMismatch``
+  with "expected boolean" — also wrong, since SQLite freely mixes
+  integers and booleans.
+
+Both code paths now use ``_truthy`` / ``_truthiness`` helpers that
+return ``True``/``False`` for any non-NULL numeric value and ``None``
+for NULL or non-coercible inputs.
+
+These oracle tests pair every interesting case against the reference
+``sqlite3`` module byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Integer-literal AND/OR — the headline bug
+# ---------------------------------------------------------------------------
+
+
+class TestIntegerLiteralAndOr:
+    def test_1_and_0(self) -> None:
+        # Was returning NULL; SQLite returns 0.
+        _check("SELECT 1 AND 0")
+
+    def test_1_and_1(self) -> None:
+        _check("SELECT 1 AND 1")
+
+    def test_0_and_0(self) -> None:
+        _check("SELECT 0 AND 0")
+
+    def test_0_and_1(self) -> None:
+        _check("SELECT 0 AND 1")
+
+    def test_1_or_0(self) -> None:
+        _check("SELECT 1 OR 0")
+
+    def test_0_or_0(self) -> None:
+        _check("SELECT 0 OR 0")
+
+    def test_1_or_1(self) -> None:
+        _check("SELECT 1 OR 1")
+
+
+# ---------------------------------------------------------------------------
+# 3-valued logic — NULL interactions
+# ---------------------------------------------------------------------------
+
+
+class TestThreeValuedLogic:
+    def test_null_and_zero_is_zero(self) -> None:
+        # FALSE dominates AND, even when paired with NULL.
+        _check("SELECT NULL AND 0")
+        _check("SELECT 0 AND NULL")
+
+    def test_null_and_one_is_null(self) -> None:
+        _check("SELECT NULL AND 1")
+        _check("SELECT 1 AND NULL")
+
+    def test_null_and_null(self) -> None:
+        _check("SELECT NULL AND NULL")
+
+    def test_null_or_one_is_one(self) -> None:
+        # TRUE dominates OR.
+        _check("SELECT NULL OR 1")
+        _check("SELECT 1 OR NULL")
+
+    def test_null_or_zero_is_null(self) -> None:
+        _check("SELECT NULL OR 0")
+        _check("SELECT 0 OR NULL")
+
+    def test_null_or_null(self) -> None:
+        _check("SELECT NULL OR NULL")
+
+
+# ---------------------------------------------------------------------------
+# Non-zero numeric values count as TRUE
+# ---------------------------------------------------------------------------
+
+
+class TestNumericTruthiness:
+    def test_negative_int_is_true(self) -> None:
+        # -1 is non-zero, so it's TRUE.
+        _check("SELECT -1 AND 1")
+        _check("SELECT -1 OR 0")
+
+    def test_large_int_is_true(self) -> None:
+        _check("SELECT 1000000 AND 1")
+
+    def test_float_zero_is_false(self) -> None:
+        _check("SELECT 0.0 AND 1")
+
+    def test_float_nonzero_is_true(self) -> None:
+        _check("SELECT 1.5 AND 1")
+        _check("SELECT 0.1 OR 0")
+
+
+# ---------------------------------------------------------------------------
+# Column-driven AND/OR — exercises the VM-level fix
+# ---------------------------------------------------------------------------
+
+
+class TestColumnAndOr:
+    SETUP = [
+        "CREATE TABLE t (a INTEGER, b INTEGER)",
+        "INSERT INTO t VALUES (1, 0), (0, 1), (1, 1), (0, 0)",
+    ]
+
+    def test_column_and(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute("SELECT a AND b FROM t ORDER BY a, b").fetchall()
+        r = conn_r.execute("SELECT a AND b FROM t ORDER BY a, b").fetchall()
+        assert m == r
+
+    def test_column_or(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute("SELECT a OR b FROM t ORDER BY a, b").fetchall()
+        r = conn_r.execute("SELECT a OR b FROM t ORDER BY a, b").fetchall()
+        assert m == r
+
+    def test_where_with_int_columns(self) -> None:
+        # WHERE a AND b — must filter to (1, 1) only.
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute(
+            "SELECT a, b FROM t WHERE a AND b ORDER BY a, b"
+        ).fetchall()
+        r = conn_r.execute(
+            "SELECT a, b FROM t WHERE a AND b ORDER BY a, b"
+        ).fetchall()
+        assert m == r
+
+
+# ---------------------------------------------------------------------------
+# Regression — boolean comparison expressions still work (this was the
+# only path that worked *before* the fix, because comparisons produced
+# real Python bools that the ``is True`` / ``is False`` checks could
+# recognise).
+# ---------------------------------------------------------------------------
+
+
+class TestBoolComparisonRegression:
+    def test_eq_and_eq(self) -> None:
+        _check("SELECT 1=1 AND 0=0")
+
+    def test_eq_or_eq(self) -> None:
+        _check("SELECT 1=2 OR 1=1")
+
+    def test_chained_comparisons(self) -> None:
+        _check("SELECT (1 < 2) AND (3 > 2)")

--- a/code/packages/python/sql-optimizer/CHANGELOG.md
+++ b/code/packages/python/sql-optimizer/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.13.0] - 2026-05-20
+
+### Fixed
+
+- **``ConstantFolding`` simplification of ``AND``/``OR`` now coerces
+  numeric literals to truth values** instead of identity-checking
+  against the Python ``True``/``False`` singletons.  The previous
+  ``is True`` / ``is False`` tests treated ``Literal(1)`` and
+  ``Literal(0)`` as neither-true-nor-false and folded them to NULL —
+  so the optimizer was turning ``SELECT 1 AND 0`` into ``SELECT NULL``
+  *before* the VM ever ran.  A new ``_truthy`` helper returns
+  ``True``/``False`` for any non-NULL numeric and ``None`` for strings/
+  other types so unfoldable operands fall through to the runtime.
+
 ## [0.12.0] - 2026-05-17
 
 ### Changed

--- a/code/packages/python/sql-optimizer/pyproject.toml
+++ b/code/packages/python/sql-optimizer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-optimizer"
-version = "0.12.0"
+version = "0.13.0"
 description = "Pure rewrite passes over sql-planner's LogicalPlan tree."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-optimizer/src/sql_optimizer/constant_folding.py
+++ b/code/packages/python/sql-optimizer/src/sql_optimizer/constant_folding.py
@@ -360,6 +360,28 @@ def _apply_binary(op: BinaryOp, lv: object, rv: object) -> object:
             raise AssertionError("unreachable")
 
 
+def _truthy(value: object) -> bool | None:
+    """SQL boolean coercion: None → None; numeric zero → False; else True.
+
+    SQLite treats any non-NULL numeric value as a boolean: ``0`` and
+    ``0.0`` are FALSE, everything else (including bools, non-zero ints
+    and floats) is TRUE.  Strings have no defined truth value for ``AND``
+    /``OR`` short-circuit folding — we return ``None`` to signal "leave
+    this as a runtime expression" so the VM can apply its own rules.
+
+    Returning ``None`` for unknown truthiness is what prevents this
+    helper from over-folding: the caller treats ``None`` as "I can't
+    tell, don't simplify on this side".
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)  # 0/0.0 → False; anything else → True
+    return None
+
+
 def _simplify_and(left: Expr, right: Expr) -> Expr | None:
     """SQL three-valued AND:
 
@@ -370,17 +392,26 @@ def _simplify_and(left: Expr, right: Expr) -> Expr | None:
     FALSE     FALSE  FALSE  FALSE
     NULL      NULL   FALSE  NULL
     ========  =====  =====  =====
+
+    Integer-literal coercion: SQLite (and we) treat any non-zero numeric
+    value as TRUE and zero as FALSE.  Without this, ``SELECT 1 AND 0``
+    used to fall through the ``is True`` / ``is False`` identity tests
+    and end up folding to NULL (which is exactly the bug this docstring
+    is preventing from coming back).
     """
-    if isinstance(left, Literal) and left.value is False:
+    lt = _truthy(left.value) if isinstance(left, Literal) else None
+    rt = _truthy(right.value) if isinstance(right, Literal) else None
+    # Truth-value rules — FALSE dominates, then short-circuit on TRUE.
+    if lt is False or rt is False:
         return Literal(value=False)
-    if isinstance(right, Literal) and right.value is False:
-        return Literal(value=False)
-    if isinstance(left, Literal) and left.value is True:
+    if lt is True and rt is True:
+        return Literal(value=True)
+    if lt is True:
         return right
-    if isinstance(right, Literal) and right.value is True:
+    if rt is True:
         return left
+    # Both literals but neither TRUE/FALSE — at least one is NULL → NULL.
     if isinstance(left, Literal) and isinstance(right, Literal):
-        # Both are literals but neither is TRUE/FALSE — one is NULL.
         return Literal(value=None)
     return None
 
@@ -395,14 +426,19 @@ def _simplify_or(left: Expr, right: Expr) -> Expr | None:
     FALSE     TRUE   FALSE  NULL
     NULL      TRUE   NULL   NULL
     ========  =====  =====  =====
+
+    Same integer-literal coercion as ``_simplify_and`` — see that
+    docstring for the rationale.
     """
-    if isinstance(left, Literal) and left.value is True:
+    lt = _truthy(left.value) if isinstance(left, Literal) else None
+    rt = _truthy(right.value) if isinstance(right, Literal) else None
+    if lt is True or rt is True:
         return Literal(value=True)
-    if isinstance(right, Literal) and right.value is True:
-        return Literal(value=True)
-    if isinstance(left, Literal) and left.value is False:
+    if lt is False and rt is False:
+        return Literal(value=False)
+    if lt is False:
         return right
-    if isinstance(right, Literal) and right.value is False:
+    if rt is False:
         return left
     if isinstance(left, Literal) and isinstance(right, Literal):
         return Literal(value=None)

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.45.0 — 2026-05-20
+
+### Fixed
+
+- **``apply_binary(AND, …)`` and ``apply_binary(OR, …)`` now coerce
+  numeric operands to truth values** instead of demanding Python
+  ``bool``.  ``apply_binary(AND, 1, 0)`` used to raise ``TypeMismatch``
+  because ``1`` isn't ``True`` (under ``is``).  SQLite has no separate
+  BOOLEAN storage class — integers and floats double as booleans, with
+  zero meaning FALSE and any other value meaning TRUE.
+
+  A new ``_truthiness`` helper returns ``True``/``False`` for any
+  non-NULL numeric, ``None`` for NULL, and (deliberately) ``None`` for
+  strings.  The latter still raises TypeMismatch to keep ill-typed
+  comparisons loud at runtime.
+
 ## 1.44.0 — 2026-05-20
 
 ### Added

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.44.0"
+version = "1.45.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/operators.py
+++ b/code/packages/python/sql-vm/src/sql_vm/operators.py
@@ -206,33 +206,67 @@ def _concat(left: SqlValue, right: SqlValue) -> SqlValue:
     return left + right
 
 
+def _truthiness(v: SqlValue) -> bool | None:
+    """Coerce a SqlValue to a SQL truth value.
+
+    SQLite has no separate BOOLEAN type at the storage level: integers
+    and floats double as booleans, with zero meaning FALSE and every
+    other numeric value (including negative numbers and floats) meaning
+    TRUE.  Python ``bool`` is a subtype of ``int`` and round-trips
+    naturally.  NULL coerces to ``None``.
+
+    Strings are deliberately ambiguous here — SQL would coerce ``'1'``
+    via NUMERIC affinity to TRUE, but the AND/OR operator never sees a
+    raw string in well-typed code, so we conservatively return ``None``
+    and let the caller raise a TypeMismatch.
+    """
+    if v is None:
+        return None
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, (int, float)):
+        return bool(v)
+    return None
+
+
 def _and(left: SqlValue, right: SqlValue) -> SqlValue:
     # Three-valued AND: FALSE dominates; NULL only if no FALSE seen.
-    if left is False or right is False:
+    # Operands are coerced via SQLite's numeric truth rule — ``1 AND 0``
+    # must yield ``0`` (FALSE), not raise TypeMismatch and definitely
+    # not silently produce NULL (the bug that lived here until now).
+    lt = _truthiness(left)
+    rt = _truthiness(right)
+    if lt is False or rt is False:
         return False
-    if left is None or right is None:
+    if lt is None or rt is None:
+        # Either NULL or non-coercible — see _truthiness for the string case.
+        if not (isinstance(left, (bool, int, float)) or left is None) \
+                or not (isinstance(right, (bool, int, float)) or right is None):
+            raise TypeMismatch(
+                expected="boolean",
+                got=f"{sql_type_name(left)}, {sql_type_name(right)}",
+                context="BinaryOp(AND)",
+            )
         return None
-    if not (_is_bool(left) and _is_bool(right)):
-        raise TypeMismatch(
-            expected="boolean",
-            got=f"{sql_type_name(left)}, {sql_type_name(right)}",
-            context="BinaryOp(AND)",
-        )
     return True
 
 
 def _or(left: SqlValue, right: SqlValue) -> SqlValue:
     # Three-valued OR: TRUE dominates; NULL only if no TRUE seen.
-    if left is True or right is True:
+    # See ``_and`` for the numeric-truthiness rationale.
+    lt = _truthiness(left)
+    rt = _truthiness(right)
+    if lt is True or rt is True:
         return True
-    if left is None or right is None:
+    if lt is None or rt is None:
+        if not (isinstance(left, (bool, int, float)) or left is None) \
+                or not (isinstance(right, (bool, int, float)) or right is None):
+            raise TypeMismatch(
+                expected="boolean",
+                got=f"{sql_type_name(left)}, {sql_type_name(right)}",
+                context="BinaryOp(OR)",
+            )
         return None
-    if not (_is_bool(left) and _is_bool(right)):
-        raise TypeMismatch(
-            expected="boolean",
-            got=f"{sql_type_name(left)}, {sql_type_name(right)}",
-            context="BinaryOp(OR)",
-        )
     return False
 
 

--- a/code/packages/python/sql-vm/tests/test_operators.py
+++ b/code/packages/python/sql-vm/tests/test_operators.py
@@ -95,15 +95,30 @@ class TestThreeValuedLogic:
         assert apply_binary(BinaryOpCode.OR, True, None) is True
         assert apply_binary(BinaryOpCode.OR, None, None) is None
 
-    def test_and_rejects_non_boolean(self) -> None:
-        # With no FALSE short-circuit, AND must validate the input types.
-        with pytest.raises(TypeMismatch):
-            apply_binary(BinaryOpCode.AND, 1, True)
+    def test_and_coerces_integer_to_truth(self) -> None:
+        # SQLite's AND coerces numeric values to truth: 1 is TRUE, 0 is
+        # FALSE.  The previous behaviour rejected ``apply_binary(AND, 1,
+        # True)`` with TypeMismatch — that was the bug that allowed
+        # ``SELECT 1 AND 0`` to fold to NULL in the optimizer; this test
+        # now pins the correct semantics.
+        assert apply_binary(BinaryOpCode.AND, 1, True) is True
+        assert apply_binary(BinaryOpCode.AND, 1, 0) is False
+        assert apply_binary(BinaryOpCode.AND, 1, 1) is True
+        assert apply_binary(BinaryOpCode.AND, 0, 1) is False
 
-    def test_or_rejects_non_boolean(self) -> None:
-        # With no TRUE short-circuit, OR must validate the input types.
+    def test_or_coerces_integer_to_truth(self) -> None:
+        # See ``test_and_coerces_integer_to_truth`` for the rationale.
+        assert apply_binary(BinaryOpCode.OR, 1, False) is True
+        assert apply_binary(BinaryOpCode.OR, 0, 0) is False
+        assert apply_binary(BinaryOpCode.OR, 0, 1) is True
+
+    def test_and_or_reject_strings(self) -> None:
+        # Strings have no defined SQL truth value here — they should still
+        # raise TypeMismatch.  Only numeric/boolean operands are coerced.
         with pytest.raises(TypeMismatch):
-            apply_binary(BinaryOpCode.OR, 1, False)
+            apply_binary(BinaryOpCode.AND, "abc", True)
+        with pytest.raises(TypeMismatch):
+            apply_binary(BinaryOpCode.OR, "abc", False)
 
 
 class TestConcat:


### PR DESCRIPTION
## Summary

`SELECT 1 AND 0` was returning **NULL** instead of `0`. SQLite has no separate BOOLEAN storage class — integers double as booleans — but two code paths were identity-checking against Python's `True`/`False`:

1. **sql-optimizer ConstantFolding**: `_simplify_and`/`_simplify_or` used `value is False` / `value is True`. Integer literals `1` and `0` failed all four identity tests, so the fold dropped through to "must be NULL" and produced `Literal(None)`. The optimizer was turning `1 AND 0` into `NULL` *before* the VM ever ran.
2. **sql-vm `apply_binary(AND, …)`**: demanded both operands be Python `bool`. `apply_binary(AND, 1, 0)` raised `TypeMismatch`, breaking column-driven `WHERE a AND b` for INTEGER columns.

Both sites now use a shared truthiness helper: `None → None`, `bool → bool`, `int/float → bool(value)` (zero is FALSE, non-zero is TRUE), everything else → None (still raises `TypeMismatch` in the VM).

26 tests: 2 sql-vm test updates + 1 new (strings still rejected) + 23 mini-sqlite oracle. Version bumps: sql-optimizer 0.12.0→0.13.0, sql-vm 1.44.0→1.45.0, mini-sqlite 1.70.0→1.71.0.

## Test plan

- [x] `pytest sql-optimizer/tests/` — 144 passed
- [x] `pytest sql-vm/tests/` — 893 passed
- [x] `pytest mini-sqlite/tests/` — 1764 passed
- [x] `SELECT 1 AND 0` etc. match `sqlite3` byte-for-byte
- [x] Column-driven `WHERE a AND b` matches `sqlite3`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)