### PR TITLE
[codex] Add Arduino CLI upload options to language core

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -28,6 +28,9 @@ metadata instead of maintaining language-local board tables. The upload
 descriptor also records whether the board appears through a USB serial bridge,
 native USB bootloader, or external serial adapter, which keeps Pro Mini-style
 boards from being treated like onboard-USB Arduinos.
+`board-vm-language-core` turns those descriptors into typed Arduino CLI upload
+options, including the port-selection step and board-package reset delegation,
+so language frontends do not need their own Arduino upload adapter matrix.
 
 The shared target registry also records physical wireless radios for the
 Arduino-family boards that have Wi-Fi or BLE hardware, including MKR/Nano

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -29,9 +29,12 @@ frontends may own ergonomic transport discovery in the short term, but the bytes
 they send and decode should come from this Rust core.
 
 Firmware flashing follows the same rule: frontends can present native options,
-but they should query `upload_plan_for_target` to learn the artifact kind,
+but they should query Rust-owned upload helpers to learn the artifact kind,
 transport requirements, reset behavior, port hint, adapter steps, and Arduino
-CLI platform/FQBN metadata for each board family.
+CLI platform/FQBN metadata for each board family. Generic clients can use
+`upload_plan_for_target`; Arduino CLI-specific clients can use
+`arduino_cli_upload_options_for_target` so native USB, USB-serial bridge, and
+external-adapter port selection stay in Rust instead of language-local tables.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -560,6 +560,24 @@ pub struct LanguagePicoUf2UploadOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageArduinoCliUploadOptions {
+    pub board_id: String,
+    pub command: String,
+    pub image_format: String,
+    pub transport: String,
+    pub reset_method: String,
+    pub platform_id: String,
+    pub fqbn: String,
+    pub port_hint: String,
+    pub port_selection_step: String,
+    pub native_usb: bool,
+    pub usb_serial_bridge: bool,
+    pub external_serial_adapter: bool,
+    pub requires_serial_port: bool,
+    pub delegate_reset_to_board_package: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageUploadOptions {
     pub board_id: String,
     pub adapter: String,
@@ -939,6 +957,35 @@ pub fn pico_uf2_upload_options_for_target(selector: &str) -> Option<LanguagePico
         volume_label: "RPI-RP2".to_owned(),
         image_extension: ".uf2".to_owned(),
         auto_detect_mount: true,
+    })
+}
+
+pub fn arduino_cli_upload_options_for_target(
+    selector: &str,
+) -> Option<LanguageArduinoCliUploadOptions> {
+    let target = detect_board_target(selector)?;
+    let upload = target.upload?;
+    if upload.adapter != TargetUploadAdapter::ArduinoCli {
+        return None;
+    }
+
+    let port_hint = upload.port_hint?;
+    Some(LanguageArduinoCliUploadOptions {
+        board_id: target.board_id.to_owned(),
+        command: upload.command.to_owned(),
+        image_format: upload_image_format_name(upload.image_format).to_owned(),
+        transport: upload_transport_name(upload.transport).to_owned(),
+        reset_method: upload_reset_method_name(upload.reset_method).to_owned(),
+        platform_id: upload.platform_id?.to_owned(),
+        fqbn: upload.fqbn?.to_owned(),
+        port_hint: upload_port_hint_name(port_hint).to_owned(),
+        port_selection_step: arduino_cli_port_selection_step(upload.port_hint).to_owned(),
+        native_usb: port_hint == TargetUploadPortHint::NativeUsb,
+        usb_serial_bridge: port_hint == TargetUploadPortHint::UsbSerialBridge,
+        external_serial_adapter: port_hint == TargetUploadPortHint::ExternalSerialAdapter,
+        requires_serial_port: upload.transport == TargetUploadTransport::Serial,
+        delegate_reset_to_board_package: upload.reset_method
+            == TargetUploadResetMethod::ArduinoBoardPackage,
     })
 }
 
@@ -5204,6 +5251,46 @@ mod tests {
         assert!(options.auto_detect_mount);
         assert!(pico_uf2_upload_options_for_target("pico-w").is_some());
         assert!(pico_uf2_upload_options_for_target("esp32").is_none());
+    }
+
+    #[test]
+    fn arduino_cli_upload_options_are_owned_by_rust_language_core() {
+        let nano_r4 = arduino_cli_upload_options_for_target("arduino:renesas_uno:nanor4").unwrap();
+        assert_eq!(nano_r4.board_id, "arduino-nano-r4");
+        assert_eq!(nano_r4.command, "arduino-cli upload");
+        assert_eq!(nano_r4.image_format, "arduino_cli_build_output");
+        assert_eq!(nano_r4.transport, "serial");
+        assert_eq!(nano_r4.reset_method, "arduino_board_package");
+        assert_eq!(nano_r4.platform_id, "arduino:renesas_uno");
+        assert_eq!(nano_r4.fqbn, "arduino:renesas_uno:nanor4");
+        assert_eq!(nano_r4.port_hint, "native_usb");
+        assert_eq!(nano_r4.port_selection_step, "select_native_usb_port");
+        assert!(nano_r4.native_usb);
+        assert!(!nano_r4.usb_serial_bridge);
+        assert!(!nano_r4.external_serial_adapter);
+        assert!(nano_r4.requires_serial_port);
+        assert!(nano_r4.delegate_reset_to_board_package);
+
+        let mega =
+            arduino_cli_upload_options_for_target("arduino:avr:mega:cpu=atmega2560").unwrap();
+        assert_eq!(mega.board_id, "arduino-mega-2560");
+        assert_eq!(mega.platform_id, "arduino:avr");
+        assert_eq!(mega.port_hint, "usb_serial_bridge");
+        assert_eq!(mega.port_selection_step, "select_usb_serial_port");
+        assert!(mega.usb_serial_bridge);
+        assert!(!mega.native_usb);
+
+        let pro_mini = arduino_cli_upload_options_for_target("arduino-pro-mini").unwrap();
+        assert_eq!(pro_mini.port_hint, "external_serial_adapter");
+        assert_eq!(
+            pro_mini.port_selection_step,
+            "select_external_serial_adapter"
+        );
+        assert!(pro_mini.external_serial_adapter);
+
+        assert!(arduino_cli_upload_options_for_target("esp32").is_none());
+        assert!(arduino_cli_upload_options_for_target("pico").is_none());
+        assert!(arduino_cli_upload_options_for_target("not-a-board").is_none());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -42,6 +42,11 @@ builder:
 - Raspberry Pi Pico targets use a Pico UF2 mass-storage profile so BOOTSEL mount
   discovery and UF2 copy behavior are exposed without frontend special cases.
 
+`board-vm-language-core` exposes typed Arduino CLI upload options from these
+profiles, including platform/FQBN, port-selection step, native USB versus
+USB-serial bridge hints, and board-package reset delegation. Language frontends
+should call that helper instead of reconstructing Arduino upload tables.
+
 Wireless metadata separates physical support from the generic front-end sugar:
 
 - every current target exposes `transport.serial`

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -134,6 +134,12 @@ same descriptors. Arduino CLI boards now report whether their upload path starts
 from a USB serial bridge, native USB bootloader port, or external serial
 adapter before delegating reset/programmer behavior to the board package.
 
+The Arduino CLI upload-options tranche exposes those adapter details as a typed
+Rust language-core resolver. Frontends can ask Rust for the platform, FQBN,
+port-selection step, native USB versus USB-serial bridge versus external
+adapter classification, and board-package reset delegation without duplicating
+the Arduino target matrix.
+
 The Arduino wireless metadata tranche records physical Wi-Fi and Bluetooth LE
 radios for non-Uno boards such as MKR WiFi 1010, Nano 33 IoT, Nano 33 BLE Rev2,
 Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi, Portenta H7 Lite Connected,


### PR DESCRIPTION
## Summary
- add typed Arduino CLI upload options in `board-vm-language-core`
- expose platform/FQBN, port-selection step, native USB / USB-serial bridge / external adapter flags, and board-package reset delegation from Rust-owned metadata
- document the adapter detail so language frontends stay thin over the target registry instead of rebuilding Arduino upload tables

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options cargo fmt -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options cargo test -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options cargo test -p board-vm-targets -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core` from `code/packages/rust`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options bash BUILD` in `code/packages/rust/board-vm-targets`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-options bash BUILD` in `code/packages/rust/board-vm-arduino`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.
