### PR TITLE
fix(sql-vm,mini-sqlite): printf %.Nf rounds half away from zero

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.75.0] - 2026-05-20
+
+### Fixed
+
+- **``printf('%.Nf', x)`` rounds half away from zero** matching SQLite
+  (via ``sql-vm 1.49.0``).  Was using Python's banker's rounding —
+  ``printf('%.0f', 4.5)`` returned ``'4'`` instead of ``'5'``.
+  9 oracle tests in ``test_tier3_printf_rounding.py``.
+
 ## [1.74.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.74.0"
+version = "1.75.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_printf_rounding.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_printf_rounding.py
@@ -1,0 +1,87 @@
+"""Oracle tests for ``printf('%.Nf', x)`` half-away-from-zero rounding.
+
+Python's ``'%f'`` formatting uses banker's rounding (round half to
+even), which produces ``printf('%.0f', 4.5) == '4'``.  SQLite (and
+C's printf in general) round half away from zero — same convention as
+the school-arithmetic ``round()`` scalar function — so the result is
+``'5'``.
+
+PR #3668 fixed ``round()`` by pre-quantizing through
+``Decimal.quantize`` with ``ROUND_HALF_UP``.  This PR applies the
+same approach to ``printf`` whenever the conversion is ``f`` (or
+``F``) and a precision is specified.  Other conversions (``%e``,
+``%g``) use significant-digit rounding, which already produces
+matching output across both engines for every test we care about, so
+they continue to delegate to Python's formatter.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# %.0f at integer half points
+# ---------------------------------------------------------------------------
+
+
+class TestPrecisionZero:
+    def test_half_positive_integers(self) -> None:
+        # 0.5 → 1, 2.5 → 3, 4.5 → 5 — all rounded up (away from zero).
+        _check("SELECT printf('%.0f', 0.5)")
+        _check("SELECT printf('%.0f', 2.5)")
+        _check("SELECT printf('%.0f', 4.5)")
+
+    def test_half_negative_integers(self) -> None:
+        # -0.5 → -1, -2.5 → -3 — sign retained, magnitude rounds up.
+        _check("SELECT printf('%.0f', -0.5)")
+        _check("SELECT printf('%.0f', -2.5)")
+
+    def test_non_half_unchanged(self) -> None:
+        _check("SELECT printf('%.0f', 3.7)")
+        _check("SELECT printf('%.0f', 3.2)")
+
+
+# ---------------------------------------------------------------------------
+# Non-zero precisions
+# ---------------------------------------------------------------------------
+
+
+class TestPrecisionN:
+    def test_one_decimal_place_half(self) -> None:
+        _check("SELECT printf('%.1f', 0.25)")
+        _check("SELECT printf('%.1f', 1.25)")
+        _check("SELECT printf('%.1f', 1.35)")
+
+    def test_three_decimal_places(self) -> None:
+        _check("SELECT printf('%.3f', 1.2345)")
+
+    def test_ieee754_representation(self) -> None:
+        # 2.355 is actually 2.3549999... in float64, so SQLite rounds
+        # down even though "2.355 rounded" would naively be "2.36".
+        # Mini-sqlite must agree with SQLite, not the naive answer.
+        _check("SELECT printf('%.2f', 2.355)")
+
+
+# ---------------------------------------------------------------------------
+# Other conversions are unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestOtherConversions:
+    def test_g_unchanged(self) -> None:
+        _check("SELECT printf('%g', 0.0001)")
+
+    def test_e_unchanged(self) -> None:
+        _check("SELECT printf('%e', 1.5)")
+
+    def test_integer_unchanged(self) -> None:
+        _check("SELECT printf('%d', 42)")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.49.0 — 2026-05-20
+
+### Fixed
+
+- **``printf('%.Nf', x)`` rounds half away from zero** matching SQLite.
+  Python's ``'%f'`` formatting uses banker's rounding so
+  ``printf('%.0f', 4.5)`` was returning ``'4'``; SQLite returns ``'5'``.
+  Pre-quantize the value via ``Decimal.quantize(..., ROUND_HALF_UP)``
+  before handing to Python's formatter — same trick used by the
+  ``round()`` scalar in 1.36.0.
+
+  Only ``%f`` / ``%F`` (fixed-point) needs the pre-quantize; ``%e``
+  and ``%g`` continue to use Python's formatter directly.
+
 ## 1.48.0 — 2026-05-20
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.48.0"
+version = "1.49.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -1557,6 +1557,26 @@ def _printf_format(template: str, args: list[SqlValue]) -> str:  # noqa: C901
                 result.append(str(val))
         elif conv in "feEgG":
             val_f = 0.0 if arg is None else float(arg)  # type: ignore[arg-type]
+            # Python's ``%f`` uses banker's rounding (round half to
+            # even); SQLite's printf rounds half away from zero, matching
+            # the school-arithmetic convention and the ``round()`` scalar.
+            # Pre-round the value here so the subsequent format string
+            # call doesn't apply the wrong rule on the rounding boundary.
+            #
+            # Only ``%f``/``%F`` (fixed-point) needs this rewrite — ``%e``
+            # and ``%g`` use significant-digit rounding which already
+            # produces matching output under both rules for almost every
+            # input we care about (and SQLite's own implementation uses
+            # the C library here, which already matches Python for those
+            # cases on every platform we test).
+            if conv in "fF" and prec_s:
+                from decimal import Decimal, ROUND_HALF_UP, localcontext
+                with localcontext() as ctx:
+                    ctx.prec = 80  # bigger than any reasonable precision
+                    quant = Decimal(10) ** -int(prec_s)
+                    val_f = float(
+                        Decimal(val_f).quantize(quant, rounding=ROUND_HALF_UP)
+                    )
             spec = f"%{flags}{width_s}"
             if prec_s:
                 spec += f".{prec_s}"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -1570,7 +1570,7 @@ def _printf_format(template: str, args: list[SqlValue]) -> str:  # noqa: C901
             # the C library here, which already matches Python for those
             # cases on every platform we test).
             if conv in "fF" and prec_s:
-                from decimal import Decimal, ROUND_HALF_UP, localcontext
+                from decimal import ROUND_HALF_UP, Decimal, localcontext
                 with localcontext() as ctx:
                     ctx.prec = 80  # bigger than any reasonable precision
                     quant = Decimal(10) ** -int(prec_s)


### PR DESCRIPTION
## Summary

Python's `'%f'` formatting uses banker's rounding, so `printf('%.0f', 4.5)` returned `'4'`; SQLite returns `'5'`. Apply the same fix used for `round()` in 1.36.0: pre-quantize via `Decimal.quantize(..., ROUND_HALF_UP)` before handing to Python's formatter.

Only `%f` / `%F` (fixed-point) needs the pre-quantize; `%e` and `%g` continue to use Python's formatter directly.

9 oracle tests. Version bumps: sql-vm 1.48.0 → 1.49.0, mini-sqlite 1.74.0 → 1.75.0.

## Test plan

- [x] `pytest sql-vm/tests/` — 895 passed
- [x] `pytest mini-sqlite/tests/test_tier3_printf_rounding.py` — 9/9
- [x] mini-sqlite full suite — 1824 passed
- [x] All cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)