### PR TITLE
feat(specs): CLOC01–03 foundational specs for Closure Compiler in Rust

### DIFF
--- a/code/specs/CLOC01-closure-compiler-overview.md
+++ b/code/specs/CLOC01-closure-compiler-overview.md
@@ -1,0 +1,291 @@
+# CLOC01 — Closure Compiler in Rust: Overview & Pipeline Architecture
+
+## Why this project exists
+
+This spec opens the **CLOC** series — a Rust reimplementation of Google's Closure
+Compiler, structured as a pipeline of small, unix-style packages. The motivating
+goals are three:
+
+1. **Understand the magic.** Closure Compiler is one of the most aggressive
+   JavaScript optimizers ever built. By rebuilding it package-by-package, with
+   every transformation visible and traceable, we make its optimization decisions
+   legible — not opaque.
+
+2. **Plumb the correlation vector from day one.** Every byte of source must carry
+   a CV ID that survives lexing, parsing, type checking, every optimization pass,
+   code emission, and source-map generation. The optimizer's "magic" is exactly
+   the set of CV contributions it appends along the way. This is a structural
+   invariant, not a feature.
+
+3. **Build a JavaScript frontend that's reusable by future backends.** The same
+   tokens, AST, and type sidecar that feed this Closure Compiler clone must also
+   feed the future V8-in-Rust clone (JS → bytecode → VM). The frontend cannot be
+   coupled to either backend. This constraint shapes every interface in the CLOC
+   series.
+
+The Closure Compiler is the first consumer. It is not the only consumer. Anything
+the CLOC pipeline learns about JavaScript — every grammar rule, every AST node,
+every CV contribution shape — must be usable by the V8 clone without modification.
+
+## Scope of "Closure Compiler" here
+
+We are cloning the optimizer, not Google's particular codebase. The deliverable is
+a `closurec` binary that:
+
+- Reads JavaScript source (any ES version from ES1 through ES2025).
+- Optionally consumes a **type sidecar** (separately produced — see CLOC04).
+- Runs a configurable pipeline of optimization passes (DCE, renaming, inlining,
+  constant folding, tree shaking, property collapsing, etc.).
+- Emits optimized JavaScript plus a standard source-map v3.
+- Reports every transformation via a CV chain that resolves each output byte back
+  to one or more input bytes.
+
+Out of scope for the MVP:
+- The Java codebase of the Google Closure Compiler.
+- TypeScript as an input language (deferred — see Section 7).
+- Polyfill injection.
+- Module bundling beyond what's required for tree shaking.
+
+## Working principle: small unix-style packages
+
+Per the repo's conventions (CLAUDE.md, `feedback_smaller_prs`,
+`feedback_parallel_execution`), every component of the pipeline is a separate
+publishable Rust crate. A pass is a package. The pass scheduler is a package. The
+emitter is a package. The CLI is a package that wires everything together. This
+maximizes parallel PR work and lets passes be tested, swapped, and reasoned about
+independently.
+
+The shape of every pass package is the same:
+
+```text
+input:   javascript-ast::Program  +  Option<type-sidecar::Sidecar>
+output:  javascript-ast::Program  +  Vec<correlation_vector::Contribution>
+```
+
+A pass never mutates its input. It returns a new tree plus the list of CV
+contributions it would append to the surviving nodes. The scheduler merges
+contributions and threads the new tree into the next pass.
+
+## The pipeline
+
+Three independent sub-pipelines converge at the AST, and one optimizer pipeline
+consumes them:
+
+```text
+JavaScript source ──► [JS frontend cascade] ───► javascript-ast::Program ─┐
+                                                                          │
+JSDoc comments ────► [JSDoc sub-pipeline]  ───► type-sidecar::Sidecar ────┤
+                                                                          ├──► [Closure passes]
+TypeScript source ─► [TS sub-pipeline]      ──► type-sidecar::Sidecar ────┤        │
+                                                                          │        ▼
+External annotations (.d.ts-style) ────────────► type-sidecar::Sidecar ───┘    optimized AST
+                                                                                   │
+                                                                          ┌────────┴────────┐
+                                                                          ▼                 ▼
+                                                                  closure-emitter   closure-source-map
+                                                                          │                 │
+                                                                          └───► closurec ◄──┘
+
+                          ... the same javascript-ast also flows into the future
+                              V8-in-Rust clone for bytecode lowering. CLOC never
+                              assumes any single backend.
+```
+
+### Sub-pipeline A — JavaScript frontend (the part we are "fixing up" first)
+
+| Crate | Role |
+| --- | --- |
+| `javascript-tokens` (new) | Shared `TokenKind` enum, version tag, and span type. Backend-agnostic. |
+| `javascript-ast` (new) | Backend-agnostic typed AST. Every node carries a `CvId`. See CLOC02. |
+| `javascript-lexer` (existing — repoint) | Wraps `GrammarLexer` over the versioned `ecmascript/esNN.tokens` grammars. Constructor takes `EsVersion`; default = latest. |
+| `javascript-parser` (existing — repoint) | Wraps `GrammarParser` over `ecmascript/esNN.grammar`. Emits `javascript-ast::Program`. |
+
+The current `javascript-lexer` and `javascript-parser` already load versioned
+grammars from `code/grammars/ecmascript/`. The fix-up is:
+
+1. Replace the empty-string `""` default version with `EsVersion::Es2025`.
+2. Stop returning generic `GrammarASTNode`; emit `javascript-ast` nodes instead.
+3. Plumb a CV from every token through every AST node (CLOC03).
+4. Retire `code/grammars/javascript.{tokens,grammar}` — the stubs are obsolete
+   once everything points at the versioned grammars.
+
+### Sub-pipeline B — JSDoc (separate grammar, feeds the type sidecar)
+
+| Crate | Role |
+| --- | --- |
+| `jsdoc-tokens`, `jsdoc-ast` | Standard token + AST crates. |
+| `jsdoc-lexer`, `jsdoc-parser` | Wrap `GrammarLexer`/`GrammarParser` over a new `code/grammars/jsdoc/` grammar pair. |
+| `jsdoc-comment-extractor` | Pulls comment spans from a `javascript-ast::Program`, hands raw text to `jsdoc-parser`. |
+| `jsdoc-types-extractor` | Walks the JSDoc AST and emits `type-sidecar::Sidecar` records keyed by the JS-side `CvId` the comment annotates. |
+
+### Sub-pipeline C — TypeScript (deferred from MVP)
+
+The TS grammar already exists at `code/grammars/typescript/ts*.grammar`. Wiring is
+deferred. The plan is symmetric to the JS frontend: `typescript-tokens`,
+`typescript-ast`, `typescript-lexer`, `typescript-parser`, plus
+`typescript-types-extractor` that emits the same `type-sidecar` format as JSDoc.
+
+The point of the sidecar format being **shared** across JSDoc and TS is that the
+Closure Compiler does not need to know which producer wrote the types. JSDoc and
+TS are interchangeable type sources.
+
+### Sub-pipeline D — Closure Compiler proper
+
+| Crate | Role |
+| --- | --- |
+| `type-sidecar` | Format spec, Rust types, (de)serializers, and CV-keyed lookup. See CLOC04. |
+| `type-sidecar-merger` | Merges multiple sidecars (e.g., JSDoc + external `.d.ts`) with a conflict policy. |
+| `closure-typechecker` | Consumes `(Program, Sidecar)`. Emits judgments and errors, keyed by CV. |
+| `closure-pass-constant-fold` | One pass per crate. Each is independently testable. |
+| `closure-pass-dce` | Dead code elimination. |
+| `closure-pass-rename` | SIMPLE/ADVANCED renaming. |
+| `closure-pass-inline` | Function inlining. |
+| `closure-pass-treeshake` | Module-level tree shaking. |
+| `closure-pass-collapse-properties` | ADVANCED-mode property collapsing. |
+| `closure-pass-remove-unused-vars` | Self-explanatory. |
+| `closure-pass-fold-control-flow` | Branch elimination, unreachable code removal. |
+| `closure-pass-pipeline` | Pass scheduler. Orders passes, tracks CV contributions, runs to fixed point where appropriate. |
+| `closure-emitter` | `javascript-ast::Program → String`. |
+| `closure-source-map` | Walks the CV chain to produce a standard source-map v3. |
+| `closure-cli` | The `closurec` binary. Argument parsing, file I/O, error reporting. |
+
+Each pass crate is its own PR. The pipeline scheduler is its own PR. Reorderings,
+new passes, and disabling passes are all configuration changes — no code change
+required for users.
+
+## Backend-agnostic invariants (the V8-reuse contract)
+
+The `javascript-ast` crate is the contract between the frontend and any backend.
+Every CLOC-series spec that touches the AST must respect these invariants. They
+exist because the same AST will later feed the V8-in-Rust clone.
+
+1. **No backend types in AST nodes.** The AST does not import from
+   `closure-*`, `type-sidecar`, IR crates, bytecode crates, or anything specific
+   to one consumer. The AST imports only from `javascript-tokens` and
+   `correlation-vector`.
+
+2. **Every node carries a CV ID, not a span.** Spans live in CV `Origin` records
+   in a parallel log. Nodes hold `CvId` (lightweight, copyable). This keeps node
+   structs small and makes the CV log the single source of truth for provenance.
+
+3. **No mutation in the public surface.** All transformations produce new trees.
+   In-place mutation makes CV reasoning much harder; we rule it out. (Internally,
+   builders may mutate during construction — they expose immutable trees.)
+
+4. **Version tag on `Program`, not on every node.** Nodes that exist in multiple
+   ES versions look the same; nodes that are version-gated (e.g., decorators)
+   simply do not appear in the AST when parsing an older version. The `Program`
+   root records which `EsVersion` produced the tree.
+
+5. **No type information in the AST.** Types live in the sidecar, keyed by CV.
+   This is the JSDoc/TS interchangeability principle: the AST is type-blind.
+
+6. **No optimization metadata in the AST.** "This is constant," "this is dead,"
+   "this was inlined" — all of these live in CV contributions, not on nodes. An
+   AST node is only the syntactic shape.
+
+These invariants are what makes the V8 clone reuse possible without copy-and-edit
+divergence. They are also what makes the Closure Compiler clone debuggable — the
+AST is small and language-shaped, and all the optimizer's "magic" is in the CV
+log next to it.
+
+## Correlation vector plumbing (summary; details in CLOC03)
+
+The CV log is created at the start of a compile and shared across every package.
+Every artifact participates:
+
+- The lexer calls `cv.create(Origin{source, location: "line:col"})` for every
+  token. `CvId` is stored on the token.
+- The parser inherits each token's `CvId` onto the AST node that consumes it. For
+  nodes built from multiple tokens, it calls `cv.merge(parents)` to create a new
+  ID with multiple parents.
+- The typechecker calls `cv.contribute(node_id, Contribution{source:
+  "typechecker", tag: "judged", meta: {...}})` for every node it judges.
+- Every pass calls `cv.contribute(...)` on nodes it inspects. Passes that remove
+  nodes call `cv.delete(node_id)`. Passes that synthesize new nodes call
+  `cv.create` with a synthetic origin.
+- The emitter records, for every byte it writes, which `CvId` produced it.
+- The source-map generator walks the CV log backwards to find each output byte's
+  root `Origin` (file:line:col) and emits source-map v3 mappings.
+
+The CV log can be turned off in production (the `enabled` flag); IDs are still
+allocated but no contributions are stored, so passes incur near-zero overhead.
+
+## Versioning the JS frontend
+
+Per the user's directive: **a single versioned package**. `javascript-lexer` and
+`javascript-parser` each expose a constructor that takes an `EsVersion` enum.
+Default is the latest (`EsVersion::Es2025`). The grammar tree under
+`code/grammars/ecmascript/` (already complete) backs every version.
+
+```rust
+let lexer = create_javascript_lexer(source, EsVersion::Es2025)?;
+let ast   = parse_javascript(source, EsVersion::Es5)?;
+```
+
+We do **not** split into one crate per ES version. The grammar files already
+encode the version boundary; the Rust packages just dispatch on the enum.
+
+## Specs in the CLOC series
+
+This series will grow as the project does. The initial set:
+
+| Spec | Title |
+| --- | --- |
+| **CLOC01** | This document — overview, pipeline, invariants. |
+| **CLOC02** | `javascript-ast` design — node types, CV, version tag, backend-agnostic contract. |
+| **CLOC03** | Correlation-vector plumbing through the JS pipeline (lexer → parser → passes → emitter). |
+| CLOC04 | `type-sidecar` format — the JSDoc/TS lingua franca. |
+| CLOC05 | JSDoc sub-pipeline — grammar, lexer/parser, types extractor. |
+| CLOC06 | Pass interface contract — what every `closure-pass-*` crate must implement. |
+| CLOC07 | Source-map generation from the CV log. |
+| CLOC08 | `closurec` CLI surface — flags, modes, error reporting. |
+
+CLOC01-03 are foundational and land first. CLOC04-08 follow as their respective
+sub-pipelines are scheduled.
+
+## Staged PR plan
+
+Per `feedback_smaller_prs` and `feedback_parallel_pr_workflow`:
+
+**Stage 0 — Foundational specs (sequential, tiny PRs):**
+- PR: CLOC01 (this doc)
+- PR: CLOC02
+- PR: CLOC03
+
+**Stage 1 — JS frontend fix-up (parallel after CLOC02-03 land):**
+- PR: Retire `code/grammars/javascript.{tokens,grammar}` stubs.
+- PR: Create `javascript-tokens` crate.
+- PR: Create `javascript-ast` crate, no CV plumbing yet (just the types).
+- PR: Plumb CV through `javascript-lexer` (every token gets a `CvId`).
+- PR: Plumb CV through `javascript-parser`, switch output to `javascript-ast`.
+- PR: Default `EsVersion` to `Es2025`; remove the empty-string "generic" mode.
+
+**Stage 2 — Sidecar + JSDoc (parallel after Stage 1):**
+- PRs per CLOC04 and CLOC05.
+
+**Stage 3 — Closure passes (massively parallel):**
+- One PR per pass crate.
+- PR for `closure-pass-pipeline` scheduler.
+- PR for `closure-typechecker`.
+
+**Stage 4 — Output:**
+- PR: `closure-emitter`.
+- PR: `closure-source-map`.
+- PR: `closure-cli` (the `closurec` binary).
+
+**Stage 5 — TypeScript sub-pipeline (deferred to here):**
+- Mirror of Stage 1 but for TS, emitting into the same `type-sidecar` format.
+
+Estimated total: 40-50 small PRs. Most of Stages 2-4 run in parallel. Stage 1 is
+the only one that bottlenecks the rest.
+
+## What this spec does **not** cover
+
+- Specific opcode-level optimization algorithms — those live in each
+  `closure-pass-*` spec (TBD).
+- The exact wire format of the type sidecar — CLOC04.
+- The pass interface in Rust trait form — CLOC06.
+- The `closurec` CLI ergonomics — CLOC08.
+
+This is the map. The territory comes next.

--- a/code/specs/CLOC02-javascript-ast.md
+++ b/code/specs/CLOC02-javascript-ast.md
@@ -1,0 +1,468 @@
+# CLOC02 — `javascript-ast`: Backend-Agnostic, CV-Bearing JavaScript AST
+
+## Why this crate is the most important one to get right
+
+Every other crate in the CLOC series consumes or produces `javascript-ast`.
+Closure passes consume it. The typechecker consumes it. The emitter consumes it.
+The JSDoc types extractor walks it to find comment anchors. The future V8 clone
+will lower it to bytecode.
+
+Because so many consumers depend on it, the AST has to be:
+
+1. **Small.** Node structs hold the syntactic shape and nothing else.
+2. **Backend-agnostic.** No type info, no optimization metadata, no IR opcodes,
+   no spans — those live in adjacent stores keyed by CV.
+3. **Immutable on the public surface.** Passes return new trees, not mutated
+   trees. CV reasoning depends on this.
+4. **Version-aware at the root only.** Per-node version tags would bloat every
+   node; the `Program` root records `EsVersion` and that's enough.
+5. **Stable.** Once a node variant lands, it does not change shape without a CLOC
+   amendment spec. Downstream crates can rely on the schema.
+
+This spec defines the crate's public surface. Implementation details (how nodes
+are stored in memory, how interning works, whether `Box` vs `Arc`) are
+implementation notes at the end.
+
+## Crate location
+
+```text
+code/packages/rust/javascript-ast/
+  BUILD
+  BUILD_windows
+  CHANGELOG.md
+  Cargo.toml
+  README.md
+  required_capabilities.json
+  src/
+    lib.rs
+    program.rs
+    statement.rs
+    expression.rs
+    declaration.rs
+    pattern.rs
+    class.rs
+    module.rs
+    literal.rs
+    version.rs
+```
+
+Crate name: `coding-adventures-javascript-ast` (matching the existing repo
+naming convention for `coding-adventures-javascript-lexer` etc.).
+
+## Dependencies (the entire whitelist)
+
+The AST crate may depend only on:
+
+- `coding-adventures-javascript-tokens` — for `TokenKind` constants used in
+  binary operator enums and similar.
+- `coding-adventures-correlation-vector` — for `CvId`.
+- `serde` + `serde_json` — only for `Serialize` / `Deserialize` derives on every
+  node. (Sidecar format and IDE tooling both need round-trippable JSON.)
+
+It must **not** depend on:
+- Any `closure-*` crate.
+- The `type-sidecar` crate.
+- Any IR or bytecode crate.
+- The `lexer` or `parser` crates (those depend on it, not the other way).
+- Any string-interning crate (we use plain `String` for v1; if interning becomes
+  necessary later, it lives behind an opaque `Symbol` type without leaking the
+  intern table).
+
+Dependency cycles in the package graph will get caught by `cargo build
+--workspace` per the repo's standard checks; this whitelist is a design
+constraint above and beyond what the compiler can enforce.
+
+## The `CvId` field
+
+Every node — every single one, no exceptions — has a `cv: CvId` field. `CvId`
+is a copy-cheap newtype defined in `correlation-vector`. The convention:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Identifier {
+    pub cv: CvId,
+    pub name: String,
+}
+```
+
+The `cv` field is conventionally first so that any pass walking nodes via
+reflection or pattern matching can pluck the CV off uniformly. Nodes wrapping
+other nodes (e.g., `BinaryExpression`) get their own `CvId` plus their children
+keep theirs.
+
+The CV log itself lives outside the AST. Nodes carry only the ID. Spans, parent
+chains, and contributions are queried from the log by ID. This is what keeps
+nodes small.
+
+## The root: `Program`
+
+```rust
+pub struct Program {
+    pub cv: CvId,
+    pub version: EsVersion,
+    pub source_type: SourceType,   // Script or Module
+    pub body: Vec<ProgramElement>,
+    pub hashbang: Option<Hashbang>, // ES2023+
+}
+
+pub enum SourceType {
+    Script,
+    Module,
+}
+
+pub enum ProgramElement {
+    Statement(Statement),
+    ImportDeclaration(ImportDeclaration),     // module-only
+    ExportDeclaration(ExportDeclaration),     // module-only
+    FunctionDeclaration(FunctionDeclaration),
+    ClassDeclaration(ClassDeclaration),
+}
+
+pub struct Hashbang {
+    pub cv: CvId,
+    pub content: String,  // text after #! up to (but excluding) newline
+}
+```
+
+`SourceType` is filled by the parser based on caller hint or shebang/file
+extension. The Closure Compiler scheduler needs this for cross-module passes;
+the V8 clone needs it because module and script have different top-level scoping
+rules.
+
+## Version
+
+```rust
+pub enum EsVersion {
+    Es1,
+    Es3,
+    Es5,
+    Es2015,
+    Es2016,
+    Es2017,
+    Es2018,
+    Es2019,
+    Es2020,
+    Es2021,
+    Es2022,
+    Es2023,
+    Es2024,
+    Es2025,
+}
+```
+
+`EsVersion` is on `Program`, **not** on individual nodes. The parser refuses to
+emit nodes whose variants are not legal at the requested version (e.g.,
+`Decorator` cannot appear in an `Es5` program). Downstream consumers should
+generally not branch on `version`; they should assume "every variant that
+appears is legal." The version tag exists for:
+
+- Emitters that may need to target a specific version (downleveling is out of
+  scope for the MVP, but the field lets future passes do it).
+- Telemetry and error messages.
+- Round-tripping (a tree that round-trips through serialization knows where it
+  came from).
+
+## Statements
+
+```rust
+pub enum Statement {
+    Block(BlockStatement),
+    Empty(EmptyStatement),
+    Expression(ExpressionStatement),
+    If(IfStatement),
+    For(ForStatement),
+    ForIn(ForInStatement),
+    ForOf(ForOfStatement),              // ES2015+
+    ForAwaitOf(ForAwaitOfStatement),    // ES2018+
+    While(WhileStatement),
+    DoWhile(DoWhileStatement),
+    Switch(SwitchStatement),
+    Try(TryStatement),                  // ES3+
+    Throw(ThrowStatement),              // ES3+
+    Return(ReturnStatement),
+    Break(BreakStatement),
+    Continue(ContinueStatement),
+    Labeled(LabeledStatement),
+    With(WithStatement),
+    Debugger(DebuggerStatement),        // ES5+
+    Variable(VariableDeclaration),      // var
+    Lexical(LexicalDeclaration),        // let / const, ES2015+
+    Using(UsingDeclaration),            // ES2025+
+    AwaitUsing(AwaitUsingDeclaration),  // ES2025+
+}
+```
+
+Each variant struct follows the same shape: `cv: CvId` plus fields for the
+construct's children. Example:
+
+```rust
+pub struct IfStatement {
+    pub cv: CvId,
+    pub test: Box<Expression>,
+    pub consequent: Box<Statement>,
+    pub alternate: Option<Box<Statement>>,
+}
+```
+
+`Box` because statements are recursive; we don't want unbounded enum size.
+
+## Expressions
+
+The expression tree mirrors the precedence cascade documented in
+`versioned-ecmascript-typescript-grammars.md` Section 7. A flat enum keeps the
+shape simple even though precedence is encoded in the parser's choice of which
+variant to produce.
+
+```rust
+pub enum Expression {
+    // Primary
+    This(ThisExpression),
+    Super(SuperExpression),              // ES2015+
+    Identifier(Identifier),
+    PrivateName(PrivateName),            // ES2022+ (only valid inside class)
+    Literal(Literal),
+    Template(TemplateLiteral),           // ES2015+
+    TaggedTemplate(TaggedTemplate),      // ES2015+
+    ArrayLiteral(ArrayLiteral),
+    ObjectLiteral(ObjectLiteral),
+    Function(FunctionExpression),
+    Arrow(ArrowFunction),                // ES2015+
+    Class(ClassExpression),              // ES2015+
+    Regex(RegexLiteral),                 // ES3+
+    NewTarget(NewTarget),                // ES2015+
+    ImportMeta(ImportMeta),              // ES2020+
+    Parenthesized(ParenthesizedExpression),
+
+    // Operators
+    Unary(UnaryExpression),
+    Update(UpdateExpression),         // ++/-- prefix or postfix
+    Binary(BinaryExpression),
+    Logical(LogicalExpression),       // &&, ||, ??
+    Assignment(AssignmentExpression),
+    Conditional(ConditionalExpression),
+    Sequence(SequenceExpression),     // a, b, c
+
+    // Access
+    Member(MemberExpression),
+    OptionalChain(OptionalChainExpression),  // ES2020+
+
+    // Calls
+    Call(CallExpression),
+    New(NewExpression),
+    Import(ImportCallExpression),   // dynamic import, ES2020+
+
+    // Iteration / control
+    Yield(YieldExpression),         // ES2015+
+    Await(AwaitExpression),         // ES2017+
+    Spread(SpreadElement),
+}
+```
+
+Selected variant structs (others follow the same pattern):
+
+```rust
+pub struct BinaryExpression {
+    pub cv: CvId,
+    pub op: BinaryOperator,    // a typed enum: Plus, Minus, Equals, ...
+    pub left: Box<Expression>,
+    pub right: Box<Expression>,
+}
+
+pub struct LogicalExpression {
+    pub cv: CvId,
+    pub op: LogicalOperator,   // And, Or, NullishCoalescing
+    pub left: Box<Expression>,
+    pub right: Box<Expression>,
+}
+
+pub struct CallExpression {
+    pub cv: CvId,
+    pub callee: Box<Expression>,
+    pub arguments: Vec<Argument>,  // Argument may be a SpreadElement
+    pub optional: bool,            // true for `f?.(...)` chains, ES2020+
+}
+
+pub struct MemberExpression {
+    pub cv: CvId,
+    pub object: Box<Expression>,
+    pub property: MemberProperty,
+    pub optional: bool,            // true for `a?.b`, ES2020+
+}
+
+pub enum MemberProperty {
+    Identifier(Identifier),     // a.b
+    Private(PrivateName),       // a.#b, ES2022+
+    Computed(Box<Expression>),  // a[expr]
+}
+```
+
+The `BinaryOperator` and `LogicalOperator` enums are exhaustive over every
+operator from ES1 through ES2025. They live in `expression.rs`.
+
+## Declarations and bindings
+
+```rust
+pub struct VariableDeclaration {
+    pub cv: CvId,
+    pub declarations: Vec<VariableDeclarator>,
+}
+
+pub struct VariableDeclarator {
+    pub cv: CvId,
+    pub id: BindingPattern,
+    pub init: Option<Expression>,
+}
+
+pub struct LexicalDeclaration {
+    pub cv: CvId,
+    pub kind: LexicalKind,          // Let or Const
+    pub declarations: Vec<VariableDeclarator>,
+}
+
+pub enum BindingPattern {
+    Identifier(Identifier),
+    Object(ObjectPattern),     // ES2015+
+    Array(ArrayPattern),       // ES2015+
+}
+```
+
+`UsingDeclaration` and `AwaitUsingDeclaration` mirror `LexicalDeclaration` but
+only accept `BindingPattern::Identifier` (the spec disallows destructuring there).
+
+## Classes and modules
+
+These are large enough to live in their own files (`class.rs`, `module.rs`).
+The variants are exhaustive over the union of ES2015 through ES2025 class and
+module syntax: heritage, static methods, accessors, fields, private members,
+static blocks, decorators, namespace imports, default exports, re-exports, and
+import attributes.
+
+The exact shape is mechanical given the grammar files under
+`code/grammars/ecmascript/`. We omit the full listing here; the rule is "one
+variant per grammar production, every variant carries `cv`."
+
+## Literals
+
+```rust
+pub enum Literal {
+    Null(NullLiteral),
+    Boolean(BooleanLiteral),
+    Number(NumberLiteral),
+    BigInt(BigIntLiteral),         // ES2020+
+    String(StringLiteral),
+}
+
+pub struct NumberLiteral {
+    pub cv: CvId,
+    pub value: f64,
+    pub raw: String,               // preserves "0xFF" vs "255", "1_000" vs "1000"
+}
+```
+
+`raw` is preserved so the emitter can round-trip literals byte-for-byte when no
+pass has touched them. Constant-folding passes that *do* touch literals will
+discard `raw` and re-render from `value`.
+
+## Side stores keyed by CV
+
+Things that look like they should be on nodes, but live elsewhere:
+
+| Concept | Where it lives | Key |
+| --- | --- | --- |
+| Source span (file, line, col, byte offset) | `correlation-vector` `Origin` entries | `CvId` |
+| Parent / lineage | `correlation-vector` log | `CvId` |
+| Pass contributions ("renamed", "inlined", ...) | `correlation-vector` log | `CvId` |
+| Resolved type | `type-sidecar::Sidecar` | `CvId` |
+| Reaching definitions, dataflow facts | Pass-internal state, keyed by `CvId` | `CvId` |
+| Comment attachments (JSDoc) | `type-sidecar` after JSDoc extraction | `CvId` |
+| Symbol table entries | `closure-typechecker` state | `CvId` |
+
+Every consumer that needs to attach data to nodes does so by keying on `CvId`
+in its own store. The AST stays clean.
+
+## Immutability and builder helpers
+
+The public types are all `pub struct` with `pub` fields, but the convention is
+that **consumers do not mutate them in place**. Passes return new trees by
+calling builder functions. Each variant gets a builder:
+
+```rust
+impl BinaryExpression {
+    pub fn new(cv: CvId, op: BinaryOperator, left: Expression, right: Expression) -> Self {
+        Self { cv, op, left: Box::new(left), right: Box::new(right) }
+    }
+}
+```
+
+Builders compute nothing; they just box children. They exist for clarity and to
+make pass code read top-down.
+
+For larger trees, a `walk` module exposes a visitor pattern (visit + visit_mut)
+that recurses through every node. Passes use this to find nodes of interest.
+The walker is the canonical way to traverse — passes never hand-roll recursion.
+
+## Construction by the parser
+
+The parser builds the AST as it reduces grammar productions. For each
+production, it:
+
+1. Collects the token spans involved.
+2. Calls `cv.create(Origin{...})` or `cv.merge(parent_ids)` to get a fresh
+   `CvId` for the new node.
+3. Constructs the node struct with that `cv` plus child nodes (whose `CvId`s
+   are already set).
+
+The parser depends on `javascript-ast` and `correlation-vector`. The AST does
+not depend on the parser.
+
+## Serialization
+
+Every node derives `Serialize` and `Deserialize`. This is required for:
+
+- IDE tooling (LSP) to ship trees to other processes.
+- Snapshot tests in passes (golden ASTs as JSON files).
+- Sidecar test fixtures.
+- Debugging via `closurec --dump-ast`.
+
+Round-tripping is byte-identical for any tree built from valid input.
+
+## Testing strategy
+
+The crate ships with three test layers:
+
+1. **Construction tests** — for every variant, build it programmatically and
+   assert field values. Pure unit, no parser involved.
+2. **Serde round-trip tests** — for every variant, serialize and deserialize,
+   assert equality.
+3. **Visitor coverage tests** — walk a small synthetic tree and assert that
+   every node is visited exactly once.
+
+Per the repo's >80% coverage rule (`feedback_repo_standards`), AST coverage
+should land at 95%+ since it's a library crate.
+
+## What this spec does **not** cover
+
+- The exact set of grammar-production-to-node mappings — that's parser internal.
+- The visitor trait's full method list — that's an implementation detail of
+  `walk.rs`, locked once the variants stabilize.
+- The TypeScript AST. TS will have its own crate (`typescript-ast`) with its own
+  spec, sharing only the type-sidecar format. JS and TS ASTs are separate types.
+- The `javascript-tokens` crate. That's a one-paragraph spec eventually (token
+  kind enum + version tag + span type); it lands as part of the Stage 1 fix-up.
+- Implementation choices around `Box` vs `Arc` vs arena allocation. The default
+  is `Box` for v1. If profiling shows allocation pressure, we'll revisit, but
+  the public API does not depend on the choice.
+
+## Open questions
+
+These are flagged for follow-up specs, not blockers for landing the AST crate:
+
+1. **Trivia.** Comments are not currently AST nodes; they live in the source via
+   spans. JSDoc extraction reads them directly from source by CV. Is that
+   enough? Or do we need an explicit `Comment` node attached to nearby
+   statements? (Closure Compiler's JSDoc consumer needs the comments anchored
+   to the *next* declaration. CV resolution can do that.)
+2. **Regex internals.** Today `RegexLiteral` stores `pattern: String` and
+   `flags: String`. A future spec may add a parsed regex AST. Not blocking.
+3. **JSX.** Out of scope for the MVP. Will get its own variants under a feature
+   flag if added later.

--- a/code/specs/CLOC03-correlation-vector-plumbing.md
+++ b/code/specs/CLOC03-correlation-vector-plumbing.md
@@ -1,0 +1,304 @@
+# CLOC03 — Correlation-Vector Plumbing Through the JavaScript Pipeline
+
+## What this spec locks down
+
+The correlation vector (CV) is what makes the Closure Compiler clone debuggable
+and the V8 clone (later) traceable. This spec defines, for every stage in the
+JavaScript pipeline, exactly what CV operations happen, on what data, and what
+contributions are appended. It does **not** describe the CV crate itself
+(`correlation-vector` already exists and is documented in its own README); it
+describes how every CLOC stage **uses** that crate.
+
+The structural invariant from this spec onward, applied with no exceptions:
+
+> Every byte of input text is reachable from at least one output byte via the
+> CV log. Conversely, every byte of output text is reachable from at least one
+> root `Origin` (file, line, column). Any pass that breaks this invariant is a
+> bug in the pass, not a feature.
+
+## The CV crate, in two sentences
+
+`correlation-vector` provides a `CorrelationLog` that issues `CvId`s and stores
+`Contribution`s appended by stages. IDs are minted via `create(Origin)` (for
+roots), `derive(parent_id, Origin)` (for one-parent children), or
+`merge(parents, Origin)` (for nodes built from multiple inputs). Contributions
+record what a named stage did to an entity: `contribute(id, Contribution{source,
+tag, meta})`.
+
+The log has an `enabled` flag. When `false`, IDs are still issued but no
+contributions or origins are stored. This is the production fast path — every
+stage runs the same code; only the storage gets dropped.
+
+## Where the log lives
+
+A single `CorrelationLog` is created at the start of a compile by `closure-cli`
+(or by the V8-clone's driver) and passed by `&mut` reference into every stage.
+Stages do not create their own logs. They do not buffer contributions; they
+append directly.
+
+```rust
+// closure-cli pseudocode
+let mut cv = CorrelationLog::new();
+cv.set_enabled(opts.trace);
+
+let program = parse_javascript_with_cv(&source, opts.version, &mut cv)?;
+let typed   = run_typechecker(program, &sidecar, &mut cv)?;
+let passes  = run_pass_pipeline(typed, &mut cv)?;
+let bytes   = emit_with_cv(&passes, &mut cv)?;
+let map     = source_map_from_log(&bytes, &cv);
+```
+
+The `&mut cv` thread is intentional: it is the *one* mutable thing in the
+compile. The AST, sidecar, and pass outputs are all immutable.
+
+## Stage 1 — Lexer (`javascript-lexer`)
+
+For every token the lexer emits, it calls `cv.create(Origin)` with:
+
+```rust
+Origin {
+    source:   <filename or "stdin">,
+    location: format!("{}:{}-{}", line, col_start, col_end),
+    timestamp: None,
+    meta:     {} // empty by default; passes that re-lex may add tags
+}
+```
+
+The resulting `CvId` is stored on the token. Today's `lexer::Token` carries a
+span; after this spec lands, it also carries `cv: CvId`. The span field stays
+(for debugging) but `cv` is the authoritative identifier.
+
+The lexer appends **no contributions**. Lexing is the act of *creation*; there
+is nothing yet to contribute about.
+
+### Skipped trivia
+
+Whitespace and comments are produced by the lexer's skip patterns. They still
+get a `CvId` each, but they are not attached to tokens. The JSDoc extractor
+(CLOC05) walks the log to find comment-origin IDs and pairs them with the
+nearest declaration's CV.
+
+## Stage 2 — Parser (`javascript-parser`)
+
+The parser reduces token sequences into `javascript-ast` nodes. For each
+production:
+
+1. Collect the `CvId`s of the consumed tokens.
+2. Mint a node `CvId` via `cv.merge(parent_ids, Origin{...})`. The `Origin`
+   on a parsed node uses the *source* of the leftmost token and a `location`
+   computed from the span union.
+3. Store that `CvId` on the constructed `javascript-ast` node.
+4. Append one contribution: `Contribution{source: "parser", tag: "constructed",
+   meta: {"rule": "<grammar_rule_name>"}}`.
+
+The `tag: "constructed"` contribution is the parser's way of recording *which
+grammar production* built the node. This is invaluable for debugging the
+parser, but it's also useful at runtime: a CLI flag like `closurec --dump-cv`
+can print the production for each node.
+
+### Synthetic semicolons (ASI)
+
+Automatic semicolon insertion produces tokens the lexer did not emit. For each
+inserted semicolon, the parser calls `cv.create(Origin{source: "asi", location:
+"<position>", meta: {"reason": "newline" | "eof" | "restricted"}})`. The
+synthetic semicolon's `CvId` is then used in the production.
+
+The contribution `tag: "asi-inserted"` is appended. Debuggers and source maps
+that hit an ASI position can show the user where the JavaScript engine would
+have placed a semicolon.
+
+## Stage 3 — Typechecker (`closure-typechecker`)
+
+For every node it judges:
+
+```rust
+cv.contribute(node.cv, Contribution {
+    source: "typechecker",
+    tag:    "judged",
+    meta:   json!({
+        "type":     "<resolved-type>",      // optional
+        "narrowed": [...],                  // narrowing applied
+        "errors":   [...]                   // type errors found here
+    }),
+});
+```
+
+The typechecker also writes a parallel `Sidecar` entry keyed by `node.cv`
+(see CLOC04). The CV contribution is the *audit trail*; the sidecar entry is
+the *result*. A consumer can ask "what's the type of node X?" by looking up X
+in the sidecar; the CV contribution explains *why* that type was chosen.
+
+## Stage 4 — Optimization passes (the `closure-pass-*` family)
+
+Every pass declares a `pass_name: &'static str` (e.g., `"dce"`, `"rename"`,
+`"constant-fold"`). For every node a pass touches, it appends a contribution
+keyed by that name.
+
+### When a pass keeps a node unchanged
+
+A pass that visits a node but decides to leave it alone appends *nothing*. CV
+entries are for changes, not for visits. Otherwise the log would balloon.
+
+### When a pass mutates a node's shape
+
+When a pass produces a new node from old ones, the new node's `CvId` is minted
+via `cv.merge(old_ids, Origin{source: "<pass_name>", location: "synthesized",
+meta: {...}})`. The contribution `tag: "synthesized"` is appended.
+
+Example: constant folding of `2 + 3` into `5`:
+
+```rust
+let original_left  = expr.left.cv;
+let original_right = expr.right.cv;
+let original_op    = expr.cv;
+
+let new_cv = cv.merge(
+    &[original_left, original_right, original_op],
+    Origin {
+        source:   "constant-fold",
+        location: "synthesized",
+        meta:     json!({ "from": "BinaryExpression", "to": "NumberLiteral" }),
+        timestamp: None,
+    },
+);
+
+cv.contribute(new_cv, Contribution {
+    source: "constant-fold",
+    tag:    "folded",
+    meta:   json!({ "value": 5, "op": "+" }),
+});
+```
+
+The CV of the original tokens `2`, `+`, `3` remains in the log — they are still
+reachable as parents of `new_cv`. The source map can therefore still attribute
+the `5` byte back to the original source range.
+
+### When a pass deletes a node
+
+```rust
+cv.contribute(deleted_node.cv, Contribution {
+    source: "dce",
+    tag:    "deleted",
+    meta:   json!({ "reason": "unreachable" | "unused" | "side-effect-free" }),
+});
+cv.delete(deleted_node.cv);  // marks the entity as removed; log entries persist
+```
+
+`delete` does *not* remove the node's CV record from the log. It marks it as
+deleted so traversals can distinguish "still present in the tree" from
+"removed by a pass." The contribution explains why.
+
+### When a pass synthesizes a new node from nothing
+
+Rare, but happens (e.g., a runtime guard insertion). The pass calls
+`cv.create(Origin{source: "<pass_name>", location: "synthesized", meta: ...})`
+to get a root `CvId` with no parents. Source maps will resolve such bytes to
+the pass that created them, not to any source line — which is correct: the
+output byte has no source-line ancestor.
+
+### Pass contribution conventions
+
+| Pass | Common tags |
+| --- | --- |
+| `constant-fold` | `folded`, `simplified` |
+| `dce` | `deleted` |
+| `rename` | `renamed` (meta: `{from, to}`) |
+| `inline` | `inlined` (meta: `{callee_cv}`), `outlined` |
+| `treeshake` | `deleted` (meta: `{reason: "unexported"}`) |
+| `collapse-properties` | `flattened` (meta: `{from_path, to_name}`) |
+| `fold-control-flow` | `branch-eliminated`, `dead-arm-removed` |
+| `remove-unused-vars` | `deleted` |
+
+Tags are conventions, not enforced. Any pass can append any tag; consistency is
+maintained by code review and the pass's own README.
+
+## Stage 5 — Emitter (`closure-emitter`)
+
+The emitter walks the optimized AST and produces a byte stream. For every
+contiguous range of output bytes that come from a single AST node, the emitter
+records a mapping `(byte_offset_start, byte_offset_end, node.cv)` in an output
+side-table.
+
+The emitter itself appends one contribution per node: `Contribution{source:
+"emitter", tag: "emitted", meta: {"start": <byte>, "end": <byte>}}`. This is
+both useful for debugging and used directly by the source-map generator.
+
+The emitter does **not** call `cv.create` or `cv.merge`. It is the last
+read-only pass; no new entities are born here.
+
+## Stage 6 — Source map generator (`closure-source-map`)
+
+The source map is built by walking the emitter's byte-to-CV side-table:
+
+```text
+for each (byte_range, cv_id) in emitter_output:
+    root = cv.resolve_root(cv_id)
+    // root_origin = (source: "app.js", location: "42:13-42:18")
+    add_source_map_segment(byte_range, root.source, root.line, root.column)
+```
+
+`cv.resolve_root(id)` walks parents of `id` until it hits an entity whose
+`Origin.source` is a real file (not `"asi"`, `"constant-fold"`, etc.). Multiple
+parents (from `merge`) are walked depth-first; the leftmost ancestor wins for
+the primary mapping. The source map v3 `names` field optionally records the
+chain.
+
+### Multi-source mappings
+
+When a single output byte has multiple source-byte ancestors (e.g., a folded
+`5` that came from `2 + 3`), the source map can either:
+
+- (default) Map to the leftmost ancestor (`2`).
+- (`--source-map-multi`) Emit additional `extensions` entries (per the source
+  map v3 extension spec) listing all ancestors.
+
+The default keeps the source map compatible with every existing tool. The
+multi flag is for advanced debugging.
+
+## Side: the `enabled` fast path
+
+In production, `closurec --no-trace` sets `cv.set_enabled(false)`. Then:
+
+- `cv.create`, `cv.derive`, `cv.merge` still return IDs (counters increment),
+  so node structs remain shape-identical.
+- `cv.contribute` becomes a no-op.
+- `cv.delete` becomes a no-op.
+- The log stays empty; memory cost is just the counter state.
+
+The source map cannot be generated when tracing is off. `closurec` either
+warns and emits no map, or errors out if `--source-map` was passed explicitly
+alongside `--no-trace`.
+
+## What every CLOC PR must include
+
+This is the closing checklist that any CLOC-series PR touching a pipeline
+stage will be reviewed against:
+
+1. Does the stage take `&mut cv: CorrelationLog`?
+2. Does it create/derive/merge IDs for every entity it produces?
+3. Does it append contributions for every change?
+4. Does it never crash when `cv.enabled == false`?
+5. Is the contribution `source` field the stage's canonical name (e.g.,
+   `"dce"`, not `"dead_code_elimination"`)?
+6. Are tags from the conventional list, or — if not — documented in the
+   crate's README?
+7. Do tests assert at least one CV contribution for at least one transformation
+   the stage performs?
+
+If a PR fails any of these, it does not merge. The CV invariant is what makes
+this whole project worth doing; we do not let it rot.
+
+## Open questions
+
+1. **Log size in advanced mode.** A full advanced-mode Closure compile of a
+   large bundle can produce millions of contributions. We may need a streaming
+   log that writes to disk past a threshold. Not blocking for MVP; flagged for
+   CLOC04 sidecar work where the same scaling concern applies.
+2. **Cross-compile reuse.** If two compiles share a source file, can their
+   CV logs be merged for cross-compile analysis? The crate supports `merge` at
+   the log level; we will spec the exact merge semantics in a follow-up if and
+   when a cross-compile use case appears.
+3. **Pass-internal CV.** Some passes (e.g., inliner) need to track interior
+   dataflow state. Should that state use CV, or use a pass-local map keyed by
+   CV? Default is the latter (pass-local map). CV is for the durable lineage,
+   not for transient analysis state.


### PR DESCRIPTION
## Summary

Opens the **CLOC** series — a Rust reimplementation of Google's Closure
Compiler structured as a pipeline of small unix-style packages. Three
foundational specs land here, before any implementation code:

- **CLOC01 — Overview & pipeline architecture.** Why this project exists; the
  three sub-pipelines (JS frontend, JSDoc, TypeScript [deferred]) converging at
  `javascript-ast`; the closure pass family downstream; backend-agnostic
  invariants so the same AST can later feed a V8-in-Rust clone; the ~40–50
  small PR plan.
- **CLOC02 — `javascript-ast` design.** The contract between the frontend and
  every consumer. Every node carries `cv: CvId`; types and pass metadata live
  outside the AST in side stores keyed by CV. Public surface, dependency
  whitelist, serde requirements, 95%+ coverage target.
- **CLOC03 — Correlation-vector plumbing.** Stage-by-stage contract from lexer
  → parser → typechecker → optimization passes → emitter → source-map
  generator. Tag conventions per pass, the `enabled` fast path, a 7-item PR
  review checklist that every pipeline-stage PR will be graded against.

## Why this is spec-only

Per the repo's specs-first rule (`feedback_repo_standards`), no implementation
code lands until the contract is reviewed. The follow-up PRs (retire stub
grammars, scaffold `javascript-tokens` and `javascript-ast`, plumb CV through
the existing `javascript-lexer`/`javascript-parser`) all depend on these three
specs being agreed on.

## Test plan

- [ ] CLOC01 plan matches what `code/grammars/ecmascript/` and
      `code/grammars/typescript/` already provide (no fictional grammars).
- [ ] CLOC02 invariants are compatible with `correlation-vector`'s actual API
      (`Origin`, `Contribution`, `CvId`).
- [ ] CLOC03 stages cover every existing crate the JS pipeline already touches
      (`javascript-lexer`, `javascript-parser`) and the planned new crates
      (`javascript-ast`, `closure-pass-*`, `closure-emitter`,
      `closure-source-map`).
- [ ] Cross-reference with `versioned-ecmascript-typescript-grammars.md` —
      the version cascade in CLOC01 should match the grammar tree it consumes.

## What's next (after this lands)

1. **CLOC04** — type-sidecar format (the JSDoc/TS lingua franca).
2. **CLOC05** — JSDoc sub-pipeline.
3. **Stage 1 fix-up PRs in parallel:** retire stub grammars, scaffold
   `javascript-tokens` and `javascript-ast`, plumb CV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)