### PR TITLE
fix(sql-vm,sql-optimizer,mini-sqlite): arithmetic edge cases match SQLite

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.73.0] - 2026-05-20
+
+### Fixed
+
+- **Arithmetic edge cases match SQLite byte-for-byte** (via
+  ``sql-vm 1.47.0`` and ``sql-optimizer 0.14.0``):
+
+  * ``x / 0`` returns NULL (was raising ``OperationalError``).
+  * ``-7 % 3`` returns ``-1`` (was ``2`` — Python's divisor-sign mod).
+  * ``7.5 % 2.0`` returns ``1.0`` (SQLite's ``%`` truncates floats to
+    int first; was ``1.5`` from true fmod).
+  * ``-7 / 2`` returns ``-3`` (was Python's ``-4`` floor-divide).
+
+  21 oracle tests in ``test_tier3_arithmetic_edge_cases.py`` cover
+  divide-by-zero / negative-dividend / negative-divisor / mixed
+  int+float / column-driven arithmetic.  The ``mod()`` scalar function
+  is also pinned (different from ``%`` — keeps true ``fmod``).
+
 ## [1.72.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.72.0"
+version = "1.73.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_arithmetic_edge_cases.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_arithmetic_edge_cases.py
@@ -1,0 +1,164 @@
+"""Arithmetic edge cases — divide-by-zero, modulo with negative operands.
+
+Three Python-vs-SQLite semantic differences uncovered by a gap audit:
+
+1. **``x / 0`` returns NULL** in SQLite (its broader "arithmetic errors
+   produce NULL" policy).  Mini-sqlite was raising ``DivisionByZero``
+   which surfaced as ``OperationalError`` to the caller — fine for a
+   strict language, but mismatched for SQL-compatible code that
+   expects ``COALESCE(a/b, 0)`` to work on rows where ``b = 0``.
+
+2. **``%`` operator follows C-style ``fmod``** — result sign matches
+   the *dividend*, not the divisor.  Python's ``%`` is the opposite:
+   ``-7 % 3 == 2`` (positive, matching divisor) in Python but ``-1``
+   in SQLite (matching dividend).
+
+3. **``%`` operator truncates floats to integers first**, then
+   computes integer modulo, then casts back to float.  So
+   ``7.5 % 2.0`` is ``1.0`` in SQLite (``int(7.5) % int(2.0) =
+   7 % 2 = 1``), not ``1.5`` like ``math.fmod`` would give.  Note
+   this is **different from the ``mod()`` scalar function**, which
+   uses true ``fmod`` and produces ``1.5``.
+
+The fixes span both the runtime VM (``sql_vm.operators._arithmetic``)
+and the constant-folding optimizer
+(``sql_optimizer.constant_folding._apply_binary``) so literal-only
+expressions are folded with SQLite semantics rather than Python's.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Divide by zero → NULL
+# ---------------------------------------------------------------------------
+
+
+class TestDivideByZero:
+    def test_int_div_zero(self) -> None:
+        # Was raising DivisionByZero (OperationalError).
+        _check("SELECT 7 / 0")
+
+    def test_float_div_zero(self) -> None:
+        _check("SELECT 7.0 / 0")
+
+    def test_float_div_zero_float(self) -> None:
+        _check("SELECT 7.0 / 0.0")
+
+    def test_div_zero_in_expression(self) -> None:
+        # COALESCE(NULL, fallback) is a common pattern with divide-by-zero
+        # since SQLite intentionally returns NULL so callers can do this.
+        _check("SELECT coalesce(7 / 0, -1)")
+
+
+# ---------------------------------------------------------------------------
+# Integer division truncates toward zero (not Python's floor)
+# ---------------------------------------------------------------------------
+
+
+class TestIntegerDivisionTruncation:
+    def test_negative_dividend(self) -> None:
+        # Python: -7 // 2 = -4 (floor); SQLite: -7 / 2 = -3 (truncate).
+        _check("SELECT -7 / 2")
+
+    def test_negative_divisor(self) -> None:
+        _check("SELECT 7 / -2")
+
+    def test_both_negative(self) -> None:
+        _check("SELECT -7 / -2")
+
+
+# ---------------------------------------------------------------------------
+# Modulo: C-style (sign follows dividend), integer-first for floats
+# ---------------------------------------------------------------------------
+
+
+class TestModuloOperator:
+    def test_positive_operands(self) -> None:
+        _check("SELECT 7 % 3")
+
+    def test_negative_dividend(self) -> None:
+        # Python: -7 % 3 = 2; SQLite: -7 % 3 = -1.
+        _check("SELECT -7 % 3")
+
+    def test_negative_divisor(self) -> None:
+        # Python: 7 % -3 = -2; SQLite: 7 % -3 = 1.
+        _check("SELECT 7 % -3")
+
+    def test_both_negative(self) -> None:
+        _check("SELECT -7 % -3")
+
+    def test_mod_by_zero(self) -> None:
+        _check("SELECT 7 % 0")
+
+    def test_float_mod_truncates_to_int(self) -> None:
+        # SQLite: 7.5 % 2.0 → int(7.5) % int(2.0) = 7 % 2 = 1 → 1.0
+        _check("SELECT 7.5 % 2.0")
+
+    def test_float_mod_truncates_15_5(self) -> None:
+        # 15.5 % 4.5 → int(15.5) % int(4.5) = 15 % 4 = 3 → 3.0
+        _check("SELECT 15.5 % 4.5")
+
+    def test_mixed_int_float(self) -> None:
+        _check("SELECT 7 % 2.5")
+        _check("SELECT 7.5 % 2")
+
+
+# ---------------------------------------------------------------------------
+# mod() scalar function uses true fmod (different from % operator!)
+# ---------------------------------------------------------------------------
+
+
+class TestModScalarFunction:
+    def test_mod_returns_float(self) -> None:
+        # Always float, even for integer inputs.
+        _check("SELECT mod(7, 3)")
+
+    def test_mod_negative_dividend(self) -> None:
+        _check("SELECT mod(-7, 3)")
+
+    def test_mod_negative_divisor(self) -> None:
+        _check("SELECT mod(7, -3)")
+
+    def test_mod_true_fmod_for_floats(self) -> None:
+        # mod() uses true fmod — fractional remainder preserved.
+        _check("SELECT mod(7.5, 2.0)")
+
+    def test_mod_by_zero_null(self) -> None:
+        _check("SELECT mod(10, 0)")
+
+
+# ---------------------------------------------------------------------------
+# Column-driven arithmetic — exercises the VM path (not just constant fold)
+# ---------------------------------------------------------------------------
+
+
+class TestColumnArithmetic:
+    SETUP = [
+        "CREATE TABLE t (a INTEGER, b INTEGER)",
+        "INSERT INTO t VALUES (7, 3), (-7, 3), (7, -3), (-7, -3), (7, 0)",
+    ]
+
+    def test_column_div(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute(
+            "SELECT a, b, a / b, a % b FROM t ORDER BY a, b"
+        ).fetchall()
+        r = conn_r.execute(
+            "SELECT a, b, a / b, a % b FROM t ORDER BY a, b"
+        ).fetchall()
+        assert m == r

--- a/code/packages/python/sql-optimizer/CHANGELOG.md
+++ b/code/packages/python/sql-optimizer/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.14.0] - 2026-05-20
+
+### Fixed
+
+- **Constant folding of ``/`` and ``%`` now matches SQLite semantics.**
+  Previously the folder used Python's ``//`` and ``%`` directly, which
+  diverges from SQLite for negative integers (Python's floor-vs-trunc,
+  and Python's divisor-sign vs SQLite's dividend-sign modulo).  Folds
+  now mirror the runtime behaviour: ``-7 / 2 → -3``, ``-7 % 3 → -1``,
+  ``7.5 % 2.0 → 1.0``.  Divisions by zero raise inside the folder
+  (caught by the existing try/except and left for the VM to evaluate
+  at runtime, where they correctly produce NULL).
+
 ## [0.13.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-optimizer/pyproject.toml
+++ b/code/packages/python/sql-optimizer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-optimizer"
-version = "0.13.0"
+version = "0.14.0"
 description = "Pure rewrite passes over sql-planner's LogicalPlan tree."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-optimizer/src/sql_optimizer/constant_folding.py
+++ b/code/packages/python/sql-optimizer/src/sql_optimizer/constant_folding.py
@@ -344,12 +344,34 @@ def _apply_binary(op: BinaryOp, lv: object, rv: object) -> object:
         case BinaryOp.MUL:
             return lv * rv  # type: ignore[operator]
         case BinaryOp.DIV:
+            # SQLite returns NULL for x / 0 rather than raising — defer
+            # to the VM by leaving the expression un-folded so the
+            # runtime error path is used uniformly.
+            if rv == 0:
+                raise ZeroDivisionError
             # Integer-style division matches SQL: 7/2 = 3 for integers.
             if isinstance(lv, int) and isinstance(rv, int) and not isinstance(lv, bool):
-                return lv // rv
+                # SQLite truncates toward zero (e.g. ``-7 / 2 == -3``),
+                # whereas Python's ``//`` floors (-7 // 2 == -4).
+                q = abs(lv) // abs(rv)
+                return -q if (lv < 0) ^ (rv < 0) else q
             return lv / rv  # type: ignore[operator]
         case BinaryOp.MOD:
-            return lv % rv  # type: ignore[operator]
+            # See the matching comment in sql_vm.operators._arithmetic
+            # for the rationale.  Briefly: SQLite's ``%`` truncates floats
+            # to integers first, then computes C-style modulo (sign
+            # follows the dividend), and casts back to float if either
+            # input was floating-point.  ``mod()`` (the scalar function)
+            # uses true fmod and is handled separately.
+            if rv == 0:
+                raise ZeroDivisionError
+            is_float = isinstance(lv, float) or isinstance(rv, float)
+            ilv, irv = int(lv), int(rv)  # type: ignore[arg-type]
+            if irv == 0:
+                raise ZeroDivisionError
+            magnitude = abs(ilv) % abs(irv)
+            result = -magnitude if ilv < 0 else magnitude
+            return float(result) if is_float else result
         case BinaryOp.CONCAT:
             # SQL || string concatenation. Both sides are strings (the SQL type
             # system guarantees this; if they aren't, fall through to TypeError

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.47.0 — 2026-05-20
+
+### Fixed
+
+- **``x / 0`` returns NULL** instead of raising ``DivisionByZero``.
+  Matches SQLite's "arithmetic errors yield NULL" policy and lets
+  callers wrap risky math in ``COALESCE(a/b, fallback)`` the way they
+  would with real sqlite3.
+
+- **``%`` operator follows C-style ``fmod`` semantics.**  Result sign
+  matches the *dividend* (not the divisor like Python's ``%``):
+  ``-7 % 3 → -1``, ``7 % -3 → 1``.
+
+- **``%`` operator truncates floats to integers first** for the
+  modulo computation, then casts back to float — so ``7.5 % 2.0 →
+  1.0`` (because ``int(7.5) % int(2.0) == 7 % 2 == 1``).  This is
+  *different* from the ``mod()`` scalar function, which still uses
+  true ``math.fmod`` for backward compatibility with portable code
+  written against the function spelling.
+
+- **``mod()`` scalar function** now also uses ``math.fmod`` correctly
+  for negative operands and always returns float (matches SQLite's
+  documented ``mod()`` behaviour).
+
 ## 1.46.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.46.0"
+version = "1.47.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/operators.py
+++ b/code/packages/python/sql-vm/src/sql_vm/operators.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from sql_backend.values import SqlValue, sql_type_name
 from sql_codegen import BinaryOpCode, UnaryOpCode
 
-from .errors import DivisionByZero, TypeMismatch
+from .errors import TypeMismatch
 
 
 def _is_bool(v: SqlValue) -> bool:
@@ -140,8 +140,11 @@ def _arithmetic(op: BinaryOpCode, left: SqlValue, right: SqlValue) -> SqlValue:
     if op is BinaryOpCode.MUL:
         return a * b
     if op is BinaryOpCode.DIV:
+        # SQLite returns NULL for ``x / 0`` rather than raising — matches its
+        # philosophy that arithmetic errors yield NULL.  Previously we raised
+        # DivisionByZero, which mini-sqlite surfaced as OperationalError.
         if b == 0:
-            raise DivisionByZero()
+            return None
         # Integer division when both operands are ints; truncate toward zero
         # as C / most SQL dialects do, not Python's floor-divide semantics.
         if isinstance(a, int) and isinstance(b, int):
@@ -151,11 +154,27 @@ def _arithmetic(op: BinaryOpCode, left: SqlValue, right: SqlValue) -> SqlValue:
     if op is BinaryOpCode.MOD:
         if b == 0:
             # SQLite returns NULL for x % 0 rather than raising an error.
-            # Python raises ZeroDivisionError; we match the SQLite behaviour here
-            # so that queries like `SELECT 5 % 0` silently yield NULL instead of
-            # crashing the VM.
             return None
-        return a % b
+        # SQLite's ``%`` is C-style ``fmod`` *with an integer cast first*:
+        # if either operand is float, both are truncated toward zero and
+        # the result is the integer modulo cast back to float.  This is
+        # different from the ``mod()`` scalar function (which uses true
+        # fmod).  Examples:
+        #
+        #     7   %  3   → 1
+        #    -7   %  3   → -1   (sign follows dividend, not Python's 2)
+        #     7   % -3   → 1
+        #     7.5 %  2.0 → 1.0  (truncate to 7 % 2, then cast back)
+        #    15.5 %  4.5 → 3.0  (truncate to 15 % 4)
+        is_float = isinstance(a, float) or isinstance(b, float)
+        ia, ib = int(a), int(b)
+        if ib == 0:
+            # Both operands truncate to 0-modulus (e.g. ``1.5 % 0.5`` →
+            # ``int(0.5) = 0``).  Mirror SQLite's NULL-on-error policy.
+            return None
+        magnitude = abs(ia) % abs(ib)
+        result = -magnitude if ia < 0 else magnitude
+        return float(result) if is_float else result
     raise TypeMismatch(expected="arithmetic op", got=op.name, context="BinaryOp")
 
 

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -556,20 +556,31 @@ def _sign(x: SqlValue) -> SqlValue:
 @register("mod")
 @null_propagating
 def _mod(x: SqlValue, y: SqlValue) -> SqlValue:
-    """Return *x* modulo *y*.
+    """Return *x* modulo *y* — C-style ``fmod`` semantics, float result.
 
-    Returns NULL for NULL inputs.  Returns NULL (not an error) for
-    division-by-zero — matching SQLite's ``x % 0 → NULL`` behaviour.
+    SQLite's ``MOD(x, y)`` is implemented on top of ``fmod`` from the
+    C math library: the result has the sign of the *dividend* (``x``)
+    and is always returned as a floating-point value (even for integer
+    inputs).  Python's built-in ``%`` operator follows the *divisor*
+    sign and preserves the integer type — neither matches.
+
+    Returns NULL for NULL inputs and for division-by-zero (matching
+    SQLite's "arithmetic errors return NULL" policy).
 
     Examples::
 
-        MOD(10, 3)   → 1
-        MOD(10, 0)   → NULL
+        MOD(10, 3)    → 1.0    (Python ``10 % 3``   == 1, same magnitude)
+        MOD(-7, 3)    → -1.0   (Python ``-7 % 3``   == 2; wrong sign)
+        MOD(7, -3)    → 1.0    (Python ``7 % -3``   == -2; wrong sign)
+        MOD(7.5, 2.0) → 1.5
+        MOD(10, 0)    → NULL
     """
     if isinstance(x, (int, float)) and isinstance(y, (int, float)):
         if y == 0:
             return None
-        return x % y  # type: ignore[operator]
+        # math.fmod implements C-style modulo: result sign matches dividend.
+        import math
+        return math.fmod(float(x), float(y))
     return None
 
 

--- a/code/packages/python/sql-vm/tests/test_operators.py
+++ b/code/packages/python/sql-vm/tests/test_operators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from sql_codegen import BinaryOpCode, UnaryOpCode
 
-from sql_vm.errors import DivisionByZero, TypeMismatch
+from sql_vm.errors import TypeMismatch
 from sql_vm.operators import apply_binary, apply_unary, like_match
 
 
@@ -30,14 +30,28 @@ class TestArithmetic:
         result = apply_binary(BinaryOpCode.DIV, 5.0, 2)
         assert result == 2.5
 
-    def test_div_by_zero(self) -> None:
-        with pytest.raises(DivisionByZero):
-            apply_binary(BinaryOpCode.DIV, 5, 0)
+    def test_div_by_zero_returns_null(self) -> None:
+        # SQLite returns NULL for x / 0 rather than raising.  Mini-sqlite
+        # used to raise DivisionByZero (surfaced as OperationalError), so
+        # any application that expected SQLite's NULL-on-error policy was
+        # crashing.  Now both DIV and MOD by zero produce NULL.
+        assert apply_binary(BinaryOpCode.DIV, 5, 0) is None
+        assert apply_binary(BinaryOpCode.DIV, 5.0, 0) is None
+        assert apply_binary(BinaryOpCode.DIV, 5, 0.0) is None
 
     def test_mod_by_zero(self) -> None:
-        # SQLite returns NULL for x % 0, unlike DIV which raises ZeroDivisionError.
-        # Our VM follows SQLite's behaviour here.
+        # Both DIV and MOD return NULL for division by zero.
         assert apply_binary(BinaryOpCode.MOD, 5, 0) is None
+
+    def test_mod_sign_follows_dividend(self) -> None:
+        # SQLite's % is C-style fmod: result sign matches the *dividend*.
+        # Python's % follows the divisor, which gives the wrong answer
+        # for negative operands (e.g. ``-7 % 3 == 2`` in Python but SQLite
+        # produces -1).  Pin the corrected C-style behaviour.
+        assert apply_binary(BinaryOpCode.MOD, -7, 3) == -1
+        assert apply_binary(BinaryOpCode.MOD, 7, -3) == 1
+        assert apply_binary(BinaryOpCode.MOD, -7, -3) == -1
+        assert apply_binary(BinaryOpCode.MOD, 7, 3) == 1
 
     def test_arithmetic_with_non_numeric_raises(self) -> None:
         with pytest.raises(TypeMismatch):


### PR DESCRIPTION
## Summary

Three Python-vs-SQLite semantic differences fixed at both the constant-folding optimizer and runtime VM layers:

1. **`x / 0` returns NULL** (was raising `OperationalError`). Matches SQLite's "arithmetic errors yield NULL" policy. `COALESCE(a/b, fallback)` now works on rows where `b = 0`.
2. **`%` operator follows C-style fmod**: result sign matches the *dividend*, not the divisor. `-7 % 3` now returns `-1` instead of `2`.
3. **`%` operator truncates floats to integers first**. `7.5 % 2.0 → 1.0` (`int(7.5) % int(2.0) = 7 % 2 = 1`), not `1.5` from true fmod. This differs from the **`mod()` scalar function**, which still uses true `math.fmod` (also fixed for negative operands and always returns float).
4. **Integer division truncates toward zero** (`-7 / 2 == -3`) in the optimizer too, matching the runtime.

26 tests: 2 sql-vm + 21 mini-sqlite oracle + 3 sql-optimizer existing. Version bumps: sql-vm 1.46.0 → 1.47.0, sql-optimizer 0.13.0 → 0.14.0, mini-sqlite 1.72.0 → 1.73.0.

## Test plan

- [x] `pytest sql-optimizer/tests/` — 144 passed
- [x] `pytest sql-vm/tests/` — 895 passed
- [x] `pytest mini-sqlite/tests/test_tier3_arithmetic_edge_cases.py` — 21/21
- [x] mini-sqlite full suite — 1799 passed (1778 prior + 21 new)
- [x] All cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)