### PR TITLE
fix(sql-vm,mini-sqlite): NOT coerces integer operands to truth

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.72.0] - 2026-05-20
+
+### Fixed
+
+- **``NOT integer_expr`` now coerces to truth** (via ``sql-vm 1.46.0``).
+  Follow-up to 1.71.0: ``NOT 0`` was still raising ``DataError`` because
+  the unary ``NOT`` operator had the same Python-bool-only check that
+  ``AND`` / ``OR`` did before being fixed.  Now ``NOT 0 → 1``,
+  ``NOT 5 → 0``, ``NOT NULL → NULL``, and ``WHERE NOT b`` filters
+  integer columns correctly.
+
+  14 oracle tests in ``test_tier3_not_truthiness.py`` covering integer/
+  float literals, NULL handling, column refs, WHERE clauses, and
+  compound expressions like ``NOT (1 AND 0)`` / ``NOT NOT NULL``.
+
 ## [1.71.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.71.0"
+version = "1.72.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_not_truthiness.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_not_truthiness.py
@@ -1,0 +1,130 @@
+"""Companion to the AND/OR integer-truthiness fix — same bug for ``NOT``.
+
+PR #3737 fixed the binary ``AND`` / ``OR`` operators to coerce integer
+operands to truth values, matching SQLite's "no separate BOOLEAN
+class; zero is FALSE, anything else is TRUE" convention.  The unary
+``NOT`` operator had the same bug at the VM level:
+``apply_unary(NOT, 1)`` raised ``TypeMismatch`` instead of returning
+``0``.
+
+These oracle tests verify that ``NOT`` now coerces integer operands
+through the same ``_truthiness`` helper that already handles
+``AND``/``OR``, matching ``sqlite3`` byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# NOT on integer literals
+# ---------------------------------------------------------------------------
+
+
+class TestNotIntegerLiteral:
+    def test_not_zero(self) -> None:
+        _check("SELECT NOT 0")
+
+    def test_not_one(self) -> None:
+        _check("SELECT NOT 1")
+
+    def test_not_large_int(self) -> None:
+        _check("SELECT NOT 5")
+
+    def test_not_negative_int(self) -> None:
+        # -1 is non-zero, so NOT -1 → 0.
+        _check("SELECT NOT -1")
+
+
+class TestNotFloatLiteral:
+    def test_not_zero_float(self) -> None:
+        _check("SELECT NOT 0.0")
+
+    def test_not_positive_float(self) -> None:
+        _check("SELECT NOT 1.5")
+
+    def test_not_negative_float(self) -> None:
+        _check("SELECT NOT -0.1")
+
+
+# ---------------------------------------------------------------------------
+# NOT NULL — should still be NULL (3-valued logic)
+# ---------------------------------------------------------------------------
+
+
+class TestNotNull:
+    def test_not_null(self) -> None:
+        _check("SELECT NOT NULL")
+
+    def test_not_null_aware(self) -> None:
+        # NOT NULL must be NULL, never TRUE/FALSE.
+        _check("SELECT NOT NULL IS NULL")  # NOT NULL → NULL; NULL IS NULL → 1
+
+
+# ---------------------------------------------------------------------------
+# NOT on column — exercises the VM path with non-constant values
+# ---------------------------------------------------------------------------
+
+
+class TestNotOnColumn:
+    SETUP = [
+        "CREATE TABLE t (b INTEGER)",
+        "INSERT INTO t VALUES (1), (0), (NULL), (-1), (5)",
+    ]
+
+    def test_not_column(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute(
+            "SELECT b, NOT b FROM t ORDER BY b"
+        ).fetchall()
+        r = conn_r.execute(
+            "SELECT b, NOT b FROM t ORDER BY b"
+        ).fetchall()
+        assert m == r
+
+    def test_where_not_column(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute(
+            "SELECT b FROM t WHERE NOT b ORDER BY b"
+        ).fetchall()
+        r = conn_r.execute(
+            "SELECT b FROM t WHERE NOT b ORDER BY b"
+        ).fetchall()
+        assert m == r
+
+
+# ---------------------------------------------------------------------------
+# Compound expressions — NOT combined with AND/OR
+# ---------------------------------------------------------------------------
+
+
+class TestNotInCompound:
+    def test_not_and(self) -> None:
+        _check("SELECT NOT (1 AND 0)")
+        _check("SELECT NOT 1 AND NOT 0")
+
+    def test_not_or(self) -> None:
+        _check("SELECT NOT (1 OR 0)")
+        _check("SELECT NOT 1 OR NOT 0")
+
+    def test_double_negation(self) -> None:
+        _check("SELECT NOT NOT 1")
+        _check("SELECT NOT NOT 0")
+        _check("SELECT NOT NOT NULL")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.46.0 — 2026-05-20
+
+### Fixed
+
+- **``apply_unary(NOT, …)`` now coerces numeric operands to truth**
+  via the same ``_truthiness`` helper used by ``AND``/``OR`` in 1.45.0.
+  ``NOT 0`` was raising ``TypeMismatch`` (expected boolean, got
+  INTEGER) and SQLite expects ``1``; same for ``NOT 5``, ``NOT 1.5``,
+  etc.  Strings still raise TypeMismatch as before.
+
 ## 1.45.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.45.0"
+version = "1.46.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/operators.py
+++ b/code/packages/python/sql-vm/src/sql_vm/operators.py
@@ -286,11 +286,17 @@ def apply_unary(op: UnaryOpCode, value: SqlValue) -> SqlValue:
             )
         return -_to_number(value)
     if op is UnaryOpCode.NOT:
-        if not _is_bool(value):
+        # Same coercion rule as the binary AND/OR path: any non-NULL numeric
+        # is a valid truth operand for NOT.  SQLite has no separate BOOLEAN
+        # storage class, so ``NOT 0`` must give ``1`` and ``NOT 5`` must
+        # give ``0``.  Strings (which have no defined truth value in this
+        # registry) still raise TypeMismatch.
+        truth = _truthiness(value)
+        if truth is None:
             raise TypeMismatch(
                 expected="boolean", got=sql_type_name(value), context="UnaryOp(NOT)"
             )
-        return not value
+        return not truth
     raise TypeMismatch(expected="unary op", got=str(op), context="UnaryOp")
 
 

--- a/code/packages/python/sql-vm/tests/test_operators.py
+++ b/code/packages/python/sql-vm/tests/test_operators.py
@@ -154,9 +154,22 @@ class TestUnary:
     def test_not_null(self) -> None:
         assert apply_unary(UnaryOpCode.NOT, None) is None
 
-    def test_not_int_raises(self) -> None:
+    def test_not_int_coerces_to_truth(self) -> None:
+        # SQLite has no separate BOOLEAN class; ``NOT 0`` is ``1`` and
+        # ``NOT 5`` is ``0``.  The previous behaviour raised
+        # TypeMismatch for any non-bool input — same family of bug as the
+        # AND/OR integer-truthiness fix.
+        assert apply_unary(UnaryOpCode.NOT, 1) is False
+        assert apply_unary(UnaryOpCode.NOT, 0) is True
+        assert apply_unary(UnaryOpCode.NOT, 5) is False
+        assert apply_unary(UnaryOpCode.NOT, -1) is False
+        assert apply_unary(UnaryOpCode.NOT, 1.5) is False
+        assert apply_unary(UnaryOpCode.NOT, 0.0) is True
+
+    def test_not_string_still_raises(self) -> None:
+        # Strings have no defined truth value here — keep the TypeMismatch.
         with pytest.raises(TypeMismatch):
-            apply_unary(UnaryOpCode.NOT, 1)
+            apply_unary(UnaryOpCode.NOT, "abc")
 
 
 class TestLike:


### PR DESCRIPTION
## Summary

Follow-up to #3737 (AND/OR integer truthiness): the unary `NOT` operator had the same Python-bool-only check. `apply_unary(NOT, 1)` raised `TypeMismatch` instead of returning `False`; SQLite expects `0` because integers double as booleans.

`NOT` now uses the same `_truthiness` helper as `AND`/`OR`: non-NULL numerics coerce to bool, NULL stays NULL, strings still raise `TypeMismatch`.

16 tests: 3 sql-vm updates + 14 mini-sqlite oracle covering integer/float literals, NULL handling, column refs in SELECT/WHERE, and compound expressions (`NOT (1 AND 0)`, `NOT NOT NULL`). Version bumps: sql-vm 1.45.0 → 1.46.0, mini-sqlite 1.71.0 → 1.72.0.

## Test plan

- [x] `pytest sql-vm/tests/` — 894 passed
- [x] `pytest mini-sqlite/tests/test_tier3_not_truthiness.py` — 14/14
- [x] mini-sqlite full suite — 1778 passed (1764 prior + 14 new)
- [x] All cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)