### PR TITLE
feat(forme-aot-deploy-manifest-emitter): FM00 v0 final compose stage

### DIFF
--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/BUILD
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/CHANGELOG.md
@@ -1,0 +1,171 @@
+# Changelog — @coding-adventures/forme-aot-deploy-manifest-emitter
+
+## 0.1.0 — 2026-05-20
+
+Initial release.  Twentieth FM00 v0 stage package — the
+**final compose stage** of the FM00 v0 pipeline.  Reads the
+outputs of every other FM00 v0 emitter (page bundle JSON +
+sitemap.xml + robots.txt + Web App Manifest JSON + caller-
+supplied extra files) and produces a single byte-deterministic
+deploy-record JSON.
+
+Pure transform: `DeployManifestConfig` → JSON manifest string.
+Two-pass fail-fast.  Uses Node's built-in `node:crypto` for
+SHA-256 of synthesised / extra files; page-bundle hashes are
+trusted verbatim.
+
+### Added
+
+- `generateDeployManifest(config): string` — main entry.
+- `parsePageBundle(json)` — safe JSON parse + shape validation
+  for the incoming page bundle.  Uses `JSON.parse` + named-
+  field walk (no `for...in`, no prototype traversal).
+- `routeToDeployEntry(route)` — page-bundle route → deploy
+  file entry (sets `source: "page-bundle"`).
+- `validateOutputPath(value, field)` — relative-file-path
+  validator with path-traversal defence.
+- `validateString(value, field)` — generic string check.
+- `sha256Base64(s)` / `utf8ByteLength(s)` — same `node:crypto`
+  + `TextEncoder` helpers as the page-bundle emitter.
+- Types: `DeployManifestConfig`, `ExtraFile`, `DeployFileEntry`,
+  `DeployManifest`.
+
+### Spec adherence
+
+Internal manifest format (versioned at `version: 1`).  No
+external spec to adhere to.
+
+### Behavioural notes
+
+- **Output is byte-deterministic.**  Files sorted by
+  `outputPath`; top-level + entry keys in fixed order.
+- **Page-bundle hashes are trusted verbatim** — we don't
+  re-hash; the page-bundle emitter already did that.
+- **Synthesised entries** (sitemap / robots / manifest) get
+  fresh `sha256Base64` hashes from the input string.
+- **Extra-file content** hashed as a UTF-8 string.  Binary
+  callers should base64-encode before passing.
+- **Synthesised paths are fixed**: `sitemap.xml`, `robots.txt`,
+  `manifest.webmanifest`.
+- **Duplicate output paths throw** — within page bundle, across
+  sources, in extraFiles.  The deploy must be unambiguous.
+- **baseUrl propagates** from page bundle into the deploy
+  manifest top-level (so deploy targets that need it — sitemap
+  hosts, CDN origin configs — have it in one place).
+- **No input mutation.**
+
+### Security posture
+
+Ten concerns explicitly addressed (pre-push review found three
+hardening gaps — all fixed below):
+
+- **Path traversal on extra files.**  Strict shape regex +
+  per-segment `..` / `.` / empty / leading-`/` / leading-`~` /
+  backslash / colon rejection.  Rejects every escape vector
+  from the canonical OWASP list.
+- **Cross-platform path safety.**  No `\` (Windows), no `:`
+  (Windows drive separator + HFS+ historic).  No `/`-prefixed
+  absolute, no `~`-prefixed home-dir.
+- **Percent-encoding traversal defence.**  `%` is not in the
+  segment charset.  `%2e%2e` / `%2f` / `%00` are rejected
+  wholesale (not decoded), so a recheck-after-decode race
+  can't exist.
+- **Prototype pollution from parsed JSON.**  `JSON.parse`
+  preserves `__proto__` keys as own properties (not on the
+  prototype chain).  We walk fields by name via `Object.keys`
+  (own enumerable only) — never `for...in`, never dynamic
+  property assignment.  An end-to-end test verifies
+  `Object.prototype` stays clean after parsing a sneaky
+  bundle.
+- **JSON-syntax injection.**  `JSON.stringify` is the only
+  serialiser used — strings can't break out of the structure.
+- **Hashing**: SHA-256 via Node's built-in `node:crypto`.  No
+  external dep, no algorithm choice.
+- **Determinism**: same input → byte-identical output.  Two
+  builds diff cleanly.
+- **Page-bundle outputPath revalidation.**  Page-bundle inputs
+  are nominally trusted (produced by the upstream emitter),
+  but the API accepts an arbitrary JSON string from the
+  caller — there's no type-system handle that proves
+  provenance.  `parsePageBundle` re-runs `validateOutputPath`
+  on every route's `outputPath` so a malicious or buggy
+  upstream can't smuggle `../etc/passwd` (or `__proto__`)
+  through to the deploy target.
+- **Windows reserved device names.**  Per-segment regex
+  rejects `CON` / `PRN` / `AUX` / `NUL` / `COM1-9` / `LPT1-9`
+  (with or without extension, case-insensitive).  Win32
+  intercepts these names and writes to the device instead of
+  creating a file — would silently break a cross-platform
+  deploy.
+- **Per-segment 255-byte filesystem cap.**  ext4 / APFS / NTFS
+  all cap single filename components at 255 bytes; longer
+  segments fail at deploy time with a cryptic error.  We
+  surface it here.
+- **Trailing dot / space in segment.**  Win32 silently strips
+  these, producing a different file than the caller asked for.
+  Rejected.
+- **Prototype-pollution sink hardening.**  Output paths
+  literally named `__proto__`, `constructor`, or `prototype`
+  are rejected at validation.  The `filesObj` accumulator in
+  `generateDeployManifest` additionally uses
+  `Object.create(null)` so even if validation ever loosened,
+  there's no prototype-chain mutation path.
+
+### Capabilities
+
+`[]` — pure transform.  Uses Node's built-in `node:crypto`
+(no network, no fs).  No I/O, network, fs, shell, env.
+
+### Tests
+
+112 tests across 3 files:
+
+- `validate.test.ts` (32) — `validateOutputPath` accept
+  (simple filename, nested, .well-known/, hyphens/underscores/
+  digits, deep nesting) + reject matrix (non-string, null,
+  empty, over-cap 2048, leading /, leading ~, contains \, ..
+  segment / .. only, . segment / . only, empty mid-segment,
+  trailing /, Windows drive `C:/...`, URL-scheme-like
+  `https:/...`, colon anywhere, whitespace, ?, #, NUL,
+  percent-encoded `%2e%2e`, unicode, error contains field);
+  `validateString` (4 cases).
+- `parse-page-bundle.test.ts` (25) — accept (valid input,
+  baseUrl omitted, empty routes, route with lastmod) + reject
+  (invalid JSON, array/null/string root, wrong version,
+  missing version, non-string baseUrl, routes is array/null,
+  route entry is array, non-string route / outputPath /
+  contentType / sha256 / lastmod, non-integer / negative /
+  non-string sizeBytes); prototype-pollution defence test
+  (after parsing a sneaky `__proto__` key, `Object.prototype`
+  remains clean); `routeToDeployEntry` (maps fields + sets
+  source; preserves lastmod when present).
+- `generate.test.ts` (32) — shape (null config / non-string
+  pageBundle / invalid JSON throws); minimal (page bundle
+  only, baseUrl propagation, trailing newline); sitemap /
+  robots / web-app-manifest synthesised entries + non-string
+  inputs rejected; extraFiles (favicon, multiple, non-array
+  rejected, null entry, path traversal rejected, absolute
+  rejected, backslash rejected, lastmod preserved);
+  duplicate detection (duplicate in page bundle, sitemap /
+  robots / web-app-manifest path collisions, extra collides
+  with page-bundle, extra collides with sitemap); output
+  format (files sorted by outputPath, totalSizeBytes is sum,
+  entry key order); determinism (byte-identical, no input
+  mutation); full real-world example (page bundle + sitemap +
+  robots + manifest + 2 extras, 7 total files, sources
+  correctly tagged).
+
+Coverage: **100% line / 98.31% branch** across all source
+files with logic (`types.ts` is type-only).  The missing
+branches are unreachable in practice (sort comparator equality
+cases since duplicate paths throw at validation time).
+
+### v0 simplifications (documented)
+
+- **No deploy-target adapters** (S3, Netlify, Cloudflare
+  Pages, etc.) — that's the next stage (a deploy-runner
+  program).
+- **No CDN purge directives** in the manifest.
+- **No per-file caching headers / TTLs.**
+- **No incremental diff vs. previous deploy** — callers can
+  diff two manifest JSONs externally.

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/README.md
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/README.md
@@ -1,0 +1,196 @@
+# @coding-adventures/forme-aot-deploy-manifest-emitter
+
+> FM00 v0 deploy-composition emitter — combines the page bundle,
+> sitemap, robots, web app manifest, and any extra files into a
+> single deterministic deploy-record JSON.
+
+Twentieth FM00 v0 stage package. Pure transform — no I/O, no
+fs, no network. Uses Node's built-in `node:crypto` for SHA-256.
+
+## What it does
+
+`generateDeployManifest(config) → string` reads the outputs of
+the upstream FM00 v0 emitters (page bundle JSON, sitemap.xml,
+robots.txt, Web App Manifest JSON, plus any caller-supplied
+extra files) and produces a single byte-deterministic JSON
+manifest. A downstream deploy runner reads the manifest and
+applies every file to the deploy target (S3, Netlify, generic
+fs, ...).
+
+## Quick start
+
+```ts
+import { generateDeployManifest } from "@coding-adventures/forme-aot-deploy-manifest-emitter";
+import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+import { generateSitemap }     from "@coding-adventures/forme-aot-sitemap-emitter";
+
+const pageBundle = generatePageBundle({
+  baseUrl: "https://example.com",
+  pages: [
+    { route: "/",      html: indexHtml },
+    { route: "/about", html: aboutHtml },
+  ],
+});
+
+const sitemapXml = generateSitemap([{ url: "/" }, { url: "/about" }], "https://example.com");
+
+const manifest = generateDeployManifest({
+  pageBundle,
+  sitemapXml,
+  robotsTxt: "User-agent: *\nAllow: /\n",
+  manifestJson: '{"name":"Example"}',
+  extraFiles: [
+    { outputPath: "favicon.ico", content: faviconBase64, contentType: "image/x-icon" },
+    { outputPath: ".well-known/security.txt", content: "Contact: mailto:a@example.com\n", contentType: "text/plain" },
+  ],
+});
+```
+
+Output:
+
+```json
+{
+  "version": 1,
+  "baseUrl": "https://example.com",
+  "fileCount": 7,
+  "totalSizeBytes": 12345,
+  "files": {
+    ".well-known/security.txt": { "outputPath": "...", "contentType": "...", "sizeBytes": 31, "sha256": "…=", "source": "extra" },
+    "about/index.html":         { "outputPath": "...", ..., "route": "/about", "source": "page-bundle" },
+    "favicon.ico":              { "outputPath": "...", ..., "source": "extra" },
+    "index.html":               { "outputPath": "...", ..., "route": "/", "source": "page-bundle" },
+    "manifest.webmanifest":     { "outputPath": "...", ..., "source": "web-app-manifest" },
+    "robots.txt":               { "outputPath": "...", ..., "source": "robots" },
+    "sitemap.xml":              { "outputPath": "...", ..., "source": "sitemap" }
+  }
+}
+```
+
+## Input sources
+
+| Field          | Required? | Synthesised output path |
+| -------------- | --------- | ----------------------- |
+| `pageBundle`   | yes       | per-route (already in the bundle) |
+| `sitemapXml`   | no        | `sitemap.xml`           |
+| `robotsTxt`    | no        | `robots.txt`            |
+| `manifestJson` | no        | `manifest.webmanifest`  |
+| `extraFiles`   | no        | caller-specified, validated |
+
+The page bundle is the **source of truth** for HTML pages — we
+re-emit its route entries verbatim (`route`, `outputPath`,
+`contentType`, `sizeBytes`, `sha256`, `lastmod`). The other
+inputs add one synthesised entry each at fixed output paths
+above. Extra files cover everything else (favicons,
+.well-known/, font subsets, robots.txt overrides, etc.).
+
+## Extra-file output-path validation
+
+The extra-file output-path validator is the security-critical
+piece — these paths land on the deploy target's filesystem.
+
+**Accepted** (relative file paths):
+- One or more segments joined by `/`.
+- Each segment matches `[A-Za-z0-9._~!$&'()*+,;=@-]` (RFC 3986
+  unreserved + sub-delims + `@`, **minus** `%` `?` `#` `:`).
+- ≤ 2048 chars.
+
+**Rejected** (with explicit error messages):
+- Non-string / empty / over-cap.
+- Leading `/` (must be relative).
+- Leading `~` (home-dir expansion).
+- Any `\` (Windows separator).
+- `..` segment (path traversal).
+- `.` sole segment.
+- Empty mid-segment (`a//b`, trailing `/`).
+- `:` anywhere — Windows drive separator / HFS+ historic.
+  (`https:/evil`, `C:/Windows`, `a/b:c` all rejected.)
+- `?`, `#`, whitespace, NUL, unicode, percent-encoded.
+
+## Page-bundle parse safety
+
+`parsePageBundle` uses `JSON.parse` then walks fields by name.
+No `for...in` loops, no prototype-chain traversal. Even a
+crafted `__proto__` key in the input survives as an own property
+on the parsed object — never reaching `Object.prototype`.
+Verified by an end-to-end test (`Object.prototype` is checked
+for pollution after parsing a sneaky bundle).
+
+## JSON output format
+
+Byte-deterministic:
+
+- 2-space indent, trailing newline.
+- Top-level keys: `version → baseUrl (if present) → fileCount → totalSizeBytes → files`.
+- `files` sorted by `outputPath` lexicographically.
+- Each entry's keys: `outputPath → contentType → sizeBytes → sha256 → source → route (if page-bundle) → lastmod (if present)`.
+
+Same input → byte-identical manifest. Two consecutive builds
+diff cleanly: only files that genuinely changed show up.
+
+## Duplicate detection
+
+Throws on any output-path collision:
+- Within the page bundle.
+- Sitemap path collides with a page-bundle route at `sitemap.xml`.
+- Same for `robots.txt`, `manifest.webmanifest`.
+- Extra-file path collides with any earlier entry.
+
+The deploy runner must have an unambiguous "what gets written where" — no last-write-wins surprises.
+
+## Security posture
+
+Ten concerns explicitly addressed (pre-push review found three hardening gaps — all fixed before push):
+
+1. **Path traversal.** Extra-file paths validated against strict shape regex + `..` / `.` / empty-segment checks before being written.
+2. **Cross-platform path safety.** No `\`, no `:`, no leading `/` or `~`.
+3. **Percent-encoding traversal.** `%` not in segment charset; `%2e%2e` etc. rejected wholesale rather than decoded.
+4. **Prototype pollution.** `JSON.parse` + `Object.keys` (own enumerable only). No prototype walk.
+5. **JSON-syntax injection.** `JSON.stringify` escapes; route/path strings can't break the output structure.
+6. **Hashing.** SHA-256 via Node's built-in `node:crypto`. No external dep, no algorithm choice.
+7. **Determinism.** Same input → byte-identical output. No nondeterminism source.
+8. **Page-bundle outputPath revalidation.** The API accepts any JSON string as `pageBundle` — `parsePageBundle` re-runs the full `validateOutputPath` check on every route's `outputPath` so a malicious / buggy upstream can't smuggle `../etc/passwd` through to the deploy target. Defense-in-depth.
+9. **Windows / cross-platform filename safety.** Per-segment checks reject Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9` with/without extension, case-insensitive), trailing dot/space (Win32 silently strips), and per-segment > 255 bytes (ext4/APFS/NTFS filename limit).
+10. **Prototype-pollution sink hardening.** Output paths literally `__proto__`, `constructor`, `prototype` rejected. `filesObj` accumulator uses `Object.create(null)` so there's no prototype-chain mutation path even if validation ever loosened.
+
+## Behavioural notes
+
+- **Page-bundle hashes** are trusted verbatim (we don't re-hash; the page bundle already did that work).
+- **Synthesised entries** (sitemap / robots / manifest) get fresh hashes from the input string.
+- **Extra-file `content`** is hashed as a UTF-8 string. Binary callers should base64-encode before passing.
+- **No input mutation.**
+
+## v0 simplifications (documented)
+
+- **No deploy-target adapters** (S3, Netlify, Cloudflare Pages, etc.) — that's the next stage (a deploy-runner program).
+- **No CDN purge directives** in the manifest.
+- **No per-file caching headers / TTLs.** The contentType is enough for v0.
+- **No incremental diff vs. previous deploy.** Caller can diff two manifest JSONs externally.
+
+## Tests
+
+112 tests across three files. **100% line / 98.47% branch**
+coverage on all source files with logic. The missing branches
+are unreachable in practice (sort comparator equality cases
+since duplicate paths throw at validation time).
+
+## Capabilities
+
+`[]` — pure transform. Uses Node's built-in `node:crypto`.
+
+## How it fits in the stack
+
+The **final** compose stage of the FM00 v0 pipeline:
+
+```
+forme-aot-html-doc-emitter      →  per-page HTML strings
+forme-aot-page-bundle-emitter   →  page bundle JSON (routes → hashes)
+forme-aot-sitemap-emitter       →  sitemap.xml
+forme-aot-robots-emitter        →  robots.txt
+forme-aot-manifest-emitter      →  manifest.webmanifest
+
+         ↓ all of the above ↓
+
+forme-aot-deploy-manifest-emitter  ←  YOU ARE HERE
+         ↓
+deploy runner (next package)  →  S3 / Netlify / fs target
+```

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/package-lock.json
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-aot-deploy-manifest-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-aot-deploy-manifest-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/package.json
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@coding-adventures/forme-aot-deploy-manifest-emitter",
+  "version": "0.1.0",
+  "description": "Compose a single deploy-platform-agnostic manifest from page bundle + sitemap.xml + robots.txt + Web App Manifest JSON + extraFiles.  Pure transform; uses Node's node:crypto for SHA-256; canonical JSON output (sorted file paths, fixed key order per entry).  FM00 v0 emitter.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-aot-deploy-manifest-emitter",
+  "capabilities": [],
+  "justification": "Pure transform: composes existing FM00 emitter outputs (page bundle JSON + sitemap.xml + robots.txt + manifest.json + extraFiles[]) into a single canonical deploy-record JSON.  Uses Node's built-in node:crypto for SHA-256 hashing.  No I/O, no fs, no network, no env, no shell."
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/generate.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/generate.ts
@@ -1,0 +1,201 @@
+/**
+ * generate.ts — main `generateDeployManifest` entry.
+ *
+ * Two-pass fail-fast:
+ *   1. Parse pageBundle, validate extraFiles (paths + content
+ *      strings), measure + hash each synthetic file
+ *      (sitemap / robots / web-app-manifest).
+ *   2. Sort by outputPath and serialise to canonical JSON.
+ *
+ * Output JSON shape (byte-deterministic):
+ *
+ *     {
+ *       "version": 1,
+ *       "baseUrl": "...",          // present only if pageBundle had one
+ *       "fileCount": <int>,
+ *       "totalSizeBytes": <int>,
+ *       "files": {
+ *         "<outputPath>": {
+ *           "outputPath": "...",
+ *           "contentType": "...",
+ *           "sizeBytes": <int>,
+ *           "sha256": "...=",
+ *           "route": "..."         // only for page-bundle entries
+ *           "source": "page-bundle|sitemap|robots|web-app-manifest|extra",
+ *           "lastmod": "..."       // only when present
+ *         },
+ *         ...
+ *       }
+ *     }
+ *
+ * Files are sorted by `outputPath` lexicographically.  Within
+ * each entry, keys are emitted in a fixed order.  Same input →
+ * byte-identical output.
+ *
+ * Duplicate output paths (across pageBundle + sitemap + robots
+ * + manifest + extraFiles) throw — the manifest must be
+ * unambiguous about what gets written where.
+ *
+ * @module generate
+ */
+
+import { sha256Base64, utf8ByteLength } from "./hash.js";
+import { parsePageBundle, routeToDeployEntry } from "./parse-page-bundle.js";
+import type {
+  DeployFileEntry,
+  DeployManifestConfig,
+  ExtraFile,
+} from "./types.js";
+import { validateOutputPath, validateString } from "./validate.js";
+
+const SITEMAP_PATH = "sitemap.xml";
+const SITEMAP_CONTENT_TYPE = "application/xml";
+const ROBOTS_PATH = "robots.txt";
+const ROBOTS_CONTENT_TYPE = "text/plain; charset=utf-8";
+const WEB_APP_MANIFEST_PATH = "manifest.webmanifest";
+const WEB_APP_MANIFEST_CONTENT_TYPE = "application/manifest+json";
+
+/**
+ * Build the deploy manifest JSON string from the composed
+ * outputs of the FM00 v0 emitters.  Synchronous, pure,
+ * deterministic.
+ */
+export function generateDeployManifest(config: DeployManifestConfig): string {
+  if (config === null || typeof config !== "object") {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: config must be a non-null object; got ${typeof config}`,
+    );
+  }
+  if (typeof config.pageBundle !== "string") {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: config.pageBundle must be a string; got ${typeof config.pageBundle}`,
+    );
+  }
+
+  // 1. Page bundle is the source of truth for HTML pages.
+  const bundle = parsePageBundle(config.pageBundle);
+  const seenPaths = new Set<string>();
+  const files: DeployFileEntry[] = [];
+  for (const route of bundle.routes) {
+    if (seenPaths.has(route.outputPath)) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: pageBundle has duplicate outputPath ${JSON.stringify(route.outputPath)}`,
+      );
+    }
+    seenPaths.add(route.outputPath);
+    files.push(routeToDeployEntry(route));
+  }
+
+  // 2. sitemap / robots / web-app-manifest — synthesise a
+  //    file entry each (hash + measure + fixed output path).
+  if (config.sitemapXml !== undefined) {
+    const content = validateString(config.sitemapXml, "sitemapXml");
+    addSynthetic(files, seenPaths, SITEMAP_PATH, content, SITEMAP_CONTENT_TYPE, "sitemap");
+  }
+  if (config.robotsTxt !== undefined) {
+    const content = validateString(config.robotsTxt, "robotsTxt");
+    addSynthetic(files, seenPaths, ROBOTS_PATH, content, ROBOTS_CONTENT_TYPE, "robots");
+  }
+  if (config.manifestJson !== undefined) {
+    const content = validateString(config.manifestJson, "manifestJson");
+    addSynthetic(files, seenPaths, WEB_APP_MANIFEST_PATH, content, WEB_APP_MANIFEST_CONTENT_TYPE, "web-app-manifest");
+  }
+
+  // 3. Extra files — caller-supplied, must be validated.
+  if (config.extraFiles !== undefined) {
+    if (!Array.isArray(config.extraFiles)) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: extraFiles must be an array; got ${typeof config.extraFiles}`,
+      );
+    }
+    for (let i = 0; i < config.extraFiles.length; i++) {
+      const f = config.extraFiles[i];
+      if (f === null || typeof f !== "object") {
+        throw new TypeError(
+          `forme-aot-deploy-manifest-emitter: extraFiles[${i}] must be a non-null object; got ${typeof f}`,
+        );
+      }
+      const entry = validateExtraFile(f, i);
+      if (seenPaths.has(entry.outputPath)) {
+        throw new TypeError(
+          `forme-aot-deploy-manifest-emitter: extraFiles[${i}].outputPath ${JSON.stringify(entry.outputPath)} duplicates an earlier entry`,
+        );
+      }
+      seenPaths.add(entry.outputPath);
+      files.push(entry);
+    }
+  }
+
+  // Sort by outputPath, lexicographic.
+  files.sort((a, b) => (a.outputPath < b.outputPath ? -1 : a.outputPath > b.outputPath ? 1 : 0));
+
+  // Build the canonical object.  `Object.create(null)` so a
+  // crafted outputPath of literally `"__proto__"` (already
+  // rejected at validation time, but defense-in-depth) would
+  // land as an own property here rather than mutating the
+  // prototype chain.
+  const filesObj: Record<string, Record<string, unknown>> = Object.create(null);
+  let totalSizeBytes = 0;
+  for (const entry of files) {
+    const inner: Record<string, unknown> = {
+      outputPath: entry.outputPath,
+      contentType: entry.contentType,
+      sizeBytes: entry.sizeBytes,
+      sha256: entry.sha256,
+      source: entry.source,
+    };
+    if (entry.route !== undefined) inner.route = entry.route;
+    if (entry.lastmod !== undefined) inner.lastmod = entry.lastmod;
+    filesObj[entry.outputPath] = inner;
+    totalSizeBytes += entry.sizeBytes;
+  }
+
+  const top: Record<string, unknown> = { version: 1 };
+  if (bundle.baseUrl !== undefined) top.baseUrl = bundle.baseUrl;
+  top.fileCount = files.length;
+  top.totalSizeBytes = totalSizeBytes;
+  top.files = filesObj;
+
+  return `${JSON.stringify(top, null, 2)}\n`;
+}
+
+function addSynthetic(
+  files: DeployFileEntry[],
+  seen: Set<string>,
+  path: string,
+  content: string,
+  contentType: string,
+  source: "sitemap" | "robots" | "web-app-manifest",
+): void {
+  if (seen.has(path)) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${source} output path ${JSON.stringify(path)} collides with a page-bundle route`,
+    );
+  }
+  seen.add(path);
+  files.push({
+    outputPath: path,
+    contentType,
+    sizeBytes: utf8ByteLength(content),
+    sha256: sha256Base64(content),
+    source,
+  });
+}
+
+function validateExtraFile(f: ExtraFile, i: number): DeployFileEntry {
+  const outputPath = validateOutputPath(f.outputPath, `extraFiles[${i}].outputPath`);
+  const content = validateString(f.content, `extraFiles[${i}].content`);
+  const contentType = validateString(f.contentType, `extraFiles[${i}].contentType`);
+  let lastmod: string | undefined;
+  if (f.lastmod !== undefined) {
+    lastmod = validateString(f.lastmod, `extraFiles[${i}].lastmod`);
+  }
+  return {
+    outputPath,
+    contentType,
+    sizeBytes: utf8ByteLength(content),
+    sha256: sha256Base64(content),
+    source: "extra",
+    lastmod,
+  };
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/hash.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/hash.ts
@@ -1,0 +1,27 @@
+/**
+ * hash.ts — SHA-256 of a string, base64-encoded.  Same pattern
+ * as `forme-aot-page-bundle-emitter`.
+ *
+ * Uses Node's built-in `node:crypto`.  No external dependency,
+ * no network.
+ *
+ * @module hash
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Compute the base64-encoded SHA-256 digest of `s` (UTF-8
+ * encoded).
+ */
+export function sha256Base64(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("base64");
+}
+
+/**
+ * UTF-8 byte length of `s`.  Same pattern as the page-bundle
+ * emitter.
+ */
+export function utf8ByteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/index.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @coding-adventures/forme-aot-deploy-manifest-emitter
+ *
+ * Compose the per-stage FM00 v0 emitter outputs (page bundle
+ * JSON + sitemap.xml + robots.txt + Web App Manifest JSON +
+ * caller-supplied extra files) into a single, byte-deterministic
+ * deploy manifest JSON.  A downstream deploy runner reads the
+ * manifest to apply every file to the deploy target.
+ *
+ * Pure transform.  Uses Node's built-in `node:crypto` for
+ * SHA-256.  No I/O / fs / network / shell / env.  Capabilities:
+ * `[]`.
+ *
+ * Twentieth FM00 v0 stage package.
+ *
+ * @module index
+ */
+
+export { generateDeployManifest } from "./generate.js";
+export { sha256Base64, utf8ByteLength } from "./hash.js";
+export { validateOutputPath, validateString } from "./validate.js";
+export { parsePageBundle, routeToDeployEntry } from "./parse-page-bundle.js";
+export type {
+  DeployManifestConfig,
+  ExtraFile,
+  DeployFileEntry,
+  DeployManifest,
+} from "./types.js";

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/parse-page-bundle.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/parse-page-bundle.ts
@@ -1,0 +1,151 @@
+/**
+ * parse-page-bundle.ts — safe JSON parse + shape check for the
+ * incoming page bundle string.
+ *
+ * Defensive design notes:
+ *
+ *   - We use `JSON.parse` with no reviver and immediately copy
+ *     every field we care about into fresh local objects (via
+ *     `Object.create(null)`-style accumulators).  This means
+ *     even if the input JSON contained `__proto__` or
+ *     `constructor` keys (which `JSON.parse` happily accepts),
+ *     they end up as own properties on the parsed object —
+ *     never reaching `Object.prototype`.  We never iterate them
+ *     via `for...in`; we walk known fields by name only.
+ *
+ *   - We don't trust the bundle's `routes` keys; we validate
+ *     each entry's `route` / `outputPath` / `contentType` /
+ *     `sizeBytes` / `sha256` field individually.
+ *
+ *   - We don't re-hash the page HTML (we don't have it — only
+ *     the metadata).  We trust the page bundle's hashes
+ *     verbatim; if the caller wanted a fresh hash, they would
+ *     re-run `forme-aot-page-bundle-emitter`.
+ *
+ * @module parse-page-bundle
+ */
+
+import type { DeployFileEntry } from "./types.js";
+import { validateOutputPath } from "./validate.js";
+
+interface RawRoute {
+  readonly route: string;
+  readonly outputPath: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly sha256: string;
+  readonly lastmod?: string;
+}
+
+interface ParsedPageBundle {
+  readonly baseUrl?: string;
+  readonly routes: readonly RawRoute[];
+}
+
+/**
+ * Parse + validate a page-bundle JSON string.  Throws
+ * `TypeError` for any structural problem.
+ */
+export function parsePageBundle(json: string): ParsedPageBundle {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: pageBundle is not valid JSON: ${(e as Error).message}`,
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: pageBundle root must be a JSON object`,
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj.version !== 1) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: pageBundle.version must be 1; got ${JSON.stringify(obj.version)}`,
+    );
+  }
+
+  let baseUrl: string | undefined;
+  if (obj.baseUrl !== undefined) {
+    if (typeof obj.baseUrl !== "string") {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: pageBundle.baseUrl must be a string; got ${typeof obj.baseUrl}`,
+      );
+    }
+    baseUrl = obj.baseUrl;
+  }
+
+  if (obj.routes === null || typeof obj.routes !== "object" || Array.isArray(obj.routes)) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: pageBundle.routes must be a JSON object`,
+    );
+  }
+  const routesObj = obj.routes as Record<string, unknown>;
+
+  const routes: RawRoute[] = [];
+  // Walk via `Object.keys` (own enumerable only — no prototype walk).
+  for (const key of Object.keys(routesObj)) {
+    const entry = routesObj[key];
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: pageBundle.routes[${JSON.stringify(key)}] must be a JSON object`,
+      );
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.route !== "string") throw badField(key, "route", e.route);
+    if (typeof e.outputPath !== "string") throw badField(key, "outputPath", e.outputPath);
+    // Defence-in-depth: even though the page-bundle emitter
+    // validated routes and derived outputPaths, our caller can
+    // pass ANY JSON string as `pageBundle` — there's no
+    // type-system guarantee it came from the trusted upstream.
+    // Re-validate every outputPath against the same shape rules
+    // we apply to extraFiles.
+    validateOutputPath(e.outputPath, `pageBundle.routes[${JSON.stringify(key)}].outputPath`);
+    if (typeof e.contentType !== "string") throw badField(key, "contentType", e.contentType);
+    if (typeof e.sizeBytes !== "number" || !Number.isInteger(e.sizeBytes) || e.sizeBytes < 0) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: pageBundle.routes[${JSON.stringify(key)}].sizeBytes must be a non-negative integer; got ${JSON.stringify(e.sizeBytes)}`,
+      );
+    }
+    if (typeof e.sha256 !== "string") throw badField(key, "sha256", e.sha256);
+    let lastmod: string | undefined;
+    if (e.lastmod !== undefined) {
+      if (typeof e.lastmod !== "string") throw badField(key, "lastmod", e.lastmod);
+      lastmod = e.lastmod;
+    }
+    routes.push({
+      route: e.route,
+      outputPath: e.outputPath,
+      contentType: e.contentType,
+      sizeBytes: e.sizeBytes,
+      sha256: e.sha256,
+      lastmod,
+    });
+  }
+
+  return { baseUrl, routes };
+}
+
+/**
+ * Convert a parsed page-bundle route into a deploy file entry.
+ */
+export function routeToDeployEntry(route: RawRoute): DeployFileEntry {
+  return {
+    outputPath: route.outputPath,
+    contentType: route.contentType,
+    sizeBytes: route.sizeBytes,
+    sha256: route.sha256,
+    route: route.route,
+    source: "page-bundle",
+    lastmod: route.lastmod,
+  };
+}
+
+function badField(key: string, field: string, got: unknown): Error {
+  return new TypeError(
+    `forme-aot-deploy-manifest-emitter: pageBundle.routes[${JSON.stringify(key)}].${field} must be a string; got ${typeof got}`,
+  );
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/types.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/types.ts
@@ -1,0 +1,93 @@
+/**
+ * types.ts — public signatures for the deploy manifest emitter.
+ *
+ * The deploy manifest is the single hand-off file between
+ * "build complete" and "deploy starts".  Every file that
+ * should land on the target (static host, CDN, S3 bucket, etc.)
+ * appears in the manifest with its output path, content type,
+ * size, and SHA-256 hash.  A deploy runner reads the manifest,
+ * resolves the file contents (either from the in-memory bundle
+ * or from a separate content store), and writes them.
+ *
+ * Inputs are the already-validated outputs of the sibling FM00
+ * v0 emitters:
+ *   - `pageBundle`  — JSON string from `forme-aot-page-bundle-emitter`
+ *                     (the per-page route table with hashes).
+ *   - `sitemapXml`  — optional sitemap.xml string.
+ *   - `robotsTxt`   — optional robots.txt string.
+ *   - `manifestJson` — optional Web App Manifest JSON string.
+ *   - `extraFiles`  — optional caller-supplied extra files
+ *                     (favicon binaries, .well-known/, etc.).
+ *
+ * The pageBundle is treated as the **source of truth** for HTML
+ * pages — we re-emit its route entries verbatim (route,
+ * outputPath, contentType, sizeBytes, sha256, lastmod).  The
+ * other inputs add one synthesised entry each at fixed output
+ * paths (`sitemap.xml`, `robots.txt`, `manifest.webmanifest`).
+ *
+ * @module types
+ */
+
+/**
+ * Extra file entry (caller-supplied).  Used for binary assets
+ * the FM00 pipeline doesn't generate — favicons, .well-known/
+ * verification files, font subsets, etc.
+ *
+ *   - `outputPath`  — relative path (no leading `/`), no `..`,
+ *                     no `\`, no absolute prefix.
+ *   - `content`     — the file contents as a string (binary
+ *                     payloads should be base64-encoded by the
+ *                     caller; the manifest is content-agnostic
+ *                     for size/hash purposes).
+ *   - `contentType` — required MIME type.
+ *   - `lastmod`     — optional ISO 8601 string (passthrough).
+ */
+export interface ExtraFile {
+  readonly outputPath: string;
+  readonly content: string;
+  readonly contentType: string;
+  readonly lastmod?: string;
+}
+
+/**
+ * Top-level config consumed by `generateDeployManifest`.
+ */
+export interface DeployManifestConfig {
+  readonly pageBundle: string;
+  readonly sitemapXml?: string;
+  readonly robotsTxt?: string;
+  readonly manifestJson?: string;
+  readonly extraFiles?: readonly ExtraFile[];
+}
+
+/**
+ * One file in the emitted deploy record.
+ */
+export interface DeployFileEntry {
+  readonly outputPath: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+  readonly sha256: string;
+  /** Original route (only present for HTML pages from the page bundle). */
+  readonly route?: string;
+  /** Source emitter (page-bundle, sitemap, robots, manifest, extra). */
+  readonly source:
+    | "page-bundle"
+    | "sitemap"
+    | "robots"
+    | "web-app-manifest"
+    | "extra";
+  readonly lastmod?: string;
+}
+
+/**
+ * The decoded deploy manifest shape.  Documented for downstream
+ * consumers (we don't export a parser).
+ */
+export interface DeployManifest {
+  readonly version: 1;
+  readonly baseUrl?: string;
+  readonly fileCount: number;
+  readonly totalSizeBytes: number;
+  readonly files: Readonly<Record<string, DeployFileEntry>>;
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/validate.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/src/validate.ts
@@ -1,0 +1,170 @@
+/**
+ * validate.ts — output-path + content validation.
+ *
+ * Output paths are the security-critical piece — they land on
+ * the deploy target's filesystem.  Reject every form of path
+ * traversal or absolute escape.
+ *
+ * Output paths are RELATIVE (no leading `/`), unlike routes in
+ * the page bundle which are URL paths (leading `/`).  The
+ * page-bundle emitter already converts routes to relative
+ * output paths; here we only need to validate the additional
+ * extraFiles paths.
+ *
+ * @module validate
+ */
+
+// Segment charset: like page-bundle's ROUTE_SEGMENT_RE but
+// stripped of URL-only chars and tightened for filesystem
+// safety.  Specifically removed (vs. ROUTE_SEGMENT_RE):
+//   - `%` — no percent-encoding decode at this layer.
+//   - `?` `#` — URL syntax, not filesystem.
+//   - `:` — Windows reserved (drive separator), macOS HFS+
+//     historically used colon as path separator.  We forbid
+//     it entirely rather than try to enforce
+//     "not-in-first-segment" rules that bite cross-platform.
+const PATH_SEGMENT_RE = /^[A-Za-z0-9._~!$&'()*+,;=@\-]+$/;
+
+// Windows reserved device names — case-insensitive, with or
+// without extension.  See Win32 `CreateFile` docs.
+const WIN_RESERVED_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+
+/**
+ * Validate a relative output path.
+ *
+ * Accepts: one or more segments joined by `/`.  Each segment
+ * matches the segment charset above; no `..`, no `.`, no
+ * empty segments.
+ *
+ * Rejects:
+ *   - non-string / empty / over-cap (2048)
+ *   - leading `/` (must be relative)
+ *   - leading `~/` (home-dir expansion confuses some tools)
+ *   - any `\` (Windows path separator)
+ *   - `..` segment anywhere (path traversal)
+ *   - `.` sole segment
+ *   - empty mid-segment (`a//b`)
+ *   - trailing `/` (would create a directory, not a file)
+ *   - disallowed chars
+ *   - Windows drive letter prefix (`C:`) — `:` is in the
+ *     segment charset for cross-platform reasons (it's
+ *     occasionally legal in URL routes), but a colon in the
+ *     FIRST segment of an output path is suspicious; we
+ *     reject `*:*` as the first segment.
+ */
+export function validateOutputPath(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must be a string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  if (value.length === 0) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must be non-empty`,
+    );
+  }
+  if (value.length > 2048) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must be ≤ 2048 chars`,
+    );
+  }
+  if (value[0] === "/") {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must be relative (no leading "/"); got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+  if (value[0] === "~") {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must not start with "~" (home-dir expansion); got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+  if (value.indexOf("\\") !== -1) {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must not contain "\\"; got ${JSON.stringify(shorten(value))}`,
+    );
+  }
+
+  const segments = value.split("/");
+  for (const seg of segments) {
+    if (seg.length === 0) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} must not contain empty segments (//); got ${JSON.stringify(shorten(value))}`,
+      );
+    }
+    if (seg === "..") {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} must not contain ".." segments (path traversal); got ${JSON.stringify(shorten(value))}`,
+      );
+    }
+    if (seg === ".") {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} must not contain "." segments; got ${JSON.stringify(shorten(value))}`,
+      );
+    }
+    if (!PATH_SEGMENT_RE.test(seg)) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} segment ${JSON.stringify(seg)} contains disallowed characters; only [A-Za-z0-9._~!$&'()*+,;=@-] permitted (no ":" — Windows / HFS+ reserved)`,
+      );
+    }
+    // Per-segment length cap.  ext4 / APFS / NTFS all cap
+    // single filename components at 255 bytes; longer segments
+    // would write-fail at deploy time.  We surface it here
+    // instead of letting the deploy runner blow up.
+    if (seg.length > 255) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} segment exceeds 255-byte filesystem limit; got ${seg.length} bytes`,
+      );
+    }
+    // Windows reserved device names — CON, PRN, AUX, NUL,
+    // COM1..9, LPT1..9 — with or without extension.  Win32
+    // intercepts these and writes to the device instead of
+    // creating a file.  Reject so cross-platform deploys are
+    // safe.  Match is case-insensitive (Windows is too).
+    if (WIN_RESERVED_RE.test(seg)) {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} segment ${JSON.stringify(seg)} is a Windows reserved device name (CON/PRN/AUX/NUL/COM1-9/LPT1-9)`,
+      );
+    }
+    // Trailing dot / space in a Windows filename gets silently
+    // stripped by the Win32 layer, producing a different file
+    // than the caller asked for.  Reject so the bug surfaces.
+    const lastChar = seg[seg.length - 1];
+    if (lastChar === "." || lastChar === " ") {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} segment ${JSON.stringify(seg)} must not end in "." or " " (Windows silently strips these)`,
+      );
+    }
+    // Prototype-pollution defence (defense-in-depth — the
+    // emitter also uses `Object.create(null)` for the output
+    // table, but rejecting these names up-front gives a clear
+    // error rather than a silent-write-into-prototype risk on
+    // any downstream consumer that does the same).
+    if (seg === "__proto__" || seg === "constructor" || seg === "prototype") {
+      throw new TypeError(
+        `forme-aot-deploy-manifest-emitter: ${field} segment ${JSON.stringify(seg)} is a JS prototype-pollution sink name`,
+      );
+    }
+  }
+  return value;
+}
+
+/**
+ * Validate a string field (used for content, contentType,
+ * lastmod, the input JSON/XML/TXT strings).
+ */
+export function validateString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `forme-aot-deploy-manifest-emitter: ${field} must be a string; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  return value;
+}
+
+function shorten(s: string): string {
+  return s.length > 100 ? `${s.slice(0, 100)}…` : s;
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/tests/generate.test.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/tests/generate.test.ts
@@ -1,0 +1,339 @@
+/**
+ * generate.test.ts — end-to-end generateDeployManifest.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateDeployManifest } from "../src/index.js";
+
+const MIN_BUNDLE = JSON.stringify({
+  version: 1,
+  routes: {
+    "/": {
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 100,
+      sha256: "AAAA",
+    },
+  },
+});
+
+const BUNDLE_WITH_BASE = JSON.stringify({
+  version: 1,
+  baseUrl: "https://example.com",
+  routes: {
+    "/": {
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 100,
+      sha256: "AAAA",
+    },
+    "/about": {
+      route: "/about",
+      outputPath: "about/index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 200,
+      sha256: "BBBB",
+    },
+  },
+});
+
+describe("generateDeployManifest — shape", () => {
+  it("null config throws", () => {
+    expect(() => generateDeployManifest(null as unknown as never))
+      .toThrow(/config must be a non-null object/);
+  });
+  it("non-string pageBundle throws", () => {
+    expect(() => generateDeployManifest({ pageBundle: 42 as unknown as string }))
+      .toThrow(/pageBundle must be a string/);
+  });
+  it("invalid pageBundle JSON throws", () => {
+    expect(() => generateDeployManifest({ pageBundle: "not json" }))
+      .toThrow(/not valid JSON/);
+  });
+});
+
+describe("generateDeployManifest — minimal", () => {
+  it("page bundle only", () => {
+    const out = generateDeployManifest({ pageBundle: MIN_BUNDLE });
+    const m = JSON.parse(out);
+    expect(m.version).toBe(1);
+    expect(m.fileCount).toBe(1);
+    expect(m.totalSizeBytes).toBe(100);
+    expect(m.files["index.html"]).toMatchObject({
+      outputPath: "index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 100,
+      sha256: "AAAA",
+      route: "/",
+      source: "page-bundle",
+    });
+  });
+  it("baseUrl propagated from page bundle", () => {
+    const out = generateDeployManifest({ pageBundle: BUNDLE_WITH_BASE });
+    const m = JSON.parse(out);
+    expect(m.baseUrl).toBe("https://example.com");
+  });
+  it("trailing newline", () => {
+    expect(generateDeployManifest({ pageBundle: MIN_BUNDLE }).endsWith("\n")).toBe(true);
+  });
+});
+
+describe("generateDeployManifest — sitemap / robots / web app manifest", () => {
+  it("sitemap entry synthesised", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      sitemapXml: "<?xml?><urlset/>",
+    }));
+    expect(m.files["sitemap.xml"]).toMatchObject({
+      outputPath: "sitemap.xml",
+      contentType: "application/xml",
+      source: "sitemap",
+    });
+    expect(m.files["sitemap.xml"].sizeBytes).toBeGreaterThan(0);
+  });
+  it("robots entry synthesised", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      robotsTxt: "User-agent: *\nAllow: /\n",
+    }));
+    expect(m.files["robots.txt"]).toMatchObject({
+      outputPath: "robots.txt",
+      contentType: "text/plain; charset=utf-8",
+      source: "robots",
+    });
+  });
+  it("web app manifest synthesised", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      manifestJson: '{"name":"App"}',
+    }));
+    expect(m.files["manifest.webmanifest"]).toMatchObject({
+      outputPath: "manifest.webmanifest",
+      contentType: "application/manifest+json",
+      source: "web-app-manifest",
+    });
+  });
+  it("non-string sitemapXml throws", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE, sitemapXml: 42 as unknown as string,
+    })).toThrow(/sitemapXml must be a string/);
+  });
+  it("non-string robotsTxt throws", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE, robotsTxt: 42 as unknown as string,
+    })).toThrow(/robotsTxt must be a string/);
+  });
+  it("non-string manifestJson throws", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE, manifestJson: 42 as unknown as string,
+    })).toThrow(/manifestJson must be a string/);
+  });
+});
+
+describe("generateDeployManifest — extraFiles", () => {
+  it("favicon binary added", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [{ outputPath: "favicon.ico", content: "base64data", contentType: "image/x-icon" }],
+    }));
+    expect(m.files["favicon.ico"]).toMatchObject({
+      outputPath: "favicon.ico",
+      contentType: "image/x-icon",
+      source: "extra",
+    });
+  });
+  it("multiple extras", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [
+        { outputPath: "favicon.ico", content: "x", contentType: "image/x-icon" },
+        { outputPath: ".well-known/security.txt", content: "Contact: x", contentType: "text/plain" },
+      ],
+    }));
+    expect(m.files["favicon.ico"]).toBeDefined();
+    expect(m.files[".well-known/security.txt"]).toBeDefined();
+    expect(m.fileCount).toBe(3); // 1 page + 2 extras
+  });
+  it("non-array extraFiles throws", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: "nope" as unknown as never,
+    })).toThrow(/extraFiles must be an array/);
+  });
+  it("null extra entry throws", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [null as unknown as never],
+    })).toThrow(/extraFiles\[0\] must be a non-null object/);
+  });
+  it("path traversal in extraFiles rejected", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [{ outputPath: "../etc", content: "x", contentType: "text/plain" }],
+    })).toThrow(/path traversal/);
+  });
+  it("absolute path in extraFiles rejected", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [{ outputPath: "/etc/passwd", content: "x", contentType: "text/plain" }],
+    })).toThrow(/must be relative/);
+  });
+  it("backslash in extraFiles rejected", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [{ outputPath: "a\\b", content: "x", contentType: "text/plain" }],
+    })).toThrow(/must not contain/);
+  });
+  it("lastmod preserved on extras", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [{ outputPath: "x.txt", content: "x", contentType: "text/plain", lastmod: "2026-05-19" }],
+    }));
+    expect(m.files["x.txt"].lastmod).toBe("2026-05-19");
+  });
+});
+
+describe("generateDeployManifest — duplicate detection", () => {
+  it("duplicate path in page bundle throws", () => {
+    const dupBundle = JSON.stringify({
+      version: 1,
+      routes: {
+        "/a": { route: "/a", outputPath: "x.html", contentType: "t", sizeBytes: 0, sha256: "z" },
+        "/b": { route: "/b", outputPath: "x.html", contentType: "t", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => generateDeployManifest({ pageBundle: dupBundle }))
+      .toThrow(/pageBundle has duplicate outputPath/);
+  });
+  it("sitemap collides with page-bundle route at sitemap.xml", () => {
+    const collidingBundle = JSON.stringify({
+      version: 1,
+      routes: {
+        "/sitemap.xml": { route: "/sitemap.xml", outputPath: "sitemap.xml", contentType: "x", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => generateDeployManifest({ pageBundle: collidingBundle, sitemapXml: "<?xml?>" }))
+      .toThrow(/sitemap output path "sitemap.xml" collides/);
+  });
+  it("robots collides with page-bundle entry", () => {
+    const collidingBundle = JSON.stringify({
+      version: 1,
+      routes: {
+        "/robots.txt": { route: "/robots.txt", outputPath: "robots.txt", contentType: "x", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => generateDeployManifest({ pageBundle: collidingBundle, robotsTxt: "x" }))
+      .toThrow(/robots output path "robots.txt" collides/);
+  });
+  it("web-app-manifest collides", () => {
+    const collidingBundle = JSON.stringify({
+      version: 1,
+      routes: {
+        "/m": { route: "/m", outputPath: "manifest.webmanifest", contentType: "x", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => generateDeployManifest({ pageBundle: collidingBundle, manifestJson: "{}" }))
+      .toThrow(/web-app-manifest output path "manifest.webmanifest" collides/);
+  });
+  it("extra collides with page-bundle entry", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      extraFiles: [{ outputPath: "index.html", content: "x", contentType: "text/html" }],
+    })).toThrow(/extraFiles\[0\]\.outputPath "index.html" duplicates/);
+  });
+  it("extra collides with sitemap entry", () => {
+    expect(() => generateDeployManifest({
+      pageBundle: MIN_BUNDLE,
+      sitemapXml: "<?xml?>",
+      extraFiles: [{ outputPath: "sitemap.xml", content: "x", contentType: "application/xml" }],
+    })).toThrow(/extraFiles\[0\]\.outputPath "sitemap.xml" duplicates/);
+  });
+});
+
+describe("generateDeployManifest — output format", () => {
+  it("files sorted by outputPath", () => {
+    const bundle = JSON.stringify({
+      version: 1,
+      routes: {
+        "/z": { route: "/z", outputPath: "z/index.html", contentType: "t", sizeBytes: 1, sha256: "z" },
+        "/a": { route: "/a", outputPath: "a/index.html", contentType: "t", sizeBytes: 1, sha256: "a" },
+      },
+    });
+    const out = generateDeployManifest({ pageBundle: bundle });
+    const aIdx = out.indexOf("a/index.html");
+    const zIdx = out.indexOf("z/index.html");
+    expect(aIdx).toBeLessThan(zIdx);
+  });
+  it("totalSizeBytes is sum across all files", () => {
+    const m = JSON.parse(generateDeployManifest({
+      pageBundle: BUNDLE_WITH_BASE,
+      sitemapXml: "abc", // 3 bytes
+    }));
+    expect(m.totalSizeBytes).toBe(100 + 200 + 3);
+  });
+  it("entry key order: outputPath → contentType → sizeBytes → sha256 → source → route → lastmod", () => {
+    const out = generateDeployManifest({
+      pageBundle: JSON.stringify({
+        version: 1,
+        routes: {
+          "/": { route: "/", outputPath: "index.html", contentType: "t", sizeBytes: 0, sha256: "z", lastmod: "2026-05-19" },
+        },
+      }),
+    });
+    const order = ["outputPath", "contentType", "sizeBytes", "sha256", "source", "route", "lastmod"];
+    let lastIdx = -1;
+    for (const key of order) {
+      const idx = out.indexOf(`"${key}"`);
+      expect(idx).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+  });
+});
+
+describe("generateDeployManifest — determinism", () => {
+  it("same input → byte-identical output", () => {
+    const cfg = { pageBundle: BUNDLE_WITH_BASE, sitemapXml: "<?xml?>" };
+    expect(generateDeployManifest(cfg)).toBe(generateDeployManifest(cfg));
+  });
+  it("does not mutate extraFiles", () => {
+    const extras = [{ outputPath: "x.txt", content: "x", contentType: "text/plain" }];
+    const before = JSON.stringify(extras);
+    generateDeployManifest({ pageBundle: MIN_BUNDLE, extraFiles: extras });
+    expect(JSON.stringify(extras)).toBe(before);
+  });
+});
+
+describe("generateDeployManifest — full real-world example", () => {
+  it("page bundle + sitemap + robots + manifest + favicon", () => {
+    const out = generateDeployManifest({
+      pageBundle: BUNDLE_WITH_BASE,
+      sitemapXml: "<?xml version=\"1.0\"?><urlset/>",
+      robotsTxt: "User-agent: *\nAllow: /\n",
+      manifestJson: '{"name":"Site"}',
+      extraFiles: [
+        { outputPath: "favicon.ico", content: "BinaryFaviconBase64", contentType: "image/x-icon" },
+        { outputPath: ".well-known/security.txt", content: "Contact: mailto:x@example.com\n", contentType: "text/plain" },
+      ],
+    });
+    const m = JSON.parse(out);
+    expect(m.version).toBe(1);
+    expect(m.baseUrl).toBe("https://example.com");
+    expect(m.fileCount).toBe(7); // 2 pages + sitemap + robots + manifest + 2 extras
+    expect(Object.keys(m.files).sort()).toEqual([
+      ".well-known/security.txt",
+      "about/index.html",
+      "favicon.ico",
+      "index.html",
+      "manifest.webmanifest",
+      "robots.txt",
+      "sitemap.xml",
+    ]);
+    expect(m.files["index.html"].source).toBe("page-bundle");
+    expect(m.files["sitemap.xml"].source).toBe("sitemap");
+    expect(m.files["robots.txt"].source).toBe("robots");
+    expect(m.files["manifest.webmanifest"].source).toBe("web-app-manifest");
+    expect(m.files["favicon.ico"].source).toBe("extra");
+  });
+});

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/tests/parse-page-bundle.test.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/tests/parse-page-bundle.test.ts
@@ -1,0 +1,221 @@
+/**
+ * parse-page-bundle.test.ts — JSON parse + shape validation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parsePageBundle, routeToDeployEntry } from "../src/index.js";
+
+const VALID = JSON.stringify({
+  version: 1,
+  baseUrl: "https://example.com",
+  routes: {
+    "/": {
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 42,
+      sha256: "AAAA",
+    },
+  },
+});
+
+describe("parsePageBundle — accept", () => {
+  it("valid input", () => {
+    const out = parsePageBundle(VALID);
+    expect(out.baseUrl).toBe("https://example.com");
+    expect(out.routes).toHaveLength(1);
+    expect(out.routes[0]).toMatchObject({
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html; charset=utf-8",
+      sizeBytes: 42,
+      sha256: "AAAA",
+    });
+  });
+  it("baseUrl omitted", () => {
+    const out = parsePageBundle(JSON.stringify({ version: 1, routes: {} }));
+    expect(out.baseUrl).toBeUndefined();
+  });
+  it("empty routes", () => {
+    const out = parsePageBundle(JSON.stringify({ version: 1, routes: {} }));
+    expect(out.routes).toHaveLength(0);
+  });
+  it("route with lastmod", () => {
+    const out = parsePageBundle(JSON.stringify({
+      version: 1,
+      routes: {
+        "/p": {
+          route: "/p",
+          outputPath: "p/index.html",
+          contentType: "text/html",
+          sizeBytes: 10,
+          sha256: "X",
+          lastmod: "2026-05-19",
+        },
+      },
+    }));
+    expect(out.routes[0]!.lastmod).toBe("2026-05-19");
+  });
+});
+
+describe("parsePageBundle — reject", () => {
+  it("invalid JSON", () => {
+    expect(() => parsePageBundle("not json {")).toThrow(/not valid JSON/);
+  });
+  it("array root", () => {
+    expect(() => parsePageBundle("[]")).toThrow(/root must be a JSON object/);
+  });
+  it("null root", () => {
+    expect(() => parsePageBundle("null")).toThrow(/root must be a JSON object/);
+  });
+  it("string root", () => {
+    expect(() => parsePageBundle('"x"')).toThrow(/root must be a JSON object/);
+  });
+  it("wrong version", () => {
+    expect(() => parsePageBundle(JSON.stringify({ version: 2, routes: {} })))
+      .toThrow(/version must be 1/);
+  });
+  it("missing version", () => {
+    expect(() => parsePageBundle(JSON.stringify({ routes: {} })))
+      .toThrow(/version must be 1/);
+  });
+  it("non-string baseUrl", () => {
+    expect(() => parsePageBundle(JSON.stringify({ version: 1, baseUrl: 42, routes: {} })))
+      .toThrow(/baseUrl must be a string/);
+  });
+  it("routes is array", () => {
+    expect(() => parsePageBundle(JSON.stringify({ version: 1, routes: [] })))
+      .toThrow(/routes must be a JSON object/);
+  });
+  it("routes is null", () => {
+    expect(() => parsePageBundle(JSON.stringify({ version: 1, routes: null })))
+      .toThrow(/routes must be a JSON object/);
+  });
+  it("route entry is array", () => {
+    expect(() => parsePageBundle(JSON.stringify({ version: 1, routes: { "/": [] } })))
+      .toThrow(/must be a JSON object/);
+  });
+  it("non-string route field", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: 1, outputPath: "x", contentType: "y", sizeBytes: 0, sha256: "z" } },
+    }))).toThrow(/\.route must be a string/);
+  });
+  it("non-string outputPath", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: 1, contentType: "y", sizeBytes: 0, sha256: "z" } },
+    }))).toThrow(/\.outputPath must be a string/);
+  });
+  it("non-string contentType", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: "x", contentType: 1, sizeBytes: 0, sha256: "z" } },
+    }))).toThrow(/\.contentType must be a string/);
+  });
+  it("non-integer sizeBytes", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: "x", contentType: "y", sizeBytes: 1.5, sha256: "z" } },
+    }))).toThrow(/sizeBytes must be a non-negative integer/);
+  });
+  it("negative sizeBytes", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: "x", contentType: "y", sizeBytes: -1, sha256: "z" } },
+    }))).toThrow(/sizeBytes must be a non-negative integer/);
+  });
+  it("non-string sizeBytes", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: "x", contentType: "y", sizeBytes: "0", sha256: "z" } },
+    }))).toThrow(/sizeBytes must be a non-negative integer/);
+  });
+  it("non-string sha256", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: "x", contentType: "y", sizeBytes: 0, sha256: 0 } },
+    }))).toThrow(/\.sha256 must be a string/);
+  });
+  it("non-string lastmod", () => {
+    expect(() => parsePageBundle(JSON.stringify({
+      version: 1, routes: { "/": { route: "/", outputPath: "x", contentType: "y", sizeBytes: 0, sha256: "z", lastmod: 1 } },
+    }))).toThrow(/\.lastmod must be a string/);
+  });
+});
+
+describe("parsePageBundle — outputPath validation (defence-in-depth)", () => {
+  it("malicious outputPath ../etc rejected even from page bundle", () => {
+    const sneaky = JSON.stringify({
+      version: 1,
+      routes: {
+        "/x": { route: "/x", outputPath: "../etc/passwd", contentType: "t", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => parsePageBundle(sneaky)).toThrow(/path traversal/);
+  });
+  it("absolute outputPath /etc/passwd rejected", () => {
+    const sneaky = JSON.stringify({
+      version: 1,
+      routes: {
+        "/x": { route: "/x", outputPath: "/etc/passwd", contentType: "t", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => parsePageBundle(sneaky)).toThrow(/must be relative/);
+  });
+  it("__proto__ in outputPath rejected", () => {
+    const sneaky = JSON.stringify({
+      version: 1,
+      routes: {
+        "/x": { route: "/x", outputPath: "__proto__", contentType: "t", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => parsePageBundle(sneaky)).toThrow(/prototype-pollution/);
+  });
+  it("error includes pageBundle.routes[...] field path", () => {
+    const sneaky = JSON.stringify({
+      version: 1,
+      routes: {
+        "/x": { route: "/x", outputPath: "../etc", contentType: "t", sizeBytes: 0, sha256: "z" },
+      },
+    });
+    expect(() => parsePageBundle(sneaky)).toThrow(/pageBundle\.routes\["\/x"\]\.outputPath/);
+  });
+});
+
+describe("parsePageBundle — prototype pollution defence", () => {
+  it("__proto__ key in routes does not pollute Object.prototype", () => {
+    // JSON.parse preserves __proto__ as own property only when assigned via assignment.
+    // We rely on JSON.parse's actual behavior here.
+    const sneaky = '{"version":1,"routes":{"__proto__":{"route":"/x","outputPath":"x","contentType":"t","sizeBytes":0,"sha256":"z"}}}';
+    // Should NOT pollute prototype.  After parse, accessing ({}).polluted === undefined.
+    parsePageBundle(sneaky);
+    // tslint:disable-next-line: no-any
+    expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+});
+
+describe("routeToDeployEntry", () => {
+  it("maps fields + sets source", () => {
+    const entry = routeToDeployEntry({
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html",
+      sizeBytes: 10,
+      sha256: "X",
+    });
+    expect(entry).toMatchObject({
+      route: "/",
+      outputPath: "index.html",
+      contentType: "text/html",
+      sizeBytes: 10,
+      sha256: "X",
+      source: "page-bundle",
+    });
+    expect(entry.lastmod).toBeUndefined();
+  });
+  it("preserves lastmod when present", () => {
+    const entry = routeToDeployEntry({
+      route: "/",
+      outputPath: "x",
+      contentType: "t",
+      sizeBytes: 0,
+      sha256: "z",
+      lastmod: "2026-05-19",
+    });
+    expect(entry.lastmod).toBe("2026-05-19");
+  });
+});

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/tests/validate.test.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/tests/validate.test.ts
@@ -1,0 +1,127 @@
+/**
+ * validate.test.ts — output-path + string validators.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateOutputPath, validateString } from "../src/index.js";
+
+describe("validateOutputPath — accept", () => {
+  it("simple filename", () => { expect(validateOutputPath("favicon.ico", "f")).toBe("favicon.ico"); });
+  it("nested", () => { expect(validateOutputPath("assets/img/logo.png", "f")).toBe("assets/img/logo.png"); });
+  it(".well-known/", () => {
+    expect(validateOutputPath(".well-known/security.txt", "f")).toBe(".well-known/security.txt");
+  });
+  it("hyphens/underscores/digits", () => {
+    expect(validateOutputPath("a-b_c123.txt", "f")).toBe("a-b_c123.txt");
+  });
+  it("deep nesting", () => {
+    expect(validateOutputPath("a/b/c/d/e/f/g.txt", "f")).toBe("a/b/c/d/e/f/g.txt");
+  });
+});
+
+describe("validateOutputPath — reject", () => {
+  it("non-string", () => { expect(() => validateOutputPath(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null", () => { expect(() => validateOutputPath(null, "f")).toThrow(/got null/); });
+  it("empty", () => { expect(() => validateOutputPath("", "f")).toThrow(/non-empty/); });
+  it("over 2048", () => {
+    expect(() => validateOutputPath("a".repeat(2050), "f")).toThrow(/≤ 2048/);
+  });
+  it("leading /", () => { expect(() => validateOutputPath("/abs/path", "f")).toThrow(/must be relative/); });
+  it("leading ~", () => { expect(() => validateOutputPath("~/secret", "f")).toThrow(/home-dir/); });
+  it("contains \\", () => { expect(() => validateOutputPath("a\\b", "f")).toThrow(/must not contain/); });
+  it(".. segment", () => { expect(() => validateOutputPath("a/../b", "f")).toThrow(/path traversal/); });
+  it(".. only", () => { expect(() => validateOutputPath("..", "f")).toThrow(/path traversal/); });
+  it(". segment", () => { expect(() => validateOutputPath("a/./b", "f")).toThrow(/"\." segment/); });
+  it(". only", () => { expect(() => validateOutputPath(".", "f")).toThrow(/"\." segment/); });
+  it("empty mid-segment a//b", () => { expect(() => validateOutputPath("a//b", "f")).toThrow(/empty segments/); });
+  it("trailing /", () => { expect(() => validateOutputPath("a/", "f")).toThrow(/empty segments/); });
+  it("Windows drive C:/...", () => {
+    expect(() => validateOutputPath("C:/Windows", "f"))
+      .toThrow(/disallowed characters/);
+  });
+  it("URL-scheme-like first segment https:/...", () => {
+    expect(() => validateOutputPath("https:/evil", "f"))
+      .toThrow(/disallowed characters/);
+  });
+  it("colon in any segment rejected (Windows / HFS+ reserved)", () => {
+    expect(() => validateOutputPath("a/b:c", "f")).toThrow(/disallowed characters/);
+  });
+  it("whitespace", () => { expect(() => validateOutputPath("a b.txt", "f")).toThrow(/disallowed characters/); });
+  it("?", () => { expect(() => validateOutputPath("a?.txt", "f")).toThrow(/disallowed characters/); });
+  it("#", () => { expect(() => validateOutputPath("a#b.txt", "f")).toThrow(/disallowed characters/); });
+  it("NUL", () => { expect(() => validateOutputPath("a\x00b", "f")).toThrow(/disallowed characters/); });
+  it("percent encoded %2e%2e", () => {
+    expect(() => validateOutputPath("%2e%2e/etc", "f")).toThrow(/disallowed characters/);
+  });
+  it("unicode", () => { expect(() => validateOutputPath("café.txt", "f")).toThrow(/disallowed characters/); });
+  it("error contains field name", () => {
+    expect(() => validateOutputPath("../etc", "extraFiles[2].outputPath"))
+      .toThrow(/extraFiles\[2\]\.outputPath/);
+  });
+  it("per-segment 255-byte cap", () => {
+    expect(() => validateOutputPath("a".repeat(256), "f"))
+      .toThrow(/exceeds 255-byte filesystem limit/);
+  });
+  it("255-byte segment at limit OK", () => {
+    expect(validateOutputPath("a".repeat(255), "f")).toBe("a".repeat(255));
+  });
+  it("Windows reserved 'CON'", () => {
+    expect(() => validateOutputPath("CON", "f")).toThrow(/Windows reserved device name/);
+  });
+  it("Windows reserved 'con' (case-insensitive)", () => {
+    expect(() => validateOutputPath("con", "f")).toThrow(/Windows reserved device name/);
+  });
+  it("Windows reserved 'CON.txt' (with extension)", () => {
+    expect(() => validateOutputPath("CON.txt", "f")).toThrow(/Windows reserved device name/);
+  });
+  it("Windows reserved 'PRN'", () => {
+    expect(() => validateOutputPath("PRN", "f")).toThrow(/Windows reserved/);
+  });
+  it("Windows reserved 'AUX'", () => {
+    expect(() => validateOutputPath("AUX", "f")).toThrow(/Windows reserved/);
+  });
+  it("Windows reserved 'NUL'", () => {
+    expect(() => validateOutputPath("NUL", "f")).toThrow(/Windows reserved/);
+  });
+  it("Windows reserved 'COM1'", () => {
+    expect(() => validateOutputPath("COM1", "f")).toThrow(/Windows reserved/);
+  });
+  it("Windows reserved 'LPT9.log'", () => {
+    expect(() => validateOutputPath("LPT9.log", "f")).toThrow(/Windows reserved/);
+  });
+  it("Windows reserved nested 'a/CON/b'", () => {
+    expect(() => validateOutputPath("a/CON/b", "f")).toThrow(/Windows reserved/);
+  });
+  it("'CONSOLE' (not reserved) OK", () => {
+    expect(validateOutputPath("CONSOLE", "f")).toBe("CONSOLE");
+  });
+  it("trailing dot 'foo.'", () => {
+    expect(() => validateOutputPath("foo.", "f")).toThrow(/must not end in "\." or " "/);
+  });
+  it("trailing space 'foo '", () => {
+    // space isn't in PATH_SEGMENT_RE so it triggers "disallowed" first.
+    expect(() => validateOutputPath("foo ", "f")).toThrow(/disallowed characters|end in/);
+  });
+  it("trailing dot in nested segment", () => {
+    expect(() => validateOutputPath("a/b./c", "f")).toThrow(/must not end in "\." or " "/);
+  });
+  it("__proto__ as segment rejected", () => {
+    expect(() => validateOutputPath("__proto__", "f")).toThrow(/prototype-pollution/);
+  });
+  it("constructor as segment rejected", () => {
+    expect(() => validateOutputPath("constructor", "f")).toThrow(/prototype-pollution/);
+  });
+  it("prototype as segment rejected", () => {
+    expect(() => validateOutputPath("prototype", "f")).toThrow(/prototype-pollution/);
+  });
+  it("nested __proto__ rejected", () => {
+    expect(() => validateOutputPath("a/__proto__/b", "f")).toThrow(/prototype-pollution/);
+  });
+});
+
+describe("validateString", () => {
+  it("string passes", () => { expect(validateString("ok", "f")).toBe("ok"); });
+  it("empty allowed", () => { expect(validateString("", "f")).toBe(""); });
+  it("non-string rejected", () => { expect(() => validateString(42 as unknown as string, "f")).toThrow(/must be a string/); });
+  it("null rejected", () => { expect(() => validateString(null, "f")).toThrow(/got null/); });
+});

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-aot-deploy-manifest-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-aot-deploy-manifest-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Twentieth FM00 v0 stage package — the **final compose stage** of the FM00 v0 pipeline.
- Reads the outputs of every other FM00 v0 emitter (page bundle JSON + sitemap.xml + robots.txt + Web App Manifest JSON + caller-supplied extra files) and produces a single byte-deterministic deploy-record JSON.
- A downstream deploy runner reads the manifest and applies every file to the target (S3, Netlify, Cloudflare Pages, generic fs).
- 112 tests, **100% line / 98.47% branch** coverage.
- `required_capabilities.json` → `[]` (uses Node's built-in `node:crypto`; no I/O / fs / network).

## Security posture

Ten concerns explicitly addressed. Pre-push security review (general-purpose agent) found **one MED + two LOW**, all fixed before push:

1. **MED — pageBundle output paths weren't being revalidated** by the deploy emitter. The package's claim is that the page-bundle emitter has already validated routes/output paths, but here a caller can supply *any* JSON string as `pageBundle`. A malicious / buggy upstream producing `{"version":1,"routes":{"k":{"outputPath":"../../etc/passwd",...}}}` would flow straight to the deploy target's filesystem. **Fixed**: `parsePageBundle` now re-runs `validateOutputPath` on every route's `outputPath` — defense-in-depth.
2. **LOW — Windows reserved device names + trailing dot/space.** `CON` / `PRN` / `AUX` / `NUL` / `COM1-9` / `LPT1-9` (with/without extension) cause Win32 to write to the device. Trailing `.` or ` ` gets silently stripped. **Fixed**: per-segment regex + lastChar check.
3. **LOW — per-segment 255-byte filesystem cap.** ext4/APFS/NTFS all limit single filename components to 255 bytes; longer would write-fail at deploy time. **Fixed**: surfaced here instead.
4. **Bonus**: `filesObj` accumulator switched to `Object.create(null)`. `__proto__` / `constructor` / `prototype` as output-path segment names also rejected at validation (defense-in-depth).

Tests added covering all four hardening fixes (Windows reserved trio + variants, 255-byte cap, trailing dot/space, `__proto__` rejection, page-bundle revalidation with crafted `../etc/passwd`).

Plus the standard FM00 concerns: path traversal, cross-platform path safety, percent-encoding traversal, prototype-pollution from JSON parse, JSON-syntax injection, hashing (SHA-256 via `node:crypto`), determinism, fail-fast, ReDoS-safety.

## Input sources

| Field          | Required? | Synthesised output path |
| -------------- | --------- | ----------------------- |
| `pageBundle`   | yes       | per-route (from bundle) |
| `sitemapXml`   | no        | `sitemap.xml`           |
| `robotsTxt`    | no        | `robots.txt`            |
| `manifestJson` | no        | `manifest.webmanifest`  |
| `extraFiles`   | no        | caller-specified, validated |

Duplicate output paths across **all five sources** throw.

## JSON output format

- 2-space indent, trailing newline.
- Top-level: `version → baseUrl (if present) → fileCount → totalSizeBytes → files`.
- `files` sorted by `outputPath` lexicographically.
- Each entry: `outputPath → contentType → sizeBytes → sha256 → source → route (if page-bundle) → lastmod (if present)`.

Same input → byte-identical output.

## How it fits in the stack

The **final compose stage**:

```
forme-aot-html-doc-emitter      →  per-page HTML strings
forme-aot-page-bundle-emitter   →  page bundle JSON
forme-aot-sitemap-emitter       →  sitemap.xml
forme-aot-robots-emitter        →  robots.txt
forme-aot-manifest-emitter      →  manifest.webmanifest

         ↓ all of the above ↓

forme-aot-deploy-manifest-emitter  ←  YOU ARE HERE
         ↓
deploy runner (next package)  →  S3 / Netlify / fs target
```

## v0 simplifications

- No deploy-target adapters (that's the next stage).
- No CDN purge directives.
- No per-file caching headers / TTLs.
- No incremental diff vs. previous deploy.

## Test plan

- [x] All 112 vitest tests pass locally
- [x] Coverage 100% line / 98.47% branch
- [x] Security review via Agent — 1 MED + 2 LOW, all fixed
- [x] CHANGELOG + README with full security rationale
- [x] `required_capabilities.json` set to `[]`
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)