### PR TITLE
[codex] Add Nano R4 Arduino native USB metadata

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -59,8 +59,10 @@ Nano R4 mirrors that header-pin metadata for the Renesas RA4M1 Nano form
 factor: A4/A5 `Wire`, D11/D12/D13 SPI with D10 chip select, and D0/D1
 `Serial1`. It also records D4/D5 CAN metadata with the external transceiver
 requirement, passive RA4M1 RTC metadata, and connector-local Qwiic `Wire1`
-metadata. Native USB, Qwiic bytecode behavior, and RTC bytecode behavior remain
-owned by later board-specific adapter tranches.
+metadata. Its native USB CDC serial/upload endpoint is target metadata rather
+than a GPIO UART, while Qwiic bytecode behavior, RTC bytecode behavior, and
+deeper USB firmware behavior remain owned by later board-specific adapter
+tranches.
 
 Opta terminals are modeled as board-local input and relay-output pins instead
 of pretending the PLC has Uno-style headers. Nicla sensor/audio/vision hardware

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -81,8 +81,8 @@ use board_vm_targets::{
     SpiBusInfo as TargetSpiBus, UartBusInfo as TargetUartBus, UploadAdapter as TargetUploadAdapter,
     UploadImageFormat as TargetUploadImageFormat, UploadInfo as TargetUploadInfo,
     UploadPortHint as TargetUploadPortHint, UploadResetMethod as TargetUploadResetMethod,
-    UploadTransport as TargetUploadTransport, WirelessInterfaceInfo as TargetWirelessInterface,
-    WirelessTransport as TargetWirelessTransport,
+    UploadTransport as TargetUploadTransport, UsbInterfaceInfo as TargetUsbInterface,
+    WirelessInterfaceInfo as TargetWirelessInterface, WirelessTransport as TargetWirelessTransport,
 };
 
 pub const LANGUAGE_CORE_VERSION_MAJOR: u16 = 0;
@@ -432,6 +432,7 @@ pub struct LanguageTargetInfo {
     pub i2c_connectors: Vec<LanguageI2cConnector>,
     pub spi_buses: Vec<LanguageSpiBus>,
     pub uart_buses: Vec<LanguageUartBus>,
+    pub usb_interfaces: Vec<LanguageUsbInterface>,
     pub can_buses: Vec<LanguageCanBus>,
     pub rtc: Option<LanguageRtc>,
     pub wireless: Vec<LanguageWirelessInterface>,
@@ -480,6 +481,18 @@ pub struct LanguageUartBus {
     pub rx_pin: u8,
     pub arduino_uart: u8,
     pub internal: bool,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageUsbInterface {
+    pub interface: u8,
+    pub name: String,
+    pub controller: String,
+    pub class: String,
+    pub native: bool,
+    pub upload: bool,
+    pub command_transport: bool,
     pub notes: String,
 }
 
@@ -1329,6 +1342,11 @@ fn language_target_info(target: &BoardTargetInfo) -> LanguageTargetInfo {
             .collect(),
         spi_buses: target.spi_buses.iter().map(language_spi_bus).collect(),
         uart_buses: target.uart_buses.iter().map(language_uart_bus).collect(),
+        usb_interfaces: target
+            .usb_interfaces
+            .iter()
+            .map(language_usb_interface)
+            .collect(),
         can_buses: target.can_buses.iter().map(language_can_bus).collect(),
         rtc: target.rtc.map(language_rtc),
         wireless: target
@@ -1414,6 +1432,19 @@ fn language_uart_bus(bus: &TargetUartBus) -> LanguageUartBus {
         arduino_uart: bus.arduino_uart,
         internal: bus.internal,
         notes: bus.notes.to_owned(),
+    }
+}
+
+fn language_usb_interface(interface: &TargetUsbInterface) -> LanguageUsbInterface {
+    LanguageUsbInterface {
+        interface: interface.interface,
+        name: interface.name.to_owned(),
+        controller: interface.controller.to_owned(),
+        class: interface.class.to_owned(),
+        native: interface.native,
+        upload: interface.upload,
+        command_transport: interface.command_transport,
+        notes: interface.notes.to_owned(),
     }
 }
 
@@ -4204,6 +4235,14 @@ mod tests {
         assert_eq!(nano_r4.uart_buses[0].tx_pin, 1);
         assert_eq!(nano_r4.uart_buses[0].rx_pin, 0);
         assert!(nano_r4.uart_buses[0].notes.contains("native USB"));
+        assert_eq!(nano_r4.usb_interfaces.len(), 1);
+        assert_eq!(nano_r4.usb_interfaces[0].name, "Native USB");
+        assert_eq!(nano_r4.usb_interfaces[0].controller, "RA4M1 native USB");
+        assert_eq!(nano_r4.usb_interfaces[0].class, "CDC serial");
+        assert!(nano_r4.usb_interfaces[0].native);
+        assert!(nano_r4.usb_interfaces[0].upload);
+        assert!(nano_r4.usb_interfaces[0].command_transport);
+        assert!(nano_r4.usb_interfaces[0].notes.contains("not a GPIO UART"));
         assert_eq!(nano_r4.can_buses.len(), 1);
         assert_eq!(nano_r4.can_buses[0].name, "CAN0");
         assert_eq!(nano_r4.can_buses[0].tx_pin, 4);

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -105,6 +105,11 @@ from A4/A5 `Wire` header pins. The descriptor names the Qwiic/STEMMA QT
 connector and RA4M1 IIC0 controller while the shared Arduino runtime keeps
 `i2c.*` bytecode adapters disabled.
 
+Nano R4 native USB metadata records the board-local CDC serial/upload endpoint
+separately from D0/D1 `Serial1`. The descriptor keeps the native USB path in
+target/upload metadata, not in GPIO UART tables, and leaves deeper
+board-specific USB firmware behavior to later adapters.
+
 Host-side validation:
 
 ```sh

--- a/code/packages/rust/board-vm-targets/src/lib.rs
+++ b/code/packages/rust/board-vm-targets/src/lib.rs
@@ -97,6 +97,18 @@ pub struct UartBusInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UsbInterfaceInfo {
+    pub interface: u8,
+    pub name: &'static str,
+    pub controller: &'static str,
+    pub class: &'static str,
+    pub native: bool,
+    pub upload: bool,
+    pub command_transport: bool,
+    pub notes: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CanBusInfo {
     pub bus: u8,
     pub name: &'static str,
@@ -236,6 +248,7 @@ pub struct BoardTargetInfo {
     pub i2c_connectors: &'static [I2cConnectorInfo],
     pub spi_buses: &'static [SpiBusInfo],
     pub uart_buses: &'static [UartBusInfo],
+    pub usb_interfaces: &'static [UsbInterfaceInfo],
     pub can_buses: &'static [CanBusInfo],
     pub rtc: Option<RtcInfo>,
     pub watchdog: Option<WatchdogInfo>,
@@ -916,6 +929,17 @@ pub const ARDUINO_NANO_R4_UART_BUSES: [UartBusInfo; 1] = [UartBusInfo {
     notes: "Arduino Nano R4 D1/D0 serial metadata only; native USB remains upload/transport metadata, not a separate GPIO UART.",
 }];
 
+pub const ARDUINO_NANO_R4_USB_INTERFACES: [UsbInterfaceInfo; 1] = [UsbInterfaceInfo {
+    interface: 0,
+    name: "Native USB",
+    controller: "RA4M1 native USB",
+    class: "CDC serial",
+    native: true,
+    upload: true,
+    command_transport: true,
+    notes: "Arduino Nano R4 native USB serial/upload metadata only; this endpoint is not a GPIO UART and board-specific firmware adapters still own deeper USB behavior.",
+}];
+
 pub const ARDUINO_NANO_R4_CAN_BUSES: [CanBusInfo; 1] = [CanBusInfo {
     bus: 0,
     name: "CAN0",
@@ -1272,6 +1296,7 @@ const fn arduino_board_target_with_buses_and_can(
         &[],
         spi_buses,
         uart_buses,
+        &[],
         can_buses,
         None,
         wireless,
@@ -1286,6 +1311,7 @@ const fn arduino_board_target_with_buses_can_and_rtc(
     i2c_connectors: &'static [I2cConnectorInfo],
     spi_buses: &'static [SpiBusInfo],
     uart_buses: &'static [UartBusInfo],
+    usb_interfaces: &'static [UsbInterfaceInfo],
     can_buses: &'static [CanBusInfo],
     rtc: Option<RtcInfo>,
     wireless: &'static [WirelessInterfaceInfo],
@@ -1312,6 +1338,7 @@ const fn arduino_board_target_with_buses_can_and_rtc(
         i2c_connectors,
         spi_buses,
         uart_buses,
+        usb_interfaces,
         can_buses,
         rtc,
         watchdog: None,
@@ -1348,6 +1375,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         i2c_connectors: &[],
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_MINIMA_UART_BUSES,
+        usb_interfaces: &[],
         can_buses: &UNO_R4_CAN_BUSES,
         rtc: Some(UNO_R4_RTC),
         watchdog: Some(UNO_R4_WATCHDOG),
@@ -1381,6 +1409,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         i2c_connectors: &[],
         spi_buses: &UNO_R4_SPI_BUSES,
         uart_buses: &UNO_R4_WIFI_UART_BUSES,
+        usb_interfaces: &[],
         can_buses: &UNO_R4_CAN_BUSES,
         rtc: Some(UNO_R4_RTC),
         watchdog: Some(UNO_R4_WATCHDOG),
@@ -1478,6 +1507,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         &ARDUINO_NANO_R4_I2C_CONNECTORS,
         &ARDUINO_NANO_R4_SPI_BUSES,
         &ARDUINO_NANO_R4_UART_BUSES,
+        &ARDUINO_NANO_R4_USB_INTERFACES,
         &ARDUINO_NANO_R4_CAN_BUSES,
         Some(ARDUINO_NANO_R4_RTC),
         &[],
@@ -1594,6 +1624,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         i2c_connectors: &[],
         spi_buses: &[],
         uart_buses: &[],
+        usb_interfaces: &[],
         can_buses: &[],
         rtc: None,
         watchdog: None,
@@ -1627,6 +1658,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         i2c_connectors: &[],
         spi_buses: &[],
         uart_buses: &[],
+        usb_interfaces: &[],
         can_buses: &[],
         rtc: None,
         watchdog: None,
@@ -1660,6 +1692,7 @@ pub const BOARD_TARGETS: [BoardTargetInfo; 31] = [
         i2c_connectors: &[],
         spi_buses: &[],
         uart_buses: &[],
+        usb_interfaces: &[],
         can_buses: &[],
         rtc: None,
         watchdog: None,
@@ -1939,6 +1972,26 @@ mod tests {
         }
 
         assert!(find_target("esp32-devkit-v1").unwrap().i2c_buses.is_empty());
+    }
+
+    #[test]
+    fn registry_exposes_usb_interface_metadata() {
+        let nano_r4 = find_target("arduino-nano-r4").unwrap();
+        assert_eq!(nano_r4.usb_interfaces, &ARDUINO_NANO_R4_USB_INTERFACES);
+        assert_eq!(nano_r4.usb_interfaces[0].name, "Native USB");
+        assert_eq!(nano_r4.usb_interfaces[0].controller, "RA4M1 native USB");
+        assert_eq!(nano_r4.usb_interfaces[0].class, "CDC serial");
+        assert!(nano_r4.usb_interfaces[0].native);
+        assert!(nano_r4.usb_interfaces[0].upload);
+        assert!(nano_r4.usb_interfaces[0].command_transport);
+        assert!(nano_r4.usb_interfaces[0].notes.contains("not a GPIO UART"));
+
+        let nano_every = find_target("arduino-nano-every").unwrap();
+        assert!(nano_every.usb_interfaces.is_empty());
+        assert_eq!(
+            nano_every.upload.unwrap().port_hint,
+            Some(UploadPortHint::UsbSerialBridge)
+        );
     }
 
     #[test]

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -179,8 +179,12 @@ runtime.
 The Nano R4 Qwiic metadata tranche records connector-local `Wire1` metadata for
 the Qwiic/STEMMA QT connector and RA4M1 IIC0 controller without folding it into
 the A4/A5 `Wire` header descriptor. `i2c.*` capabilities stay disabled for the
-shared Arduino runtime; native USB and bytecode behavior remain follow-up
-adapter metadata.
+shared Arduino runtime.
+
+The Nano R4 native USB metadata tranche records the native CDC serial/upload
+endpoint separately from D0/D1 `Serial1`. The descriptor keeps native USB in
+Rust-owned target/upload metadata rather than GPIO UART tables; deeper USB
+firmware behavior remains follow-up adapter metadata.
 
 The next tranches should deepen board-specific firmware/upload adapters and
 richer peripheral tables for each family without moving generic Arduino


### PR DESCRIPTION
## Summary
- add Nano R4 native USB CDC serial/upload interface metadata to Rust-owned board targets
- surface USB interface descriptors through board-vm-language-core without moving behavior into language frontends
- document native USB as target/upload metadata, not a GPIO UART, with deeper USB firmware behavior left to later adapter work

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-native-usb-metadata cargo fmt -p board-vm-targets -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-native-usb-metadata cargo test -p board-vm-targets -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-native-usb-metadata cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-native-usb-metadata bash BUILD` in `code/packages/rust/board-vm-targets`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-native-usb-metadata bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-nano-r4-native-usb-metadata bash BUILD` in `code/packages/rust/board-vm-arduino`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.
