### PR TITLE
feat(javascript-ast): scaffold crate with Program root (CLOC02 Phase 1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -159,6 +159,7 @@ members = [
     "jit-profiling-insights",
     "ldp-format",
     "itf",
+    "javascript-ast",
     "javascript-lexer",
     "javascript-parser",
     "javascript-tokens",

--- a/code/packages/rust/javascript-ast/BUILD
+++ b/code/packages/rust/javascript-ast/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-javascript-ast -- --nocapture

--- a/code/packages/rust/javascript-ast/BUILD_windows
+++ b/code/packages/rust/javascript-ast/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-javascript-ast -- --nocapture

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-21
+
+### Added
+- New crate scaffolded per CLOC02 Phase 1.
+- `Program` struct: AST root carrying `cv: CvId`, `version: EsVersion`, and `source_type: SourceType`. Per CLOC02, the version tag lives only on `Program` — never on individual nodes.
+- `SourceType` enum (`Script` / `Module`) with derives `Debug, Clone, Copy, PartialEq, Eq, Hash`.
+- `CvId` type alias for `String` matching the current `correlation-vector` representation (see module-level docs for the migration plan to a true newtype).
+- `Program::new(cv, version, source_type)` constructor.
+- Module-level docs enumerate the six backend-agnostic invariants from CLOC02 and the dependency whitelist.
+- Test suite covering: synthetic construction with each `SourceType`, `Clone` + `PartialEq`, compile-time `Copy` assertions on `SourceType` and `EsVersion`.
+
+### Notes
+- Dependencies are exactly `coding-adventures-correlation-vector` and `coding-adventures-javascript-tokens`. No serde for v1 — round-trippable JSON ships in a follow-up once consumers actually need it.
+- The `Statement` / `Expression` / `Declaration` / class / module / literal variants from CLOC02 are deferred to follow-up PRs to keep this scaffolding small.

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "coding-adventures-javascript-ast"
+version = "0.1.0"
+edition = "2021"
+description = "Backend-agnostic JavaScript AST — every node carries a CV ID per CLOC02; reusable by the Closure-Compiler-clone and the future V8-in-Rust clone."
+
+[dependencies]
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -1,0 +1,43 @@
+# coding-adventures-javascript-ast
+
+Backend-agnostic JavaScript AST. The contract between the JS frontend and every
+consumer downstream: the Closure-Compiler-clone (typechecker, passes, emitter),
+the future V8-in-Rust clone (bytecode lowering), JSDoc and TypeScript
+type-extractors, IDE tooling.
+
+Per [CLOC02](../../../specs/CLOC02-javascript-ast.md), the AST holds **only the
+syntactic shape**. Spans, type information, optimization metadata, and parent
+chains all live in adjacent stores keyed by `CvId` — never on AST nodes
+themselves. That's what makes the same AST safe to share across multiple
+backends.
+
+## Dependency whitelist
+
+- `coding-adventures-correlation-vector` — for the `CvId` type.
+- `coding-adventures-javascript-tokens` — for `EsVersion`.
+
+Nothing else. No `closure-*`, no `type-sidecar`, no IR or bytecode crates. The
+whitelist is what keeps the AST reusable.
+
+## What's here in v1 (this crate's first PR)
+
+- [`Program`] — the AST root.
+- [`SourceType`] — `Script` or `Module`.
+- A `CvId` type alias for `String` (matching the current `correlation-vector`
+  representation; see the module docs for the migration plan).
+
+## What's coming (follow-up PRs)
+
+Per CLOC02:
+
+- `Statement`, `Expression`, `Declaration`, `Pattern`, `Class`, `Module`,
+  `Literal` variants — landing in their own files (`statement.rs`,
+  `expression.rs`, …) so each diff stays reviewable.
+- A `walk` visitor pattern over the whole tree.
+- Builder helpers.
+
+## Why this is a separate crate
+
+If the AST lived in `javascript-parser`, every consumer would depend on the
+parser. Splitting it out keeps the layering clean and lets the future V8 clone
+reuse the parser's output without taking on the parser's dependencies.

--- a/code/packages/rust/javascript-ast/required_capabilities.json
+++ b/code/packages/rust/javascript-ast/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/javascript-ast",
+  "capabilities": [],
+  "justification": "Pure data type definitions. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -1,0 +1,173 @@
+//! Backend-agnostic JavaScript AST.
+//!
+//! # What this crate is for
+//!
+//! `javascript-ast` defines the AST that the JavaScript frontend emits and
+//! that *every* downstream consumer reads. Per
+//! [CLOC02](../../specs/CLOC02-javascript-ast.md), this includes:
+//!
+//! - The Closure-Compiler-clone's typechecker, optimization passes, emitter.
+//! - The future V8-in-Rust clone's bytecode lowering pass.
+//! - JSDoc and TypeScript types extractors (they walk the AST looking for
+//!   comment anchors).
+//! - IDE tooling — LSP, hover, completion, debug adapters.
+//!
+//! Because so many consumers depend on it, the AST is intentionally **small**.
+//! See the invariants below.
+//!
+//! # Backend-agnostic invariants (CLOC02 §"Backend-agnostic invariants")
+//!
+//! 1. **No backend types in AST nodes.** The crate imports only from
+//!    `correlation-vector` and `javascript-tokens`. Never from `closure-*`,
+//!    `type-sidecar`, IR/bytecode crates.
+//! 2. **Every node carries a CV ID, not a span.** Spans live in CV `Origin`
+//!    records in a parallel log. The AST stores only the lightweight `CvId`.
+//! 3. **No mutation in the public surface.** Passes return new trees; they
+//!    do not mutate inputs.
+//! 4. **Version tag on `Program`, not on every node.** Per-node version tags
+//!    would bloat every variant; the parser refuses to emit nodes that aren't
+//!    legal at the requested version, so downstream readers can assume
+//!    "every variant present is legal."
+//! 5. **No type information in the AST.** Types live in
+//!    `coding-adventures-type-sidecar`, keyed by `CvId`.
+//! 6. **No optimization metadata in the AST.** "This is dead," "this was
+//!    inlined" — all of that lives in CV contributions.
+//!
+//! # What v1 contains
+//!
+//! This is the scaffolding PR: just the [`Program`] root node and the
+//! [`SourceType`] enum it carries. The big variant trees (`Statement`,
+//! `Expression`, declarations, patterns, class members, module syntax,
+//! literals) ship in their own follow-up PRs to keep diffs small.
+//!
+//! # Note on `CvId`
+//!
+//! CLOC02 specifies `cv: CvId` where `CvId` is a "copy-cheap newtype". The
+//! current `correlation-vector` crate represents CV IDs as plain `String`
+//! (see `correlation-vector` v0.x). To avoid coupling the two crates'
+//! release cycles, this crate type-aliases [`CvId`] to `String` for v1. A
+//! future PR can promote it to a real newtype without changing the public
+//! surface much — the existing fields would just take `CvId` directly.
+//!
+//! [`CvId`]: type@CvId
+
+use coding_adventures_javascript_tokens::EsVersion;
+
+/// A correlation-vector identifier. Aliased to `String` for v1 to match the
+/// current `correlation-vector` crate's representation. See the module-level
+/// docs note on `CvId` for the migration plan.
+pub type CvId = String;
+
+/// The top of the AST. Every JavaScript compile produces exactly one
+/// `Program`. Holds the ES version that produced the tree, the
+/// script/module discriminator, and (in follow-up PRs) the body.
+///
+/// Per CLOC02 the `version` field is recorded *only here* — individual
+/// nodes never carry a version. Downstream readers can assume any variant
+/// they see is legal at `self.version`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Program {
+    /// CV identifier for this program. Populated by the parser via
+    /// `cv.merge(token_ids, Origin{source: filename, ...})`.
+    pub cv: CvId,
+
+    /// The ECMAScript edition the parser used.
+    pub version: EsVersion,
+
+    /// Whether this source was parsed as a script or a module. The parser
+    /// picks based on caller hint, file extension, or shebang. Closure
+    /// passes and the V8 clone both need this — module and script have
+    /// different top-level scoping rules.
+    pub source_type: SourceType,
+}
+
+/// Whether a [`Program`] was parsed as a script or a module.
+///
+/// The top-level scoping rules differ between the two: scripts have a
+/// shared global scope and allow non-strict-mode features by default;
+/// modules are always strict and have per-file scopes plus
+/// `import`/`export` syntax.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SourceType {
+    Script,
+    Module,
+}
+
+impl Program {
+    /// Construct a `Program` with the given CV id, version, and source type.
+    /// Helper used by the parser; tests and synthetic-AST authors can use
+    /// it too.
+    pub fn new(cv: CvId, version: EsVersion, source_type: SourceType) -> Self {
+        Self {
+            cv,
+            version,
+            source_type,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn program_constructs_with_synthetic_cv() {
+        // The parser will populate `cv` via correlation-vector's
+        // `cv.merge(..)` call. For unit testing we just use a synthetic
+        // string — the AST crate doesn't care what's inside.
+        let program = Program::new(
+            "synthetic.1".to_string(),
+            EsVersion::Es2025,
+            SourceType::Module,
+        );
+
+        assert_eq!(program.cv, "synthetic.1");
+        assert_eq!(program.version, EsVersion::Es2025);
+        assert_eq!(program.source_type, SourceType::Module);
+    }
+
+    #[test]
+    fn program_supports_both_source_types() {
+        let script = Program::new(
+            "s.1".to_string(),
+            EsVersion::Es5,
+            SourceType::Script,
+        );
+        let module = Program::new(
+            "m.1".to_string(),
+            EsVersion::Es2025,
+            SourceType::Module,
+        );
+
+        assert_eq!(script.source_type, SourceType::Script);
+        assert_eq!(module.source_type, SourceType::Module);
+        assert_ne!(script.source_type, module.source_type);
+    }
+
+    #[test]
+    fn program_clone_eq() {
+        let p1 = Program::new(
+            "c.1".to_string(),
+            EsVersion::Es2020,
+            SourceType::Script,
+        );
+        let p2 = p1.clone();
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn source_type_is_copy() {
+        // SourceType derives Copy so it's cheap to pass around. Compile-time
+        // check via the `Copy` bound.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<SourceType>();
+    }
+
+    #[test]
+    fn version_is_copy() {
+        // EsVersion is also Copy, so it can live on every node without
+        // worrying about clones.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<EsVersion>();
+    }
+}


### PR DESCRIPTION
## Summary

Second new-crate PR for the Closure-Compiler-in-Rust pipeline. Scaffolds
`coding-adventures-javascript-ast` — the **backend-agnostic AST** that's the
contract between the JS frontend and every consumer downstream (Closure
passes, the future V8 clone, JSDoc/TS extractors, IDE tooling).

### What's here (v1)

- **`Program`** struct: AST root with `cv: CvId`, `version: EsVersion`,
  `source_type: SourceType`. Version lives **only on `Program`** per CLOC02.
- **`SourceType`** enum: `Script` / `Module` — top-level scoping differs.
- **`CvId`** type alias for `String` (matches current `correlation-vector`
  representation; module docs include the migration path to a true newtype).
- **`Program::new`** constructor.

### CLOC02 backend-agnostic invariants enforced

The dependency whitelist is the load-bearing constraint:

- ✅ Imports only `correlation-vector` and `javascript-tokens`.
- ❌ No `closure-*`, no `type-sidecar`, no IR/bytecode crates.

Plus:

- ✅ Every node carries `CvId`, not a span (spans live in the CV log).
- ✅ No mutation on the public surface.
- ✅ Version tag on `Program` only.
- ✅ No type info on nodes (CLOC04 sidecar handles that).
- ✅ No optimization metadata on nodes (CLOC03 CV log handles that).

### What's coming (follow-up PRs)

Per CLOC02:

- `Statement`, `Expression`, `Declaration`, `Pattern`, `Class`, `Module`,
  `Literal` variants — one PR per variant family.
- `walk` visitor pattern.
- Builder helpers.
- serde derives (when a consumer needs round-trippable JSON).
- Promotion of `CvId` from `String` alias to a true newtype.

## Test plan

- [x] `cargo test -p coding-adventures-javascript-ast` — 5 tests pass
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl` error unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

Public-API coverage:
- `program_constructs_with_synthetic_cv`
- `program_supports_both_source_types`
- `program_clone_eq`
- `source_type_is_copy` (compile-time assertion)
- `version_is_copy` (compile-time assertion)

## What's next

1. **Plumb CV through `javascript-lexer`** — every emitted token gets a `CvId`.
2. **Plumb CV through `javascript-parser`** — switch output to
   `javascript-ast::Program`.
3. **Migrate lexer/parser to take `EsVersion`** (instead of `&str`).
4. **Extend `javascript-tokens`** with `TokenKind` + `Span` types.
5. Stage 2+ (type-sidecar crate, JSDoc grammar/crates, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)