### PR TITLE
Add summary count flag accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this package will be documented in this file.
 - Delta-direction helpers for supervisor drain run reports.
 - Status aliases for supervisor drain run reports.
 - Row-count match helpers for supervisor drain run reports and summaries.
+- Planned-count match and drift flag accessors for supervisor drain run
+  summaries.
 - Run-status accessors for supervisor drain run summaries.
 - Count-drift presence flags for supervisor drain run reports and summaries.
 - Stable count-drift classifications for supervisor drain run reports and

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -55,6 +55,8 @@ The crate keeps the boundary narrow:
   follow-up pressure
 - supervisor drain reports and summaries expose row-count match helpers for
   host scheduler checks
+- supervisor drain run summaries expose exact planned-count match and drift
+  flag accessors for host branching
 - supervisor drain run summaries expose typed run-status accessors for
   continuation, follow-up, checkpoint, and budget decisions
 - supervisor drain run summaries expose count-drift presence flags beside

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1344,17 +1344,37 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return whether planned and replayed row counts match.
     pub fn matches_record_count(&self) -> bool {
-        self.matches_planned_record_count
+        self.matches_planned_record_count()
     }
 
     /// Return whether planned and replayed follow-up pressure counts match.
     pub fn matches_follow_up_pressure(&self) -> bool {
+        self.matches_planned_follow_up_record_count()
+    }
+
+    /// Return whether the actual run delivered the planned number of rows.
+    pub fn matches_planned_record_count(&self) -> bool {
+        self.matches_planned_record_count
+    }
+
+    /// Return whether the actual run preserved the planned follow-up pressure count.
+    pub fn matches_planned_follow_up_record_count(&self) -> bool {
         self.matches_planned_follow_up_record_count
+    }
+
+    /// Return whether row count drift was observed.
+    pub fn has_record_count_drift(&self) -> bool {
+        self.has_record_count_drift
+    }
+
+    /// Return whether follow-up pressure count drift was observed.
+    pub fn has_follow_up_record_count_drift(&self) -> bool {
+        self.has_follow_up_record_count_drift
     }
 
     /// Return whether any planned-vs-actual count drift was observed.
     pub fn has_count_drift(&self) -> bool {
-        self.has_record_count_drift || self.has_follow_up_record_count_drift
+        self.has_record_count_drift() || self.has_follow_up_record_count_drift()
     }
 
     /// Return the typed count-drift classification.
@@ -3293,7 +3313,9 @@ mod tests {
         assert_eq!(summary.record_count_delta, 0);
         assert_eq!(summary.follow_up_record_count_delta, 0);
         assert!(!summary.has_record_count_drift);
+        assert!(!summary.has_record_count_drift());
         assert!(!summary.has_follow_up_record_count_drift);
+        assert!(!summary.has_follow_up_record_count_drift());
         assert!(!summary.has_count_drift());
         assert_eq!(
             summary.count_drift_kind,
@@ -3786,8 +3808,10 @@ mod tests {
         assert!(!summary.requires_host_investigation);
         assert!(!summary.requires_host_investigation());
         assert!(summary.matches_planned_record_count);
+        assert!(summary.matches_planned_record_count());
         assert!(summary.matches_record_count());
         assert!(summary.matches_planned_follow_up_record_count);
+        assert!(summary.matches_planned_follow_up_record_count());
         assert!(summary.matches_follow_up_pressure());
         assert!(!summary.reached_end_of_log);
         assert!(!summary.reached_end_of_log());
@@ -3852,7 +3876,9 @@ mod tests {
         assert!(!report.missed_planned_records());
         assert_eq!(summary.record_count_delta, 1);
         assert!(summary.has_record_count_drift);
+        assert!(summary.has_record_count_drift());
         assert!(!summary.has_follow_up_record_count_drift);
+        assert!(!summary.has_follow_up_record_count_drift());
         assert!(summary.has_count_drift());
         assert_eq!(
             summary.count_drift_kind,
@@ -3982,7 +4008,9 @@ mod tests {
         assert_eq!(summary.record_count_delta, 0);
         assert_eq!(summary.follow_up_record_count_delta, -1);
         assert!(!summary.has_record_count_drift);
+        assert!(!summary.has_record_count_drift());
         assert!(summary.has_follow_up_record_count_drift);
+        assert!(summary.has_follow_up_record_count_drift());
         assert!(summary.has_count_drift());
         assert_eq!(
             summary.count_drift_kind,
@@ -4001,7 +4029,9 @@ mod tests {
         assert!(summary.requires_host_investigation);
         assert!(summary.requires_host_investigation());
         assert!(summary.matches_planned_record_count);
+        assert!(summary.matches_planned_record_count());
         assert!(!summary.matches_planned_follow_up_record_count);
+        assert!(!summary.matches_planned_follow_up_record_count());
         assert!(!summary.matches_follow_up_pressure());
         assert!(!summary.replayed_extra_follow_up_records());
         assert!(summary.missed_planned_follow_up_records());


### PR DESCRIPTION
## Summary
- add exact planned-count match and individual drift accessors on supervisor drain run summaries
- route existing summary alias helpers through the exact accessors
- cover the new accessors in summary tests and docs

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD