### PR TITLE
Add stored checkpoint scalar accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file.
 - Query and inventory helpers over persisted audit records.
 - Deterministic checkpoint pages for incremental audit replay.
 - Durable named checkpoint state for supervisors that resume audit replay.
+- Timestamp and call-id scalar accessors for stored checkpoint state.
 - Checkpointed replay helpers that deliver bounded pages into audit sinks and
   advance durable named checkpoints.
 - Starting and next checkpoint scalar accessors for checkpoint replay summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -19,6 +19,8 @@ The crate keeps the boundary narrow:
   after restarts without reprocessing the whole store
 - supervisors can persist named replay checkpoints through the same D18A
   storage backend and advance them without regressing reader state
+- stored checkpoints expose timestamp and call-id scalar accessors for host
+  state logs
 - supervisors can replay bounded pages from named checkpoints into audit sinks
   and advance the durable cursor after delivery
 - checkpoint replay summaries expose starting and next checkpoint scalar

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -573,6 +573,18 @@ pub struct ToolAuditStoredCheckpoint {
     pub updated_at: u64,
 }
 
+impl ToolAuditStoredCheckpoint {
+    /// Return the durable checkpoint timestamp for host state logs.
+    pub fn checkpoint_timestamp_ms(&self) -> u64 {
+        self.checkpoint.timestamp_ms
+    }
+
+    /// Return the durable checkpoint call id for host state logs.
+    pub fn checkpoint_call_id(&self) -> &str {
+        &self.checkpoint.call_id
+    }
+}
+
 /// Summary for replaying one named checkpoint page into a sink.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolAuditCheckpointReplaySummary {
@@ -2789,6 +2801,8 @@ mod tests {
                 stored.checkpoint,
                 ToolAuditReadCheckpoint::new(151, "call_2")
             );
+            assert_eq!(stored.checkpoint_timestamp_ms(), 151);
+            assert_eq!(stored.checkpoint_call_id(), "call_2");
         }
 
         {
@@ -2803,6 +2817,8 @@ mod tests {
                 stored.checkpoint,
                 ToolAuditReadCheckpoint::new(151, "call_2")
             );
+            assert_eq!(stored.checkpoint_timestamp_ms(), 151);
+            assert_eq!(stored.checkpoint_call_id(), "call_2");
         }
 
         let _ = fs::remove_dir_all(&root);
@@ -2825,11 +2841,15 @@ mod tests {
             first.checkpoint,
             ToolAuditReadCheckpoint::new(151, "call_2")
         );
+        assert_eq!(first.checkpoint_timestamp_ms(), 151);
+        assert_eq!(first.checkpoint_call_id(), "call_2");
         assert_eq!(older.checkpoint, first.checkpoint);
         assert_eq!(
             newer.checkpoint,
             ToolAuditReadCheckpoint::new(151, "call_3")
         );
+        assert_eq!(newer.checkpoint_timestamp_ms(), 151);
+        assert_eq!(newer.checkpoint_call_id(), "call_3");
         assert_eq!(
             store
                 .fetch_checkpoint("supervisor")


### PR DESCRIPTION
## Summary
- add timestamp and call-id scalar accessors on ToolAuditStoredCheckpoint
- cover persisted, resumed, and advanced stored checkpoint states
- document the host state-log helper surface

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD