### PR TITLE
feat(mosaic-emit-xaml): PR-6 — pkg-grid compiles + CLI wiring

### DIFF
--- a/code/packages/rust/mosaic-compile/Cargo.toml
+++ b/code/packages/rust/mosaic-compile/Cargo.toml
@@ -16,6 +16,7 @@ mosaic-emit-webcomponent = { path = "../mosaic-emit-webcomponent" }
 mosaic-emit-html = { path = "../mosaic-emit-html" }
 mosaic-emit-react = { path = "../mosaic-emit-react" }
 mosaic-emit-paint = { path = "../mosaic-emit-paint" }
+mosaic-emit-xaml = { path = "../mosaic-emit-xaml" }
 mosmodel-compiler = { path = "../mosmodel-compiler" }
 moslayout-compiler = { path = "../moslayout-compiler" }
 mosstyle-compiler = { path = "../mosstyle-compiler" }

--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -153,9 +153,14 @@ fn run(result: cli_builder::types::ParseResult) {
             process::exit(1);
         });
 
-    if backend != "webcomponent" && backend != "html" && backend != "react" && backend != "paint" {
+    if backend != "webcomponent"
+        && backend != "html"
+        && backend != "react"
+        && backend != "paint"
+        && backend != "xaml"
+    {
         eprintln!(
-            "mosaic-compile: --backend must be 'webcomponent', 'html', 'react', or 'paint', got '{backend}'"
+            "mosaic-compile: --backend must be 'webcomponent', 'html', 'react', 'paint', or 'xaml', got '{backend}'"
         );
         process::exit(1);
     }
@@ -344,8 +349,8 @@ fn require_pipeline_flag<'a>(name: &str, value: Option<&'a str>) -> &'a str {
 /// Run the three-file pipeline path: compile `.mil`, `.mll`, `.msl` to a
 /// single output file using the new pipeline-aware backend emitter.
 ///
-/// Currently only `--backend react` is wired here; the other backends will
-/// follow when they gain their own pipeline entry points. The legacy
+/// Currently `--backend react` and `--backend xaml` are wired here; the
+/// other backends (swiftui, qt) will follow when they're added. The legacy
 /// `--backend X SOURCE.mosaic` path continues to work unchanged for any of
 /// the four backends.
 fn run_pipeline(
@@ -355,10 +360,10 @@ fn run_pipeline(
     style_path: &str,
     output_path: Option<&str>,
 ) {
-    if backend != "react" {
+    if backend != "react" && backend != "xaml" {
         eprintln!(
             "mosaic-compile: pipeline mode (--interface/--layout/--style) \
-             currently supports only --backend react (got '{backend}'). \
+             currently supports --backend react or --backend xaml (got '{backend}'). \
              Use legacy SOURCE mode for other backends."
         );
         process::exit(1);
@@ -406,23 +411,79 @@ fn run_pipeline(
             process::exit(1);
         });
 
-    // -- 4. Lower the triple to a React TSX file ----------------------------
-    let result = mosaic_emit_react::pipeline::from_pipeline(
-        &mosmodel_out.component,
-        &layout_out.def,
-        &style_out.def,
-    )
-    .unwrap_or_else(|e| {
-        eprintln!("mosaic-compile: react pipeline emit error: {e}");
-        process::exit(1);
-    });
+    // -- 4. Branch on backend. React emits one .tsx file; XAML emits a
+    // triple (.xaml, .xaml.cs, .Event.cs) plus zero-or-more RowVm .cs
+    // files (one per `For` block).
+    match backend {
+        "react" => {
+            let result = mosaic_emit_react::pipeline::from_pipeline(
+                &mosmodel_out.component,
+                &layout_out.def,
+                &style_out.def,
+            )
+            .unwrap_or_else(|e| {
+                eprintln!("mosaic-compile: react pipeline emit error: {e}");
+                process::exit(1);
+            });
+            let out = output_path
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{}.tsx", result.component_name));
+            write_file_or_die(&out, &result.output);
+            eprintln!("Written: {out}");
+        }
+        "xaml" => {
+            let result = mosaic_emit_xaml::from_pipeline(
+                &mosmodel_out.component,
+                &layout_out.def,
+                &style_out.def,
+                None,
+                &mosaic_emit_xaml::EmitOptions::default(),
+            )
+            .unwrap_or_else(|e| {
+                eprintln!("mosaic-compile: xaml pipeline emit error: {e}");
+                process::exit(1);
+            });
+            // `output_path` is treated as a *base* for the three (or
+            // more) generated files. Default base = the component name.
+            let base = output_path
+                .map(str::to_string)
+                .unwrap_or_else(|| result.component_name.clone());
+            // Strip a trailing `.xaml` if the user passed e.g. `Grid.xaml`
+            // so the C# files don't end up as `Grid.xaml.xaml.cs`.
+            let base = base
+                .strip_suffix(".xaml")
+                .map(str::to_string)
+                .unwrap_or(base);
 
-    // -- 5. Write the output ------------------------------------------------
-    let out = output_path
-        .map(str::to_string)
-        .unwrap_or_else(|| format!("{}.tsx", result.component_name));
-    write_file_or_die(&out, &result.output);
-    eprintln!("Written: {out}");
+            let xaml_path = format!("{base}.xaml");
+            let cs_path = format!("{base}.xaml.cs");
+            let evt_path = format!("{base}.Event.cs");
+            write_file_or_die(&xaml_path, &result.xaml);
+            write_file_or_die(&cs_path, &result.code_behind);
+            write_file_or_die(&evt_path, &result.events);
+            eprintln!("Written: {xaml_path}");
+            eprintln!("Written: {cs_path}");
+            eprintln!("Written: {evt_path}");
+            // Per-For RowVm files (PR-2). One side-file per For block.
+            for vm in &result.for_view_models {
+                // The base path's parent directory is where the RowVm
+                // lands; treat `base` as a path-like value and split
+                // on the last separator so the RowVm sits next to the
+                // matching XAML file.
+                let rv_path = match base.rfind(|c| c == '/' || c == '\\') {
+                    Some(idx) => format!("{}/{}", &base[..idx], vm.filename),
+                    None => vm.filename.clone(),
+                };
+                write_file_or_die(&rv_path, &vm.source);
+                eprintln!("Written: {rv_path}");
+            }
+        }
+        _ => {
+            // Already validated above; defensive.
+            eprintln!("mosaic-compile: unsupported pipeline backend '{backend}'");
+            process::exit(1);
+        }
+    }
 }
 
 // ===========================================================================

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — PR-6 — mosaic-pkg-grid through xaml + CLI wiring
+
+### Added — `mosaic-compile --backend xaml` CLI wiring
+
+- `mosaic-compile --interface X.mil --layout X.mll --style X.msl
+  --backend xaml [-o BASE]` now compiles a three-file Mosaic
+  pipeline triple to a WinUI 3 component triple.
+- The `--backend` validation list grew `xaml`.
+- `run_pipeline` branches on backend: `react` emits one `.tsx`
+  file (unchanged from before); `xaml` emits the triple
+  (`{base}.xaml`, `{base}.xaml.cs`, `{base}.Event.cs`) plus
+  zero-or-more RowVm `.cs` files. `BASE` is treated as a file-name
+  prefix; the default is the component name. A trailing `.xaml` in
+  `BASE` is stripped so `Grid.xaml` produces three sensibly-named
+  files instead of `Grid.xaml.xaml.cs` etc.
+- Three new prints (`Written: ...`) per invocation in xaml mode.
+- `mosaic-compile`'s `Cargo.toml` now depends on `mosaic-emit-xaml`.
+
+### Added — End-to-end integration test against `mosaic-pkg-grid`
+
+- New `tests/pkg_grid_compiles_to_xaml.rs` integration test.
+- Resolves `mosaic-pkg-grid`'s source root relative to
+  `CARGO_MANIFEST_DIR` (steps up four directory levels), then
+  compiles each component (`Grid`, `Cell`, `Column`) through the
+  three IR compilers and the XAML emitter.
+- 5 tests cover: package source resolution; each component lowers
+  through `from_pipeline` without error; Grid (the complex
+  component using HostTable + For + Cell component reference)
+  produces the expected XAML structure (UserControl root,
+  ItemsRepeater for For, `<grid:Cell/>` reference, xmlns:grid
+  declaration); Grid produces RowVm side-files.
+- This is the spec §17 PR-6 capstone — the XAML emitter is
+  "done" in the spec sense when `mosaic-pkg-grid` compiles cleanly
+  end-to-end, which it now does.
+
+### What's NOT in this PR (deferred to PR-7)
+
+- **VisiCalc Windows demo** (`demo/visicalc/windows/xaml/`) — the
+  full end-to-end app that consumes the compiled `mosaic-pkg-grid`
+  package and a hand-written `FormulaBar` component. PR-7 lands
+  this directory, the `windows/build.ps1` driver, and the
+  hand-written C# host code (`State.cs` mirroring
+  `src/app/state.ts`).
+- **`dotnet build` smoke test** on Windows CI. Requires the
+  Microsoft .NET SDK + Windows App SDK; will land alongside the
+  demo so we have a real consumer to validate against.
+- **Manifest-driven CLI** (`mosaic-compile pkg <path> --backend xaml`)
+  that walks `mosaic-package.toml`, parses dependency manifests,
+  and constructs the `ComponentRegistry`. The single-component
+  invocation works today; the multi-component package invocation
+  needs the resolver wired into `run_pkg`.
+
+### Tests
+
+- 5 new integration tests in `tests/pkg_grid_compiles_to_xaml.rs`.
+- Unit tests unchanged: 104 still pass.
+- Total across unit + integration: 109.
+
 ## [Unreleased] — PR-5 — Component reference resolution
 
 ### Added — `ComponentRegistry` public type

--- a/code/packages/rust/mosaic-emit-xaml/tests/pkg_grid_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/pkg_grid_compiles_to_xaml.rs
@@ -1,0 +1,251 @@
+//! Integration test: end-to-end compile every component in
+//! `mosaic-pkg-grid` through the XAML backend.
+//!
+//! This is the spec §17 PR-6 capstone test — the WinUI 3 / XAML
+//! emitter is "done" in the spec sense when it can lower every
+//! component in `mosaic-pkg-grid` (`Grid`, `Cell`, `Column`) without
+//! hitting `UnsupportedPrimitive`, `UnsupportedExpression`, or any
+//! other failure path.
+//!
+//! What this test verifies:
+//!
+//!   1. Each component's `.mil` / `.mll` / `.dark.msl` parses through
+//!      the three IR compilers (mosmodel / moslayout / mosstyle).
+//!   2. The triple lowers through `mosaic_emit_xaml::from_pipeline`
+//!      without error.
+//!   3. The XAML output contains a `<UserControl>` root.
+//!   4. The code-behind output declares a `partial class
+//!      {Component} : UserControl`.
+//!   5. The Event union output declares `record {Component}Event`.
+//!
+//! What this test does NOT verify:
+//!
+//!   - That `dotnet build` accepts the emitted source (Windows-only;
+//!     tracked as a follow-up that needs the MSBuild toolchain).
+//!   - That the rendered XAML is visually correct (no headless XAML
+//!     renderer in the CI matrix).
+//!   - That the package's intended UI behaviour (selection, editing)
+//!     wires correctly end-to-end.
+//!
+//! The companion `mosaic-pkg-grid::tests::package_compiles` test
+//! verifies the same three-file shape against the three IR
+//! compilers; this test extends it to the XAML emitter.
+//!
+//! Note on path resolution: mosaic-emit-xaml lives in
+//! `code/packages/rust/mosaic-emit-xaml/` and mosaic-pkg-grid lives
+//! in `code/packages/mosaic-pkg-grid/`. We resolve relative to
+//! `CARGO_MANIFEST_DIR` (set to the mosaic-emit-xaml crate root by
+//! Cargo) and step up four directory levels to find the package.
+
+use std::fs;
+use std::path::PathBuf;
+
+const COMPONENTS: &[&str] = &["Grid", "Cell", "Column"];
+
+fn pkg_grid_src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent() // mosaic-emit-xaml → rust/
+        .and_then(|p| p.parent()) // rust → packages/
+        .map(|p| p.join("mosaic-pkg-grid").join("src"))
+        .expect("derive mosaic-pkg-grid src root from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn pkg_grid_root_resolves_and_contains_each_component() {
+    let root = pkg_grid_src_root();
+    assert!(
+        root.exists(),
+        "mosaic-pkg-grid src root not found at {:?}",
+        root
+    );
+    for c in COMPONENTS {
+        assert!(
+            root.join(format!("{c}.mil")).exists(),
+            "missing {c}.mil under {:?}",
+            root
+        );
+        assert!(
+            root.join(format!("{c}.mll")).exists(),
+            "missing {c}.mll under {:?}",
+            root
+        );
+        // Only Grid and Cell ship a `.dark.msl`; Column is metadata-
+        // only so it skips style. We don't assert presence here.
+    }
+}
+
+/// Compile one component through the three IR compilers and then
+/// through the XAML emitter. Returns the (xaml, code_behind, events)
+/// triple as strings.
+fn compile_component(name: &str) -> (String, String, String) {
+    let root = pkg_grid_src_root();
+    let mil = root.join(format!("{name}.mil"));
+    let mll = root.join(format!("{name}.mll"));
+    let msl = root.join(format!("{name}.dark.msl"));
+
+    let mil_src = fs::read_to_string(&mil)
+        .unwrap_or_else(|e| panic!("read {:?}: {e}", mil));
+    let mll_src = fs::read_to_string(&mll)
+        .unwrap_or_else(|e| panic!("read {:?}: {e}", mll));
+    // .msl is optional — Column is metadata-only.
+    let msl_src = fs::read_to_string(&msl).ok();
+
+    // 1. mosmodel
+    let mosmodel_out = mosmodel_compiler::compile(&mil_src)
+        .unwrap_or_else(|errs| panic!("mosmodel {name}: {errs:?}"));
+
+    // 2. moslayout (with interface validation)
+    let layout_out = moslayout_compiler::compile(
+        &mll_src,
+        Some(&mosmodel_out.descriptor_json),
+    )
+    .unwrap_or_else(|errs| panic!("moslayout {name}: {errs:?}"));
+
+    // 3. mosstyle (empty when there's no .dark.msl)
+    let style_def = match msl_src {
+        Some(src) => {
+            let style_out = mosstyle_compiler::compile(
+                &src,
+                Some(&layout_out.part_map_json),
+            )
+            .unwrap_or_else(|errs| panic!("mosstyle {name}: {errs:?}"));
+            style_out.def
+        }
+        None => mosstyle_compiler::StyleDef {
+            component_name: name.to_string(),
+            parts: Vec::new(),
+        },
+    };
+
+    // 4. The XAML backend. We provide a `ComponentRegistry` that
+    //    registers Grid's siblings (`Cell`, `Column`) so Grid.mll's
+    //    `Cell` reference resolves to a component-ref `<pkg:Cell/>`
+    //    rather than an `UnknownComponent` error.
+    let mut reg = mosaic_emit_xaml::ComponentRegistry::new();
+    reg.register(
+        "Cell",
+        "grid",
+        "using:Mosaic.Package.Grid",
+        "mosaic-pkg-grid",
+    );
+    reg.register(
+        "Column",
+        "grid",
+        "using:Mosaic.Package.Grid",
+        "mosaic-pkg-grid",
+    );
+    // Grid itself is the active component; we don't register Grid
+    // because it would shadow the self-reference (it isn't ever
+    // referenced from inside Grid.mll, only from VisiCalc's host).
+
+    let opts = mosaic_emit_xaml::EmitOptions::default();
+    let result = mosaic_emit_xaml::from_pipeline(
+        &mosmodel_out.component,
+        &layout_out.def,
+        &style_def,
+        Some(&reg),
+        &opts,
+    )
+    .unwrap_or_else(|e| panic!("xaml emit {name}: {e}"));
+
+    (result.xaml, result.code_behind, result.events)
+}
+
+#[test]
+fn cell_component_lowers_to_xaml_without_error() {
+    let (xaml, code_behind, events) = compile_component("Cell");
+    assert!(xaml.contains("<UserControl"), "Cell XAML missing UserControl root");
+    assert!(
+        code_behind.contains("public sealed partial class Cell : UserControl"),
+        "Cell code-behind missing partial class"
+    );
+    assert!(
+        events.contains("CellEvent"),
+        "Cell events file missing CellEvent record"
+    );
+}
+
+#[test]
+fn column_component_lowers_to_xaml_without_error() {
+    // Column is metadata-only — slot-bearing but no children. The
+    // XAML should still be syntactically valid (UserControl with an
+    // empty body or a self-closing root tag).
+    let (xaml, code_behind, _events) = compile_component("Column");
+    assert!(xaml.contains("<UserControl"));
+    assert!(
+        code_behind.contains("public sealed partial class Column : UserControl"),
+        "Column code-behind missing partial class"
+    );
+}
+
+#[test]
+fn grid_component_lowers_to_xaml_without_error() {
+    // Grid is the headline component — uses HostTable + sub-tags +
+    // For + Cell (component reference). All five PR-1..PR-5
+    // pieces of the spec's §17 roadmap must work together for this
+    // test to pass.
+    let (xaml, code_behind, events) = compile_component("Grid");
+    assert!(xaml.contains("<UserControl"));
+    // HostTable lowered.
+    assert!(
+        xaml.contains("<Grid>") || xaml.contains("<Grid "),
+        "Grid XAML missing <Grid> from HostTable lowering, got:\n{xaml}"
+    );
+    // For block lowered to ItemsRepeater.
+    assert!(
+        xaml.contains("<ItemsRepeater"),
+        "Grid XAML missing <ItemsRepeater> from For lowering, got:\n{xaml}"
+    );
+    // Cell reference lowered with the registered xmlns prefix.
+    assert!(
+        xaml.contains("<grid:Cell"),
+        "Grid XAML missing <grid:Cell> component reference, got:\n{xaml}"
+    );
+    // xmlns declaration on UserControl.
+    assert!(
+        xaml.contains("xmlns:grid=\"using:Mosaic.Package.Grid\""),
+        "Grid XAML missing xmlns:grid declaration, got:\n{xaml}"
+    );
+    // Code-behind has the partial class.
+    assert!(
+        code_behind.contains("public sealed partial class Grid : UserControl"),
+        "Grid code-behind missing partial class"
+    );
+    // Three emits (onNavigate, onEditCommit, onEditCancel) → three records.
+    assert!(events.contains("Navigate"));
+    assert!(events.contains("EditCommit"));
+    assert!(events.contains("EditCancel"));
+}
+
+#[test]
+fn grid_emits_for_view_models() {
+    // Grid.mll uses a `For` block over `viewport-rows`. The XAML
+    // emitter should produce a generated RowVm record for it.
+    let root = pkg_grid_src_root();
+    let mil_src = fs::read_to_string(root.join("Grid.mil")).unwrap();
+    let mll_src = fs::read_to_string(root.join("Grid.mll")).unwrap();
+    let msl_src = fs::read_to_string(root.join("Grid.dark.msl")).unwrap();
+
+    let mosmodel_out = mosmodel_compiler::compile(&mil_src).unwrap();
+    let layout_out =
+        moslayout_compiler::compile(&mll_src, Some(&mosmodel_out.descriptor_json)).unwrap();
+    let style_out =
+        mosstyle_compiler::compile(&msl_src, Some(&layout_out.part_map_json)).unwrap();
+
+    let mut reg = mosaic_emit_xaml::ComponentRegistry::new();
+    reg.register("Cell", "grid", "using:Mosaic.Package.Grid", "mosaic-pkg-grid");
+
+    let result = mosaic_emit_xaml::from_pipeline(
+        &mosmodel_out.component,
+        &layout_out.def,
+        &style_out.def,
+        Some(&reg),
+        &mosaic_emit_xaml::EmitOptions::default(),
+    )
+    .unwrap();
+
+    assert!(
+        !result.for_view_models.is_empty(),
+        "Grid should produce at least one RowVm from its For block"
+    );
+}


### PR DESCRIPTION
## Summary

Sixth and capstone implementation PR from \`code/specs/mosaic-emit-xaml.md\` §17. With this PR, the entire XAML backend track is on main: scaffold (PR-1) + If/For/Expr (PR-2) + Host* primitives (PR-3) + HostTable (PR-4) + component-reference resolver (PR-5) + this PR's pkg-grid through xaml.

## mosaic-compile --backend xaml CLI wiring

\`mosaic-compile --interface X.mil --layout X.mll --style X.msl --backend xaml [-o BASE]\` now compiles a three-file Mosaic pipeline triple to a WinUI 3 component triple:

- \`{base}.xaml\` — UserControl markup
- \`{base}.xaml.cs\` — code-behind partial class (DPs, Dispatch event, Host* handlers, ExprLowerer helpers)
- \`{base}.Event.cs\` — discriminated event-union records

Plus zero-or-more \`{ComponentName}_{AsName}Vm.cs\` RowVm side-files (one per For block).

The default BASE is the component name. A trailing \`.xaml\` in BASE is stripped so \`Grid.xaml\` produces three sensibly-named files.

## End-to-end integration test against mosaic-pkg-grid

New \`tests/pkg_grid_compiles_to_xaml.rs\` integration test compiles each component (Grid, Cell, Column) through the three IR compilers + the XAML emitter.

**5 tests verify:**
- Package source resolution
- Cell, Column, Grid each lower through \`from_pipeline\` without error
- Grid (the complex component using HostTable + For + Cell component reference) produces the expected XAML structure: UserControl root, ItemsRepeater for For, \`<grid:Cell/>\` reference, \`xmlns:grid\` declaration
- Grid produces RowVm side-files

This is the spec §17 PR-6 capstone — the XAML emitter is \"done\" when mosaic-pkg-grid compiles cleanly end-to-end, which it now does.

## Tests

- 5 new integration tests (\`pkg_grid_compiles_to_xaml.rs\`)
- 104 unit tests unchanged
- **Total: 109 tests pass**

## Spec coverage

Per §17:
- ✅ PR-1: scaffold + 9 simple primitives
- ✅ PR-2: If / Else / For + ExprLowerer
- ✅ PR-3: HostInput / HostButton / HostScroll
- ✅ PR-4: HostTable + section sub-tags
- ✅ PR-5: component-reference resolver
- ✅ **PR-6: mosaic-pkg-grid through xaml + CLI wiring** (this)

**The entire XAML backend track from \`code/specs/mosaic-emit-xaml.md\` §17 is now landed.**

## Deferred to PR-7

- **VisiCalc Windows demo** (\`demo/visicalc/windows/xaml/\`) — the full end-to-end app consuming the compiled mosaic-pkg-grid package and a hand-written FormulaBar component. Lands in PR-7 with the \`windows/build.ps1\` driver and the hand-written C# host code (\`State.cs\` mirroring \`src/app/state.ts\`).
- **\`dotnet build\` smoke test** on Windows CI. Requires the .NET SDK + Windows App SDK; will land alongside the demo.
- **\`mosaic-compile pkg <path> --backend xaml\`** — multi-component package invocation that walks dependency manifests to build the ComponentRegistry. The single-component invocation works today; the package mode wires into \`run_pkg\` in a follow-up.

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)