### PR TITLE
Add checkpoint page scalar accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this package will be documented in this file.
 - Query and inventory helpers over persisted audit records.
 - Deterministic checkpoint pages for incremental audit replay.
 - Durable named checkpoint state for supervisors that resume audit replay.
+- Next-checkpoint timestamp and call-id scalar accessors for checkpoint pages.
 - Timestamp and call-id scalar accessors for stored checkpoint state.
 - Checkpointed replay helpers that deliver bounded pages into audit sinks and
   advance durable named checkpoints.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -17,6 +17,8 @@ The crate keeps the boundary narrow:
   with call-id-level storage failures
 - supervisors can read deterministic checkpoint pages to resume audit replay
   after restarts without reprocessing the whole store
+- checkpoint pages expose next-checkpoint timestamp and call-id scalar
+  accessors for host replay logs
 - supervisors can persist named replay checkpoints through the same D18A
   storage backend and advance them without regressing reader state
 - stored checkpoints expose timestamp and call-id scalar accessors for host

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -560,6 +560,16 @@ impl ToolAuditCheckpointPage {
     pub fn len(&self) -> usize {
         self.records.len()
     }
+
+    /// Return the checkpoint timestamp to use for the next read.
+    pub fn next_checkpoint_timestamp_ms(&self) -> u64 {
+        self.next_checkpoint.timestamp_ms
+    }
+
+    /// Return the checkpoint call id to use for the next read.
+    pub fn next_checkpoint_call_id(&self) -> &str {
+        &self.next_checkpoint.call_id
+    }
 }
 
 /// Durable named replay checkpoint stored beside audit rows.
@@ -2739,6 +2749,8 @@ mod tests {
             first.next_checkpoint,
             ToolAuditReadCheckpoint::new(120, "call_1")
         );
+        assert_eq!(first.next_checkpoint_timestamp_ms(), 120);
+        assert_eq!(first.next_checkpoint_call_id(), "call_1");
         assert_eq!(first.inventory.completed_records, 1);
 
         let second = store
@@ -2756,12 +2768,16 @@ mod tests {
             second.next_checkpoint,
             ToolAuditReadCheckpoint::new(151, "call_2")
         );
+        assert_eq!(second.next_checkpoint_timestamp_ms(), 151);
+        assert_eq!(second.next_checkpoint_call_id(), "call_2");
 
         let empty = store
             .query_audits_after_checkpoint(&second.next_checkpoint, Some(10))
             .unwrap();
         assert!(empty.is_empty());
         assert_eq!(empty.next_checkpoint, second.next_checkpoint);
+        assert_eq!(empty.next_checkpoint_timestamp_ms(), 151);
+        assert_eq!(empty.next_checkpoint_call_id(), "call_2");
     }
 
     #[test]
@@ -2781,6 +2797,8 @@ mod tests {
             page.next_checkpoint,
             ToolAuditReadCheckpoint::new(120, "call_b")
         );
+        assert_eq!(page.next_checkpoint_timestamp_ms(), 120);
+        assert_eq!(page.next_checkpoint_call_id(), "call_b");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add next-checkpoint timestamp and call-id scalar accessors on ToolAuditCheckpointPage
- cover incremental, empty, and call-id tiebreaker pages
- document the host replay log accessors

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD