### PR TITLE
feat(javascript-lexer/parser): add EsVersion-typed APIs alongside &str-based ones

### DIFF
--- a/code/packages/rust/javascript-lexer/CHANGELOG.md
+++ b/code/packages/rust/javascript-lexer/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-javascript-lexer` crate will be documented in this file.
 
+## [0.4.0] - 2026-05-21
+
+### Added
+- New dependency on `coding-adventures-javascript-tokens` for the shared `EsVersion` enum.
+- `create_javascript_lexer_typed(source, EsVersion) -> GrammarLexer` — infallible typed constructor; no unknown-version error path.
+- `tokenize_javascript_typed(source, EsVersion) -> Result<Vec<Token>, String>` — typed tokenizer; only error is tokenization itself.
+- `pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;` — typed default. New code should prefer this over the string `DEFAULT_VERSION`.
+- New tests covering the typed APIs: `tokenize_typed_es2015`, `default_es_version_constant_is_es2025`, `all_typed_versions_load`, `create_lexer_typed_returns_grammar_lexer`.
+
+### Notes
+- The existing `&str`-based APIs (`create_javascript_lexer`, `tokenize_javascript`, `DEFAULT_VERSION`) are kept for backwards compatibility. The typed APIs are the preferred surface going forward.
+- This PR is part of CLOC02 Phase 1 — see CLOC01/CLOC02 in `code/specs/` for the broader rollout.
+
 ## [0.3.0] - 2026-05-20
 
 ### Removed

--- a/code/packages/rust/javascript-lexer/Cargo.toml
+++ b/code/packages/rust/javascript-lexer/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "coding-adventures-javascript-lexer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "JavaScript lexer — tokenizes JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven lexer."
 
 [dependencies]
 grammar-tools = { path = "../grammar-tools" }
 lexer = { path = "../lexer" }
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }

--- a/code/packages/rust/javascript-lexer/src/lib.rs
+++ b/code/packages/rust/javascript-lexer/src/lib.rs
@@ -1,5 +1,6 @@
 //! JavaScript lexer backed by compiled ECMAScript token grammars (es1 through es2025).
 
+use coding_adventures_javascript_tokens::EsVersion;
 use lexer::grammar_lexer::GrammarLexer;
 use lexer::token::Token;
 
@@ -7,6 +8,9 @@ mod _grammar;
 
 pub const SUPPORTED_VERSIONS: &[&str] = _grammar::SUPPORTED_VERSIONS;
 pub const DEFAULT_VERSION: &str = "es2025";
+
+/// Typed default version. New code should prefer this over [`DEFAULT_VERSION`].
+pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;
 
 fn validate_version(version: &str) -> Result<&str, String> {
     if SUPPORTED_VERSIONS.contains(&version) {
@@ -36,6 +40,32 @@ pub fn create_javascript_lexer<'src>(
 pub fn tokenize_javascript(source: &str, version: &str) -> Result<Vec<Token>, String> {
     let version = validate_version(version)?;
     let grammar = _grammar::token_grammar(version)
+        .expect("compiled JavaScript token grammar missing supported version");
+    let mut lexer = GrammarLexer::new(source, &grammar);
+    lexer
+        .tokenize()
+        .map_err(|e| format!("JavaScript tokenization failed: {e}"))
+}
+
+/// Typed version of [`create_javascript_lexer`]. Takes an [`EsVersion`]
+/// directly; cannot fail with an unknown-version error.
+pub fn create_javascript_lexer_typed<'src>(
+    source: &'src str,
+    version: EsVersion,
+) -> GrammarLexer<'src> {
+    let grammar = _grammar::token_grammar(version.as_str())
+        .expect("compiled JavaScript token grammar missing supported version");
+    GrammarLexer::new(source, &grammar)
+}
+
+/// Typed version of [`tokenize_javascript`]. Takes an [`EsVersion`] directly;
+/// cannot fail with an unknown-version error. The only error path is
+/// tokenization itself.
+pub fn tokenize_javascript_typed(
+    source: &str,
+    version: EsVersion,
+) -> Result<Vec<Token>, String> {
+    let grammar = _grammar::token_grammar(version.as_str())
         .expect("compiled JavaScript token grammar missing supported version");
     let mut lexer = GrammarLexer::new(source, &grammar);
     lexer
@@ -75,5 +105,33 @@ mod tests {
             let tokens = tokenize_javascript("42;", version).unwrap();
             assert_eq!(tokens[0].type_, TokenType::Number, "version {version:?}");
         }
+    }
+
+    #[test]
+    fn tokenize_typed_es2015() {
+        let tokens = tokenize_javascript_typed("let x = 1;", EsVersion::Es2015).unwrap();
+        assert_eq!(tokens[0].type_, TokenType::Keyword);
+        assert_eq!(tokens[0].value, "let");
+    }
+
+    #[test]
+    fn default_es_version_constant_is_es2025() {
+        assert_eq!(DEFAULT_ES_VERSION, EsVersion::Es2025);
+        // And it must agree with the string DEFAULT_VERSION.
+        assert_eq!(DEFAULT_ES_VERSION.as_str(), DEFAULT_VERSION);
+    }
+
+    #[test]
+    fn all_typed_versions_load() {
+        for &version in EsVersion::ALL {
+            let tokens = tokenize_javascript_typed("42;", version).unwrap();
+            assert_eq!(tokens[0].type_, TokenType::Number, "version {version}");
+        }
+    }
+
+    #[test]
+    fn create_lexer_typed_returns_grammar_lexer() {
+        // Constructor returns infallibly (no unknown-version path).
+        let _lexer = create_javascript_lexer_typed("var x = 1;", EsVersion::Es5);
     }
 }

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.4.0] - 2026-05-21
+
+### Added
+- New dependency on `coding-adventures-javascript-tokens` for the shared `EsVersion` enum.
+- `create_javascript_parser_typed(source, EsVersion) -> Result<GrammarParser, String>` — typed constructor; no unknown-version error path.
+- `parse_javascript_typed(source, EsVersion) -> Result<GrammarASTNode, String>` — typed parser.
+- `pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;` — typed default.
+- New tests covering the typed APIs: `parse_typed_es2015`, `default_es_version_constant_is_es2025`, `all_typed_versions_load`, `create_parser_typed`.
+
+### Notes
+- The existing `&str`-based APIs are kept for backwards compatibility. Typed APIs are the preferred surface going forward.
+- The typed parser delegates to `javascript-lexer`'s `tokenize_javascript_typed`, so token/grammar versions are guaranteed to come from the same ECMAScript edition.
+
 ## [0.3.0] - 2026-05-20
 
 ### Removed

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser."
 
@@ -9,3 +9,4 @@ grammar-tools = { path = "../grammar-tools" }
 lexer = { path = "../lexer" }
 parser = { path = "../parser" }
 coding-adventures-javascript-lexer = { path = "../javascript-lexer" }
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }

--- a/code/packages/rust/javascript-parser/src/lib.rs
+++ b/code/packages/rust/javascript-parser/src/lib.rs
@@ -1,7 +1,11 @@
 //! JavaScript parser backed by compiled ECMAScript parser grammars (es1 through es2025).
 
-use coding_adventures_javascript_lexer::tokenize_javascript;
+use coding_adventures_javascript_lexer::{tokenize_javascript, tokenize_javascript_typed};
+use coding_adventures_javascript_tokens::EsVersion;
 use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+/// Typed default version. New code should prefer this over the string form.
+pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;
 
 mod _grammar;
 
@@ -35,6 +39,29 @@ pub fn parse_javascript(source: &str, version: &str) -> Result<GrammarASTNode, S
         .map_err(|e| format!("JavaScript parse failed: {e}"))
 }
 
+/// Typed version of [`create_javascript_parser`]. Takes an [`EsVersion`]
+/// directly; cannot fail with an unknown-version error.
+pub fn create_javascript_parser_typed(
+    source: &str,
+    version: EsVersion,
+) -> Result<GrammarParser, String> {
+    let tokens = tokenize_javascript_typed(source, version)?;
+    let grammar = _grammar::parser_grammar(version.as_str())
+        .expect("compiled JavaScript parser grammar missing supported version");
+    Ok(GrammarParser::new(tokens, grammar))
+}
+
+/// Typed version of [`parse_javascript`]. Takes an [`EsVersion`] directly.
+pub fn parse_javascript_typed(
+    source: &str,
+    version: EsVersion,
+) -> Result<GrammarASTNode, String> {
+    let mut parser = create_javascript_parser_typed(source, version)?;
+    parser
+        .parse()
+        .map_err(|e| format!("JavaScript parse failed: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -57,5 +84,29 @@ mod tests {
             let ast = parse_javascript("", version).unwrap();
             assert_eq!(ast.rule_name, "program", "version {version:?}");
         }
+    }
+
+    #[test]
+    fn parse_typed_es2015() {
+        let ast = parse_javascript_typed("let x = 1;", EsVersion::Es2015).unwrap();
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn default_es_version_constant_is_es2025() {
+        assert_eq!(DEFAULT_ES_VERSION, EsVersion::Es2025);
+    }
+
+    #[test]
+    fn all_typed_versions_load() {
+        for &version in EsVersion::ALL {
+            let ast = parse_javascript_typed("", version).unwrap();
+            assert_eq!(ast.rule_name, "program", "version {version}");
+        }
+    }
+
+    #[test]
+    fn create_parser_typed() {
+        let _parser = create_javascript_parser_typed("var x = 1;", EsVersion::Es5).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Adds typed `EsVersion`-based APIs to `javascript-lexer` and
`javascript-parser` alongside the existing `&str`-based ones, per CLOC02
Phase 1. Typed surface is the preferred way for new code; the string
APIs are kept untouched for backwards compatibility.

### `javascript-lexer` (`0.3.0` → `0.4.0`)

- New dep on `coding-adventures-javascript-tokens` for `EsVersion`.
- `create_javascript_lexer_typed(source, EsVersion) -> GrammarLexer` —
  **infallible** (the enum can only hold valid editions, so the
  unknown-version error path is gone).
- `tokenize_javascript_typed(source, EsVersion) -> Result<Vec<Token>, String>`
  — only error path is tokenization itself.
- `pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;` — typed
  default; the test pins `DEFAULT_ES_VERSION.as_str() == DEFAULT_VERSION`.
- 4 new tests including iteration over `EsVersion::ALL`.

### `javascript-parser` (`0.3.0` → `0.4.0`)

- New dep on `coding-adventures-javascript-tokens`.
- `create_javascript_parser_typed(source, EsVersion)` and
  `parse_javascript_typed(source, EsVersion)`.
- The typed parser delegates to `tokenize_javascript_typed`, so tokens
  and grammar are guaranteed to come from the same edition.
- `pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;`.
- 4 new tests.

### Backwards compatibility

All existing `&str`-based APIs (`create_javascript_lexer`,
`tokenize_javascript`, `create_javascript_parser`, `parse_javascript`,
`DEFAULT_VERSION`, `SUPPORTED_VERSIONS`) are kept untouched. Dependent
crates migrate at their own pace. Once consumers are off the string
surface, it can be deprecated in a follow-up.

## Test plan

- [x] `cargo test -p coding-adventures-javascript-lexer
      -p coding-adventures-javascript-parser` — all 15 tests pass
      (8 lexer + 7 parser)
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      error unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

## What's next

1. **Extend `javascript-tokens`** with `TokenKind` enum and `Span` type
   per CLOC02.
2. **CV plumbing** through lexer (every token gets a `CvId`).
3. **CV plumbing** through parser; switch output to `javascript-ast`.
4. Stage 2+ — `type-sidecar` crate, JSDoc grammar/crates, …

🤖 Generated with [Claude Code](https://claude.com/claude-code)