### PR TITLE
Add WHATWG character reference audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -54,6 +54,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser fragment-context audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser character-reference
+  audit generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -216,6 +216,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-character-reference-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_character_reference_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -58,6 +58,9 @@ documented in this file.
 - Generated WHATWG fragment-context audit fixture over html5lib table, shell,
   block, foreign-content, text-mode, select/list, template, and ordinary
   fragment parsing contexts, with a dedicated parser regression test.
+- Generated WHATWG character-reference audit fixture over html5lib named,
+  numeric, ambiguous ampersand, attribute, RCDATA, and fragment-context
+  character-reference cases, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -72,7 +75,8 @@ documented in this file.
   tree-insertion, frameset, table, form/interactive, text-control,
   foreign-content, formatting, ruby, noscript, head/body, document-shell,
   void-element, list-item, paragraph, block-boundary, fragment-context,
-  template, and select/list audit checks on the same parser and DOM dump path.
+  character-reference, template, and select/list audit checks on the same
+  parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -243,6 +243,16 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_c
   --check
 ```
 
+The generated `tests/fixtures/whatwg-character-reference-audit.json` fixture
+indexes named references, numeric references, ambiguous ampersands, attribute
+references, parser-driven RCDATA references, and fragment-context
+character-reference handling:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -207,6 +207,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_c
   --check
 ```
 
+`whatwg-character-reference-audit.json` is a generated index over
+tree-construction cases that stress named references, numeric references,
+ambiguous ampersands, attribute references, parser-driven RCDATA references,
+and fragment-context character-reference handling:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG character-reference audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-character-reference-audit.json"
+
+RAWTEXT_MARKUP = re.compile(
+    r"<(?:script|style|xmp|iframe|noembed|noframes|plaintext)(?:\s|/|>)",
+    re.I,
+)
+RCDATA_MARKUP = re.compile(r"<(?:title|textarea)(?:\s|/|>)", re.I)
+ATTRIBUTE_REFERENCE = re.compile(r"=[^>]*&")
+NUMERIC_REFERENCE = re.compile(r"&#x?[0-9a-fA-F]+;?")
+NAMED_REFERENCE = re.compile(r"&[A-Za-z][A-Za-z0-9]+;?")
+
+CASE_AXES = (
+    {
+        "axis": "character-reference-numeric-boundary",
+        "reason": "numeric character reference decoding and recovery in parser DOM text",
+    },
+    {
+        "axis": "character-reference-named-boundary",
+        "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+    },
+    {
+        "axis": "character-reference-attribute-boundary",
+        "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+    },
+    {
+        "axis": "character-reference-rcdata-boundary",
+        "reason": "character references in parser-driven RCDATA title and textarea content",
+    },
+    {
+        "axis": "character-reference-ambiguous-ampersand",
+        "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+    },
+    {
+        "axis": "character-reference-fragment-context",
+        "reason": "character reference handling inside html5lib fragment contexts",
+    },
+)
+
+
+@dataclass(frozen=True)
+class SmokeCase:
+    source: str
+    data: str
+    fragment_context: str | None
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    cases = parse_cases(input_path)
+    fixture = build_fixture(cases)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG character-reference audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_cases(path: Path) -> list[SmokeCase]:
+    cases: list[SmokeCase] = []
+    lines = path.read_text(errors="replace").splitlines()
+    source = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line:
+            continue
+        if line.startswith("#source "):
+            source = line.removeprefix("#source ").strip()
+            continue
+        if line != "#data":
+            raise SystemExit(f"expected #data after {source}, got {line!r}")
+
+        data: list[str] = []
+        while index < len(lines):
+            data_line = lines[index]
+            index += 1
+            if data_line == "#errors":
+                break
+            data.append(data_line)
+
+        fragment_context = None
+        while index < len(lines):
+            metadata_line = lines[index]
+            index += 1
+            if metadata_line == "#document":
+                break
+            if metadata_line == "#document-fragment":
+                if index >= len(lines):
+                    raise SystemExit(f"missing fragment context after {source}")
+                fragment_context = lines[index]
+                index += 1
+
+        while index < len(lines):
+            document_line = lines[index]
+            if document_line == "#data" or document_line.startswith("#source "):
+                break
+            index += 1
+
+        case_data = "\n".join(data)
+        if is_character_reference_case(case_data):
+            cases.append(
+                SmokeCase(
+                    source=source,
+                    data=case_data,
+                    fragment_context=fragment_context,
+                )
+            )
+
+    if not cases:
+        raise SystemExit(f"{path} does not contain any character-reference audit cases")
+    return cases
+
+
+def is_character_reference_case(data: str) -> bool:
+    return "&" in data
+
+
+def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for case in cases:
+        if case.source in seen:
+            raise SystemExit(f"duplicate selected source: {case.source}")
+        seen.add(case.source)
+        axis = axis_for_case(case)
+        selected.append(
+            {
+                "id": stable_case_id(case.source),
+                "source": case.source,
+                "axis": axis,
+                "reason": reason_for_axis(axis),
+            }
+        )
+
+    counts_by_axis = {
+        axis["axis"]: sum(1 for case in selected if case["axis"] == axis["axis"])
+        for axis in CASE_AXES
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-character-reference-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction "
+            "cases that stress named and numeric character references, "
+            "ambiguous ampersands, attribute references, parser-driven RCDATA, "
+            "and fragment-context character-reference handling."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def axis_for_case(case: SmokeCase) -> str:
+    data = case.data
+
+    if case.fragment_context is not None:
+        return "character-reference-fragment-context"
+    if RCDATA_MARKUP.search(data):
+        return "character-reference-rcdata-boundary"
+    if ATTRIBUTE_REFERENCE.search(data):
+        return "character-reference-attribute-boundary"
+    if NUMERIC_REFERENCE.search(data):
+        return "character-reference-numeric-boundary"
+    if NAMED_REFERENCE.search(data):
+        return "character-reference-named-boundary"
+    if RAWTEXT_MARKUP.search(data):
+        return "character-reference-ambiguous-ampersand"
+    return "character-reference-ambiguous-ampersand"
+
+
+def reason_for_axis(axis: str) -> str:
+    for axis_info in CASE_AXES:
+        if axis_info["axis"] == axis:
+            return axis_info["reason"]
+    raise SystemExit(f"unknown character-reference audit axis: {axis}")
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-character-reference-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-character-reference-audit.json
@@ -1,0 +1,922 @@
+{
+  "case_count": 151,
+  "cases": [
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-170",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:170"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-171",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:171"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-172",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:172"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-173",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:173"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-174",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:174"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-175",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:175"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-176",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:176"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-177",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:177"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "entities01-dat-178",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "entities01.dat:178"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "entities01-dat-179",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "entities01.dat:179"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities01-dat-180",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities01.dat:180"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-181",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:181"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-182",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:182"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "entities01-dat-183",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "entities01.dat:183"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-184",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:184"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "entities01-dat-185",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "entities01.dat:185"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-186",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:186"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "entities01-dat-187",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "entities01.dat:187"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "entities01-dat-188",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "entities01.dat:188"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-189",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:189"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-190",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:190"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-191",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:191"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-192",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:192"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-193",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:193"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-194",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:194"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-195",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:195"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-196",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:196"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-197",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:197"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-198",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:198"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-199",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:199"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-200",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:200"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-201",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:201"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-202",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:202"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-203",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:203"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-204",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:204"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-205",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:205"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-206",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:206"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-207",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:207"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-208",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:208"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-209",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:209"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-210",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:210"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-211",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:211"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-212",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:212"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-213",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:213"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-214",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:214"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-215",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:215"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-216",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:216"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-217",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:217"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-218",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:218"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-219",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:219"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-220",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:220"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-221",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:221"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-222",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:222"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-223",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:223"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-224",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:224"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-225",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:225"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-226",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:226"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-227",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:227"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-228",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:228"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-229",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:229"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-230",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:230"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-231",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:231"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-232",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:232"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-233",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:233"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-234",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:234"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-235",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:235"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-236",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:236"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-237",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:237"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-238",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:238"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-239",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:239"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-240",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:240"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-241",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:241"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-242",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:242"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-243",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:243"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "entities01-dat-244",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "entities01.dat:244"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-245",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:245"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-246",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:246"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-247",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:247"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-248",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:248"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-249",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:249"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-250",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:250"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-251",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:251"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-252",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:252"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-253",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:253"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-254",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:254"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-255",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:255"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-256",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:256"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-257",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:257"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-258",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:258"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-259",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:259"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-260",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:260"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-261",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:261"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-262",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:262"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "entities02-dat-263",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "entities02.dat:263"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-264",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:264"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-265",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:265"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-266",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:266"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-267",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:267"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-268",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:268"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-269",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:269"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "entities02-dat-270",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "entities02.dat:270"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "html5test-com-dat-277",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "html5test-com.dat:277"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "html5test-com-dat-278",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "html5test-com.dat:278"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "html5test-com-dat-279",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "html5test-com.dat:279"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "html5test-com-dat-280",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "html5test-com.dat:280"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "html5test-com-dat-281",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "html5test-com.dat:281"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "plain-text-unsafe-dat-349",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "plain-text-unsafe.dat:349"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-849",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:849"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-860",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:860"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-861",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:861"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-862",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:862"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-946",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:946"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-957",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:957"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1214",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1214"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1215",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1215"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1216",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1216"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1217",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1217"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1218",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1218"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1219",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1219"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1220",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1220"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1221",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1221"
+    },
+    {
+      "axis": "character-reference-attribute-boundary",
+      "id": "tests2-dat-18",
+      "reason": "character references and ambiguous ampersands inside parser DOM attributes",
+      "source": "tests2.dat:18"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "tests2-dat-20",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "tests2.dat:20"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "tests2-dat-21",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "tests2.dat:21"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "tests2-dat-22",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "tests2.dat:22"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "tests2-dat-23",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "tests2.dat:23"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "tests2-dat-24",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "tests2.dat:24"
+    },
+    {
+      "axis": "character-reference-ambiguous-ampersand",
+      "id": "tests2-dat-25",
+      "reason": "ambiguous ampersands and malformed references preserved through parser DOM text",
+      "source": "tests2.dat:25"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests2-dat-31",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests2.dat:31"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests2-dat-32",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests2.dat:32"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests5-dat-13",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests5.dat:13"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests5-dat-14",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests5.dat:14"
+    },
+    {
+      "axis": "character-reference-numeric-boundary",
+      "id": "tests3-dat-12",
+      "reason": "numeric character reference decoding and recovery in parser DOM text",
+      "source": "tests3.dat:12"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests6-dat-3",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests6.dat:3"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests6-dat-4",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests6.dat:4"
+    },
+    {
+      "axis": "character-reference-fragment-context",
+      "id": "tests4-dat-4",
+      "reason": "character reference handling inside html5lib fragment contexts",
+      "source": "tests4.dat:4"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-82",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:82"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-93",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:93"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-94",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:94"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-95",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:95"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-179",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:179"
+    },
+    {
+      "axis": "character-reference-rcdata-boundary",
+      "id": "tests16-dat-190",
+      "reason": "character references in parser-driven RCDATA title and textarea content",
+      "source": "tests16.dat:190"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-1",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:1"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-2",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:2"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-3",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:3"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-4",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:4"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-5",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:5"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-6",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:6"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-7",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:7"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "tests24-dat-8",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "tests24.dat:8"
+    },
+    {
+      "axis": "character-reference-named-boundary",
+      "id": "webkit01-dat-16",
+      "reason": "named character reference decoding and semicolon boundary recovery in parser DOM text",
+      "source": "webkit01.dat:16"
+    }
+  ],
+  "counts_by_axis": {
+    "character-reference-ambiguous-ampersand": 11,
+    "character-reference-attribute-boundary": 20,
+    "character-reference-fragment-context": 1,
+    "character-reference-named-boundary": 40,
+    "character-reference-numeric-boundary": 63,
+    "character-reference-rcdata-boundary": 16
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress named and numeric character references, ambiguous ampersands, attribute references, parser-driven RCDATA, and fragment-context character-reference handling.",
+  "format": "whatwg-html-character-reference-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_character_reference_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_character_reference_audit_test.rs
@@ -1,0 +1,86 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_CHARACTER_REFERENCE_AUDIT: &str =
+    include_str!("fixtures/whatwg-character-reference-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct CharacterReferenceAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<CharacterReferenceAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CharacterReferenceAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_character_reference_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-character-reference-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 150);
+    assert_axis_count(&suite, "character-reference-numeric-boundary", 60);
+    assert_axis_count(&suite, "character-reference-named-boundary", 40);
+    assert_axis_count(&suite, "character-reference-attribute-boundary", 20);
+    assert_axis_count(&suite, "character-reference-rcdata-boundary", 16);
+    assert_axis_count(&suite, "character-reference-ambiguous-ampersand", 10);
+    assert_axis_count(&suite, "character-reference-fragment-context", 1);
+}
+
+#[test]
+fn whatwg_character_reference_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> CharacterReferenceAuditSuite {
+    serde_json::from_str(WHATWG_CHARACTER_REFERENCE_AUDIT)
+        .expect("WHATWG character-reference audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &CharacterReferenceAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG character-reference parser audit over 151 html5lib tree-construction cases
- cover named and numeric references, ambiguous ampersands, attributes, RCDATA, and fragment context handling
- wire the generator into fixture manifest checks and add parser DOM regression coverage

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_block_boundary_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_character_reference_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser