### PR TITLE
Flatten summary checkpoint scalars

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this package will be documented in this file.
 - Workload accessors for supervisor drain run summaries.
 - Last-checkpoint scalar accessors for supervisor drain run reports and
   summaries.
+- Flattened last-checkpoint timestamp and call-id fields in supervisor drain
+  run summaries.
 - Flattened planned and replayed follow-up row counts in supervisor drain run
   summaries.
 - Follow-up pressure drift flags in supervisor drain run reports and summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -45,6 +45,8 @@ The crate keeps the boundary narrow:
   budget, planned, replayed, and delta fields
 - supervisor drain reports and summaries expose last-checkpoint scalar accessors
   for timestamp and call-id host logs
+- supervisor drain run summaries flatten last-checkpoint timestamp and call-id
+  fields for payload-free checkpoint logging
 - supervisor drain run summaries flatten planned and replayed follow-up row
   counts for host routing decisions
 - supervisor drain run summaries flag when planned and replayed follow-up

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1047,6 +1047,8 @@ impl ToolAuditSupervisorDrainRunReport {
             requires_follow_up: self.requires_follow_up(),
             advanced_checkpoint: self.advanced_checkpoint(),
             last_checkpoint: self.last_checkpoint().cloned(),
+            last_checkpoint_timestamp_ms: self.last_checkpoint_timestamp_ms(),
+            last_checkpoint_call_id: self.last_checkpoint_call_id().map(str::to_owned),
         }
     }
 
@@ -1267,6 +1269,10 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub advanced_checkpoint: bool,
     /// Last replay checkpoint observed by the actual run.
     pub last_checkpoint: Option<ToolAuditReadCheckpoint>,
+    /// Timestamp for the last replay checkpoint observed by the actual run.
+    pub last_checkpoint_timestamp_ms: Option<u64>,
+    /// Call id for the last replay checkpoint observed by the actual run.
+    pub last_checkpoint_call_id: Option<String>,
 }
 
 impl ToolAuditSupervisorDrainRunSummary {
@@ -1502,14 +1508,12 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return the timestamp for the last replay checkpoint observed by the actual run.
     pub fn last_checkpoint_timestamp_ms(&self) -> Option<u64> {
-        self.last_checkpoint()
-            .map(|checkpoint| checkpoint.timestamp_ms)
+        self.last_checkpoint_timestamp_ms
     }
 
     /// Return the call id for the last replay checkpoint observed by the actual run.
     pub fn last_checkpoint_call_id(&self) -> Option<&str> {
-        self.last_checkpoint()
-            .map(|checkpoint| checkpoint.call_id.as_str())
+        self.last_checkpoint_call_id.as_deref()
     }
 }
 
@@ -3868,6 +3872,8 @@ mod tests {
         assert!(summary.advanced_checkpoint());
         assert_eq!(summary.last_checkpoint, report.last_checkpoint().cloned());
         assert_eq!(summary.last_checkpoint(), report.last_checkpoint());
+        assert_eq!(summary.last_checkpoint_timestamp_ms, Some(120));
+        assert_eq!(summary.last_checkpoint_call_id.as_deref(), Some("call_2"));
         assert!(summary.has_last_checkpoint());
         assert_eq!(summary.last_checkpoint_timestamp_ms(), Some(120));
         assert_eq!(summary.last_checkpoint_call_id(), Some("call_2"));


### PR DESCRIPTION
## Summary
- add flattened last-checkpoint timestamp and call-id fields to supervisor drain run summaries
- wire summary checkpoint scalar accessors through the flattened fields
- cover the flattened checkpoint scalar fields in the summary host-field test

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD