### PR TITLE
Add replay summary checkpoint scalar accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this package will be documented in this file.
 - Durable named checkpoint state for supervisors that resume audit replay.
 - Checkpointed replay helpers that deliver bounded pages into audit sinks and
   advance durable named checkpoints.
+- Starting and next checkpoint scalar accessors for checkpoint replay summaries.
 - Read-only supervisor checkpoint status inspection before draining.
 - Starting and next checkpoint scalar accessors for supervisor checkpoint
   status.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -21,6 +21,8 @@ The crate keeps the boundary narrow:
   storage backend and advance them without regressing reader state
 - supervisors can replay bounded pages from named checkpoints into audit sinks
   and advance the durable cursor after delivery
+- checkpoint replay summaries expose starting and next checkpoint scalar
+  accessors for host replay logs
 - supervisors can inspect named checkpoint status before draining without
   advancing durable cursor state
 - supervisor checkpoint status exposes starting and next checkpoint scalar

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -596,6 +596,26 @@ impl ToolAuditCheckpointReplaySummary {
         self.replayed_records == 0
     }
 
+    /// Return the starting checkpoint timestamp for host replay logs.
+    pub fn starting_checkpoint_timestamp_ms(&self) -> u64 {
+        self.starting_checkpoint.timestamp_ms
+    }
+
+    /// Return the starting checkpoint call id for host replay logs.
+    pub fn starting_checkpoint_call_id(&self) -> &str {
+        &self.starting_checkpoint.call_id
+    }
+
+    /// Return the checkpoint timestamp saved after this replay page.
+    pub fn next_checkpoint_timestamp_ms(&self) -> u64 {
+        self.next_checkpoint.timestamp_ms
+    }
+
+    /// Return the checkpoint call id saved after this replay page.
+    pub fn next_checkpoint_call_id(&self) -> &str {
+        &self.next_checkpoint.call_id
+    }
+
     /// Return whether any replayed row needs follow-up.
     pub fn requires_follow_up(&self) -> bool {
         self.inventory.requires_follow_up()
@@ -2892,6 +2912,10 @@ mod tests {
             first.next_checkpoint,
             ToolAuditReadCheckpoint::new(120, "call_3")
         );
+        assert_eq!(first.starting_checkpoint_timestamp_ms(), 0);
+        assert_eq!(first.starting_checkpoint_call_id(), "");
+        assert_eq!(first.next_checkpoint_timestamp_ms(), 120);
+        assert_eq!(first.next_checkpoint_call_id(), "call_3");
         assert_eq!(
             first
                 .stored_checkpoint
@@ -2918,6 +2942,10 @@ mod tests {
             second.next_checkpoint,
             ToolAuditReadCheckpoint::new(151, "call_2")
         );
+        assert_eq!(second.starting_checkpoint_timestamp_ms(), 120);
+        assert_eq!(second.starting_checkpoint_call_id(), "call_3");
+        assert_eq!(second.next_checkpoint_timestamp_ms(), 151);
+        assert_eq!(second.next_checkpoint_call_id(), "call_2");
         assert_eq!(second.replayed_records, 1);
         assert!(second.requires_follow_up());
         assert_eq!(
@@ -2944,6 +2972,10 @@ mod tests {
             ToolAuditReadCheckpoint::beginning()
         );
         assert_eq!(empty.next_checkpoint, ToolAuditReadCheckpoint::beginning());
+        assert_eq!(empty.starting_checkpoint_timestamp_ms(), 0);
+        assert_eq!(empty.starting_checkpoint_call_id(), "");
+        assert_eq!(empty.next_checkpoint_timestamp_ms(), 0);
+        assert_eq!(empty.next_checkpoint_call_id(), "");
         assert_eq!(empty.stored_checkpoint, None);
         assert!(sink.records().is_empty());
         assert!(store.fetch_checkpoint("supervisor").unwrap().is_none());


### PR DESCRIPTION
## Summary
- add starting/next checkpoint timestamp and call-id accessors on ToolAuditCheckpointReplaySummary
- cover non-empty and empty checkpoint replay summaries
- document the host replay-log helper surface

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD