### PR TITLE
Add supervisor drain plan budget helpers

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -47,7 +47,8 @@ All notable changes to this package will be documented in this file.
 - Planned-count match and drift flag accessors for supervisor drain run
   summaries.
 - Run-status accessors for supervisor drain run summaries.
-- Remaining tick-budget helpers for supervisor drain run reports and summaries.
+- Remaining tick-budget helpers for supervisor drain plans, reports, and
+  summaries.
 - Flattened idle, progress, and continuation flags in supervisor drain run
   summaries.
 - Count-drift presence flags for supervisor drain run reports and summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -63,8 +63,8 @@ The crate keeps the boundary narrow:
   flag accessors for host branching
 - supervisor drain run summaries expose typed run-status accessors for
   continuation, follow-up, checkpoint, and budget decisions
-- supervisor drain reports and summaries expose remaining tick-budget helpers
-  for host scheduler budget logs
+- supervisor drain plans, reports, and summaries expose remaining tick-budget
+  helpers for host scheduler budget logs
 - supervisor drain run summaries flatten idle, progress, and continuation flags
   for host log entries
 - supervisor drain run summaries expose count-drift presence flags beside

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -716,6 +716,21 @@ impl ToolAuditSupervisorDrainPlanSummary {
         self.pages.len()
     }
 
+    /// Return how many requested planning ticks were not needed.
+    pub fn remaining_tick_budget(&self) -> usize {
+        self.max_ticks.saturating_sub(self.page_count())
+    }
+
+    /// Return whether the plan consumed every requested planning tick.
+    pub fn used_all_ticks(&self) -> bool {
+        self.remaining_tick_budget() == 0
+    }
+
+    /// Return whether more planning ticks were available when planning stopped.
+    pub fn has_remaining_tick_budget(&self) -> bool {
+        self.remaining_tick_budget() > 0
+    }
+
     /// Return whether no rows are waiting in the planned run.
     pub fn is_idle(&self) -> bool {
         self.planned_records == 0
@@ -2992,6 +3007,9 @@ mod tests {
         assert_eq!(plan.max_records_per_tick, 2);
         assert_eq!(plan.max_ticks, 2);
         assert_eq!(plan.page_count(), 2);
+        assert_eq!(plan.remaining_tick_budget(), 0);
+        assert!(plan.used_all_ticks());
+        assert!(!plan.has_remaining_tick_budget());
         assert_eq!(plan.planned_records, 4);
         assert_eq!(plan.inventory.total_records, 4);
         assert_eq!(plan.inventory.failed_records, 1);
@@ -3044,6 +3062,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(plan.page_count(), 3);
+        assert_eq!(plan.remaining_tick_budget(), 0);
+        assert!(plan.used_all_ticks());
+        assert!(!plan.has_remaining_tick_budget());
         assert_eq!(plan.planned_records, 4);
         assert!(plan.reached_end_of_log());
         assert!(!plan.exhausted_tick_budget());
@@ -3065,6 +3086,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(plan.page_count(), 1);
+        assert_eq!(plan.remaining_tick_budget(), 2);
+        assert!(!plan.used_all_ticks());
+        assert!(plan.has_remaining_tick_budget());
         assert_eq!(plan.planned_records, 0);
         assert!(plan.is_idle());
         assert!(!plan.has_pending_records());


### PR DESCRIPTION
## Summary
- add remaining tick-budget helpers to supervisor drain preflight plans
- cover budget-used and budget-remaining plan cases in audit-store tests
- update audit-store docs and changelog for plan/report/summary budget helpers

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD