### PR TITLE
Add supervisor checkpoint status scalar accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this package will be documented in this file.
 - Checkpointed replay helpers that deliver bounded pages into audit sinks and
   advance durable named checkpoints.
 - Read-only supervisor checkpoint status inspection before draining.
+- Starting and next checkpoint scalar accessors for supervisor checkpoint
+  status.
 - Read-only bounded supervisor drain plans that preview pages and follow-up
   pressure without advancing durable checkpoints.
 - Payload-free follow-up row counts in audit inventory summaries for host

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -23,6 +23,8 @@ The crate keeps the boundary narrow:
   and advance the durable cursor after delivery
 - supervisors can inspect named checkpoint status before draining without
   advancing durable cursor state
+- supervisor checkpoint status exposes starting and next checkpoint scalar
+  accessors for host status logs
 - supervisors can plan bounded drain pages without emitting rows, so schedulers
   can preview workload and follow-up pressure before committing a tick
 - supervisors can drain one checkpointed page per tick and inspect progress,

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -639,6 +639,26 @@ impl ToolAuditSupervisorCheckpointStatus {
         self.has_pending_records()
     }
 
+    /// Return the starting checkpoint timestamp for host status logs.
+    pub fn starting_checkpoint_timestamp_ms(&self) -> u64 {
+        self.starting_checkpoint.timestamp_ms
+    }
+
+    /// Return the starting checkpoint call id for host status logs.
+    pub fn starting_checkpoint_call_id(&self) -> &str {
+        &self.starting_checkpoint.call_id
+    }
+
+    /// Return the checkpoint timestamp the next drain page would advance to.
+    pub fn next_checkpoint_timestamp_ms(&self) -> u64 {
+        self.next_checkpoint.timestamp_ms
+    }
+
+    /// Return the checkpoint call id the next drain page would advance to.
+    pub fn next_checkpoint_call_id(&self) -> &str {
+        &self.next_checkpoint.call_id
+    }
+
     /// Return whether more rows may remain beyond the inspected page.
     pub fn should_continue_after_page(&self) -> bool {
         !self.reached_end_of_log
@@ -2963,6 +2983,10 @@ mod tests {
         assert!(status.should_continue_after_page());
         assert!(status.requires_follow_up());
         assert!(status.would_advance_checkpoint());
+        assert_eq!(status.starting_checkpoint_timestamp_ms(), 120);
+        assert_eq!(status.starting_checkpoint_call_id(), "call_1");
+        assert_eq!(status.next_checkpoint_timestamp_ms(), 151);
+        assert_eq!(status.next_checkpoint_call_id(), "call_3");
         assert_eq!(status.inventory.total_records, 2);
         assert_eq!(
             status
@@ -3002,6 +3026,10 @@ mod tests {
         assert!(!status.should_continue_after_page());
         assert!(!status.requires_follow_up());
         assert!(!status.would_advance_checkpoint());
+        assert_eq!(status.starting_checkpoint_timestamp_ms(), 0);
+        assert_eq!(status.starting_checkpoint_call_id(), "");
+        assert_eq!(status.next_checkpoint_timestamp_ms(), 0);
+        assert_eq!(status.next_checkpoint_call_id(), "");
         assert_eq!(status.stored_checkpoint, None);
         assert!(store.fetch_checkpoint("supervisor").unwrap().is_none());
     }


### PR DESCRIPTION
## Summary
- add starting and next checkpoint scalar accessors to supervisor checkpoint status
- cover pending and idle checkpoint status scalar values
- document the status log helper surface

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD