### PR TITLE
Add WHATWG paragraph audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -48,6 +48,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser list-item audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser paragraph audit
+  generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -195,6 +195,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-paragraph-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_paragraph_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -47,6 +47,10 @@ documented in this file.
   implied-end-tag recovery, nested list boundaries, paragraph/list
   interactions, formatting reconstruction, and list-in-table recovery cases,
   with a dedicated parser regression test.
+- Generated WHATWG paragraph audit fixture over html5lib paragraph implied-end
+  tags, formatting reconstruction, table/foster-parenting boundaries, form
+  controls, text modes, headings, special end-tag recovery, and fragment
+  contexts, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -60,8 +64,8 @@ documented in this file.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
   foreign-content, formatting, ruby, noscript, head/body, document-shell,
-  void-element, list-item, template, and select/list audit checks on the same
-  parser and DOM dump path.
+  void-element, list-item, paragraph, template, and select/list audit checks on
+  the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -214,6 +214,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_
   --check
 ```
 
+The generated `tests/fixtures/whatwg-paragraph-audit.json` fixture indexes
+paragraph implied-end tags, formatting reconstruction, table/foster-parenting
+boundaries, form controls, text modes, headings, special end-tag recovery, and
+fragment contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -175,6 +175,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_
   --check
 ```
 
+`whatwg-paragraph-audit.json` is a generated index over tree-construction
+cases that stress paragraph implied-end tags, formatting reconstruction,
+table/foster-parenting boundaries, form controls, text modes, headings,
+special end-tag recovery, and fragment contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG paragraph audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-paragraph-audit.json"
+
+PARAGRAPH_MARKUP = re.compile(r"</?p(?:\s|/|>)", re.I)
+BLOCK_MARKUP = re.compile(
+    r"<(?:address|article|aside|blockquote|center|details|dialog|dir|div|dl|fieldset|figcaption|figure|footer|header|hgroup|main|menu|nav|ol|section|ul)(?:\s|/|>)",
+    re.I,
+)
+HEADING_MARKUP = re.compile(r"<h[1-6](?:\s|/|>)", re.I)
+TABLE_MARKUP = re.compile(
+    r"<(?:table|tbody|tfoot|thead|tr|td|th|caption)(?:\s|/|>)",
+    re.I,
+)
+FORM_MARKUP = re.compile(r"<(?:form|button|input|select|textarea)(?:\s|/|>)", re.I)
+TEXT_MODE_MARKUP = re.compile(
+    r"<(?:pre|listing|plaintext|textarea|script|style|title)(?:\s|/|>)",
+    re.I,
+)
+FORMATTING_MARKUP = re.compile(
+    r"</?(?:a|b|big|code|em|font|i|nobr|s|small|strike|strong|tt|u)(?:\s|/|>)",
+    re.I,
+)
+SPECIAL_PARAGRAPH_END_MARKUP = re.compile(r"</(?:p|br)(?:\s|/|>)", re.I)
+
+CASE_AXES = (
+    {
+        "axis": "paragraph-form-boundary",
+        "reason": "paragraph boundaries around form controls and interactive descendants",
+    },
+    {
+        "axis": "paragraph-formatting-boundary",
+        "reason": "paragraph boundaries with active formatting reconstruction",
+    },
+    {
+        "axis": "paragraph-block-boundary",
+        "reason": "paragraph implied end tags before block-level boundaries",
+    },
+    {
+        "axis": "paragraph-basic-boundary",
+        "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+    },
+    {
+        "axis": "paragraph-table-boundary",
+        "reason": "paragraph boundaries around table insertion and foster parenting modes",
+    },
+    {
+        "axis": "paragraph-text-mode-boundary",
+        "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+    },
+    {
+        "axis": "paragraph-special-end-tag",
+        "reason": "special paragraph and br end-tag recovery paths",
+    },
+    {
+        "axis": "paragraph-heading-boundary",
+        "reason": "paragraph implied end tags before heading starts",
+    },
+    {
+        "axis": "paragraph-fragment-context",
+        "reason": "paragraph handling in html5lib fragment contexts",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG paragraph audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_paragraph_case(case_data):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any paragraph audit cases")
+    return cases
+
+
+def is_paragraph_case(data: str) -> bool:
+    return PARAGRAPH_MARKUP.search(data) is not None
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-paragraph-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction cases "
+            "that stress paragraph implied end tags, formatting reconstruction, "
+            "table/foster-parenting boundaries, form controls, text modes, "
+            "headings, special end-tag recovery, and fragment contexts."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data
+
+    if case.fragment_context is not None:
+        return "paragraph-fragment-context"
+    if TABLE_MARKUP.search(data):
+        return "paragraph-table-boundary"
+    if TEXT_MODE_MARKUP.search(data):
+        return "paragraph-text-mode-boundary"
+    if FORM_MARKUP.search(data):
+        return "paragraph-form-boundary"
+    if FORMATTING_MARKUP.search(data):
+        return "paragraph-formatting-boundary"
+    if HEADING_MARKUP.search(data):
+        return "paragraph-heading-boundary"
+    if BLOCK_MARKUP.search(data):
+        return "paragraph-block-boundary"
+    if SPECIAL_PARAGRAPH_END_MARKUP.search(data):
+        return "paragraph-special-end-tag"
+    return "paragraph-basic-boundary"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown paragraph audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-paragraph-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-paragraph-audit.json
@@ -1,0 +1,2299 @@
+{
+  "case_count": 380,
+  "cases": [
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-1",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:1"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-2",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:2"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "adoption01-dat-6",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "adoption01.dat:6"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-7",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:7"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-8",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:8"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-9",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:9"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-10",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:10"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption01-dat-17",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption01.dat:17"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "adoption02-dat-18",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "adoption02.dat:18"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-20",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:20"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-21",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:21"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-22",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:22"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-23",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:23"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-24",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:24"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-25",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:25"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-26",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:26"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-27",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:27"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-28",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:28"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-29",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:29"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-30",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:30"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-31",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:31"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-32",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:32"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-33",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:33"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-34",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:34"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-35",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:35"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-36",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:36"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-37",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:37"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-38",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:38"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-39",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:39"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-40",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:40"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-41",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:41"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-42",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:42"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-43",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:43"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-44",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:44"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-45",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:45"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-46",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:46"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-47",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:47"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-48",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:48"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-49",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:49"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-50",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:50"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-51",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:51"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "blocks-dat-52",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "blocks.dat:52"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "blocks-dat-53",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "blocks.dat:53"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-54",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:54"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-55",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:55"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-56",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:56"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-57",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:57"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-58",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:58"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-59",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:59"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "blocks-dat-60",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "blocks.dat:60"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "blocks-dat-61",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "blocks.dat:61"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-62",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:62"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-63",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:63"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "blocks-dat-64",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "blocks.dat:64"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "blocks-dat-65",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "blocks.dat:65"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-66",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:66"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "blocks-dat-67",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "blocks.dat:67"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "domjs-unsafe-dat-133",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "domjs-unsafe.dat:133"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "html5test-com-dat-291",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "html5test-com.dat:291"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "inbody01-dat-296",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "inbody01.dat:296"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "main-element-dat-303",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "main-element.dat:303"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "main-element-dat-304",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "main-element.dat:304"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "menuitem-element-dat-313",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "menuitem-element.dat:313"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "menuitem-element-dat-314",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "menuitem-element.dat:314"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "menuitem-element-dat-324",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "menuitem-element.dat:324"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "noscript01-dat-341",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "noscript01.dat:341"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "noscript01-dat-342",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "noscript01.dat:342"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "plain-text-unsafe-dat-371",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "plain-text-unsafe.dat:371"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "quirks01-dat-382",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "quirks01.dat:382"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "quirks01-dat-383",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "quirks01.dat:383"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "quirks01-dat-384",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "quirks01.dat:384"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "quirks01-dat-385",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "quirks01.dat:385"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "search-element-dat-433",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "search-element.dat:433"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "search-element-dat-434",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "search-element.dat:434"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tables01-dat-440",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tables01.dat:440"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests1-dat-567",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests1.dat:567"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-588",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:588"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-591",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:591"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-592",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:592"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests1-dat-594",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests1.dat:594"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-617",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:617"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-618",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:618"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-619",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:619"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-620",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:620"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-622",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:622"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-634",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:634"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-635",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:635"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-636",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:636"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-637",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:637"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-638",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:638"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-639",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:639"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-640",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:640"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-641",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:641"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-653",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:653"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-654",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:654"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests1-dat-655",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests1.dat:655"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests1-dat-656",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests1.dat:656"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests1-dat-657",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests1.dat:657"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests1-dat-658",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests1.dat:658"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-661",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:661"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-663",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:663"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-664",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:664"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-675",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:675"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests1-dat-676",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests1.dat:676"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-689",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:689"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-690",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:690"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-691",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:691"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-692",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:692"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-693",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:693"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-694",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:694"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-695",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:695"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-696",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:696"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-697",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:697"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-698",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:698"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-699",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:699"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests10-dat-709",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests10.dat:709"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-712",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:712"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests10-dat-713",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests10.dat:713"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests10-dat-714",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests10.dat:714"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests12-dat-745",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests12.dat:745"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests12-dat-746",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests12.dat:746"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests15-dat-754",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests15.dat:754"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests15-dat-755",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests15.dat:755"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-1015",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:1015"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-1016",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:1016"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-1017",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:1017"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-1018",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:1018"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-1019",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:1019"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-1020",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:1020"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1022",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1022"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests19-dat-1024",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests19.dat:1024"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1025",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1025"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests19-dat-1027",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests19.dat:1027"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1036",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1036"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-1044",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:1044"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-1045",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:1045"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-1046",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:1046"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-1047",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:1047"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-1048",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:1048"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1055",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1055"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-1056",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:1056"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1059",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1059"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1060",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1060"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-1061",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:1061"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-1095",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:1095"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-1096",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:1096"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-1115",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:1115"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests19-dat-1116",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests19.dat:1116"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1117",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1117"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1118",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1118"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1119",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1119"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1120",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1120"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1121",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1121"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1122",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1122"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1123",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1123"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1124",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1124"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1125",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1125"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1126",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1126"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1127",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1127"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1128",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1128"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1129",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1129"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1130",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1130"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1131",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1131"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1132",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1132"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1133",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1133"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1134",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1134"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1135",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1135"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1136",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1136"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1137",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1137"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1138",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1138"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1139",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1139"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1140",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1140"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1141",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1141"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1142",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1142"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1143",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1143"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1144",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1144"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests20-dat-1145",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests20.dat:1145"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests20-dat-1146",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests20.dat:1146"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1147",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1147"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1148",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1148"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1149",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1149"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1150",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1150"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests20-dat-1151",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests20.dat:1151"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests20-dat-1152",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests20.dat:1152"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1153",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1153"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1154",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1154"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1155",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1155"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1156",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1156"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests20-dat-1158",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests20.dat:1158"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests20-dat-1160",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests20.dat:1160"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests20-dat-1161",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests20.dat:1161"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests20-dat-1165",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests20.dat:1165"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-1209",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:1209"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-1210",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:1210"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-1211",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:1211"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-1212",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:1212"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-1213",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:1213"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests26-dat-1257",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests26.dat:1257"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests26-dat-1258",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests26.dat:1258"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests26-dat-1259",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests26.dat:1259"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests26-dat-1260",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests26.dat:1260"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests26-dat-1261",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests26.dat:1261"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests26-dat-1263",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests26.dat:1263"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests26-dat-1264",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests26.dat:1264"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests26-dat-1266",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests26.dat:1266"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests2-dat-10",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests2.dat:10"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests2-dat-26",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests2.dat:26"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests2-dat-27",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests2.dat:27"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests2-dat-28",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests2.dat:28"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests2-dat-29",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests2.dat:29"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests2-dat-30",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests2.dat:30"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests2-dat-58",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests2.dat:58"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests2-dat-59",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests2.dat:59"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests5-dat-11",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests5.dat:11"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-13",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:13"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-14",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:14"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-15",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:15"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-16",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:16"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-17",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:17"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-18",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:18"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests9-dat-19",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests9.dat:19"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests9-dat-20",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests9.dat:20"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests9-dat-21",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests9.dat:21"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests9-dat-22",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests9.dat:22"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests9-dat-23",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests9.dat:23"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests2-dat-61",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests2.dat:61"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests3-dat-20",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests3.dat:20"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests3-dat-23",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests3.dat:23"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests3-dat-24",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests3.dat:24"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests7-dat-14",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests7.dat:14"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests7-dat-15",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests7.dat:15"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests7-dat-29",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests7.dat:29"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests8-dat-10",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests8.dat:10"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests1-dat-2",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests1.dat:2"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-23",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:23"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-26",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:26"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-27",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:27"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests1-dat-29",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests1.dat:29"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-52",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:52"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-53",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:53"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-54",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:54"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-55",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:55"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-57",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:57"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-69",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:69"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-70",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:70"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-71",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:71"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-72",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:72"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-73",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:73"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-74",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:74"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-75",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:75"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-76",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:76"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-88",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:88"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-89",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:89"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests1-dat-90",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests1.dat:90"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests1-dat-91",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests1.dat:91"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests1-dat-92",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests1.dat:92"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests1-dat-93",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests1.dat:93"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-96",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:96"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-98",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:98"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests1-dat-99",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests1.dat:99"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests1-dat-110",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests1.dat:110"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests1-dat-111",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests1.dat:111"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-12",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:12"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-13",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:13"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-14",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:14"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-15",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:15"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-16",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:16"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-17",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:17"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests10-dat-18",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests10.dat:18"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-19",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:19"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-20",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:20"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-21",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:21"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-22",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:22"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests10-dat-32",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests10.dat:32"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests10-dat-35",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests10.dat:35"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests10-dat-36",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests10.dat:36"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests10-dat-37",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests10.dat:37"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests12-dat-1",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests12.dat:1"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests12-dat-2",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests12.dat:2"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests15-dat-1",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests15.dat:1"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests15-dat-2",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests15.dat:2"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-2",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:2"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-3",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:3"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-4",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:4"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-5",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:5"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-6",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:6"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-7",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:7"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-9",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:9"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests19-dat-11",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests19.dat:11"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-12",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:12"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests19-dat-14",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests19.dat:14"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-23",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:23"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-31",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:31"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-32",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:32"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-33",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:33"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-34",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:34"
+    },
+    {
+      "axis": "paragraph-heading-boundary",
+      "id": "tests19-dat-35",
+      "reason": "paragraph implied end tags before heading starts",
+      "source": "tests19.dat:35"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-42",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:42"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-43",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:43"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-46",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:46"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-47",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:47"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests19-dat-48",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests19.dat:48"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-82",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:82"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests19-dat-83",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests19.dat:83"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests19-dat-102",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests19.dat:102"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests19-dat-103",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests19.dat:103"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-1",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:1"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-2",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:2"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-3",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:3"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-4",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:4"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-5",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:5"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-6",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:6"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-7",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:7"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-8",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:8"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-9",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:9"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-10",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:10"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-11",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:11"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-12",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:12"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-13",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:13"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-14",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:14"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-15",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:15"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-16",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:16"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-17",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:17"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-18",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:18"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-19",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:19"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-20",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:20"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-21",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:21"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-22",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:22"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-23",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:23"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-24",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:24"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-25",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:25"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-26",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:26"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-27",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:27"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-28",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:28"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests20-dat-29",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests20.dat:29"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests20-dat-30",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests20.dat:30"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-31",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:31"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-32",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:32"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-33",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:33"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-34",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:34"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "tests20-dat-35",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "tests20.dat:35"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests20-dat-36",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests20.dat:36"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-37",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:37"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-38",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:38"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-39",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:39"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests20-dat-40",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests20.dat:40"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests20-dat-42",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests20.dat:42"
+    },
+    {
+      "axis": "paragraph-block-boundary",
+      "id": "tests20-dat-44",
+      "reason": "paragraph implied end tags before block-level boundaries",
+      "source": "tests20.dat:44"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests20-dat-45",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests20.dat:45"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "tests20-dat-49",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "tests20.dat:49"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-1",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:1"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-2",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:2"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-3",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:3"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-4",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:4"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests23-dat-5",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests23.dat:5"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests26-dat-10",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests26.dat:10"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests26-dat-11",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests26.dat:11"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests26-dat-12",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests26.dat:12"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tests26-dat-13",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tests26.dat:13"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tests26-dat-14",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tests26.dat:14"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "tests26-dat-16",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "tests26.dat:16"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests26-dat-17",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests26.dat:17"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "tests26-dat-19",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "tests26.dat:19"
+    },
+    {
+      "axis": "paragraph-fragment-context",
+      "id": "foreign-fragment-dat-58",
+      "reason": "paragraph handling in html5lib fragment contexts",
+      "source": "foreign-fragment.dat:58"
+    },
+    {
+      "axis": "paragraph-fragment-context",
+      "id": "foreign-fragment-dat-59",
+      "reason": "paragraph handling in html5lib fragment contexts",
+      "source": "foreign-fragment.dat:59"
+    },
+    {
+      "axis": "paragraph-fragment-context",
+      "id": "foreign-fragment-dat-60",
+      "reason": "paragraph handling in html5lib fragment contexts",
+      "source": "foreign-fragment.dat:60"
+    },
+    {
+      "axis": "paragraph-fragment-context",
+      "id": "foreign-fragment-dat-62",
+      "reason": "paragraph handling in html5lib fragment contexts",
+      "source": "foreign-fragment.dat:62"
+    },
+    {
+      "axis": "paragraph-fragment-context",
+      "id": "foreign-fragment-dat-65",
+      "reason": "paragraph handling in html5lib fragment contexts",
+      "source": "foreign-fragment.dat:65"
+    },
+    {
+      "axis": "paragraph-fragment-context",
+      "id": "foreign-fragment-dat-66",
+      "reason": "paragraph handling in html5lib fragment contexts",
+      "source": "foreign-fragment.dat:66"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "scripted-adoption01-dat-1",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "scripted/adoption01.dat:1"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "scripted-ark-dat-1",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "scripted/ark.dat:1"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tricky01-dat-1",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tricky01.dat:1"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tricky01-dat-2",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tricky01.dat:2"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "tricky01-dat-3",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "tricky01.dat:3"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tricky01-dat-7",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tricky01.dat:7"
+    },
+    {
+      "axis": "paragraph-table-boundary",
+      "id": "tricky01-dat-8",
+      "reason": "paragraph boundaries around table insertion and foster parenting modes",
+      "source": "tricky01.dat:8"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "webkit01-dat-13",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "webkit01.dat:13"
+    },
+    {
+      "axis": "paragraph-text-mode-boundary",
+      "id": "webkit01-dat-40",
+      "reason": "paragraph boundaries around pre, listing, plaintext, and text-mode elements",
+      "source": "webkit01.dat:40"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "webkit02-dat-2",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "webkit02.dat:2"
+    },
+    {
+      "axis": "paragraph-formatting-boundary",
+      "id": "webkit02-dat-3",
+      "reason": "paragraph boundaries with active formatting reconstruction",
+      "source": "webkit02.dat:3"
+    }
+  ],
+  "counts_by_axis": {
+    "paragraph-basic-boundary": 51,
+    "paragraph-block-boundary": 56,
+    "paragraph-form-boundary": 75,
+    "paragraph-formatting-boundary": 73,
+    "paragraph-fragment-context": 6,
+    "paragraph-heading-boundary": 12,
+    "paragraph-special-end-tag": 25,
+    "paragraph-table-boundary": 48,
+    "paragraph-text-mode-boundary": 34
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress paragraph implied end tags, formatting reconstruction, table/foster-parenting boundaries, form controls, text modes, headings, special end-tag recovery, and fragment contexts.",
+  "format": "whatwg-html-paragraph-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_paragraph_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_paragraph_audit_test.rs
@@ -1,0 +1,88 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct ParagraphAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<ParagraphAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParagraphAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_paragraph_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-paragraph-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 380);
+    assert_axis_count(&suite, "paragraph-form-boundary", 70);
+    assert_axis_count(&suite, "paragraph-formatting-boundary", 70);
+    assert_axis_count(&suite, "paragraph-block-boundary", 55);
+    assert_axis_count(&suite, "paragraph-basic-boundary", 50);
+    assert_axis_count(&suite, "paragraph-table-boundary", 45);
+    assert_axis_count(&suite, "paragraph-text-mode-boundary", 30);
+    assert_axis_count(&suite, "paragraph-special-end-tag", 25);
+    assert_axis_count(&suite, "paragraph-heading-boundary", 10);
+    assert_axis_count(&suite, "paragraph-fragment-context", 6);
+}
+
+#[test]
+fn whatwg_paragraph_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> ParagraphAuditSuite {
+    serde_json::from_str(WHATWG_PARAGRAPH_AUDIT)
+        .expect("WHATWG paragraph audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &ParagraphAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG paragraph audit fixture over 380 html5lib tree-construction cases
- cover paragraph implied-end handling across form, formatting, block, table, text-mode, heading, special-end-tag, fragment, and basic paragraph axes
- add a parser regression test plus fixture manifest/docs/changelog wiring

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_paragraph_audit
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser