### PR TITLE
feat(mosaic-pkg-card): U29 — second userland package proof point

### DIFF
--- a/code/packages/mosaic-pkg-card/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-card/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.1.0
+
+Initial release. Exports a single Card component built from Box + Column + Text — primitives that are stable in every Mosaic backend today.
+
+This package is intentionally minimal: it's the smallest possible
+proof point for the UI29 userland-package architecture, demonstrating
+that:
+
+1. A `mosaic-package.toml` parses cleanly
+2. .mil/.mll/.msl source files compile end-to-end
+3. The component composes from kernel primitives only — no
+   bespoke Rust code in any backend
+
+A second userland package (mosaic-pkg-grid, #3647) exercises the
+richer kernel surface (For/If/HostTable). Card stays simple to make
+the architecture as easy to reason about as possible.

--- a/code/packages/mosaic-pkg-card/Cargo.toml
+++ b/code/packages/mosaic-pkg-card/Cargo.toml
@@ -1,0 +1,32 @@
+# Cargo.toml — smoke-test harness for mosaic-pkg-card.
+#
+# This package's primary deliverables are .mil / .mll / .msl source files
+# (consumed by mosaic-compile and downstream emitters), NOT a Rust crate.
+# The Cargo.toml exists ONLY to host an integration smoke test that runs
+# each source file through its respective compiler crate and asserts the
+# whole package round-trips at the language-frontend layer.
+#
+# `[workspace]` is empty so this Cargo project does NOT join the main
+# code/packages/rust workspace.  It lives at code/packages/mosaic-pkg-card
+# (outside the rust/ tree), is conceptually a Mosaic package (not a Rust
+# crate), and runs as a standalone Cargo project via `cargo test`.
+
+[workspace]
+# Intentionally empty: opt out of the parent workspace.
+
+[package]
+name        = "mosaic-pkg-card-smoke"
+version     = "0.1.0"
+edition     = "2021"
+description = "Smoke-test harness for the mosaic-pkg-card component package"
+publish     = false
+
+[dev-dependencies]
+mosmodel-compiler   = { path = "../rust/mosmodel-compiler" }
+moslayout-compiler  = { path = "../rust/moslayout-compiler" }
+mosstyle-compiler   = { path = "../rust/mosstyle-compiler" }
+toml                = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic-pkg-card/README.md
+++ b/code/packages/mosaic-pkg-card/README.md
@@ -1,0 +1,95 @@
+# mosaic-pkg-card
+
+The **simplest possible** Mosaic userland component package — a one-component
+package that proves the UI29 userland-package architecture works end-to-end
+TODAY, using only kernel primitives that have been stable in every backend
+since UI29 landed.
+
+## What it is
+
+A single `Card` component:
+
+```text
+Card
+├─ title   (text)
+├─ body    (text)
+└─ footer  (text)
+```
+
+No events.  No loops.  No conditionals.  No host tables.  Just three text
+slots, laid out as a titled panel and themed with a dark stylesheet.
+
+## What it proves
+
+The Mosaic project ships kernel primitives (`Box`, `Column`, `Row`, `Text`,
+`HostInput`, `If`, `For`, `HostTable`, …) and a three-language frontend
+(`.mil` for component interfaces, `.mll` for layout, `.msl` for style).  The
+UI29 spec promises that **userland packages can be authored on top of those
+primitives** without touching emitter code in any backend.
+
+`mosaic-pkg-card` is the smallest possible demonstration of that promise:
+
+| Layer                     | File                | Compiles via                |
+| ------------------------- | ------------------- | --------------------------- |
+| Package manifest          | `mosaic-package.toml` | TOML (UI29 §4.2 shape)    |
+| Component interface       | `src/Card.mil`      | `mosmodel-compiler`          |
+| Layout (kernel-only tree) | `src/Card.mll`      | `moslayout-compiler`         |
+| Dark theme                | `src/Card.dark.msl` | `mosstyle-compiler`          |
+
+The integration test `tests/package_compiles.rs` runs all four files
+through their compilers and asserts the resulting IR shape — see the test
+for the precise contract.
+
+## Relationship to mosaic-pkg-grid (#3647)
+
+The two packages divide the design space deliberately:
+
+- **`mosaic-pkg-grid`** pushes on the kernel's *expressive surface* — it
+  uses `For` to iterate over `viewport-rows`, `If` to switch between
+  display and edit cells, and `HostTable` / `HostInput` to delegate the
+  hard parts to the platform.  It's the test that the rich primitives
+  hold together as a system.
+- **`mosaic-pkg-card`** pushes on the *plumbing*.  By stripping the
+  component down to Box + Column + Text — three primitives that every
+  backend has shipped since UI29 day one — it isolates the question
+  "does the package architecture (manifest + .mil + .mll + .msl) actually
+  work?" from the question "do the advanced primitives all lower
+  correctly?"
+
+If Grid's smoke test ever regresses for kernel-primitive reasons, Card's
+should still pass — making Card a useful tripwire for distinguishing
+architecture-level breakage from primitive-level breakage.
+
+## Layout
+
+```text
+mosaic-pkg-card/
+├── mosaic-package.toml      # UI29 §4.2 manifest
+├── Cargo.toml               # standalone smoke-test crate (empty [workspace])
+├── README.md                # this file
+├── CHANGELOG.md
+├── src/
+│   ├── Card.mil             # interface — 3 text slots, 0 emits
+│   ├── Card.mll             # layout   — Column[card-root] of three Boxes
+│   └── Card.dark.msl        # theme    — 4 parts (root + title + body + footer)
+└── tests/
+    └── package_compiles.rs  # asserts the whole package compiles
+```
+
+## Running the smoke test
+
+```bash
+cd code/packages/mosaic-pkg-card
+cargo test
+```
+
+The smoke test is self-contained.  It reads each source file relative to
+`CARGO_MANIFEST_DIR`, calls the appropriate compiler crate (which it picks
+up from `../rust/<name>` via path dependencies), and asserts on the
+resulting IR shape rather than on any emitted string — that way the test
+keeps passing as backends evolve, as long as the language frontend stays
+true to its contracts.
+
+## License
+
+MIT OR Apache-2.0

--- a/code/packages/mosaic-pkg-card/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-card/mosaic-package.toml
@@ -1,0 +1,32 @@
+# mosaic-package.toml — manifest for mosaic-pkg-card.
+#
+# Conforms to the UI29 §4.2 package-manifest shape: a [package] table for
+# identity, [components] listing the publicly exported components, an empty
+# [dependencies] table (this package is built only from UI29 kernel
+# primitives — no other userland packages), and a [kernel] table declaring
+# the UI29 kernel revision the package targets.
+#
+# Why this package exists
+# -----------------------
+# mosaic-pkg-card is the *minimum-viable* userland package: a single Card
+# component composed entirely from Box + Column + Text — three kernel
+# primitives that have been stable in every Mosaic backend since UI29
+# landed.  It is intentionally simpler than its sibling mosaic-pkg-grid
+# (which exercises For / If / HostTable) so the package-architecture
+# plumbing (manifest, .mil compile, .mll compile, .msl compile) can be
+# audited in isolation.
+
+[package]
+name = "mosaic-pkg-card"
+version = "0.1.0"
+description = "A simple Card component built on UI29 kernel primitives — proves the architecture with the smallest possible package"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Card"]
+
+[dependencies]
+# no other packages — built only from UI29 kernel primitives
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic-pkg-card/src/Card.dark.msl
+++ b/code/packages/mosaic-pkg-card/src/Card.dark.msl
@@ -1,0 +1,49 @@
+// Card.dark.msl — dark-theme stylesheet for the Card component.
+//
+// Targets the four parts declared by Card.mll:
+//
+//   card-root    the outer Column wrapper — owns the surface fill,
+//                border, and padding around the whole card
+//   card-title   bold, brighter, larger — the visual anchor of the card
+//   card-body    body copy — softer, comfortable reading colour
+//   card-footer  muted caption-style metadata — quietest part of the card
+//
+// Palette
+// -------
+//   #2d2d30  surface fill, matches VS Code's elevated dark surface
+//   #3f3f46  hairline border, the same edge VS Code uses on panels
+//   #ffffff  primary title text — maximum contrast against #2d2d30
+//   #cccccc  body text — comfortable for paragraphs without being harsh
+//   #9d9d9d  caption / footer — clearly subordinate to body copy
+//
+// All units are explicit px values.  The Mosaic style grammar requires a
+// unit suffix on length values; bare numbers are reserved for unitless
+// properties (line-height, flex, etc.).
+
+style Card {
+  part card-root {
+    background:   #2d2d30 ;
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #3f3f46 ;
+    padding:      12px ;
+  }
+
+  part card-title {
+    color:          #ffffff ;
+    font-weight:    bold ;
+    font-size:      16px ;
+    padding-bottom: 8px ;
+  }
+
+  part card-body {
+    color:          #cccccc ;
+    font-size:      13px ;
+    padding-bottom: 8px ;
+  }
+
+  part card-footer {
+    color:     #9d9d9d ;
+    font-size: 11px ;
+  }
+}

--- a/code/packages/mosaic-pkg-card/src/Card.mil
+++ b/code/packages/mosaic-pkg-card/src/Card.mil
@@ -1,0 +1,30 @@
+// Card.mil — interface for a simple, display-only Card component.
+//
+// A Card is the simplest possible composite UI element: a titled,
+// captioned panel.  It has three text slots (title / body / footer) and
+// zero emits — Cards don't fire events, the host handles any wrapping
+// click/keyboard interaction itself by placing the Card inside an
+// actionable container.
+//
+// Why three slots and not one?
+// ----------------------------
+// A single `content: text` slot would force the host to embed visual
+// hierarchy in the string (e.g. via Markdown), which then has to be
+// parsed by every backend.  Splitting into title / body / footer lets
+// the .mll lay them out with backend-native semantics (font weight,
+// padding, color) and lets the .msl theme each region independently —
+// which is the entire point of the part system.
+//
+// Why no emits?
+// -------------
+// Cards are display surfaces.  Wrapping interaction (click to open a
+// detail view, etc.) belongs to the host's parent component, not the
+// Card itself — the same way an HTML <article> doesn't have an onClick
+// in the spec.  This keeps Card the simplest possible proof of the
+// userland-package shape.
+
+component Card {
+  slot title  : text ;
+  slot body   : text ;
+  slot footer : text ;
+}

--- a/code/packages/mosaic-pkg-card/src/Card.mll
+++ b/code/packages/mosaic-pkg-card/src/Card.mll
@@ -1,0 +1,48 @@
+// Card.mll — layout for the Card component.
+//
+// Decomposition (kernel primitives only — Box, Column, Text):
+//
+//   Column [ card-root ]            ← vertical stack, the outer themable part
+//     Box [ card-title ]            ← the title region (stylable)
+//       Text ( content: slot: title )
+//     Box [ card-body ]             ← the body region (stylable)
+//       Text ( content: slot: body )
+//     Box [ card-footer ]           ← the footer region (stylable)
+//       Text ( content: slot: footer )
+//
+// Why a Box around each Text and not just three Texts?
+// ----------------------------------------------------
+// mosstyle targets `part` names, and parts are attached to layout nodes
+// — typically containers, not leaf text nodes.  Wrapping each region in
+// a Box gives the .msl four independently styleable parts (root + title
+// + body + footer), which is what makes the component themable.  A bare
+// Text would force the theme onto the kernel Text primitive itself,
+// which leaks Card-shaped concerns into a kernel primitive.
+//
+// Why Column and not three Boxes stacked manually?
+// ------------------------------------------------
+// `Column` IS the kernel primitive for "stack vertically" — using it
+// directly is preferred over re-deriving vertical stacking from raw
+// Box positioning.  Every backend already knows how to lower Column
+// (UI29 kernel v1), so we get correct flex/stack behaviour on every
+// emitter for free.
+//
+// Every primitive used here (Box, Column, Text) is part of the UI29
+// kernel v1 surface that has shipped in every backend — there are no
+// `If` / `For` / `HostTable` / userland refs anywhere in this file.
+// That makes Card the cleanest possible proof point that a userland
+// package compiles end-to-end TODAY.
+
+layout Card {
+  Column [ card-root ] {
+    Box [ card-title ] {
+      Text ( content: slot: title )
+    }
+    Box [ card-body ] {
+      Text ( content: slot: body )
+    }
+    Box [ card-footer ] {
+      Text ( content: slot: footer )
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-card/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-card/tests/package_compiles.rs
@@ -1,0 +1,250 @@
+//! package_compiles — smoke test for the mosaic-pkg-card package.
+//!
+//! Mirrors the test in `mosaic-pkg-grid/tests/package_compiles.rs`, but
+//! pared down to the minimum that this package needs.  Card has exactly
+//! one component, no loops, no conditionals, no host-table references,
+//! and only kernel primitives that are stable in every backend — so the
+//! whole package SHOULD compile clean end-to-end.  If any of these
+//! assertions ever fails, it's a regression in the kernel-frontend
+//! pipeline (mosmodel / moslayout / mosstyle), not in this package.
+//!
+//! What this asserts
+//! -----------------
+//!   1. mosaic-package.toml parses as TOML and matches the §4.2 shape:
+//!      - [components].exports == ["Card"]
+//!      - [kernel].version    == "1"
+//!   2. src/Card.mil compiles via mosmodel_compiler::compile, and the
+//!      resulting interface has exactly three slots (title / body /
+//!      footer, all `text`) and zero emits.
+//!   3. src/Card.mll compiles via moslayout_compiler::compile against
+//!      the .mil interface descriptor, and the layout tree is:
+//!        Column [card-root]
+//!          Box [card-title]
+//!          Box [card-body]
+//!          Box [card-footer]
+//!   4. src/Card.dark.msl compiles via mosstyle_compiler::compile
+//!      against the .mll part map, and produces exactly four parts:
+//!      card-root / card-title / card-body / card-footer.
+//!   5. The expected source tree is on disk (belt-and-suspenders).
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Path helpers — anchor everything to the package root.
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn src_path(name: &str) -> PathBuf {
+    package_root().join("src").join(name)
+}
+
+fn read_source(name: &str) -> String {
+    let path = src_path(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest
+// ---------------------------------------------------------------------------
+
+#[test]
+fn manifest_declares_expected_exports() {
+    let manifest_src = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("manifest mosaic-package.toml must exist at the package root");
+
+    let value: toml::Value = toml::from_str(&manifest_src)
+        .expect("mosaic-package.toml must parse as valid TOML");
+
+    // [package].name
+    let name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("[package].name must be set");
+    assert_eq!(name, "mosaic-pkg-card", "[package].name mismatch");
+
+    // [package].version
+    let version = value
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[package].version must be set");
+    assert_eq!(version, "0.1.0", "[package].version must be 0.1.0 for the initial release");
+
+    // [components].exports
+    let exports = value
+        .get("components")
+        .and_then(|c| c.get("exports"))
+        .and_then(|e| e.as_array())
+        .expect("[components].exports must be an array");
+    let export_names: Vec<&str> = exports.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        export_names,
+        vec!["Card"],
+        "[components].exports must list exactly Card"
+    );
+
+    // [kernel].version
+    let kernel_version = value
+        .get("kernel")
+        .and_then(|k| k.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[kernel].version must be set");
+    assert_eq!(kernel_version, "1", "[kernel].version must target UI29 kernel v1");
+
+    // [dependencies] table present (even if empty) — §4.2 shape requirement.
+    assert!(
+        value.get("dependencies").is_some(),
+        "[dependencies] table must be present (may be empty)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. mosmodel — Card.mil compilation
+// ---------------------------------------------------------------------------
+
+/// The .mil must compile, name the component `Card`, expose exactly the
+/// three text slots, and declare zero emits.
+#[test]
+fn card_mil_compiles_with_expected_interface() {
+    let src = read_source("Card.mil");
+    let out = mosmodel_compiler::compile(&src)
+        .unwrap_or_else(|e| panic!("Card.mil failed to compile via mosmodel_compiler:\n{:#?}", e));
+
+    assert_eq!(
+        out.component.component, "Card",
+        "Card.mil must declare component named 'Card'"
+    );
+
+    // Slots — exactly three, in declared order, all of type text.
+    let slot_names: Vec<&str> = out.component.slots.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        slot_names,
+        vec!["title", "body", "footer"],
+        "Card must expose exactly three slots in order: title, body, footer"
+    );
+    for slot in &out.component.slots {
+        assert!(
+            matches!(slot.r#type, mosmodel_compiler::SlotType::Text),
+            "slot `{}` must be of type text (got {:?})",
+            slot.name, slot.r#type
+        );
+    }
+
+    // Emits — Card is display-only.
+    assert!(
+        out.component.emits.is_empty(),
+        "Card must declare zero emits (got {} emits: {:?})",
+        out.component.emits.len(),
+        out.component
+            .emits
+            .iter()
+            .map(|e| e.name.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. moslayout — Card.mll compilation
+// ---------------------------------------------------------------------------
+
+/// The .mll must compile against the .mil interface and yield the tree
+/// described in the file's doc-comment: Column[card-root] with three
+/// Box children named card-title / card-body / card-footer.
+#[test]
+fn card_mll_compiles_against_its_interface() {
+    let mil_src = read_source("Card.mil");
+    let mil_out = mosmodel_compiler::compile(&mil_src)
+        .unwrap_or_else(|e| panic!("Card.mil precompile failed: {:#?}", e));
+
+    let mll_src = read_source("Card.mll");
+    let mll_out = moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json))
+        .unwrap_or_else(|e| panic!("Card.mll failed to compile via moslayout_compiler:\n{:#?}", e));
+
+    let root = &mll_out.def.root;
+    assert_eq!(root.tag, "Column", "Card root must be a Column");
+    assert_eq!(
+        root.part_name.as_deref(),
+        Some("card-root"),
+        "Card root Column must be named part `card-root`"
+    );
+    assert_eq!(
+        root.children.len(),
+        3,
+        "Card root must contain exactly three Box children (got {})",
+        root.children.len()
+    );
+
+    let expected_parts = ["card-title", "card-body", "card-footer"];
+    for (child, expected_part) in root.children.iter().zip(expected_parts.iter()) {
+        assert_eq!(
+            child.tag, "Box",
+            "each direct child of the Column must be a Box (got `{}`)",
+            child.tag
+        );
+        assert_eq!(
+            child.part_name.as_deref(),
+            Some(*expected_part),
+            "Box must be named part `{}`",
+            expected_part
+        );
+        // Each Box wraps a single Text node.
+        assert_eq!(
+            child.children.len(),
+            1,
+            "Box[{}] must contain exactly one child Text node",
+            expected_part
+        );
+        assert_eq!(
+            child.children[0].tag, "Text",
+            "Box[{}] must wrap a Text node",
+            expected_part
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. mosstyle — Card.dark.msl compilation
+// ---------------------------------------------------------------------------
+
+/// The .msl must compile against the part map produced by Card.mll and
+/// produce exactly four part entries — one for each part declared in
+/// the layout (card-root + card-title + card-body + card-footer).
+#[test]
+fn card_dark_msl_compiles_against_its_part_map() {
+    let mll_src = read_source("Card.mll");
+    let mll_out = moslayout_compiler::compile(&mll_src, None)
+        .unwrap_or_else(|e| panic!("Card.mll precompile failed: {:#?}", e));
+
+    let msl_src = read_source("Card.dark.msl");
+    let msl_out = mosstyle_compiler::compile(&msl_src, Some(&mll_out.part_map_json))
+        .unwrap_or_else(|e| panic!("Card.dark.msl failed to compile via mosstyle_compiler:\n{:#?}", e));
+
+    let part_names: Vec<&str> = msl_out.def.parts.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(
+        part_names,
+        vec!["card-root", "card-title", "card-body", "card-footer"],
+        "Card.dark.msl must declare exactly four parts in the order: \
+         card-root, card-title, card-body, card-footer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Source-shape sanity
+// ---------------------------------------------------------------------------
+
+/// Belt-and-suspenders: every file the package promises is on disk.
+#[test]
+fn source_tree_has_expected_shape() {
+    let expected = ["Card.mil", "Card.mll", "Card.dark.msl"];
+    for name in expected {
+        let path = src_path(name);
+        assert!(
+            path.exists(),
+            "expected package source file missing: {}",
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `mosaic-pkg-card`: the **simplest possible** userland Mosaic component package — a single `Card` component built from only `Box`, `Column`, and `Text`, all kernel primitives that have been stable in every backend since UI29 landed.
- No `For`, no `If`, no `HostTable`, no `HostInput`, no events. Three text slots (title / body / footer), four themable parts, one dark stylesheet.
- Frames itself as a sibling of `mosaic-pkg-grid` (#3647). Grid stresses the kernel's *expressive surface* (loops, conditionals, host tables); Card stresses the *package plumbing* (manifest + .mil/.mll/.msl pipeline) in isolation, so a regression in one is easy to distinguish from a regression in the other.

## What's in the package

```
code/packages/mosaic-pkg-card/
├── mosaic-package.toml      # UI29 §4.2 manifest — exports = ["Card"], kernel = "1"
├── Cargo.toml               # standalone smoke-test crate (empty [workspace])
├── README.md
├── CHANGELOG.md
├── src/
│   ├── Card.mil             # 3 text slots, 0 emits
│   ├── Card.mll             # Column[card-root] of three Box[card-{title,body,footer}]
│   └── Card.dark.msl        # 4 themed parts
└── tests/
    └── package_compiles.rs  # 5 smoke-test assertions
```

The smoke test runs every source file through its compiler and asserts on the resulting IR shape:

1. `mosaic-package.toml` parses, exports `["Card"]`, targets kernel `"1"`.
2. `Card.mil` compiles via `mosmodel_compiler::compile` — exactly three `text` slots in order, zero emits.
3. `Card.mll` compiles via `moslayout_compiler::compile` against the .mil descriptor — root is `Column[card-root]` with three `Box` children named `card-title` / `card-body` / `card-footer`, each wrapping one `Text`.
4. `Card.dark.msl` compiles via `mosstyle_compiler::compile` against the .mll part map — produces exactly four parts in the expected order.
5. Expected source files exist on disk.

## Test plan

- [x] `cd code/packages/mosaic-pkg-card && cargo test` → all 5 tests pass locally
- [ ] CI runs the integration test against current `main`
- [ ] `mosaic-package.toml` round-trips through any future package-loader work without manifest-shape regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)