### PR TITLE
[codex] Add Arduino CLI upload execution plans

### DIFF
--- a/code/packages/rust/board-vm-arduino/README.md
+++ b/code/packages/rust/board-vm-arduino/README.md
@@ -38,7 +38,8 @@ path emits the `arduino-cli upload` invocation template, leaving language
 frontends to fill concrete port and firmware-image paths rather than maintain
 their own flag tables. The same Rust-owned path can now build the concrete
 Arduino CLI upload argv after a frontend supplies the selected port and
-firmware-image path.
+firmware-image path, and can wrap that argv in an execution plan with reset and
+runtime rediscovery steps for native-USB and serial-adapter boards.
 
 The shared target registry also records physical wireless radios for the
 Arduino-family boards that have Wi-Fi or BLE hardware, including MKR/Nano

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -46,6 +46,10 @@ frontends should fill with concrete paths.
 `arduino_cli_upload_command_with_options_for_target` go one step further by
 building concrete `arduino-cli upload` argv from the selected port, firmware
 image, optional upload properties, and verify flag.
+`arduino_cli_upload_execution_plan_for_target` layers reset and rediscovery
+metadata onto that concrete argv, so language frontends can execute the command
+while still asking Rust whether the selected port is native USB, a USB serial
+bridge, or an external adapter and whether runtime rediscovery is expected.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -634,6 +634,29 @@ pub struct LanguageArduinoCliUploadCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageArduinoCliUploadExecutionPlan {
+    pub board_id: String,
+    pub executable: String,
+    pub args: Vec<String>,
+    pub fqbn: String,
+    pub port: String,
+    pub input_file: String,
+    pub upload_properties: Vec<String>,
+    pub verify: bool,
+    pub port_hint: String,
+    pub port_selection_step: String,
+    pub reset_method: String,
+    pub reset_delegated_to_board_package: bool,
+    pub bootloader_touch_baud: Option<u32>,
+    pub expects_port_reenumeration: bool,
+    pub wait_for_runtime_rediscovery: bool,
+    pub serial_adapter_required: bool,
+    pub steps: Vec<String>,
+    pub success_exit_codes: Vec<i32>,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageUploadOptions {
     pub board_id: String,
     pub adapter: String,
@@ -1163,6 +1186,66 @@ pub fn arduino_cli_upload_command_with_options_for_target(
         port_hint: invocation.port_hint,
         port_selection_step: invocation.port_selection_step,
         notes: arduino_cli_upload_command_notes().to_owned(),
+    })
+}
+
+pub fn arduino_cli_upload_execution_plan_for_target(
+    selector: &str,
+    port: &str,
+    input_file: &str,
+) -> Option<LanguageArduinoCliUploadExecutionPlan> {
+    arduino_cli_upload_execution_plan_with_options_for_target(
+        selector,
+        port,
+        input_file,
+        &[],
+        false,
+    )
+}
+
+pub fn arduino_cli_upload_execution_plan_with_options_for_target(
+    selector: &str,
+    port: &str,
+    input_file: &str,
+    upload_properties: &[&str],
+    verify: bool,
+) -> Option<LanguageArduinoCliUploadExecutionPlan> {
+    let command = arduino_cli_upload_command_with_options_for_target(
+        selector,
+        port,
+        input_file,
+        upload_properties,
+        verify,
+    )?;
+    let target = detect_board_target(selector)?;
+    let upload = target.upload?;
+    if upload.adapter != TargetUploadAdapter::ArduinoCli {
+        return None;
+    }
+    let port_hint = upload.port_hint?;
+    let options = arduino_cli_upload_options_for_target(selector)?;
+    let discovery = arduino_cli_port_discovery_for_target(selector)?;
+
+    Some(LanguageArduinoCliUploadExecutionPlan {
+        board_id: command.board_id,
+        executable: command.executable,
+        args: command.args,
+        fqbn: command.fqbn,
+        port: command.port,
+        input_file: command.input_file,
+        upload_properties: command.upload_properties,
+        verify: command.verify,
+        port_hint: command.port_hint,
+        port_selection_step: command.port_selection_step,
+        reset_method: options.reset_method,
+        reset_delegated_to_board_package: discovery.reset_delegated_to_board_package,
+        bootloader_touch_baud: discovery.bootloader_touch_baud,
+        expects_port_reenumeration: discovery.expects_port_reenumeration,
+        wait_for_runtime_rediscovery: discovery.wait_for_runtime_rediscovery,
+        serial_adapter_required: discovery.serial_adapter_required,
+        steps: arduino_cli_upload_execution_steps(port_hint),
+        success_exit_codes: vec![0],
+        notes: arduino_cli_upload_execution_notes(port_hint).to_owned(),
     })
 }
 
@@ -1813,6 +1896,49 @@ fn arduino_cli_upload_invocation_notes(hint: TargetUploadPortHint) -> &'static s
 
 fn arduino_cli_upload_command_notes() -> &'static str {
     "Concrete Arduino CLI argv built by Rust after target resolution, port selection, and firmware artifact selection."
+}
+
+fn arduino_cli_upload_execution_steps(port_hint: TargetUploadPortHint) -> Vec<String> {
+    match port_hint {
+        TargetUploadPortHint::NativeUsb => vec![
+            "use_selected_native_usb_port".to_owned(),
+            "delegate_reset_to_board_package".to_owned(),
+            "run_arduino_cli_upload".to_owned(),
+            "wait_for_runtime_port_rediscovery".to_owned(),
+        ],
+        TargetUploadPortHint::UsbSerialBridge => vec![
+            "use_selected_usb_serial_bridge".to_owned(),
+            "delegate_reset_to_board_package".to_owned(),
+            "run_arduino_cli_upload".to_owned(),
+            "reuse_selected_serial_port".to_owned(),
+        ],
+        TargetUploadPortHint::ExternalSerialAdapter => vec![
+            "use_selected_external_serial_adapter".to_owned(),
+            "delegate_reset_to_board_package".to_owned(),
+            "run_arduino_cli_upload".to_owned(),
+            "reuse_selected_serial_port".to_owned(),
+        ],
+        _ => vec![
+            "use_selected_serial_port".to_owned(),
+            "delegate_reset_to_board_package".to_owned(),
+            "run_arduino_cli_upload".to_owned(),
+        ],
+    }
+}
+
+fn arduino_cli_upload_execution_notes(port_hint: TargetUploadPortHint) -> &'static str {
+    match port_hint {
+        TargetUploadPortHint::NativeUsb => {
+            "Rust-owned Arduino CLI execution plan delegates native USB bootloader reset to the board package and expects runtime CDC rediscovery after upload."
+        }
+        TargetUploadPortHint::UsbSerialBridge => {
+            "Rust-owned Arduino CLI execution plan keeps the selected USB serial bridge port stable while the board package handles reset and programmer behavior."
+        }
+        TargetUploadPortHint::ExternalSerialAdapter => {
+            "Rust-owned Arduino CLI execution plan requires the caller-provided external serial adapter port and delegates reset/programmer behavior to the board package."
+        }
+        _ => "Rust-owned Arduino CLI execution plan for running the generated upload command.",
+    }
 }
 
 fn language_upload_plan(board_id: &str, upload: TargetUploadInfo) -> LanguageUploadPlan {
@@ -5723,6 +5849,113 @@ mod tests {
         )
         .is_none());
         assert!(arduino_cli_upload_command_for_target(
+            "esp32",
+            "/dev/cu.usbserial-esp32",
+            "/tmp/esp32.bin"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn arduino_cli_upload_execution_plan_is_owned_by_rust_language_core() {
+        let plan = arduino_cli_upload_execution_plan_for_target(
+            "arduino:renesas_uno:nanor4",
+            "/dev/cu.usbmodem101",
+            "/tmp/board-vm-nano-r4.bin",
+        )
+        .unwrap();
+        assert_eq!(plan.board_id, "arduino-nano-r4");
+        assert_eq!(plan.executable, "arduino-cli");
+        assert_eq!(plan.fqbn, "arduino:renesas_uno:nanor4");
+        assert_eq!(plan.port, "/dev/cu.usbmodem101");
+        assert_eq!(plan.input_file, "/tmp/board-vm-nano-r4.bin");
+        assert_eq!(plan.port_hint, "native_usb");
+        assert_eq!(plan.port_selection_step, "select_native_usb_port");
+        assert_eq!(plan.reset_method, "arduino_board_package");
+        assert!(plan.reset_delegated_to_board_package);
+        assert_eq!(
+            plan.bootloader_touch_baud,
+            Some(ARDUINO_CLI_NATIVE_USB_BOOTLOADER_TOUCH_BAUD)
+        );
+        assert!(plan.expects_port_reenumeration);
+        assert!(plan.wait_for_runtime_rediscovery);
+        assert!(!plan.serial_adapter_required);
+        assert_eq!(
+            plan.steps,
+            vec![
+                "use_selected_native_usb_port",
+                "delegate_reset_to_board_package",
+                "run_arduino_cli_upload",
+                "wait_for_runtime_port_rediscovery",
+            ]
+        );
+        assert_eq!(plan.success_exit_codes, vec![0]);
+        assert!(plan.notes.contains("native USB bootloader reset"));
+        assert_eq!(
+            plan.args,
+            vec![
+                "upload",
+                "-p",
+                "/dev/cu.usbmodem101",
+                "-b",
+                "arduino:renesas_uno:nanor4",
+                "-i",
+                "/tmp/board-vm-nano-r4.bin",
+            ]
+        );
+
+        let plan = arduino_cli_upload_execution_plan_with_options_for_target(
+            "arduino-mega-2560",
+            "COM7",
+            "C:/tmp/mega.hex",
+            &["upload.speed=115200"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(plan.board_id, "arduino-mega-2560");
+        assert_eq!(plan.port_hint, "usb_serial_bridge");
+        assert_eq!(plan.bootloader_touch_baud, None);
+        assert!(!plan.expects_port_reenumeration);
+        assert!(!plan.wait_for_runtime_rediscovery);
+        assert!(!plan.serial_adapter_required);
+        assert!(plan.verify);
+        assert_eq!(plan.upload_properties, vec!["upload.speed=115200"]);
+        assert_eq!(
+            plan.steps,
+            vec![
+                "use_selected_usb_serial_bridge",
+                "delegate_reset_to_board_package",
+                "run_arduino_cli_upload",
+                "reuse_selected_serial_port",
+            ]
+        );
+        assert!(plan.notes.contains("USB serial bridge port"));
+
+        let plan = arduino_cli_upload_execution_plan_for_target(
+            "arduino-pro-mini",
+            "/dev/cu.usbserial-1420",
+            "/tmp/pro-mini.hex",
+        )
+        .unwrap();
+        assert_eq!(plan.port_hint, "external_serial_adapter");
+        assert!(plan.serial_adapter_required);
+        assert_eq!(
+            plan.steps,
+            vec![
+                "use_selected_external_serial_adapter",
+                "delegate_reset_to_board_package",
+                "run_arduino_cli_upload",
+                "reuse_selected_serial_port",
+            ]
+        );
+
+        assert!(arduino_cli_upload_execution_plan_for_target(
+            "arduino-pro-mini",
+            "",
+            "/tmp/pro-mini.hex"
+        )
+        .is_none());
+        assert!(arduino_cli_upload_execution_plan_for_target(
             "esp32",
             "/dev/cu.usbserial-esp32",
             "/tmp/esp32.bin"

--- a/code/packages/rust/board-vm-targets/README.md
+++ b/code/packages/rust/board-vm-targets/README.md
@@ -55,6 +55,9 @@ paths into Rust-owned `arduino-cli upload` flags instead of rebuilding the
 command shape. The matching command builder now accepts the concrete selected
 port and firmware image path and returns the final argv, including optional
 Arduino CLI upload properties and verify mode.
+The execution-plan helper composes that argv with reset and rediscovery steps,
+preserving native-USB bootloader behavior and serial-adapter expectations
+without making the target registry open devices or spawn `arduino-cli`.
 
 Wireless metadata separates physical support from the generic front-end sugar:
 

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -205,6 +205,10 @@ shared across Ruby, Python, Lua, Java, JS, and future CLIs. Arduino CLI plans
 must preserve whether the board expects an onboard USB serial bridge, a native
 USB bootloader port, or an external serial adapter so frontends do not infer
 that from board names.
+For Arduino CLI targets, SDKs should use the Rust-owned execution plan after
+port and firmware-image selection so argv construction, reset delegation, and
+runtime rediscovery expectations stay shared even when the language layer owns
+the final process launch.
 
 Selector handling follows the same ownership boundary. If a frontend receives
 an Arduino CLI FQBN such as `arduino:renesas_uno:nanor4`, it should ask the Rust

--- a/code/specs/BVM06-board-target-matrix.md
+++ b/code/specs/BVM06-board-target-matrix.md
@@ -158,6 +158,13 @@ language core keeps the FQBN, flag order, optional upload-property expansion,
 and verify flag placement centralized, so language frontends do not assemble
 Arduino CLI commands locally.
 
+The Arduino CLI upload execution-plan tranche composes that concrete argv with
+the reset and rediscovery lifecycle. Native USB boards keep their 1200-baud
+bootloader touch and runtime CDC rediscovery expectations in Rust-owned
+metadata, while USB-serial bridge and external-adapter boards explicitly reuse
+the selected serial port after the board package handles reset/programmer
+behavior.
+
 The Arduino wireless metadata tranche records physical Wi-Fi and Bluetooth LE
 radios for non-Uno boards such as MKR WiFi 1010, Nano 33 IoT, Nano 33 BLE Rev2,
 Nano RP2040 Connect, Nano ESP32, GIGA R1 WiFi, Portenta H7 Lite Connected,


### PR DESCRIPTION
## Summary
- add a Rust-owned Arduino CLI upload execution plan that composes concrete argv with reset and rediscovery lifecycle metadata
- preserve native USB, USB serial bridge, and external serial adapter behavior in language-core instead of frontend tables
- update Board VM specs and package READMEs to document the new execution-plan tranche

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command bash BUILD in code/packages/rust/board-vm-language-core, code/packages/rust/board-vm-targets, and code/packages/rust/board-vm-arduino
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Generated build-plan.json and code/packages/rust/Cargo.lock were removed before committing.