### PR TITLE
Add checkpoint scalar accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this package will be documented in this file.
 - Typed classifier accessors for supervisor drain run summaries.
 - Workload accessors for supervisor drain run reports.
 - Workload accessors for supervisor drain run summaries.
+- Last-checkpoint scalar accessors for supervisor drain run reports and
+  summaries.
 - Flattened planned and replayed follow-up row counts in supervisor drain run
   summaries.
 - Follow-up pressure drift flags in supervisor drain run reports and summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -43,6 +43,8 @@ The crate keeps the boundary narrow:
   scheduler and investigation decisions
 - supervisor drain reports and summaries expose workload accessors for checkpoint,
   budget, planned, replayed, and delta fields
+- supervisor drain reports and summaries expose last-checkpoint scalar accessors
+  for timestamp and call-id host logs
 - supervisor drain run summaries flatten planned and replayed follow-up row
   counts for host routing decisions
 - supervisor drain run summaries flag when planned and replayed follow-up

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1175,6 +1175,23 @@ impl ToolAuditSupervisorDrainRunReport {
     pub fn last_checkpoint(&self) -> Option<&ToolAuditReadCheckpoint> {
         self.drain.last_checkpoint()
     }
+
+    /// Return whether the actual run observed a replay checkpoint.
+    pub fn has_last_checkpoint(&self) -> bool {
+        self.last_checkpoint().is_some()
+    }
+
+    /// Return the timestamp for the last replay checkpoint observed by the actual run.
+    pub fn last_checkpoint_timestamp_ms(&self) -> Option<u64> {
+        self.last_checkpoint()
+            .map(|checkpoint| checkpoint.timestamp_ms)
+    }
+
+    /// Return the call id for the last replay checkpoint observed by the actual run.
+    pub fn last_checkpoint_call_id(&self) -> Option<&str> {
+        self.last_checkpoint()
+            .map(|checkpoint| checkpoint.call_id.as_str())
+    }
 }
 
 /// Payload-free, flattened host summary for a bounded supervisor drain run.
@@ -1476,6 +1493,23 @@ impl ToolAuditSupervisorDrainRunSummary {
     /// Return the last replay checkpoint observed by the actual run.
     pub fn last_checkpoint(&self) -> Option<&ToolAuditReadCheckpoint> {
         self.last_checkpoint.as_ref()
+    }
+
+    /// Return whether the actual run observed a replay checkpoint.
+    pub fn has_last_checkpoint(&self) -> bool {
+        self.last_checkpoint().is_some()
+    }
+
+    /// Return the timestamp for the last replay checkpoint observed by the actual run.
+    pub fn last_checkpoint_timestamp_ms(&self) -> Option<u64> {
+        self.last_checkpoint()
+            .map(|checkpoint| checkpoint.timestamp_ms)
+    }
+
+    /// Return the call id for the last replay checkpoint observed by the actual run.
+    pub fn last_checkpoint_call_id(&self) -> Option<&str> {
+        self.last_checkpoint()
+            .map(|checkpoint| checkpoint.call_id.as_str())
     }
 }
 
@@ -3228,6 +3262,9 @@ mod tests {
             report.last_checkpoint(),
             Some(&ToolAuditReadCheckpoint::new(120, "call_4"))
         );
+        assert!(report.has_last_checkpoint());
+        assert_eq!(report.last_checkpoint_timestamp_ms(), Some(120));
+        assert_eq!(report.last_checkpoint_call_id(), Some("call_4"));
         assert_eq!(sink.records().len(), 4);
         assert_eq!(
             store
@@ -3831,6 +3868,9 @@ mod tests {
         assert!(summary.advanced_checkpoint());
         assert_eq!(summary.last_checkpoint, report.last_checkpoint().cloned());
         assert_eq!(summary.last_checkpoint(), report.last_checkpoint());
+        assert!(summary.has_last_checkpoint());
+        assert_eq!(summary.last_checkpoint_timestamp_ms(), Some(120));
+        assert_eq!(summary.last_checkpoint_call_id(), Some("call_2"));
         assert!(!summary.is_idle());
         assert!(summary.made_progress());
         assert!(summary.should_continue());


### PR DESCRIPTION
## Summary
- add last-checkpoint presence, timestamp, and call-id helpers on supervisor drain run reports
- expose the same checkpoint scalar helpers on flattened supervisor drain run summaries
- cover report and summary checkpoint scalar helpers in existing drain tests

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD