### PR TITLE
Add supervisor drain plan page checkpoint accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this package will be documented in this file.
   summaries.
 - Per-page drain, continuation, and checkpoint-advance helpers for supervisor
   drain plans.
+- Starting and next checkpoint scalar accessors for supervisor drain plan pages.
 - Flattened idle, progress, and continuation flags in supervisor drain run
   summaries.
 - Count-drift presence flags for supervisor drain run reports and summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -67,6 +67,8 @@ The crate keeps the boundary narrow:
   helpers for host scheduler budget logs
 - supervisor drain plan pages expose per-page drain, continuation, and
   checkpoint-advance helpers for host preflight scheduling
+- supervisor drain plan pages expose starting and next checkpoint scalar
+  accessors for host preflight logs
 - supervisor drain run summaries flatten idle, progress, and continuation flags
   for host log entries
 - supervisor drain run summaries expose count-drift presence flags beside

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -688,6 +688,26 @@ impl ToolAuditSupervisorDrainPlanPage {
         self.has_pending_records()
     }
 
+    /// Return the starting checkpoint timestamp for host preflight logs.
+    pub fn starting_checkpoint_timestamp_ms(&self) -> u64 {
+        self.starting_checkpoint.timestamp_ms
+    }
+
+    /// Return the starting checkpoint call id for host preflight logs.
+    pub fn starting_checkpoint_call_id(&self) -> &str {
+        &self.starting_checkpoint.call_id
+    }
+
+    /// Return the checkpoint timestamp a matching drain tick would advance to.
+    pub fn next_checkpoint_timestamp_ms(&self) -> u64 {
+        self.next_checkpoint.timestamp_ms
+    }
+
+    /// Return the checkpoint call id a matching drain tick would advance to.
+    pub fn next_checkpoint_call_id(&self) -> &str {
+        &self.next_checkpoint.call_id
+    }
+
     /// Return whether more rows may remain beyond this planned page.
     pub fn should_continue_after_page(&self) -> bool {
         !self.reached_end_of_log
@@ -3048,6 +3068,10 @@ mod tests {
         assert!(plan.pages[0].should_drain());
         assert!(plan.pages[0].should_continue_after_page());
         assert!(plan.pages[0].would_advance_checkpoint());
+        assert_eq!(plan.pages[0].starting_checkpoint_timestamp_ms(), 120);
+        assert_eq!(plan.pages[0].starting_checkpoint_call_id(), "call_1");
+        assert_eq!(plan.pages[0].next_checkpoint_timestamp_ms(), 120);
+        assert_eq!(plan.pages[0].next_checkpoint_call_id(), "call_3");
         assert_eq!(
             plan.pages[0].next_checkpoint,
             ToolAuditReadCheckpoint::new(120, "call_3")
@@ -3058,6 +3082,10 @@ mod tests {
         assert!(plan.pages[1].should_continue_after_page());
         assert!(plan.pages[1].requires_follow_up());
         assert!(plan.pages[1].would_advance_checkpoint());
+        assert_eq!(plan.pages[1].starting_checkpoint_timestamp_ms(), 120);
+        assert_eq!(plan.pages[1].starting_checkpoint_call_id(), "call_3");
+        assert_eq!(plan.pages[1].next_checkpoint_timestamp_ms(), 151);
+        assert_eq!(plan.pages[1].next_checkpoint_call_id(), "call_5");
         assert_eq!(
             store
                 .fetch_checkpoint("supervisor")
@@ -3095,6 +3123,10 @@ mod tests {
         assert!(!plan.pages[2].should_drain());
         assert!(!plan.pages[2].should_continue_after_page());
         assert!(!plan.pages[2].would_advance_checkpoint());
+        assert_eq!(plan.pages[2].starting_checkpoint_timestamp_ms(), 120);
+        assert_eq!(plan.pages[2].starting_checkpoint_call_id(), "call_4");
+        assert_eq!(plan.pages[2].next_checkpoint_timestamp_ms(), 120);
+        assert_eq!(plan.pages[2].next_checkpoint_call_id(), "call_4");
         assert_eq!(
             plan.last_checkpoint(),
             Some(&ToolAuditReadCheckpoint::new(120, "call_4"))
@@ -3119,6 +3151,10 @@ mod tests {
         assert!(!plan.has_pending_records());
         assert!(!plan.pages[0].should_drain());
         assert!(!plan.pages[0].should_continue_after_page());
+        assert_eq!(plan.pages[0].starting_checkpoint_timestamp_ms(), 0);
+        assert_eq!(plan.pages[0].starting_checkpoint_call_id(), "");
+        assert_eq!(plan.pages[0].next_checkpoint_timestamp_ms(), 0);
+        assert_eq!(plan.pages[0].next_checkpoint_call_id(), "");
         assert!(!plan.requires_follow_up());
         assert!(!plan.pages[0].would_advance_checkpoint());
         assert!(!plan.would_advance_checkpoint());


### PR DESCRIPTION
## Summary
- add starting and next checkpoint scalar accessors to supervisor drain plan pages
- cover populated, continuation, and idle planned-page checkpoints
- document the preflight log helper surface

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD