### PR TITLE
[codex] Add Nano R4 Arduino Qwiic metadata

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -58,8 +58,9 @@ A4/A5 Wire, D11/D12/D13 SPI with D10 as the default chip-select pin, and D0/D1
 Nano R4 mirrors that header-pin metadata for the Renesas RA4M1 Nano form
 factor: A4/A5 `Wire`, D11/D12/D13 SPI with D10 chip select, and D0/D1
 `Serial1`. It also records D4/D5 CAN metadata with the external transceiver
-requirement plus passive RA4M1 RTC metadata. Native USB, Qwiic `Wire1`, and RTC
-bytecode behavior remain owned by later board-specific adapter tranches.
+requirement, passive RA4M1 RTC metadata, and connector-local Qwiic `Wire1`
+metadata. Native USB, Qwiic bytecode behavior, and RTC bytecode behavior remain
+owned by later board-specific adapter tranches.
 
 Opta terminals are modeled as board-local input and relay-output pins instead
 of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -76,9 +76,9 @@ use board_vm_protocol::{
 use board_vm_targets::{
     all_targets, BoardFamily, BoardTargetInfo, CanBusInfo as TargetCanBus,
     DigitalPinInfo as TargetDigitalPin, I2cBusInfo as TargetI2cBus,
-    NetworkInterfaceInfo as TargetNetworkInterface, NetworkProtocol as TargetNetworkProtocol,
-    OnboardLed as TargetOnboardLed, RtcInfo as TargetRtc, SpiBusInfo as TargetSpiBus,
-    UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
+    I2cConnectorInfo as TargetI2cConnector, NetworkInterfaceInfo as TargetNetworkInterface,
+    NetworkProtocol as TargetNetworkProtocol, OnboardLed as TargetOnboardLed, RtcInfo as TargetRtc,
+    SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
     UploadImageFormat as TargetUploadImageFormat, UploadInfo as TargetUploadInfo,
     UploadPortHint as TargetUploadPortHint, UploadResetMethod as TargetUploadResetMethod,
     UploadTransport as TargetUploadTransport, WirelessInterfaceInfo as TargetWirelessInterface,
@@ -429,6 +429,7 @@ pub struct LanguageTargetInfo {
     pub digital_pin_count: usize,
     pub digital_pins: Vec<LanguageDigitalPin>,
     pub i2c_buses: Vec<LanguageI2cBus>,
+    pub i2c_connectors: Vec<LanguageI2cConnector>,
     pub spi_buses: Vec<LanguageSpiBus>,
     pub uart_buses: Vec<LanguageUartBus>,
     pub can_buses: Vec<LanguageCanBus>,
@@ -447,6 +448,16 @@ pub struct LanguageI2cBus {
     pub sda_pin: u8,
     pub scl_pin: u8,
     pub qwiic: bool,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageI2cConnector {
+    pub bus: u8,
+    pub name: String,
+    pub connector: String,
+    pub arduino_object: String,
+    pub controller: String,
     pub notes: String,
 }
 
@@ -1311,6 +1322,11 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             .map(language_digital_pin)
             .collect(),
         i2c_buses: target.i2c_buses.iter().map(language_i2c_bus).collect(),
+        i2c_connectors: target
+            .i2c_connectors
+            .iter()
+            .map(language_i2c_connector)
+            .collect(),
         spi_buses: target.spi_buses.iter().map(language_spi_bus).collect(),
         uart_buses: target.uart_buses.iter().map(language_uart_bus).collect(),
         can_buses: target.can_buses.iter().map(language_can_bus).collect(),
@@ -1363,6 +1379,17 @@ fn language_i2c_bus(bus: &TargetI2cBus) -> LanguageI2cBus {
         scl_pin: bus.scl_pin,
         qwiic: bus.qwiic,
         notes: bus.notes.to_owned(),
+    }
+}
+
+fn language_i2c_connector(connector: &TargetI2cConnector) -> LanguageI2cConnector {
+    LanguageI2cConnector {
+        bus: connector.bus,
+        name: connector.name.to_owned(),
+        connector: connector.connector.to_owned(),
+        arduino_object: connector.arduino_object.to_owned(),
+        controller: connector.controller.to_owned(),
+        notes: connector.notes.to_owned(),
     }
 }
 
@@ -4161,6 +4188,12 @@ mod tests {
         assert_eq!(nano_r4.i2c_buses[0].sda_pin, 18);
         assert_eq!(nano_r4.i2c_buses[0].scl_pin, 19);
         assert!(nano_r4.i2c_buses[0].notes.contains("Qwiic Wire1"));
+        assert_eq!(nano_r4.i2c_connectors.len(), 1);
+        assert_eq!(nano_r4.i2c_connectors[0].name, "Wire1");
+        assert_eq!(nano_r4.i2c_connectors[0].connector, "Qwiic/STEMMA QT");
+        assert_eq!(nano_r4.i2c_connectors[0].arduino_object, "Wire1");
+        assert_eq!(nano_r4.i2c_connectors[0].controller, "RA4M1 IIC0");
+        assert!(nano_r4.i2c_connectors[0].notes.contains("connector-local"));
         assert_eq!(nano_r4.spi_buses.len(), 1);
         assert_eq!(nano_r4.spi_buses[0].copi_pin, 11);
         assert_eq!(nano_r4.spi_buses[0].cipo_pin, 12);

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -100,6 +100,11 @@ Nano R4 RTC metadata records the RA4M1 real-time clock as a passive descriptor.
 The shared Arduino runtime still leaves `rtc.*` bytecode adapters disabled until
 a board-specific firmware path owns clock access.
 
+Nano R4 Qwiic metadata records the board-local `Wire1` connector separately
+from A4/A5 `Wire` header pins. The descriptor names the Qwiic/STEMMA QT
+connector and RA4M1 IIC0 controller while the shared Arduino runtime keeps
+`i2c.*` bytecode adapters disabled.
+
 Host-side validation:
 
 ```sh

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -65,6 +65,16 @@ pub struct I2cBusInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct I2cConnectorInfo {
+    pub bus: u8,
+    pub name: &'static str,
+    pub connector: &'static str,
+    pub arduino_object: &'static str,
+    pub controller: &'static str,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SpiBusInfo {
     pub bus: u8,
     pub name: &'static str,
@@ -223,6 +233,7 @@ pub struct BoardTargetInfo {
     pub digital_pin_count: usize,
     pub digital_pins: &'static [DigitalPinInfo],
     pub i2c_buses: &'static [I2cBusInfo],
+    pub i2c_connectors: &'static [I2cConnectorInfo],
     pub spi_buses: &'static [SpiBusInfo],
     pub uart_buses: &'static [UartBusInfo],
     pub can_buses: &'static [CanBusInfo],
@@ -873,7 +884,16 @@ pub const ARDUINO_NANO_R4_I2C_BUSES: [I2cBusInfo; 1] = [I2cBusInfo {
     sda_pin: 18,
     scl_pin: 19,
     qwiic: false,
-    notes: "Arduino Nano R4 A4/A5 Wire metadata only; the separate Qwiic Wire1 connector needs connector-local metadata before it is exposed here.",
+    notes: "Arduino Nano R4 A4/A5 Wire header metadata only; the separate Qwiic Wire1 connector is exposed as connector-local metadata.",
+}];
+
+pub const ARDUINO_NANO_R4_I2C_CONNECTORS: [I2cConnectorInfo; 1] = [I2cConnectorInfo {
+    bus: 1,
+    name: "Wire1",
+    connector: "Qwiic/STEMMA QT",
+    arduino_object: "Wire1",
+    controller: "RA4M1 IIC0",
+    notes: "Arduino Nano R4 connector-local Qwiic/STEMMA QT I2C metadata only; shared Arduino runtime does not enable i2c.* bytecode adapters yet.",
 }];
 
 pub const ARDUINO_NANO_R4_SPI_BUSES: [SpiBusInfo; 1] = [SpiBusInfo {
@@ -1249,6 +1269,7 @@ const fn arduino_board_target_with_buses_and_can(
         target,
         digital_pins,
         i2c_buses,
+        &[],
         spi_buses,
         uart_buses,
         can_buses,
@@ -1262,6 +1283,7 @@ const fn arduino_board_target_with_buses_can_and_rtc(
     target: board_vm_arduino::ArduinoTargetDescriptor,
     digital_pins: &'static [DigitalPinInfo],
     i2c_buses: &'static [I2cBusInfo],
+    i2c_connectors: &'static [I2cConnectorInfo],
     spi_buses: &'static [SpiBusInfo],
     uart_buses: &'static [UartBusInfo],
     can_buses: &'static [CanBusInfo],
@@ -1287,6 +1309,7 @@ const fn arduino_board_target_with_buses_can_and_rtc(
         digital_pin_count: digital_pins.len(),
         digital_pins,
         i2c_buses,
+        i2c_connectors,
         spi_buses,
         uart_buses,
         can_buses,
@@ -1322,6 +1345,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         digital_pin_count: UNO_R4_DIGITAL_PINS.len(),
         digital_pins: &UNO_R4_DIGITAL_PINS,
         i2c_buses: &UNO_R4_MINIMA_I2C_BUSES,
+        i2c_connectors: &[],
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_MINIMA_UART_BUSES,
         can_buses: &UNO_R4_CAN_BUSES,
@@ -1354,6 +1378,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         digital_pin_count: UNO_R4_DIGITAL_PINS.len(),
         digital_pins: &UNO_R4_DIGITAL_PINS,
         i2c_buses: &UNO_R4_WIFI_I2C_BUSES,
+        i2c_connectors: &[],
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_WIFI_UART_BUSES,
         can_buses: &UNO_R4_CAN_BUSES,
@@ -1450,6 +1475,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         board_vm_arduino::ARDUINO_NANO_R4,
         &ARDUINO_NANO_R4_DIGITAL_PINS,
         &ARDUINO_NANO_R4_I2C_BUSES,
+        &ARDUINO_NANO_R4_I2C_CONNECTORS,
         &ARDUINO_NANO_R4_SPI_BUSES,
         &ARDUINO_NANO_R4_UART_BUSES,
         &ARDUINO_NANO_R4_CAN_BUSES,
@@ -1565,6 +1591,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         digital_pin_count: ESP32_DIGITAL_PINS.len(),
         digital_pins: &ESP32_DIGITAL_PINS,
         i2c_buses: &[],
+        i2c_connectors: &[],
         spi_buses: &[],
         uart_buses: &[],
         can_buses: &[],
@@ -1597,6 +1624,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         digital_pin_count: PICO_DIGITAL_PINS.len(),
         digital_pins: &PICO_DIGITAL_PINS,
         i2c_buses: &[],
+        i2c_connectors: &[],
         spi_buses: &[],
         uart_buses: &[],
         can_buses: &[],
@@ -1629,6 +1657,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         digital_pin_count: PICO_DIGITAL_PINS.len(),
         digital_pins: &PICO_DIGITAL_PINS,
         i2c_buses: &[],
+        i2c_connectors: &[],
         spi_buses: &[],
         uart_buses: &[],
         can_buses: &[],
@@ -1895,6 +1924,12 @@ mod tests {
         assert_eq!(nano_r4.i2c_buses[0].sda_pin, 18);
         assert_eq!(nano_r4.i2c_buses[0].scl_pin, 19);
         assert!(nano_r4.i2c_buses[0].notes.contains("Qwiic Wire1"));
+        assert_eq!(nano_r4.i2c_connectors, &ARDUINO_NANO_R4_I2C_CONNECTORS);
+        assert_eq!(nano_r4.i2c_connectors[0].name, "Wire1");
+        assert_eq!(nano_r4.i2c_connectors[0].connector, "Qwiic/STEMMA QT");
+        assert_eq!(nano_r4.i2c_connectors[0].arduino_object, "Wire1");
+        assert_eq!(nano_r4.i2c_connectors[0].controller, "RA4M1 IIC0");
+        assert!(nano_r4.i2c_connectors[0].notes.contains("connector-local"));
         for target in [
             uno_r3, nano, pro_mini, mega, leonardo, micro, nano_every, nano_r4,
         ] {

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -174,7 +174,13 @@ for the shared Arduino runtime.
 
 The Nano R4 RTC metadata tranche records the RA4M1 real-time clock as passive
 target metadata and keeps `rtc.*` capabilities disabled for the shared Arduino
-runtime. Native USB and Qwiic `Wire1` details remain follow-up adapter metadata.
+runtime.
+
+The Nano R4 Qwiic metadata tranche records connector-local `Wire1` metadata for
+the Qwiic/STEMMA QT connector and RA4M1 IIC0 controller without folding it into
+the A4/A5 `Wire` header descriptor. `i2c.*` capabilities stay disabled for the
+shared Arduino runtime; native USB and bytecode behavior remain follow-up
+adapter metadata.
 
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino


### PR DESCRIPTION
## Summary
- Add connector-local Nano R4 Qwiic/STEMMA QT `Wire1` metadata without folding it into the A4/A5 `Wire` header descriptor.
- Surface the new I2C connector descriptor through `board-vm-language-core` while keeping shared Arduino `i2c.*` capabilities disabled.
- Document the Nano R4 Qwiic metadata tranche in the target package, Arduino package, and Board VM target matrix spec.

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-qwiic-metadata cargo fmt -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-qwiic-metadata cargo test -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-qwiic-metadata cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-qwiic-metadata bash BUILD` in `code/packages/rust/board-vm-targets`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-qwiic-metadata bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-qwiic-metadata bash BUILD` in `code/packages/rust/board-vm-arduino`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.