### PR TITLE
Add WHATWG fragment context audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -52,6 +52,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser block-boundary audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser fragment-context audit
+  generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -209,6 +209,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-fragment-context-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_fragment_context_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -55,6 +55,9 @@ documented in this file.
   sectioning, list-container, heading, formatting, table, foreign-content,
   template, form, text-mode, ruby, select/list, and fragment-context cases,
   with a dedicated parser regression test.
+- Generated WHATWG fragment-context audit fixture over html5lib table, shell,
+  block, foreign-content, text-mode, select/list, template, and ordinary
+  fragment parsing contexts, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -68,8 +71,8 @@ documented in this file.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
   foreign-content, formatting, ruby, noscript, head/body, document-shell,
-  void-element, list-item, paragraph, block-boundary, template, and select/list
-  audit checks on the same parser and DOM dump path.
+  void-element, list-item, paragraph, block-boundary, fragment-context,
+  template, and select/list audit checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -234,6 +234,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_block_boun
   --check
 ```
 
+The generated `tests/fixtures/whatwg-fragment-context-audit.json` fixture
+indexes table, shell, block, foreign-content, text-mode, select/list, template,
+and ordinary fragment parsing contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -197,6 +197,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_block_boun
   --check
 ```
 
+`whatwg-fragment-context-audit.json` is a generated index over
+tree-construction cases that stress table, shell, block, foreign-content,
+text-mode, select/list, template, and ordinary fragment parsing contexts:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG fragment-context audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-fragment-context-audit.json"
+
+TABLE_CONTEXTS = {
+    "caption",
+    "colgroup",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+}
+TEXT_MODE_CONTEXTS = {
+    "iframe",
+    "noembed",
+    "noframes",
+    "noscript",
+    "plaintext",
+    "script",
+    "style",
+    "textarea",
+    "title",
+    "xmp",
+}
+SELECT_CONTEXTS = {"optgroup", "option", "select"}
+SHELL_CONTEXTS = {"body", "frameset", "head", "html"}
+
+FOREIGN_CONTEXT = re.compile(r"^(?:math|svg)(?:\s|$)", re.I)
+FOREIGN_MARKUP = re.compile(r"</?(?:svg|math|foreignObject|desc)(?:\s|/|>)", re.I)
+TEMPLATE_MARKUP = re.compile(r"</?template(?:\s|/|>)", re.I)
+BLOCK_MARKUP = re.compile(
+    r"</?(?:address|article|aside|blockquote|center|details|dialog|dir|div|dl|"
+    r"fieldset|figcaption|figure|footer|header|hgroup|main|menu|nav|ol|p|section|"
+    r"summary|ul|h[1-6]|li|dt|dd)(?:\s|/|>)",
+    re.I,
+)
+
+CASE_AXES = (
+    {
+        "axis": "fragment-table-context",
+        "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+    },
+    {
+        "axis": "fragment-basic-context",
+        "reason": "fragment parser context with ordinary phrasing and element boundaries",
+    },
+    {
+        "axis": "fragment-block-context",
+        "reason": "fragment parser context around block and implied-end-tag boundaries",
+    },
+    {
+        "axis": "fragment-shell-context",
+        "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+    },
+    {
+        "axis": "fragment-foreign-context",
+        "reason": "fragment parser context in SVG and MathML integration modes",
+    },
+    {
+        "axis": "fragment-text-mode-context",
+        "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+    },
+    {
+        "axis": "fragment-select-context",
+        "reason": "fragment parser context in select, option, and optgroup insertion modes",
+    },
+    {
+        "axis": "fragment-template-context",
+        "reason": "fragment parser context seeded from template insertion modes",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG fragment-context audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if fragment_context is not None:
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any fragment-context audit cases")
+    return cases
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "context": case.fragment_context,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-fragment-context-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction "
+            "cases that stress fragment parsing contexts across table, shell, "
+            "block, foreign-content, text-mode, select/list, "
+            "template, and ordinary phrasing modes."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data
+    context = case.fragment_context or ""
+    context_head = context.split()[0].lower()
+
+    if context_head in TABLE_CONTEXTS:
+        return "fragment-table-context"
+    if context_head in TEXT_MODE_CONTEXTS:
+        return "fragment-text-mode-context"
+    if context_head in SELECT_CONTEXTS:
+        return "fragment-select-context"
+    if FOREIGN_CONTEXT.search(context) or FOREIGN_MARKUP.search(data):
+        return "fragment-foreign-context"
+    if context_head == "template" or TEMPLATE_MARKUP.search(data):
+        return "fragment-template-context"
+    if context_head in SHELL_CONTEXTS:
+        return "fragment-shell-context"
+    if BLOCK_MARKUP.search(data):
+        return "fragment-block-context"
+    return "fragment-basic-context"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown fragment-context audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-fragment-context-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-fragment-context-audit.json
@@ -1,0 +1,1362 @@
+{
+  "case_count": 192,
+  "cases": [
+    {
+      "axis": "fragment-basic-context",
+      "context": "div",
+      "id": "tests4-dat-1",
+      "reason": "fragment parser context with ordinary phrasing and element boundaries",
+      "source": "tests4.dat:1"
+    },
+    {
+      "axis": "fragment-text-mode-context",
+      "context": "textarea",
+      "id": "tests4-dat-2",
+      "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+      "source": "tests4.dat:2"
+    },
+    {
+      "axis": "fragment-text-mode-context",
+      "context": "textarea",
+      "id": "tests4-dat-3",
+      "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+      "source": "tests4.dat:3"
+    },
+    {
+      "axis": "fragment-text-mode-context",
+      "context": "style",
+      "id": "tests4-dat-4",
+      "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+      "source": "tests4.dat:4"
+    },
+    {
+      "axis": "fragment-text-mode-context",
+      "context": "plaintext",
+      "id": "tests4-dat-5",
+      "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+      "source": "tests4.dat:5"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests4-dat-6",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests4.dat:6"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "head",
+      "id": "tests4-dat-7",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests4.dat:7"
+    },
+    {
+      "axis": "fragment-text-mode-context",
+      "context": "title",
+      "id": "tests4-dat-8",
+      "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+      "source": "tests4.dat:8"
+    },
+    {
+      "axis": "fragment-block-context",
+      "context": "div",
+      "id": "tests6-dat-7",
+      "reason": "fragment parser context around block and implied-end-tag boundaries",
+      "source": "tests6.dat:7"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests6-dat-18",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:18"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests6-dat-21",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:21"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests6-dat-25",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:25"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "colgroup",
+      "id": "tests6-dat-27",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:27"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "frameset",
+      "id": "tests6-dat-30",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests6.dat:30"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "body",
+      "id": "tests6-dat-32",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests6.dat:32"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests6-dat-34",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:34"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests6-dat-35",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:35"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests6-dat-37",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:37"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests6-dat-39",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:39"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests6-dat-44",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests6.dat:44"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests6-dat-45",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests6.dat:45"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests7-dat-28",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests7.dat:28"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "body",
+      "id": "tests-innerhtml-1-dat-1",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:1"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "body",
+      "id": "tests-innerhtml-1-dat-2",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:2"
+    },
+    {
+      "axis": "fragment-basic-context",
+      "context": "div",
+      "id": "tests-innerhtml-1-dat-3",
+      "reason": "fragment parser context with ordinary phrasing and element boundaries",
+      "source": "tests_innerHTML_1.dat:3"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests-innerhtml-1-dat-4",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:4"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "body",
+      "id": "tests-innerhtml-1-dat-5",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:5"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "body",
+      "id": "tests-innerhtml-1-dat-6",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:6"
+    },
+    {
+      "axis": "fragment-basic-context",
+      "context": "div",
+      "id": "tests-innerhtml-1-dat-7",
+      "reason": "fragment parser context with ordinary phrasing and element boundaries",
+      "source": "tests_innerHTML_1.dat:7"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests-innerhtml-1-dat-8",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:8"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-9",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:9"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-10",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:10"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-11",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:11"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-12",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:12"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-13",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:13"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-14",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:14"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-15",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:15"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-16",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:16"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-17",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:17"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-18",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:18"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "table",
+      "id": "tests-innerhtml-1-dat-19",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:19"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-20",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:20"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-21",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:21"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-22",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:22"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-23",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:23"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-24",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:24"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-25",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:25"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-26",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:26"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-27",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:27"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-28",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:28"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-29",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:29"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-30",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:30"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-31",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:31"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-32",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:32"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-33",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:33"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-34",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:34"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "caption",
+      "id": "tests-innerhtml-1-dat-35",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:35"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "colgroup",
+      "id": "tests-innerhtml-1-dat-36",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:36"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "colgroup",
+      "id": "tests-innerhtml-1-dat-37",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:37"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-38",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:38"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-39",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:39"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-40",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:40"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-41",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:41"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-42",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:42"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-43",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:43"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-44",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:44"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-45",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:45"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-46",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:46"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-48",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:48"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-50",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:50"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-51",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:51"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-52",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:52"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-53",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:53"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-54",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:54"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-55",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:55"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-56",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:56"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-57",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:57"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-58",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:58"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-59",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:59"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-60",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:60"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-61",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:61"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-62",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:62"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-63",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:63"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-64",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:64"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-65",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:65"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-66",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:66"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-67",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:67"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-68",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:68"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-69",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:69"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-70",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:70"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-71",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:71"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-72",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:72"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-73",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:73"
+    },
+    {
+      "axis": "fragment-select-context",
+      "context": "select",
+      "id": "tests-innerhtml-1-dat-75",
+      "reason": "fragment parser context in select, option, and optgroup insertion modes",
+      "source": "tests_innerHTML_1.dat:75"
+    },
+    {
+      "axis": "fragment-select-context",
+      "context": "select",
+      "id": "tests-innerhtml-1-dat-77",
+      "reason": "fragment parser context in select, option, and optgroup insertion modes",
+      "source": "tests_innerHTML_1.dat:77"
+    },
+    {
+      "axis": "fragment-select-context",
+      "context": "select",
+      "id": "tests-innerhtml-1-dat-78",
+      "reason": "fragment parser context in select, option, and optgroup insertion modes",
+      "source": "tests_innerHTML_1.dat:78"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests-innerhtml-1-dat-79",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:79"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "frameset",
+      "id": "tests-innerhtml-1-dat-80",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:80"
+    },
+    {
+      "axis": "fragment-shell-context",
+      "context": "html",
+      "id": "tests-innerhtml-1-dat-81",
+      "reason": "fragment parser context seeded from html, head, body, and frameset elements",
+      "source": "tests_innerHTML_1.dat:81"
+    },
+    {
+      "axis": "fragment-text-mode-context",
+      "context": "script",
+      "id": "tests4-dat-9",
+      "reason": "fragment parser context for RCDATA, RAWTEXT, PLAINTEXT, and legacy text modes",
+      "source": "tests4.dat:9"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "tests-innerhtml-1-dat-47",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:47"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "tests-innerhtml-1-dat-49",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:49"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "tests-innerhtml-1-dat-74",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "tests_innerHTML_1.dat:74"
+    },
+    {
+      "axis": "fragment-block-context",
+      "context": "div",
+      "id": "adoption01-dat-18",
+      "reason": "fragment parser context around block and implied-end-tag boundaries",
+      "source": "adoption01.dat:18"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg path",
+      "id": "foreign-fragment-dat-1",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:1"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg path",
+      "id": "foreign-fragment-dat-2",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:2"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg path",
+      "id": "foreign-fragment-dat-3",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:3"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg path",
+      "id": "foreign-fragment-dat-4",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:4"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg path",
+      "id": "foreign-fragment-dat-5",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:5"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg foreignObject",
+      "id": "foreign-fragment-dat-6",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:6"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-7",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:7"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg title",
+      "id": "foreign-fragment-dat-8",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:8"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-9",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:9"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mfenced",
+      "id": "foreign-fragment-dat-10",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:10"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math malignmark",
+      "id": "foreign-fragment-dat-11",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:11"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math math",
+      "id": "foreign-fragment-dat-12",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:12"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math annotation-xml",
+      "id": "foreign-fragment-dat-13",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:13"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mtext",
+      "id": "foreign-fragment-dat-14",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:14"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mi",
+      "id": "foreign-fragment-dat-15",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:15"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mo",
+      "id": "foreign-fragment-dat-16",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:16"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mn",
+      "id": "foreign-fragment-dat-17",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:17"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math ms",
+      "id": "foreign-fragment-dat-18",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:18"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math ms",
+      "id": "foreign-fragment-dat-19",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:19"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math ms",
+      "id": "foreign-fragment-dat-20",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:20"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math ms",
+      "id": "foreign-fragment-dat-21",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:21"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math ms",
+      "id": "foreign-fragment-dat-22",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:22"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mn",
+      "id": "foreign-fragment-dat-23",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:23"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mn",
+      "id": "foreign-fragment-dat-24",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:24"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mn",
+      "id": "foreign-fragment-dat-25",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:25"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mn",
+      "id": "foreign-fragment-dat-26",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:26"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mo",
+      "id": "foreign-fragment-dat-27",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:27"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mo",
+      "id": "foreign-fragment-dat-28",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:28"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mo",
+      "id": "foreign-fragment-dat-29",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:29"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mo",
+      "id": "foreign-fragment-dat-30",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:30"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mi",
+      "id": "foreign-fragment-dat-31",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:31"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mi",
+      "id": "foreign-fragment-dat-32",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:32"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mi",
+      "id": "foreign-fragment-dat-33",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:33"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mi",
+      "id": "foreign-fragment-dat-34",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:34"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mtext",
+      "id": "foreign-fragment-dat-35",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:35"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mtext",
+      "id": "foreign-fragment-dat-36",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:36"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mtext",
+      "id": "foreign-fragment-dat-37",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:37"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math mtext",
+      "id": "foreign-fragment-dat-38",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:38"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math annotation-xml",
+      "id": "foreign-fragment-dat-39",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:39"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math annotation-xml",
+      "id": "foreign-fragment-dat-40",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:40"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math math",
+      "id": "foreign-fragment-dat-41",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:41"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math math",
+      "id": "foreign-fragment-dat-42",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:42"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg foreignObject",
+      "id": "foreign-fragment-dat-43",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:43"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg foreignObject",
+      "id": "foreign-fragment-dat-44",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:44"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg title",
+      "id": "foreign-fragment-dat-45",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:45"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg title",
+      "id": "foreign-fragment-dat-46",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:46"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-47",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:47"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-48",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:48"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-49",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:49"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-50",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:50"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-51",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:51"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-52",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:52"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-53",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:53"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-54",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:54"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-55",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:55"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-56",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:56"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg desc",
+      "id": "foreign-fragment-dat-57",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:57"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "div",
+      "id": "foreign-fragment-dat-58",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:58"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-59",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:59"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "div",
+      "id": "foreign-fragment-dat-60",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:60"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "div",
+      "id": "foreign-fragment-dat-61",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:61"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-62",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:62"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-63",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:63"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-64",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:64"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-65",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:65"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg svg",
+      "id": "foreign-fragment-dat-66",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "foreign-fragment.dat:66"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "math-dat-1",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:1"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "math-dat-2",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:2"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "thead",
+      "id": "math-dat-3",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:3"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tfoot",
+      "id": "math-dat-4",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:4"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "math-dat-5",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:5"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "math-dat-6",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:6"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "math-dat-7",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:7"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "math-dat-8",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "math.dat:8"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "td",
+      "id": "svg-dat-1",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:1"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tr",
+      "id": "svg-dat-2",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:2"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "thead",
+      "id": "svg-dat-3",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:3"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tfoot",
+      "id": "svg-dat-4",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:4"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "svg-dat-5",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:5"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "svg-dat-6",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:6"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "svg-dat-7",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:7"
+    },
+    {
+      "axis": "fragment-table-context",
+      "context": "tbody",
+      "id": "svg-dat-8",
+      "reason": "fragment parser context inside table, row, column, caption, and cell modes",
+      "source": "svg.dat:8"
+    },
+    {
+      "axis": "fragment-block-context",
+      "context": "div",
+      "id": "webkit02-dat-12",
+      "reason": "fragment parser context around block and implied-end-tag boundaries",
+      "source": "webkit02.dat:12"
+    },
+    {
+      "axis": "fragment-block-context",
+      "context": "div",
+      "id": "webkit02-dat-17",
+      "reason": "fragment parser context around block and implied-end-tag boundaries",
+      "source": "webkit02.dat:17"
+    },
+    {
+      "axis": "fragment-block-context",
+      "context": "div",
+      "id": "webkit02-dat-18",
+      "reason": "fragment parser context around block and implied-end-tag boundaries",
+      "source": "webkit02.dat:18"
+    },
+    {
+      "axis": "fragment-select-context",
+      "context": "select",
+      "id": "webkit02-dat-19",
+      "reason": "fragment parser context in select, option, and optgroup insertion modes",
+      "source": "webkit02.dat:19"
+    },
+    {
+      "axis": "fragment-template-context",
+      "context": "template",
+      "id": "template-dat-109",
+      "reason": "fragment parser context seeded from template insertion modes",
+      "source": "template.dat:109"
+    },
+    {
+      "axis": "fragment-select-context",
+      "context": "select",
+      "id": "tests-innerhtml-1-dat-76",
+      "reason": "fragment parser context in select, option, and optgroup insertion modes",
+      "source": "tests_innerHTML_1.dat:76"
+    }
+  ],
+  "counts_by_axis": {
+    "fragment-basic-context": 3,
+    "fragment-block-context": 5,
+    "fragment-foreign-context": 66,
+    "fragment-select-context": 5,
+    "fragment-shell-context": 15,
+    "fragment-table-context": 91,
+    "fragment-template-context": 1,
+    "fragment-text-mode-context": 6
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress fragment parsing contexts across table, shell, block, foreign-content, text-mode, select/list, template, and ordinary phrasing modes.",
+  "format": "whatwg-html-fragment-context-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_fragment_context_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_fragment_context_audit_test.rs
@@ -1,0 +1,98 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
+    include_str!("fixtures/whatwg-fragment-context-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct FragmentContextAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<FragmentContextAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FragmentContextAuditCase {
+    id: String,
+    source: String,
+    context: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_fragment_context_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-fragment-context-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 190);
+    assert_axis_count(&suite, "fragment-table-context", 90);
+    assert_axis_count(&suite, "fragment-foreign-context", 60);
+    assert_axis_count(&suite, "fragment-shell-context", 13);
+    assert_axis_count(&suite, "fragment-text-mode-context", 6);
+    assert_axis_count(&suite, "fragment-block-context", 5);
+    assert_axis_count(&suite, "fragment-select-context", 5);
+    assert_axis_count(&suite, "fragment-basic-context", 3);
+    assert_axis_count(&suite, "fragment-template-context", 1);
+}
+
+#[test]
+fn whatwg_fragment_context_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty()
+                && !case.context.is_empty()
+                && !case.axis.is_empty()
+                && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        assert_eq!(
+            source_case.fragment_context.as_deref(),
+            Some(case.context.as_str()),
+            "case `{}` should keep its fragment context",
+            case.source
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> FragmentContextAuditSuite {
+    serde_json::from_str(WHATWG_FRAGMENT_CONTEXT_AUDIT)
+        .expect("WHATWG fragment-context audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &FragmentContextAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG fragment-context audit fixture over 192 html5lib tree-construction fragment cases
- cover table, shell, block, foreign-content, text-mode, select/list, template, and ordinary fragment parsing contexts
- add a parser regression test and wire the generator into the shared generated fixture manifest

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_block_boundary_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- cargo test -p coding-adventures-html-parser whatwg_fragment_context_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser