### PR TITLE
Add WHATWG legacy element audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -56,6 +56,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser character-reference
   audit generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser legacy/edge element
+  audit generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser document-shell audit
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser template audit

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -223,6 +223,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-legacy-element-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_legacy_element_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-document-shell-audit",
             (
                 str(PARSER_FIXTURE_DIR / "generate_whatwg_document_shell_audit_fixture.py"),

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -61,6 +61,9 @@ documented in this file.
 - Generated WHATWG character-reference audit fixture over html5lib named,
   numeric, ambiguous ampersand, attribute, RCDATA, and fragment-context
   character-reference cases, with a dedicated parser regression test.
+- Generated WHATWG legacy/edge element audit fixture over html5lib `isindex`,
+  obsolete `menuitem`, `main`/`search`, pending-spec, tricky recovery, and
+  namespace-sensitivity cases, with a dedicated parser regression test.
 - Generated WHATWG document-shell audit fixture over html5lib doctype, comment,
   html/head/body synthesis, frameset-boundary, and shell fragment-context
   cases, with a dedicated parser regression test.
@@ -75,8 +78,8 @@ documented in this file.
   tree-insertion, frameset, table, form/interactive, text-control,
   foreign-content, formatting, ruby, noscript, head/body, document-shell,
   void-element, list-item, paragraph, block-boundary, fragment-context,
-  character-reference, template, and select/list audit checks on the same
-  parser and DOM dump path.
+  character-reference, legacy/edge element, template, and select/list audit
+  checks on the same parser and DOM dump path.
 - The html5lib source-coverage audit now has a checked JSON report plus
   `--write-report` and `--check-report` modes for parser/tokenizer fixture
   drift detection.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -253,6 +253,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_
   --check
 ```
 
+The generated `tests/fixtures/whatwg-legacy-element-audit.json` fixture
+indexes `isindex`, obsolete `menuitem`, `main`/`search`, pending-spec, tricky
+recovery, and namespace-sensitivity cases:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py \
+  --check
+```
+
 The generated `tests/fixtures/whatwg-document-shell-audit.json` fixture indexes
 doctypes, comments, `html`/`head`/`body` synthesis, frameset boundaries, and
 shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -218,6 +218,17 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_
   --check
 ```
 
+`whatwg-legacy-element-audit.json` is a generated index over
+tree-construction cases that stress `isindex`, obsolete `menuitem`,
+`main`/`search`, pending-spec, tricky recovery, and namespace-sensitivity
+cases:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py \
+  --check
+```
+
 `whatwg-document-shell-audit.json` is a generated index over tree-construction
 cases that stress doctypes, comments, `html`/`head`/`body` synthesis, frameset
 boundaries, and shell fragment contexts:

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG legacy/edge element audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-legacy-element-audit.json"
+
+CASE_FAMILIES = (
+    {
+        "source_file": "isindex.dat",
+        "axis": "legacy-isindex",
+        "reason": "obsolete isindex insertion and form-control replacement recovery",
+    },
+    {
+        "source_file": "menuitem-element.dat",
+        "axis": "obsolete-menuitem",
+        "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+    },
+    {
+        "source_file": "main-element.dat",
+        "axis": "main-element-boundary",
+        "reason": "main element boundaries around paragraphs and nested main starts",
+    },
+    {
+        "source_file": "search-element.dat",
+        "axis": "search-element-boundary",
+        "reason": "search element boundaries around paragraphs and nested search starts",
+    },
+    {
+        "source_file": "pending-spec-changes.dat",
+        "axis": "pending-spec-boundary",
+        "reason": "pending WHATWG tree-construction edge cases in the checked corpus",
+    },
+    {
+        "source_file": "pending-spec-changes-plain-text-unsafe.dat",
+        "axis": "pending-spec-boundary",
+        "reason": "pending WHATWG tree-construction edge cases in the checked corpus",
+    },
+    {
+        "source_file": "tricky01.dat",
+        "axis": "tricky-parser-recovery",
+        "reason": "legacy tricky parser recovery cases retained by html5lib",
+    },
+    {
+        "source_file": "namespace-sensitivity.dat",
+        "axis": "namespace-sensitivity",
+        "reason": "namespace-sensitive integration-point recovery in the parser DOM",
+    },
+)
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    sources = parse_sources(input_path)
+    fixture = build_fixture(sources)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG legacy/edge element audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_sources(path: Path) -> list[str]:
+    sources: list[str] = []
+    for line in path.read_text(errors="replace").splitlines():
+        if line.startswith("#source "):
+            sources.append(line.removeprefix("#source ").strip())
+    if not sources:
+        raise SystemExit(f"{path} does not contain any #source markers")
+    return sources
+
+
+def build_fixture(sources: list[str]) -> dict[str, object]:
+    selected = []
+    seen = set()
+
+    for source in sources:
+        family = family_for_source(source)
+        if family is None:
+            continue
+        if source in seen:
+            raise SystemExit(f"duplicate selected source: {source}")
+        seen.add(source)
+        selected.append(
+            {
+                "id": stable_case_id(source),
+                "source": source,
+                "axis": family["axis"],
+                "reason": family["reason"],
+            }
+        )
+
+    if not selected:
+        raise SystemExit("no legacy/edge element audit cases matched configured families")
+
+    axes = list(dict.fromkeys(family["axis"] for family in CASE_FAMILIES))
+    counts_by_axis = {
+        axis: sum(1 for case in selected if case["axis"] == axis) for axis in axes
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-legacy-element-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction "
+            "cases that stress legacy, obsolete, pending-spec, tricky, and "
+            "namespace-sensitive element recovery."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def family_for_source(source: str) -> dict[str, str] | None:
+    source_file = source.split(":", 1)[0]
+    for family in CASE_FAMILIES:
+        if source_file == family["source_file"]:
+            return family
+    return None
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-legacy-element-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-legacy-element-audit.json
@@ -1,0 +1,281 @@
+{
+  "case_count": 44,
+  "cases": [
+    {
+      "axis": "legacy-isindex",
+      "id": "isindex-dat-299",
+      "reason": "obsolete isindex insertion and form-control replacement recovery",
+      "source": "isindex.dat:299"
+    },
+    {
+      "axis": "legacy-isindex",
+      "id": "isindex-dat-300",
+      "reason": "obsolete isindex insertion and form-control replacement recovery",
+      "source": "isindex.dat:300"
+    },
+    {
+      "axis": "legacy-isindex",
+      "id": "isindex-dat-301",
+      "reason": "obsolete isindex insertion and form-control replacement recovery",
+      "source": "isindex.dat:301"
+    },
+    {
+      "axis": "legacy-isindex",
+      "id": "isindex-dat-302",
+      "reason": "obsolete isindex insertion and form-control replacement recovery",
+      "source": "isindex.dat:302"
+    },
+    {
+      "axis": "main-element-boundary",
+      "id": "main-element-dat-303",
+      "reason": "main element boundaries around paragraphs and nested main starts",
+      "source": "main-element.dat:303"
+    },
+    {
+      "axis": "main-element-boundary",
+      "id": "main-element-dat-304",
+      "reason": "main element boundaries around paragraphs and nested main starts",
+      "source": "main-element.dat:304"
+    },
+    {
+      "axis": "main-element-boundary",
+      "id": "main-element-dat-305",
+      "reason": "main element boundaries around paragraphs and nested main starts",
+      "source": "main-element.dat:305"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-306",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:306"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-307",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:307"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-308",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:308"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-309",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:309"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-310",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:310"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-311",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:311"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-312",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:312"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-313",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:313"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-314",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:314"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-315",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:315"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-316",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:316"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-317",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:317"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-318",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:318"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-319",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:319"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-320",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:320"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-321",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:321"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-322",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:322"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-323",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:323"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-324",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:324"
+    },
+    {
+      "axis": "obsolete-menuitem",
+      "id": "menuitem-element-dat-325",
+      "reason": "obsolete menuitem parsing through body, list, table, and select contexts",
+      "source": "menuitem-element.dat:325"
+    },
+    {
+      "axis": "namespace-sensitivity",
+      "id": "namespace-sensitivity-dat-326",
+      "reason": "namespace-sensitive integration-point recovery in the parser DOM",
+      "source": "namespace-sensitivity.dat:326"
+    },
+    {
+      "axis": "pending-spec-boundary",
+      "id": "pending-spec-changes-plain-text-unsafe-dat-345",
+      "reason": "pending WHATWG tree-construction edge cases in the checked corpus",
+      "source": "pending-spec-changes-plain-text-unsafe.dat:345"
+    },
+    {
+      "axis": "pending-spec-boundary",
+      "id": "pending-spec-changes-dat-346",
+      "reason": "pending WHATWG tree-construction edge cases in the checked corpus",
+      "source": "pending-spec-changes.dat:346"
+    },
+    {
+      "axis": "pending-spec-boundary",
+      "id": "pending-spec-changes-dat-347",
+      "reason": "pending WHATWG tree-construction edge cases in the checked corpus",
+      "source": "pending-spec-changes.dat:347"
+    },
+    {
+      "axis": "pending-spec-boundary",
+      "id": "pending-spec-changes-dat-348",
+      "reason": "pending WHATWG tree-construction edge cases in the checked corpus",
+      "source": "pending-spec-changes.dat:348"
+    },
+    {
+      "axis": "search-element-boundary",
+      "id": "search-element-dat-433",
+      "reason": "search element boundaries around paragraphs and nested search starts",
+      "source": "search-element.dat:433"
+    },
+    {
+      "axis": "search-element-boundary",
+      "id": "search-element-dat-434",
+      "reason": "search element boundaries around paragraphs and nested search starts",
+      "source": "search-element.dat:434"
+    },
+    {
+      "axis": "search-element-boundary",
+      "id": "search-element-dat-435",
+      "reason": "search element boundaries around paragraphs and nested search starts",
+      "source": "search-element.dat:435"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-1",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:1"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-2",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:2"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-3",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:3"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-4",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:4"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-5",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:5"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-6",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:6"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-7",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:7"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-8",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:8"
+    },
+    {
+      "axis": "tricky-parser-recovery",
+      "id": "tricky01-dat-9",
+      "reason": "legacy tricky parser recovery cases retained by html5lib",
+      "source": "tricky01.dat:9"
+    }
+  ],
+  "counts_by_axis": {
+    "legacy-isindex": 4,
+    "main-element-boundary": 3,
+    "namespace-sensitivity": 1,
+    "obsolete-menuitem": 20,
+    "pending-spec-boundary": 4,
+    "search-element-boundary": 3,
+    "tricky-parser-recovery": 9
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress legacy, obsolete, pending-spec, tricky, and namespace-sensitive element recovery.",
+  "format": "whatwg-html-legacy-element-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_legacy_element_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_legacy_element_audit_test.rs
@@ -1,0 +1,87 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_LEGACY_ELEMENT_AUDIT: &str =
+    include_str!("fixtures/whatwg-legacy-element-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct LegacyElementAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<LegacyElementAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyElementAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_legacy_element_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-legacy-element-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 44);
+    assert_axis_count(&suite, "legacy-isindex", 4);
+    assert_axis_count(&suite, "obsolete-menuitem", 20);
+    assert_axis_count(&suite, "main-element-boundary", 3);
+    assert_axis_count(&suite, "search-element-boundary", 3);
+    assert_axis_count(&suite, "pending-spec-boundary", 4);
+    assert_axis_count(&suite, "tricky-parser-recovery", 9);
+    assert_axis_count(&suite, "namespace-sensitivity", 1);
+}
+
+#[test]
+fn whatwg_legacy_element_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> LegacyElementAuditSuite {
+    serde_json::from_str(WHATWG_LEGACY_ELEMENT_AUDIT)
+        .expect("WHATWG legacy/edge element audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &LegacyElementAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG legacy/edge element parser audit over 44 html5lib tree-construction cases
- cover isindex, obsolete menuitem, main/search, pending-spec, tricky recovery, and namespace-sensitivity cases
- wire the generator into fixture manifest checks and add parser DOM regression coverage

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --expect-tree-upstream-cases 1778 --expect-tree-local-cases 2485 --expect-tokenizer-upstream-cases 6806 --expect-tokenizer-local-raw-cases 7015 --expect-normalized-cases 7242 --expect-normalized-skipped 0
- python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py /tmp/html5lib-tests-codex-audit --check-report
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_block_boundary_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser