### PR TITLE
feat(mosaic-pkg-dialog): U29 — cross-backend Dialog component

### DIFF
--- a/code/packages/mosaic-pkg-dialog/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-dialog/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to `mosaic-pkg-dialog` are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/) and
+the package follows semantic versioning.
+
+## 0.1.0 — 2026-05-20
+
+Initial release.  Ships a single Dialog component used as the
+cross-backend smoke test for the UI29 kernel.
+
+### Added
+
+- `mosaic-package.toml` manifest declaring
+  `[components].exports = ["Dialog"]` and targeting UI29 kernel
+  version `"1"`.
+- `Dialog.mil`: interface with three text slots (`title`, `message`,
+  `close-label`) and one zero-payload emit (`onClose`).
+- `Dialog.mll`: layout composed of `Box` (outer frame, `dialog-root`),
+  `Column` (vertical stack, `dialog-stack`), and three inner `Box`
+  parts (`dialog-title`, `dialog-message`, `dialog-actions`) wrapping
+  two `Text` leaves and one `HostButton`.
+- `Dialog.dark.msl`: dark-theme stylesheet covering all four named
+  parts.
+- `tests/package_compiles.rs`: integration smoke test that round-trips
+  every source file through `mosmodel-compiler`, `moslayout-compiler`,
+  and `mosstyle-compiler`, asserts the structural shape of the layout
+  tree, and drives `mosaic-package-artifact-builder::build_package` for
+  every backend the builder currently supports (React, SwiftUI, Qt) —
+  asserting a non-empty `Dialog.<ext>` lands on disk for each.
+
+### Deliberate scope decisions
+
+- **Only Box, Column, Text, HostButton.**  The "lowest-common-denominator"
+  primitive set — every Mosaic backend on `main` today (React, SwiftUI,
+  Qt, WebComponent, HTML, XAML) lowers all four.  No `If`, no `For`, no
+  `HostTable`, because those primitives are still landing in parallel
+  PRs and are not present in every backend yet.
+- **Visibility is host-controlled.**  v0.1.0 has no `visible: bool`
+  slot; the host decides whether to mount Dialog by including or
+  excluding it from its parent's layout tree.  This works on every
+  backend today and avoids gating v0.1.0 on cross-backend `If` parity.
+- **WebComponent and HTML artifact-builder skip.**  The
+  `mosaic-package-artifact-builder` crate currently returns
+  `UnsupportedBackend` for `Backend::WebComponent` and `Backend::Html`
+  (their `from_pipeline` entry points are landing in parallel PRs).
+  The smoke test asserts that current behaviour, so the day those PRs
+  land the test fails loudly and a contributor knows to promote the
+  variants into `SUPPORTED_BACKENDS`.
+- **XAML is not exercised.**  XAML is not yet a variant of the artifact
+  builder's `Backend` enum (its emitter is still landing under the
+  `feat(mosaic-emit-xaml)` PR series), so this package's smoke test
+  cannot drive it.  The README's primitive-availability table is the
+  source of truth for what *parses*; the smoke test is the source of
+  truth for what *the builder lowers today*.
+
+### v0.2.0 plans
+
+- Add `slot visible : bool` plus an `If ( when: slot: visible )` gate
+  once `If` lands across React/SwiftUI/Qt (currently only HTML,
+  WebComponent, and XAML have it).
+- Add an `onOpen` companion emit (optional symmetry with `onClose`).
+- Light-theme `Dialog.light.msl` once the multi-theme cascade lands in
+  mosstyle.

--- a/code/packages/mosaic-pkg-dialog/Cargo.toml
+++ b/code/packages/mosaic-pkg-dialog/Cargo.toml
@@ -1,0 +1,37 @@
+# Cargo.toml — smoke-test harness for mosaic-pkg-dialog.
+#
+# This package's primary deliverables are .mil / .mll / .msl source files
+# (consumed by mosaic-compile and downstream emitters), NOT a Rust crate.
+# The Cargo.toml exists ONLY to host an integration smoke test that runs
+# each source file through its respective compiler crate and then drives
+# the full per-backend artifact builder against the same source tree.
+#
+# `[workspace]` is empty so this Cargo project does NOT join the main
+# code/packages/rust workspace.  It lives at code/packages/mosaic-pkg-dialog
+# (outside the rust/ tree), is conceptually a Mosaic package (not a Rust
+# crate), and runs as a standalone Cargo project via `cargo test`.
+
+[workspace]
+# Intentionally empty: opt out of the parent workspace.
+
+[package]
+name        = "mosaic-pkg-dialog"
+version     = "0.1.0"
+edition     = "2021"
+description = "Smoke-test harness for the mosaic-pkg-dialog component package"
+publish     = false
+
+# The crate has no library code — it exists for the integration test below.
+[lib]
+path       = "src/lib.rs"
+
+[dev-dependencies]
+mosmodel-compiler              = { path = "../rust/mosmodel-compiler" }
+moslayout-compiler             = { path = "../rust/moslayout-compiler" }
+mosstyle-compiler              = { path = "../rust/mosstyle-compiler" }
+mosaic-package-artifact-builder = { path = "../rust/mosaic-package-artifact-builder" }
+toml                            = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic-pkg-dialog/README.md
+++ b/code/packages/mosaic-pkg-dialog/README.md
@@ -1,0 +1,170 @@
+# mosaic-pkg-dialog
+
+> A simple cross-backend Dialog component — title, message, close button —
+> built on UI29 kernel primitives.
+
+This is the **cross-backend smoke test** for the Mosaic kernel.  A
+single userland component that compiles cleanly through *every* Mosaic
+emitter on `main` today: React, SwiftUI, Qt, WebComponent, HTML, and
+XAML.  If a kernel change breaks any of those backends, Dialog is the
+fastest way to find out.
+
+## Why this package exists
+
+`mosaic-pkg-grid` exercises the rich end of the kernel — `For`, `If`,
+`HostTable` and its sub-tags, userland component composition, expression
+lowering — and is therefore gated on a long tail of in-flight PRs
+landing across all six backends.  Dialog goes the other way: it touches
+*only* the four primitives that are already present in every backend
+today, so it can act as a tripwire for kernel regressions without
+waiting on any of those PRs.
+
+## What this package exports
+
+One component, listed in `mosaic-package.toml`'s `[components].exports`:
+
+| Component | Role | File trio |
+|---|---|---|
+| `Dialog` | Title + message + close button overlay | `Dialog.mil` / `Dialog.mll` / `Dialog.dark.msl` |
+
+## The interface
+
+```mil
+component Dialog {
+  slot title       : text ;
+  slot message     : text ;
+  slot close-label : text ;
+
+  emit onClose ;
+}
+```
+
+Three text slots and one zero-payload event.  Hosts set the three
+strings and listen for `onClose`; everything else is layout and style.
+
+## The layout
+
+```mll
+layout Dialog {
+  Box [ dialog-root ] {
+    Column [ dialog-stack ] {
+      Box [ dialog-title ]   { Text ( content: slot: title   ) }
+      Box [ dialog-message ] { Text ( content: slot: message ) }
+      Box [ dialog-actions ] {
+        HostButton (
+          label: slot: close-label ,
+          onTap: emit: onClose
+        )
+      }
+    }
+  }
+}
+```
+
+Four parts (`dialog-root`, `dialog-title`, `dialog-message`,
+`dialog-actions`) for hosts to theme.  Four primitives total:
+
+| Primitive  | Why this one |
+|---|---|
+| `Box`        | Stylable container — owns the `part` annotations |
+| `Column`     | Vertical stack across title → message → actions |
+| `Text`       | Static read-only label binding (title, message) |
+| `HostButton` | Native clickable with platform-appropriate semantics |
+
+**No `If`. No `For`. No `HostTable`.** Those primitives exist in some
+backends but not yet in all — see "primitive availability" below.
+
+## How it fits in the stack
+
+```
+              ┌────────────────────────────────────────────┐
+              │  Host application (.mll uses `Dialog`)     │
+              └─────────────────────┬──────────────────────┘
+                                    │ component reference
+                                    ▼
+              ┌────────────────────────────────────────────┐
+              │  mosaic-pkg-dialog (this package)          │
+              │  Dialog → Box + Column + Text + HostButton │
+              └─────────────────────┬──────────────────────┘
+                                    │ kernel primitives only
+                                    ▼
+              ┌────────────────────────────────────────────┐
+              │  UI29 kernel (15 primitives)               │
+              └─────────────────────┬──────────────────────┘
+                                    │ per-backend lowering
+                                    ▼
+        React / SwiftUI / Qt / WebComponent / HTML / XAML
+```
+
+## Primitive availability (the "why these four" answer)
+
+A v0.1.0 Dialog could in principle use richer primitives — e.g. `If`
+to gate its own visibility — but those primitives are not yet uniformly
+implemented across all six emitters.  The current map (as of the
+commit landing this package):
+
+| Primitive   | React | SwiftUI | Qt | WebComp | HTML | XAML |
+|---|---|---|---|---|---|---|
+| `Box`         | yes | yes | yes | yes | yes | yes |
+| `Row`/`Column`/`Stack` | yes | yes | yes | yes | yes | yes |
+| `Text`        | yes | yes | yes | yes | yes | yes |
+| `Image`       | yes | yes | yes | yes | yes | yes |
+| `Spacer`/`Divider`/`Icon` | yes | yes | yes | yes | yes | yes |
+| `HostInput`   | yes | yes | yes | yes | yes | yes |
+| `HostButton`  | yes | yes | yes | yes | yes | yes |
+| `HostScroll`  | yes | yes | yes | yes | yes | yes |
+| `HostTable`   | yes | yes | yes | yes | yes | yes |
+| `If` / `Else` | landing | landing | landing | yes | yes | yes |
+| `For`         | landing | landing | landing | yes | yes | yes |
+
+Dialog uses only rows of the table that are all-yes.
+
+## v0.2.0 plans
+
+Once `If` is wired across React/SwiftUI/Qt, v0.2.0 will grow:
+
+* **`slot visible : bool`** — an internal visibility gate.
+* **`If ( when: slot: visible )`** wrapping the layout root.
+* **`emit onOpen`** (optional) — companion event to `onClose`.
+
+Until then, the host is the source of truth for whether Dialog is
+mounted: a parent component conditionally renders Dialog by including
+or excluding it from its layout tree.  This works in every backend
+today, because every backend's host language already has its own
+conditional-rendering story.
+
+## Smoke test
+
+```bash
+cd code/packages/mosaic-pkg-dialog
+cargo test
+```
+
+The smoke test asserts:
+
+1. `mosaic-package.toml` parses and declares exactly `exports = ["Dialog"]`.
+2. `Dialog.mil` compiles via `mosmodel-compiler` (3 slots, 1 emit).
+3. `Dialog.mll` compiles via `moslayout-compiler` against the `.mil`,
+   and the resulting tree has the exact Box → Column → Box×3 shape
+   with `HostButton` inside `dialog-actions`.
+4. `Dialog.dark.msl` compiles via `mosstyle-compiler` against the
+   layout's part map and declares all four parts.
+5. The per-backend artifact builder produces a non-empty Dialog
+   artifact for every backend it currently wires (React, SwiftUI, Qt).
+   WebComponent and HTML are SKIPPED with a documented `UnsupportedBackend`
+   assertion — when those wiring PRs land, the relevant `Backend` enum
+   variants flip into `SUPPORTED_BACKENDS` in
+   `tests/package_compiles.rs` and the test starts covering them.
+
+## Position in UI29's roadmap
+
+* **U29-P1 (this package)**: ship the smallest userland package proving
+  end-to-end kernel + emitter + artifact-builder integration.
+* **U29-P2**: a richer companion (Tabs, Tooltip, Toast) — gated on
+  cross-backend `If` parity.
+* **U29-D-dialog**: a demo app that imports this package and renders a
+  one-click "Are you sure?" overlay on every backend.
+
+## License
+
+MIT OR Apache-2.0.

--- a/code/packages/mosaic-pkg-dialog/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-dialog/mosaic-package.toml
@@ -1,0 +1,28 @@
+# mosaic-package.toml — manifest for mosaic-pkg-dialog.
+#
+# Conforms to the UI29 §4.2 package-manifest shape: a [package] table for
+# identity, [components] listing the publicly exported components, an empty
+# [dependencies] table (this package is built only from UI29 kernel
+# primitives — no other userland packages), and a [kernel] table declaring
+# the UI29 kernel revision the package targets.
+#
+# Dialog is intentionally the smallest "real" userland component: it stress-
+# tests the package shape and the cross-backend compile path without leaning
+# on primitives that have not yet landed in every backend.  The only
+# primitives it uses (Box, Column, Text, HostButton) are present in every
+# Mosaic backend on main today.
+
+[package]
+name = "mosaic-pkg-dialog"
+version = "0.1.0"
+description = "A simple cross-backend Dialog component (title + message + close button) built on UI29 kernel primitives"
+license = "MIT OR Apache-2.0"
+
+[components]
+exports = ["Dialog"]
+
+[dependencies]
+# no other packages — built only from UI29 kernel primitives
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic-pkg-dialog/src/Dialog.dark.msl
+++ b/code/packages/mosaic-pkg-dialog/src/Dialog.dark.msl
@@ -1,0 +1,41 @@
+// Dialog.dark.msl — dark theme styles for the Dialog component.
+//
+// Targets the four named parts declared in Dialog.mll:
+//
+//   dialog-root      outer frame: background, border, padding, default text colour
+//   dialog-title     heading: larger font, bolder, white-on-dark
+//   dialog-message   body text: regular weight, slightly smaller, inherits colour
+//   dialog-actions   action row: deliberately empty in v0.1.0 — host can
+//                    override alignment via composition (mosstyle cascade
+//                    rules let a host-level .msl tighten this without
+//                    forking the package)
+//
+// Colour palette: VS Code Dark+ derived.
+//   #2d2d30   panel background (matches Code's editor side panel)
+//   #3f3f46   subtle border between dialog and content beneath it
+//   #cccccc   default text colour for the dialog body
+//   #ffffff   pure white for the title to give it visual weight
+
+style Dialog {
+  part dialog-root {
+    background:   #2d2d30 ;
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #3f3f46 ;
+    padding:      16px ;
+    color:        #cccccc ;
+  }
+  part dialog-title {
+    font-size:      16px ;
+    font-weight:    bold ;
+    color:          #ffffff ;
+    padding-bottom: 8px ;
+  }
+  part dialog-message {
+    font-size:      13px ;
+    padding-bottom: 16px ;
+  }
+  part dialog-actions {
+    /* host can override alignment via composition */
+  }
+}

--- a/code/packages/mosaic-pkg-dialog/src/Dialog.mil
+++ b/code/packages/mosaic-pkg-dialog/src/Dialog.mil
@@ -1,0 +1,33 @@
+// Dialog.mil — interface for the Dialog component.
+//
+// A Dialog is the simplest "real" userland component the Mosaic framework
+// can host: a styled container that shows a title, a body message, and a
+// single button to dismiss itself.  It is deliberately minimal so it can
+// compile cleanly against every backend on main today (React, SwiftUI, Qt,
+// WebComponent, HTML, XAML) — the cross-backend smoke test for the kernel.
+//
+// Slot vocabulary
+// ---------------
+//   title         the heading line shown at the top of the dialog
+//   message       the body text shown between the title and the actions
+//   close-label   the label shown on the close button (e.g. "OK", "Close")
+//
+// Emit vocabulary
+// ---------------
+//   onClose       fired when the close button is activated; the host is
+//                 responsible for tearing the Dialog down (the v0.1.0
+//                 Dialog does not gate its own visibility — see README).
+//
+// v0.2.0 will add a `visible: bool` slot plus an `If (when: ...)` gate
+// once the `If` primitive is available across every backend (today only
+// HTML, WebComponent, and XAML have it; React/SwiftUI/Qt are still
+// landing it in parallel PRs).  Until then, the host decides whether to
+// render Dialog at all by mounting/unmounting it externally.
+
+component Dialog {
+  slot title       : text ;
+  slot message     : text ;
+  slot close-label : text ;
+
+  emit onClose ;
+}

--- a/code/packages/mosaic-pkg-dialog/src/Dialog.mll
+++ b/code/packages/mosaic-pkg-dialog/src/Dialog.mll
@@ -1,0 +1,54 @@
+// Dialog.mll — layout for the Dialog component.
+//
+// Decomposition (kernel primitives only):
+//
+//   Box [dialog-root]                ← stylable outer frame
+//     Column [dialog-stack]          ← vertical stack: title, message, actions
+//       Box [dialog-title]           ← stylable title row (its own `part`)
+//         Text (content: slot: title)
+//       Box [dialog-message]         ← stylable message row
+//         Text (content: slot: message)
+//       Box [dialog-actions]         ← stylable actions row
+//         HostButton                 ← kernel-canonical clickable
+//           label: slot: close-label
+//           onTap : emit: onClose
+//
+// Why only Box / Column / Text / HostButton?
+// ------------------------------------------
+// These four primitives are the lowest-common-denominator set: every
+// Mosaic backend on main today (React, SwiftUI, Qt, WebComponent, HTML,
+// XAML) lowers them.  `If` is only present in HTML, WebComponent, and
+// XAML right now; `For` is only present in HTML, WebComponent, and (just
+// landing) React; `HostTable` is only present in React/SwiftUI/Qt/WebComp/
+// HTML/XAML but adds complexity Dialog does not need.  Sticking to the
+// LCD set makes Dialog the cross-backend smoke test that proves *every*
+// emitter can ingest a userland package end-to-end.
+//
+// Why nested Boxes for the parts?
+// -------------------------------
+// mosstyle attaches style rules to *parts* (named via the `[part-name]`
+// bracket annotation).  We want the title, message, and actions row to
+// each be individually stylable — different padding, font, alignment —
+// so each gets its own Box wrapper that owns a part name.  The inner
+// Text / HostButton primitives stay style-free; they pick up colour and
+// font from their parent Box via CSS inheritance (or its backend
+// equivalent).
+
+layout Dialog {
+  Box [ dialog-root ] {
+    Column [ dialog-stack ] {
+      Box [ dialog-title ] {
+        Text ( content: slot: title )
+      }
+      Box [ dialog-message ] {
+        Text ( content: slot: message )
+      }
+      Box [ dialog-actions ] {
+        HostButton (
+          label: slot: close-label ,
+          onTap: emit: onClose
+        )
+      }
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-dialog/src/lib.rs
+++ b/code/packages/mosaic-pkg-dialog/src/lib.rs
@@ -1,0 +1,14 @@
+//! mosaic-pkg-dialog — userland Mosaic component package.
+//!
+//! This crate is intentionally empty.  The package's real deliverables are
+//! the `.mil` / `.mll` / `.msl` source files under `src/` and the
+//! `mosaic-package.toml` manifest at the package root — they describe a
+//! single component (Dialog) composed entirely from UI29 kernel
+//! primitives that exist in every Mosaic backend today (Box, Column, Text,
+//! HostButton).
+//!
+//! The Rust crate exists only so a smoke-test integration test can run
+//! Dialog's three source files through the mosmodel / moslayout / mosstyle
+//! compilers and, on top of that, drive the per-backend artifact builder
+//! across every backend the builder currently supports.  See
+//! `tests/package_compiles.rs`.

--- a/code/packages/mosaic-pkg-dialog/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-dialog/tests/package_compiles.rs
@@ -1,0 +1,409 @@
+//! package_compiles — smoke test for the mosaic-pkg-dialog package.
+//!
+//! Dialog is the framework's cross-backend smoke test: a single userland
+//! component that compiles cleanly through *every* Mosaic emitter without
+//! reaching for primitives that exist in only some backends.  If this
+//! test passes, the language frontend and at least the three "ready"
+//! backend artifact emitters (React, SwiftUI, Qt) can ingest a userland
+//! package end-to-end.
+//!
+//! What this test asserts
+//! ----------------------
+//!
+//! 1. The manifest at `mosaic-package.toml` parses and declares exactly
+//!    `exports = ["Dialog"]`.
+//! 2. `Dialog.mil` compiles via `mosmodel_compiler::compile`, with three
+//!    slots (`title`, `message`, `close-label`) and one emit (`onClose`).
+//! 3. `Dialog.mll` compiles via `moslayout_compiler::compile`, validated
+//!    against the `.mil`'s interface descriptor.  We also walk the
+//!    resulting layout tree and assert the structural shape the spec
+//!    promised:
+//!
+//!        Box [dialog-root]
+//!          Column [dialog-stack]
+//!            Box [dialog-title]    -> Text
+//!            Box [dialog-message]  -> Text
+//!            Box [dialog-actions]  -> HostButton
+//!
+//! 4. `Dialog.dark.msl` compiles via `mosstyle_compiler::compile` against
+//!    the layout's part map, and the resulting style IR declares all
+//!    four parts (`dialog-root`, `dialog-title`, `dialog-message`,
+//!    `dialog-actions`).
+//! 5. The per-backend artifact builder — the same crate that
+//!    `mosaic-compile pkg build` drives — produces a non-empty
+//!    `Dialog.<ext>` for every backend it currently supports (React,
+//!    SwiftUI, Qt).  WebComponent and HTML are SKIPPED with a documented
+//!    comment because today's builder returns `UnsupportedBackend` for
+//!    those two enum variants (their `from_pipeline` entry points are
+//!    landing in parallel PRs).  XAML is not yet in the builder's enum
+//!    at all, so it is not exercised here.
+//!
+//! When a future PR lights up the WebComponent / HTML / XAML backends in
+//! the artifact builder, this test will start covering them automatically
+//! — just remove the skip comment and the relevant Backend variants from
+//! `BACKENDS_SKIPPED`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mosaic_package_artifact_builder::{build_package, Backend, BuildError, BuildOptions};
+
+/// Anchor every path resolution to the package root.  `CARGO_MANIFEST_DIR`
+/// is set by Cargo at compile time, so this is deterministic regardless of
+/// where `cargo test` was invoked from.
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn src_path(name: &str) -> PathBuf {
+    package_root().join("src").join(name)
+}
+
+fn read_source(name: &str) -> String {
+    let path = src_path(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest
+// ---------------------------------------------------------------------------
+
+/// Parses `mosaic-package.toml` and asserts the UI29 §4.2 minimum surface:
+/// `[package]` identity, `[components].exports = ["Dialog"]`, an empty
+/// `[dependencies]`, and `[kernel].version = "1"`.
+#[test]
+fn manifest_declares_dialog_export() {
+    let manifest_src = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("manifest mosaic-package.toml must exist at the package root");
+
+    let value: toml::Value = toml::from_str(&manifest_src)
+        .expect("mosaic-package.toml must parse as valid TOML");
+
+    // [package].name
+    let name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("[package].name must be set");
+    assert_eq!(name, "mosaic-pkg-dialog", "[package].name mismatch");
+
+    // [package].version
+    let version = value
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[package].version must be set");
+    assert_eq!(version, "0.1.0", "[package].version must be 0.1.0");
+
+    // [components].exports
+    let exports = value
+        .get("components")
+        .and_then(|c| c.get("exports"))
+        .and_then(|e| e.as_array())
+        .expect("[components].exports must be an array");
+    let export_names: Vec<&str> = exports.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        export_names,
+        vec!["Dialog"],
+        "[components].exports must list exactly Dialog"
+    );
+
+    // [kernel].version
+    let kernel_version = value
+        .get("kernel")
+        .and_then(|k| k.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[kernel].version must be set");
+    assert_eq!(kernel_version, "1", "[kernel].version must target UI29 kernel v1");
+}
+
+// ---------------------------------------------------------------------------
+// 2. mosmodel — Dialog.mil compilation
+// ---------------------------------------------------------------------------
+
+/// `Dialog.mil` must compile and declare exactly the slots/emits the spec
+/// promises.  We assert both names AND types so a future contributor who
+/// accidentally renames a slot (e.g. `title` → `header`) trips the test
+/// loudly, instead of the change silently propagating into a backend
+/// artifact that no longer matches the published interface.
+#[test]
+fn mil_declares_three_slots_and_one_emit() {
+    let src = read_source("Dialog.mil");
+    let out = mosmodel_compiler::compile(&src)
+        .unwrap_or_else(|errs| panic!("Dialog.mil failed to compile: {:#?}", errs));
+
+    assert_eq!(out.component.component, "Dialog", "component name must be Dialog");
+
+    // Slots — name + type, in source order.
+    let slot_names: Vec<&str> = out
+        .component
+        .slots
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect();
+    assert_eq!(
+        slot_names,
+        vec!["title", "message", "close-label"],
+        "Dialog must declare exactly slots: title, message, close-label (in that order)"
+    );
+    for slot in &out.component.slots {
+        assert!(
+            matches!(slot.r#type, mosmodel_compiler::SlotType::Text),
+            "slot {} must be of type text (got {:?})",
+            slot.name,
+            slot.r#type
+        );
+    }
+
+    // Emits — name + zero-arg payload.
+    let emit_names: Vec<&str> = out
+        .component
+        .emits
+        .iter()
+        .map(|e| e.name.as_str())
+        .collect();
+    assert_eq!(
+        emit_names,
+        vec!["onClose"],
+        "Dialog must declare exactly one emit: onClose"
+    );
+    assert!(
+        out.component.emits[0].params.is_empty(),
+        "onClose must be a zero-arg emit (got {:?})",
+        out.component.emits[0].params
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. moslayout — Dialog.mll compilation + structural shape
+// ---------------------------------------------------------------------------
+
+/// `Dialog.mll` must compile against the `.mil` interface AND have the
+/// exact tree shape the README documents.  Asserting the shape (not just
+/// "it compiled") catches the failure mode where the file still parses
+/// but a primitive name has been changed — e.g. `Column` -> `Stack` —
+/// which would silently change every emitter's output layout.
+#[test]
+fn mll_compiles_with_expected_shape() {
+    let mil_src = read_source("Dialog.mil");
+    let mil_out = mosmodel_compiler::compile(&mil_src)
+        .unwrap_or_else(|e| panic!("Dialog.mil precompile failed: {:#?}", e));
+
+    let mll_src = read_source("Dialog.mll");
+    let mll_out = moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json))
+        .unwrap_or_else(|e| panic!("Dialog.mll failed to compile: {:#?}", e));
+
+    let root = &mll_out.def.root;
+
+    // Layer 1: Box [dialog-root]
+    assert_eq!(root.tag, "Box", "root node must be a Box");
+    assert_eq!(
+        root.part_name.as_deref(),
+        Some("dialog-root"),
+        "root Box must own the `dialog-root` part"
+    );
+    assert_eq!(root.children.len(), 1, "Box[dialog-root] has exactly one child (the Column)");
+
+    // Layer 2: Column [dialog-stack]
+    let stack = &root.children[0];
+    assert_eq!(stack.tag, "Column", "layer-2 node must be a Column");
+    assert_eq!(
+        stack.part_name.as_deref(),
+        Some("dialog-stack"),
+        "stack Column must own the `dialog-stack` part"
+    );
+    assert_eq!(
+        stack.children.len(),
+        3,
+        "Column[dialog-stack] must have exactly three children (title, message, actions)"
+    );
+
+    // Layer 3a: Box [dialog-title] -> Text
+    let title_box = &stack.children[0];
+    assert_eq!(title_box.tag, "Box");
+    assert_eq!(title_box.part_name.as_deref(), Some("dialog-title"));
+    assert_eq!(title_box.children.len(), 1);
+    assert_eq!(title_box.children[0].tag, "Text", "title Box wraps a Text");
+
+    // Layer 3b: Box [dialog-message] -> Text
+    let message_box = &stack.children[1];
+    assert_eq!(message_box.tag, "Box");
+    assert_eq!(message_box.part_name.as_deref(), Some("dialog-message"));
+    assert_eq!(message_box.children.len(), 1);
+    assert_eq!(message_box.children[0].tag, "Text", "message Box wraps a Text");
+
+    // Layer 3c: Box [dialog-actions] -> HostButton
+    let actions_box = &stack.children[2];
+    assert_eq!(actions_box.tag, "Box");
+    assert_eq!(actions_box.part_name.as_deref(), Some("dialog-actions"));
+    assert_eq!(actions_box.children.len(), 1);
+    assert_eq!(
+        actions_box.children[0].tag, "HostButton",
+        "actions Box must wrap a HostButton (the close button)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. mosstyle — Dialog.dark.msl compilation + part coverage
+// ---------------------------------------------------------------------------
+
+/// `Dialog.dark.msl` must compile against the layout's part map AND
+/// declare style blocks for all four named parts.  We do not assert the
+/// inside of each block — colours/sizes may evolve — but the *set of
+/// parts* is a public surface of the package (a host writing a custom
+/// theme will target the same part names), so we assert it.
+#[test]
+fn msl_compiles_and_declares_four_parts() {
+    let mll_src = read_source("Dialog.mll");
+    let mll_out = moslayout_compiler::compile(&mll_src, None)
+        .unwrap_or_else(|e| panic!("Dialog.mll precompile failed: {:#?}", e));
+
+    let msl_src = read_source("Dialog.dark.msl");
+    let msl_out = mosstyle_compiler::compile(&msl_src, Some(&mll_out.part_map_json))
+        .unwrap_or_else(|e| panic!("Dialog.dark.msl failed to compile: {:#?}", e));
+
+    let part_names: Vec<&str> = msl_out.def.parts.iter().map(|p| p.name.as_str()).collect();
+    let mut sorted = part_names.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec!["dialog-actions", "dialog-message", "dialog-root", "dialog-title"],
+        "Dialog.dark.msl must declare exactly four parts: dialog-root, \
+         dialog-title, dialog-message, dialog-actions (got {:?})",
+        part_names
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Per-backend artifact compilation
+// ---------------------------------------------------------------------------
+
+/// The list of backends the artifact builder currently wires.  React /
+/// SwiftUI / Qt have a `from_pipeline` entry point; WebComponent and Html
+/// return `UnsupportedBackend` today.  XAML is not represented in the
+/// builder's `Backend` enum at all (its emitter is still landing in the
+/// `feat(mosaic-emit-xaml)` PR series), so it cannot be exercised from
+/// this test until the builder is taught about it.
+const SUPPORTED_BACKENDS: &[Backend] = &[Backend::React, Backend::SwiftUI, Backend::Qt];
+
+/// Backends that the artifact builder knows about but does not yet wire.
+/// We assert each of these returns the documented `UnsupportedBackend`
+/// error rather than silently succeeding or crashing — that way the day
+/// they DO get wired, this assertion flips and we know to move the
+/// variant up into `SUPPORTED_BACKENDS`.
+const SKIPPED_BACKENDS: &[Backend] = &[Backend::WebComponent, Backend::Html];
+
+/// For each supported backend, drive `build_package` and assert it
+/// produces a non-empty `Dialog.<ext>` (plus the package index file).
+#[test]
+fn supported_backends_build_dialog_artifact() {
+    // Stage output into a sibling `target/dialog-artifacts` directory so
+    // a developer running `cargo test` can inspect the generated files
+    // after the fact.  We use `target/` because Cargo already excludes it
+    // from version control.
+    let out_root = package_root().join("target").join("dialog-artifacts");
+    // Clean previous run so stale files from a removed backend don't
+    // confuse a curious reader.
+    let _ = fs::remove_dir_all(&out_root);
+
+    for backend in SUPPORTED_BACKENDS {
+        let opts = BuildOptions {
+            package_root: package_root(),
+            output_root: out_root.clone(),
+            backend: *backend,
+        };
+        let result = build_package(&opts).unwrap_or_else(|e| {
+            panic!("artifact build for {:?} failed: {}", backend, e);
+        });
+
+        assert_eq!(
+            result.components_built,
+            vec!["Dialog".to_string()],
+            "{:?} build must report exactly Dialog as the built component",
+            backend
+        );
+
+        // The first artifact is the per-component file; the last is the
+        // package index (index.ts / index.swift / qmldir).  We sanity-
+        // check both.
+        let component_artifact = result
+            .artifacts
+            .iter()
+            .find(|p| p.file_name().and_then(|s| s.to_str()) != Some("index.ts")
+                && p.file_name().and_then(|s| s.to_str()) != Some("index.swift")
+                && p.file_name().and_then(|s| s.to_str()) != Some("qmldir"))
+            .unwrap_or_else(|| {
+                panic!("{:?} build produced no per-component artifact", backend)
+            });
+
+        let body = fs::read_to_string(component_artifact).unwrap_or_else(|e| {
+            panic!(
+                "could not read {:?}'s artifact at {}: {}",
+                backend,
+                component_artifact.display(),
+                e
+            )
+        });
+        assert!(
+            !body.trim().is_empty(),
+            "{:?} produced an empty Dialog artifact at {}",
+            backend,
+            component_artifact.display()
+        );
+        // Every backend either uses `Dialog` as the function/struct/type
+        // name (React/SwiftUI/Qt) or references it in the index — so the
+        // name must appear somewhere in the artifact body.
+        assert!(
+            body.contains("Dialog"),
+            "{:?} artifact at {} does not mention the component name 'Dialog':\n{}",
+            backend,
+            component_artifact.display(),
+            body
+        );
+    }
+}
+
+/// Backends the builder knows about but has not wired yet must return
+/// `UnsupportedBackend`.  This is a documentation test: it captures the
+/// CURRENT state of the artifact builder so the day WebComponent or Html
+/// is wired, this test fails loudly and the contributor knows to flip
+/// the relevant variant into `SUPPORTED_BACKENDS`.
+#[test]
+fn skipped_backends_return_unsupported() {
+    let out_root = package_root().join("target").join("dialog-artifacts-skip");
+    for backend in SKIPPED_BACKENDS {
+        let opts = BuildOptions {
+            package_root: package_root(),
+            output_root: out_root.clone(),
+            backend: *backend,
+        };
+        let err = build_package(&opts).unwrap_err();
+        assert!(
+            matches!(err, BuildError::UnsupportedBackend(b) if b == *backend),
+            "expected UnsupportedBackend({:?}), got {:?}",
+            backend,
+            err
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Source-shape sanity
+// ---------------------------------------------------------------------------
+
+/// Belt-and-suspenders: every file the package promises must be on disk.
+/// Catches the failure mode where a `.mll` or `.msl` is accidentally
+/// deleted in a refactor and the compile-test still passes because the
+/// `for` loop simply iterates zero files.
+#[test]
+fn source_tree_has_expected_shape() {
+    for name in ["Dialog.mil", "Dialog.mll", "Dialog.dark.msl"] {
+        let path = src_path(name);
+        assert!(
+            path.exists(),
+            "expected package source file missing: {}",
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- New userland Mosaic component package `mosaic-pkg-dialog` exporting a single `Dialog` component (title + message + close button) built **only** from the lowest-common-denominator UI29 kernel primitives: `Box`, `Column`, `Text`, `HostButton`.
- No `If`, no `For`, no `HostTable` — every primitive Dialog uses is present in **every** Mosaic emitter on `main` today (React, SwiftUI, Qt, WebComponent, HTML, XAML). Dialog acts as the cross-backend smoke test for the UI29 kernel.
- Visibility is host-controlled in v0.1.0 (host mounts/unmounts Dialog itself). v0.2.0 will add a `visible: bool` slot + `If` gate once `If` lands across React/SwiftUI/Qt.

## Shape

```
mosaic-pkg-dialog/
├── mosaic-package.toml        # exports = ["Dialog"], kernel = "1"
├── Cargo.toml                 # standalone, [workspace] opt-out
├── README.md
├── CHANGELOG.md
└── src/
    ├── Dialog.mil             # 3 slots (title, message, close-label), 1 emit (onClose)
    ├── Dialog.mll             # Box[dialog-root] → Column[dialog-stack] → Box×3 → Text/Text/HostButton
    └── Dialog.dark.msl        # 4 parts: dialog-root/title/message/actions
tests/
└── package_compiles.rs        # 7 smoke tests
```

## Smoke test coverage

The integration test (`cargo test` from the package root) asserts:

1. Manifest parses with `[components].exports = ["Dialog"]` and `[kernel].version = "1"`.
2. `Dialog.mil` compiles via `mosmodel-compiler` with 3 text slots and 1 zero-arg emit.
3. `Dialog.mll` compiles via `moslayout-compiler` against the `.mil` AND the resulting tree has the exact `Box → Column → Box×3 → Text/Text/HostButton` shape with the four expected `part` names.
4. `Dialog.dark.msl` compiles via `mosstyle-compiler` and declares all four parts.
5. `mosaic_package_artifact_builder::build_package` produces a non-empty `Dialog.<ext>` for every backend it currently wires (React, SwiftUI, Qt).
6. WebComponent and HTML are SKIPPED with a documented `UnsupportedBackend` assertion (their `from_pipeline` entry points land in parallel PRs; XAML isn't yet a `Backend` enum variant).

## Test plan

- [x] `cd code/packages/mosaic-pkg-dialog && cargo test` — all 7 tests pass locally
- [x] React, SwiftUI, Qt artifacts written to `target/dialog-artifacts/<backend>/Dialog.<ext>`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)