### PR TITLE
Add WHATWG miscellaneous recovery audit fixture

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -64,6 +64,8 @@ documented in this file.
   generator alongside the other parser audit fixture generators.
 - The generated fixture manifest now includes the parser select/list audit
   generator alongside the other parser audit fixture generators.
+- The generated fixture manifest now includes the parser miscellaneous
+  recovery audit generator alongside the other parser audit fixture generators.
 - Parser-facing seeded RCDATA/RAWTEXT/script end-tag continuation contexts,
   including end-tag-name, whitespace, attributes, and self-closing substates
   with current-end-tag and temporary-buffer seeding.

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -250,6 +250,13 @@ def default_checks() -> list[FixtureCheck]:
                 "--check",
             ),
         ),
+        FixtureCheck(
+            "whatwg-misc-recovery-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_misc_recovery_audit_fixture.py"),
+                "--check",
+            ),
+        ),
     ]
 
 

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -74,6 +74,11 @@ documented in this file.
 - Generated WHATWG select/list audit fixture over html5lib select shell,
   option implied-end, optgroup-boundary, select-in-table, fragment-context, and
   stray select/list end-tag cases, with a dedicated parser regression test.
+- Generated WHATWG miscellaneous recovery audit fixture over html5lib
+  XML/processing-instruction-looking markup, bogus comments, CDATA-as-text,
+  malformed tag opens, plain text and whitespace shells, duplicate doctypes,
+  unknown/custom elements, and legacy compatibility cases, with a dedicated
+  parser regression test.
 - Shared html5lib tree-construction test helpers keep smoke and focused
   tree-insertion, frameset, table, form/interactive, text-control,
   foreign-content, formatting, ruby, noscript, head/body, document-shell,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -260,3 +260,14 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_lis
 python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py \
   --check
 ```
+
+`whatwg-misc-recovery-audit.json` is a generated index over tree-construction
+cases that stress XML/processing-instruction-looking markup, bogus comments,
+CDATA-as-text, malformed tag opens, plain text and whitespace shells, duplicate
+doctypes, unknown elements, and legacy compatibility elements:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py \
+  --check
+```

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG miscellaneous recovery audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-misc-recovery-audit.json"
+
+CASE_GROUPS = (
+    {
+        "axis": "xml-pi-looking-markup",
+        "reason": "XML declaration and processing-instruction-looking input recovery",
+        "sources": (
+            "comments01.dat:79",
+            "comments01.dat:80",
+            "comments01.dat:81",
+            "html5test-com.dat:282",
+            "tests1.dat:605",
+            "tests1.dat:606",
+            "tests1.dat:609",
+            "tests1.dat:612",
+        ),
+    },
+    {
+        "axis": "bogus-comment-and-cdata",
+        "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+        "sources": (
+            "html5test-com.dat:283",
+            "html5test-com.dat:284",
+            "tests1.dat:607",
+            "tests1.dat:608",
+            "tests1.dat:610",
+            "tests1.dat:611",
+            "tests1.dat:613",
+            "tests1.dat:614",
+            "tests2.dat:35",
+            "tests2.dat:42",
+            "tests2.dat:43",
+            "tests2.dat:44",
+            "tests2.dat:60",
+            "tests2.dat:62",
+        ),
+    },
+    {
+        "axis": "text-whitespace-shell",
+        "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+        "sources": (
+            "html5test-com.dat:276",
+            "plain-text-unsafe.dat:356",
+            "tests1.dat:566",
+            "tests1.dat:627",
+            "tests2.dat:1",
+            "tests2.dat:46",
+            "tests2.dat:50",
+            "webkit01.dat:1",
+        ),
+    },
+    {
+        "axis": "malformed-tag-open",
+        "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+        "sources": (
+            "tests1.dat:601",
+            "tests1.dat:602",
+            "tests1.dat:603",
+            "tests1.dat:604",
+            "tests1.dat:642",
+            "webkit01.dat:4",
+            "webkit01.dat:11",
+            "webkit01.dat:14",
+            "webkit02.dat:1",
+        ),
+    },
+    {
+        "axis": "legacy-compat-elements",
+        "reason": "obsolete and compatibility element recovery outside larger families",
+        "sources": (
+            "tests1.dat:648",
+            "tests19.dat:1021",
+            "tests19.dat:1102",
+            "tests25.dat:1236",
+            "tests25.dat:1237",
+            "tests25.dat:1238",
+            "webkit02.dat:10",
+        ),
+    },
+    {
+        "axis": "custom-element-recovery",
+        "reason": "unknown/custom element nesting, attributes, and stray end-tag recovery",
+        "sources": (
+            "webkit01.dat:8",
+            "webkit01.dat:9",
+            "webkit01.dat:10",
+        ),
+    },
+    {
+        "axis": "duplicate-doctype-recovery",
+        "reason": "duplicate doctype and doctype-looking declaration recovery",
+        "sources": (
+            "domjs-unsafe.dat:147",
+            "tests2.dat:45",
+        ),
+    },
+)
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    sources = parse_sources(input_path)
+    fixture = build_fixture(sources)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG miscellaneous recovery audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_sources(path: Path) -> list[str]:
+    sources: list[str] = []
+    for line in path.read_text(errors="replace").splitlines():
+        if line.startswith("#source "):
+            sources.append(line.removeprefix("#source ").strip())
+    if not sources:
+        raise SystemExit(f"{path} does not contain any #source markers")
+    return sources
+
+
+def build_fixture(sources: list[str]) -> dict[str, object]:
+    case_by_source = configured_cases_by_source()
+    selected = []
+    seen = set()
+
+    for source in sources:
+        case = case_by_source.get(source)
+        if case is None:
+            continue
+        if source in seen:
+            raise SystemExit(f"duplicate selected source: {source}")
+        seen.add(source)
+        selected.append(
+            {
+                "id": stable_case_id(source),
+                "source": source,
+                "axis": case["axis"],
+                "reason": case["reason"],
+            }
+        )
+
+    missing_sources = [source for source in case_by_source if source not in seen]
+    if missing_sources:
+        raise SystemExit(
+            "missing configured miscellaneous recovery sources: "
+            + ", ".join(missing_sources)
+        )
+
+    axes = [case_group["axis"] for case_group in CASE_GROUPS]
+    counts_by_axis = {
+        axis: sum(1 for case in selected if case["axis"] == axis) for axis in axes
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-misc-recovery-audit/v1",
+        "description": (
+            "Focused parser audit over selected html5lib tree-construction "
+            "cases that stress miscellaneous recovery around XML/PI-looking "
+            "markup, bogus comments, CDATA-as-text, malformed tag opens, "
+            "plain text, duplicate doctypes, unknown/custom elements, and "
+            "legacy compatibility elements."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def configured_cases_by_source() -> dict[str, dict[str, str]]:
+    cases: dict[str, dict[str, str]] = {}
+    for case_group in CASE_GROUPS:
+        for source in case_group["sources"]:
+            if source in cases:
+                raise SystemExit(f"duplicate configured source: {source}")
+            cases[source] = {
+                "axis": case_group["axis"],
+                "reason": case_group["reason"],
+            }
+    return cases
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-misc-recovery-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-misc-recovery-audit.json
@@ -1,0 +1,323 @@
+{
+  "case_count": 51,
+  "cases": [
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "comments01-dat-79",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "comments01.dat:79"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "comments01-dat-80",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "comments01.dat:80"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "comments01-dat-81",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "comments01.dat:81"
+    },
+    {
+      "axis": "duplicate-doctype-recovery",
+      "id": "domjs-unsafe-dat-147",
+      "reason": "duplicate doctype and doctype-looking declaration recovery",
+      "source": "domjs-unsafe.dat:147"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "html5test-com-dat-276",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "html5test-com.dat:276"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "html5test-com-dat-282",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "html5test-com.dat:282"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "html5test-com-dat-283",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "html5test-com.dat:283"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "html5test-com-dat-284",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "html5test-com.dat:284"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "plain-text-unsafe-dat-356",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "plain-text-unsafe.dat:356"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "tests1-dat-566",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "tests1.dat:566"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "tests1-dat-601",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "tests1.dat:601"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "tests1-dat-602",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "tests1.dat:602"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "tests1-dat-603",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "tests1.dat:603"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "tests1-dat-604",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "tests1.dat:604"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "tests1-dat-605",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "tests1.dat:605"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "tests1-dat-606",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "tests1.dat:606"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests1-dat-607",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests1.dat:607"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests1-dat-608",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests1.dat:608"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "tests1-dat-609",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "tests1.dat:609"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests1-dat-610",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests1.dat:610"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests1-dat-611",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests1.dat:611"
+    },
+    {
+      "axis": "xml-pi-looking-markup",
+      "id": "tests1-dat-612",
+      "reason": "XML declaration and processing-instruction-looking input recovery",
+      "source": "tests1.dat:612"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests1-dat-613",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests1.dat:613"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests1-dat-614",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests1.dat:614"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "tests1-dat-627",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "tests1.dat:627"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "tests1-dat-642",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "tests1.dat:642"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "tests1-dat-648",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "tests1.dat:648"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "tests19-dat-1021",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "tests19.dat:1021"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "tests19-dat-1102",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "tests19.dat:1102"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "tests25-dat-1236",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "tests25.dat:1236"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "tests25-dat-1237",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "tests25.dat:1237"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "tests25-dat-1238",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "tests25.dat:1238"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "tests2-dat-1",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "tests2.dat:1"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests2-dat-35",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests2.dat:35"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests2-dat-42",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests2.dat:42"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests2-dat-43",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests2.dat:43"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests2-dat-44",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests2.dat:44"
+    },
+    {
+      "axis": "duplicate-doctype-recovery",
+      "id": "tests2-dat-45",
+      "reason": "duplicate doctype and doctype-looking declaration recovery",
+      "source": "tests2.dat:45"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "tests2-dat-46",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "tests2.dat:46"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "tests2-dat-50",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "tests2.dat:50"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests2-dat-60",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests2.dat:60"
+    },
+    {
+      "axis": "bogus-comment-and-cdata",
+      "id": "tests2-dat-62",
+      "reason": "bogus comment, malformed declaration, and CDATA-as-text recovery",
+      "source": "tests2.dat:62"
+    },
+    {
+      "axis": "text-whitespace-shell",
+      "id": "webkit01-dat-1",
+      "reason": "plain text, whitespace, NUL, and minimal document-shell recovery",
+      "source": "webkit01.dat:1"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "webkit01-dat-4",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "webkit01.dat:4"
+    },
+    {
+      "axis": "custom-element-recovery",
+      "id": "webkit01-dat-8",
+      "reason": "unknown/custom element nesting, attributes, and stray end-tag recovery",
+      "source": "webkit01.dat:8"
+    },
+    {
+      "axis": "custom-element-recovery",
+      "id": "webkit01-dat-9",
+      "reason": "unknown/custom element nesting, attributes, and stray end-tag recovery",
+      "source": "webkit01.dat:9"
+    },
+    {
+      "axis": "custom-element-recovery",
+      "id": "webkit01-dat-10",
+      "reason": "unknown/custom element nesting, attributes, and stray end-tag recovery",
+      "source": "webkit01.dat:10"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "webkit01-dat-11",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "webkit01.dat:11"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "webkit01-dat-14",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "webkit01.dat:14"
+    },
+    {
+      "axis": "malformed-tag-open",
+      "id": "webkit02-dat-1",
+      "reason": "incomplete tag-open, bogus end-tag, long attribute, and slash recovery",
+      "source": "webkit02.dat:1"
+    },
+    {
+      "axis": "legacy-compat-elements",
+      "id": "webkit02-dat-10",
+      "reason": "obsolete and compatibility element recovery outside larger families",
+      "source": "webkit02.dat:10"
+    }
+  ],
+  "counts_by_axis": {
+    "bogus-comment-and-cdata": 14,
+    "custom-element-recovery": 3,
+    "duplicate-doctype-recovery": 2,
+    "legacy-compat-elements": 7,
+    "malformed-tag-open": 9,
+    "text-whitespace-shell": 8,
+    "xml-pi-looking-markup": 8
+  },
+  "description": "Focused parser audit over selected html5lib tree-construction cases that stress miscellaneous recovery around XML/PI-looking markup, bogus comments, CDATA-as-text, malformed tag opens, plain text, duplicate doctypes, unknown/custom elements, and legacy compatibility elements.",
+  "format": "whatwg-html-misc-recovery-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_misc_recovery_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_misc_recovery_audit_test.rs
@@ -1,0 +1,87 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_MISC_RECOVERY_AUDIT: &str =
+    include_str!("fixtures/whatwg-misc-recovery-audit.json");
+
+#[derive(Debug, Deserialize)]
+struct MiscRecoveryAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<MiscRecoveryAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MiscRecoveryAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_misc_recovery_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-misc-recovery-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert!(suite.case_count >= 51);
+    assert_axis_count(&suite, "xml-pi-looking-markup", 8);
+    assert_axis_count(&suite, "bogus-comment-and-cdata", 14);
+    assert_axis_count(&suite, "text-whitespace-shell", 8);
+    assert_axis_count(&suite, "malformed-tag-open", 9);
+    assert_axis_count(&suite, "legacy-compat-elements", 7);
+    assert_axis_count(&suite, "custom-element-recovery", 3);
+    assert_axis_count(&suite, "duplicate-doctype-recovery", 2);
+}
+
+#[test]
+fn whatwg_misc_recovery_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> MiscRecoveryAuditSuite {
+    serde_json::from_str(WHATWG_MISC_RECOVERY_AUDIT)
+        .expect("WHATWG miscellaneous recovery audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &MiscRecoveryAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary
- add a generated WHATWG miscellaneous recovery audit over 51 html5lib tree-construction cases
- cover XML/PI-looking markup, bogus comments, CDATA-as-text, malformed tag opens, plain text/whitespace shells, duplicate doctypes, custom elements, and legacy compatibility elements
- wire the new generator into the generated HTML fixture manifest and document it in parser/lexer changelogs

## Validation
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_legacy_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_character_reference_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_fragment_context_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_block_boundary_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_void_element_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_head_body_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_template_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_document_shell_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_formatting_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_text_control_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_form_interactive_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_frameset_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/generate_whatwg_tree_insertion_audit_fixture.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- cargo test -p coding-adventures-html-parser whatwg_misc_recovery_audit
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser