### PR TITLE
[codex] Build Arduino CLI upload commands

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -36,7 +36,9 @@ native-USB 1200-baud bootloader touch and runtime port rediscovery expectation
 for boards whose Arduino package owns that behavior. The same language-core
 path emits the `arduino-cli upload` invocation template, leaving language
 frontends to fill concrete port and firmware-image paths rather than maintain
-their own flag tables.
+their own flag tables. The same Rust-owned path can now build the concrete
+Arduino CLI upload argv after a frontend supplies the selected port and
+firmware-image path.
 
 The shared target registry also records physical wireless radios for the
 Arduino-family boards that have Wi-Fi or BLE hardware, including MKR/Nano

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -42,6 +42,10 @@ reset path. `arduino_cli_upload_invocation_for_target` keeps the final
 `arduino-cli upload` flag template Rust-owned too, including the FQBN, port,
 input-file, input-directory, upload-property, and verify flags language
 frontends should fill with concrete paths.
+`arduino_cli_upload_command_for_target` and
+`arduino_cli_upload_command_with_options_for_target` go one step further by
+building concrete `arduino-cli upload` argv from the selected port, firmware
+image, optional upload properties, and verify flag.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -619,6 +619,21 @@ pub struct LanguageArduinoCliUploadInvocation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageArduinoCliUploadCommand {
+    pub board_id: String,
+    pub executable: String,
+    pub args: Vec<String>,
+    pub fqbn: String,
+    pub port: String,
+    pub input_file: String,
+    pub upload_properties: Vec<String>,
+    pub verify: bool,
+    pub port_hint: String,
+    pub port_selection_step: String,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageUploadOptions {
     pub board_id: String,
     pub adapter: String,
@@ -1088,6 +1103,66 @@ pub fn arduino_cli_upload_invocation_for_target(
         accepts_input_dir: true,
         accepts_upload_properties: true,
         notes: arduino_cli_upload_invocation_notes(port_hint).to_owned(),
+    })
+}
+
+pub fn arduino_cli_upload_command_for_target(
+    selector: &str,
+    port: &str,
+    input_file: &str,
+) -> Option<LanguageArduinoCliUploadCommand> {
+    arduino_cli_upload_command_with_options_for_target(selector, port, input_file, &[], false)
+}
+
+pub fn arduino_cli_upload_command_with_options_for_target(
+    selector: &str,
+    port: &str,
+    input_file: &str,
+    upload_properties: &[&str],
+    verify: bool,
+) -> Option<LanguageArduinoCliUploadCommand> {
+    let invocation = arduino_cli_upload_invocation_for_target(selector)?;
+    if port.trim().is_empty()
+        || input_file.trim().is_empty()
+        || upload_properties
+            .iter()
+            .any(|property| property.trim().is_empty())
+    {
+        return None;
+    }
+
+    let mut args = vec![
+        invocation.subcommand.clone(),
+        invocation.port_flag.clone(),
+        port.to_owned(),
+        invocation.fqbn_flag.clone(),
+        invocation.fqbn.clone(),
+        invocation.input_file_flag.clone(),
+        input_file.to_owned(),
+    ];
+    for property in upload_properties {
+        args.push(invocation.upload_property_flag.clone());
+        args.push((*property).to_owned());
+    }
+    if verify {
+        args.push(invocation.verify_flag.clone());
+    }
+
+    Some(LanguageArduinoCliUploadCommand {
+        board_id: invocation.board_id,
+        executable: invocation.executable,
+        args,
+        fqbn: invocation.fqbn,
+        port: port.to_owned(),
+        input_file: input_file.to_owned(),
+        upload_properties: upload_properties
+            .iter()
+            .map(|property| (*property).to_owned())
+            .collect(),
+        verify,
+        port_hint: invocation.port_hint,
+        port_selection_step: invocation.port_selection_step,
+        notes: arduino_cli_upload_command_notes().to_owned(),
     })
 }
 
@@ -1734,6 +1809,10 @@ fn arduino_cli_upload_invocation_notes(hint: TargetUploadPortHint) -> &'static s
         }
         _ => "Fill the port placeholder with the Arduino upload port and the input placeholder with a concrete Board VM firmware image.",
     }
+}
+
+fn arduino_cli_upload_command_notes() -> &'static str {
+    "Concrete Arduino CLI argv built by Rust after target resolution, port selection, and firmware artifact selection."
 }
 
 fn language_upload_plan(board_id: &str, upload: TargetUploadInfo) -> LanguageUploadPlan {
@@ -5559,6 +5638,96 @@ mod tests {
         assert!(arduino_cli_upload_invocation_for_target("esp32").is_none());
         assert!(arduino_cli_upload_invocation_for_target("pico").is_none());
         assert!(arduino_cli_upload_invocation_for_target("not-a-board").is_none());
+    }
+
+    #[test]
+    fn arduino_cli_upload_command_is_owned_by_rust_language_core() {
+        let command = arduino_cli_upload_command_for_target(
+            "arduino:renesas_uno:nanor4",
+            "/dev/cu.usbmodem101",
+            "/tmp/board-vm-nano-r4.bin",
+        )
+        .unwrap();
+        assert_eq!(command.board_id, "arduino-nano-r4");
+        assert_eq!(command.executable, "arduino-cli");
+        assert_eq!(command.fqbn, "arduino:renesas_uno:nanor4");
+        assert_eq!(command.port, "/dev/cu.usbmodem101");
+        assert_eq!(command.input_file, "/tmp/board-vm-nano-r4.bin");
+        assert_eq!(command.port_hint, "native_usb");
+        assert_eq!(command.port_selection_step, "select_native_usb_port");
+        assert!(!command.verify);
+        assert!(command.upload_properties.is_empty());
+        assert_eq!(
+            command.args,
+            vec![
+                "upload",
+                "-p",
+                "/dev/cu.usbmodem101",
+                "-b",
+                "arduino:renesas_uno:nanor4",
+                "-i",
+                "/tmp/board-vm-nano-r4.bin",
+            ]
+        );
+        assert!(command.notes.contains("Concrete Arduino CLI argv"));
+
+        let command = arduino_cli_upload_command_with_options_for_target(
+            "arduino-mega-2560",
+            "COM7",
+            "C:/tmp/mega.hex",
+            &["upload.speed=115200", "programmer=arduinoasisp"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(command.board_id, "arduino-mega-2560");
+        assert_eq!(command.port_hint, "usb_serial_bridge");
+        assert!(command.verify);
+        assert_eq!(
+            command.upload_properties,
+            vec!["upload.speed=115200", "programmer=arduinoasisp"]
+        );
+        assert_eq!(
+            command.args,
+            vec![
+                "upload",
+                "-p",
+                "COM7",
+                "-b",
+                "arduino:avr:mega:cpu=atmega2560",
+                "-i",
+                "C:/tmp/mega.hex",
+                "--upload-property",
+                "upload.speed=115200",
+                "--upload-property",
+                "programmer=arduinoasisp",
+                "-t",
+            ]
+        );
+
+        assert!(
+            arduino_cli_upload_command_for_target("arduino-pro-mini", "", "/tmp/pro-mini.hex")
+                .is_none()
+        );
+        assert!(arduino_cli_upload_command_for_target(
+            "arduino-pro-mini",
+            "/dev/cu.usbserial-1420",
+            ""
+        )
+        .is_none());
+        assert!(arduino_cli_upload_command_with_options_for_target(
+            "arduino-pro-mini",
+            "/dev/cu.usbserial-1420",
+            "/tmp/pro-mini.hex",
+            &[""],
+            false,
+        )
+        .is_none());
+        assert!(arduino_cli_upload_command_for_target(
+            "esp32",
+            "/dev/cu.usbserial-esp32",
+            "/tmp/esp32.bin"
+        )
+        .is_none());
     }
 
     #[test]

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -52,7 +52,9 @@ USB-serial bridge and external-adapter boards keep their simpler port paths.
 The final Arduino CLI invocation template is likewise emitted from
 `board-vm-language-core`, so frontends fill concrete port and firmware-image
 paths into Rust-owned `arduino-cli upload` flags instead of rebuilding the
-command shape.
+command shape. The matching command builder now accepts the concrete selected
+port and firmware image path and returns the final argv, including optional
+Arduino CLI upload properties and verify mode.
 
 Wireless metadata separates physical support from the generic front-end sugar:
 

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -152,6 +152,12 @@ upload-property flag, verify flag, and placeholder argument template so
 frontends fill concrete port and firmware-image paths without re-creating an
 Arduino CLI flag table.
 
+The Arduino CLI upload command tranche converts that template into concrete
+argv after a frontend supplies the selected port and firmware-image path. Rust
+language core keeps the FQBN, flag order, optional upload-property expansion,
+and verify flag placement centralized, so language frontends do not assemble
+Arduino CLI commands locally.
+
 The Arduino wireless metadata tranche records physical Wi-Fi and Bluetooth LE
 radios for non-Uno boards such as MKR WiFi 1010, Nano 33 IoT, Nano 33 BLE Rev2,
 Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi, Portenta H7 Lite Connected,


### PR DESCRIPTION
## Summary
- add Rust-owned Arduino CLI upload command builders that turn target metadata plus a concrete port and firmware image into final argv
- support optional upload properties and verify mode without language frontends assembling Arduino CLI flags
- document the new command tranche in the Board VM target matrix and package READMEs

## Validation
- cargo fmt -p board-vm-language-core
- cargo test -p board-vm-language-core
- cargo test -p board-vm-targets -p board-vm-language-core
- cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-targets
- bash BUILD in code/packages/rust/board-vm-arduino
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check