### PR TITLE
[codex] Add Arduino CLI runtime port handoff

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -63,6 +63,12 @@ language frontends do not parse CLI diagnostics themselves.
 `arduino_cli_upload_result_for_process_output` performs the same classification
 directly from the process-launch contract after the frontend captures
 stdout/stderr.
+`arduino_cli_upload_runtime_handoff_for_execution_plan` and
+`arduino_cli_upload_runtime_handoff_for_process_output` derive the Board VM
+transport port to open after a successful upload. Native USB boards prefer the
+`New upload port:` value reported by Arduino CLI and otherwise carry the
+rediscovery requirement with the selected upload port; USB serial bridge and
+external-adapter targets reuse the selected port.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -698,6 +698,17 @@ pub struct LanguageArduinoCliUploadResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageArduinoCliUploadRuntimeHandoff {
+    pub board_id: String,
+    pub upload_port: String,
+    pub runtime_port: String,
+    pub runtime_port_source: String,
+    pub wait_for_runtime_rediscovery: bool,
+    pub port_hint: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageUploadOptions {
     pub board_id: String,
     pub adapter: String,
@@ -1386,6 +1397,55 @@ pub fn arduino_cli_upload_result_for_process_output(
         process.wait_for_runtime_rediscovery,
         &process.success_exit_codes,
         exit_code,
+        stdout,
+        stderr,
+    )
+}
+
+pub fn arduino_cli_new_upload_port(output: &str) -> Option<String> {
+    output.lines().rev().find_map(|line| {
+        let (_, port) = line.split_once("New upload port:")?;
+        let port = port
+            .trim()
+            .split_once(" (")
+            .map_or_else(|| port.trim(), |(port, _)| port.trim());
+
+        (!port.is_empty()).then(|| port.to_owned())
+    })
+}
+
+pub fn arduino_cli_upload_runtime_handoff_for_execution_plan(
+    plan: &LanguageArduinoCliUploadExecutionPlan,
+    exit_code: i32,
+    stdout: &str,
+    stderr: &str,
+) -> Option<LanguageArduinoCliUploadRuntimeHandoff> {
+    let result = arduino_cli_upload_result_for_execution_plan(plan, exit_code, stdout, stderr);
+    arduino_cli_upload_runtime_handoff(
+        plan.board_id.clone(),
+        &plan.port,
+        plan.port_hint.clone(),
+        result.success,
+        result.wait_for_runtime_rediscovery,
+        stdout,
+        stderr,
+    )
+}
+
+pub fn arduino_cli_upload_runtime_handoff_for_process_output(
+    process: &LanguageArduinoCliUploadProcess,
+    selected_upload_port: &str,
+    exit_code: i32,
+    stdout: &str,
+    stderr: &str,
+) -> Option<LanguageArduinoCliUploadRuntimeHandoff> {
+    let result = arduino_cli_upload_result_for_process_output(process, exit_code, stdout, stderr);
+    arduino_cli_upload_runtime_handoff(
+        process.board_id.clone(),
+        selected_upload_port,
+        process.port_hint.clone(),
+        result.success,
+        result.wait_for_runtime_rediscovery,
         stdout,
         stderr,
     )
@@ -2150,6 +2210,74 @@ fn arduino_cli_upload_result_with_success_exit_codes(
         port_hint,
         message: arduino_cli_upload_result_message(failure_kind).to_owned(),
         diagnostic: arduino_cli_upload_diagnostic(stdout, stderr),
+    }
+}
+
+fn arduino_cli_upload_runtime_handoff(
+    board_id: String,
+    selected_upload_port: &str,
+    port_hint: String,
+    success: bool,
+    wait_for_runtime_rediscovery: bool,
+    stdout: &str,
+    stderr: &str,
+) -> Option<LanguageArduinoCliUploadRuntimeHandoff> {
+    if !success {
+        return None;
+    }
+
+    let selected_upload_port = selected_upload_port.trim();
+    let new_upload_port = wait_for_runtime_rediscovery
+        .then(|| {
+            arduino_cli_new_upload_port(stdout).or_else(|| arduino_cli_new_upload_port(stderr))
+        })
+        .flatten();
+    let (runtime_port, runtime_port_source) = match new_upload_port {
+        Some(port) => (port, "arduino_cli_new_upload_port"),
+        None => {
+            if selected_upload_port.is_empty() {
+                return None;
+            }
+
+            (selected_upload_port.to_owned(), "selected_upload_port")
+        }
+    };
+
+    Some(LanguageArduinoCliUploadRuntimeHandoff {
+        board_id,
+        upload_port: selected_upload_port.to_owned(),
+        runtime_port,
+        runtime_port_source: runtime_port_source.to_owned(),
+        wait_for_runtime_rediscovery,
+        port_hint: port_hint.clone(),
+        message: arduino_cli_upload_runtime_handoff_message(
+            &port_hint,
+            runtime_port_source,
+            wait_for_runtime_rediscovery,
+        )
+        .to_owned(),
+    })
+}
+
+fn arduino_cli_upload_runtime_handoff_message(
+    port_hint: &str,
+    runtime_port_source: &str,
+    wait_for_runtime_rediscovery: bool,
+) -> &'static str {
+    match (wait_for_runtime_rediscovery, runtime_port_source, port_hint) {
+        (true, "arduino_cli_new_upload_port", _) => {
+            "Arduino CLI reported the runtime port after native USB upload; open Board VM transport on that port."
+        }
+        (true, _, _) => {
+            "Arduino CLI did not report a new runtime port; wait for native USB runtime rediscovery before opening Board VM transport."
+        }
+        (false, _, "usb_serial_bridge") => {
+            "Upload used an onboard USB serial bridge; reuse the selected port for Board VM transport."
+        }
+        (false, _, "external_serial_adapter") => {
+            "Upload used an external serial adapter; reuse the selected adapter port for Board VM transport."
+        }
+        _ => "Reuse the selected upload port for Board VM transport after successful upload.",
     }
 }
 
@@ -6453,6 +6581,100 @@ mod tests {
         assert!(result.retryable);
 
         assert!(arduino_cli_upload_result_for_target("esp32", 1, "", "Error").is_none());
+    }
+
+    #[test]
+    fn arduino_cli_upload_runtime_handoff_is_owned_by_rust_language_core() {
+        assert_eq!(
+            arduino_cli_new_upload_port(
+                "Sketch uses 30720 bytes.\nNew upload port: /dev/cu.usbmodem1101 (serial)\n"
+            ),
+            Some("/dev/cu.usbmodem1101".to_owned())
+        );
+        assert_eq!(
+            arduino_cli_new_upload_port(
+                "New upload port: /dev/cu.usbmodem9070692469E42 (serial)\n\
+                 New upload port: /dev/cu.usbmodem1101 (serial)\n"
+            ),
+            Some("/dev/cu.usbmodem1101".to_owned())
+        );
+        assert_eq!(
+            arduino_cli_new_upload_port("No new serial port found."),
+            None
+        );
+
+        let native_plan = arduino_cli_upload_execution_plan_for_target(
+            "arduino-nano-r4",
+            "/dev/cu.usbmodem9070692469E42",
+            "/tmp/board-vm-nano-r4.bin",
+        )
+        .unwrap();
+        let handoff = arduino_cli_upload_runtime_handoff_for_execution_plan(
+            &native_plan,
+            0,
+            "Resetting board...\nNew upload port: /dev/cu.usbmodem1101 (serial)\n",
+            "",
+        )
+        .unwrap();
+        assert_eq!(handoff.board_id, "arduino-nano-r4");
+        assert_eq!(handoff.upload_port, "/dev/cu.usbmodem9070692469E42");
+        assert_eq!(handoff.runtime_port, "/dev/cu.usbmodem1101");
+        assert_eq!(handoff.runtime_port_source, "arduino_cli_new_upload_port");
+        assert!(handoff.wait_for_runtime_rediscovery);
+        assert_eq!(handoff.port_hint, "native_usb");
+        assert!(handoff.message.contains("reported the runtime port"));
+
+        let stderr_handoff = arduino_cli_upload_runtime_handoff_for_execution_plan(
+            &native_plan,
+            0,
+            "Done uploading.\n",
+            "New upload port: /dev/cu.usbmodem2201 (serial)\n",
+        )
+        .unwrap();
+        assert_eq!(stderr_handoff.runtime_port, "/dev/cu.usbmodem2201");
+
+        let fallback = arduino_cli_upload_runtime_handoff_for_execution_plan(
+            &native_plan,
+            0,
+            "Done uploading.\n",
+            "",
+        )
+        .unwrap();
+        assert_eq!(fallback.runtime_port, "/dev/cu.usbmodem9070692469E42");
+        assert_eq!(fallback.runtime_port_source, "selected_upload_port");
+        assert!(fallback.wait_for_runtime_rediscovery);
+        assert!(fallback
+            .message
+            .contains("did not report a new runtime port"));
+
+        let bridge_process = arduino_cli_upload_process_for_target(
+            "arduino:avr:mega:cpu=atmega2560",
+            "COM7",
+            "C:/tmp/mega.hex",
+        )
+        .unwrap();
+        let bridge_handoff = arduino_cli_upload_runtime_handoff_for_process_output(
+            &bridge_process,
+            "COM7",
+            0,
+            "Done uploading.\nNew upload port: COM8 (serial)\n",
+            "",
+        )
+        .unwrap();
+        assert_eq!(bridge_handoff.board_id, "arduino-mega-2560");
+        assert_eq!(bridge_handoff.runtime_port, "COM7");
+        assert_eq!(bridge_handoff.runtime_port_source, "selected_upload_port");
+        assert!(!bridge_handoff.wait_for_runtime_rediscovery);
+        assert_eq!(bridge_handoff.port_hint, "usb_serial_bridge");
+        assert!(bridge_handoff.message.contains("USB serial bridge"));
+
+        assert!(arduino_cli_upload_runtime_handoff_for_execution_plan(
+            &native_plan,
+            1,
+            "",
+            "Error: programmer is not responding",
+        )
+        .is_none());
     }
 
     #[test]

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -214,6 +214,11 @@ codes, and rediscovery hints stay uniform across language adapters. SDKs should
 feed the resulting Arduino CLI exit code, stdout, and stderr back into Rust
 language core so upload status, retryability, port-selection, board-package
 install, firmware-artifact, and rediscovery hints stay shared too.
+After a successful Arduino CLI upload, SDKs should also ask Rust for the
+runtime handoff port. Native USB targets should use Arduino CLI's reported
+`New upload port:` value when present and otherwise keep the Rust-owned
+rediscovery hint with the selected upload port; USB serial bridge and external
+adapter targets should reuse the selected port.
 
 Selector handling follows the same ownership boundary. If a frontend receives
 an Arduino CLI FQBN such as `arduino:renesas_uno:nanor4`, it should ask the Rust


### PR DESCRIPTION
## Summary
- add a Rust-owned Arduino CLI runtime handoff struct and helpers for execution-plan and process-output callers
- parse Arduino CLI `New upload port:` output so native USB uploads can hand frontends the runtime transport port
- document the SDK boundary for asking Rust for the post-upload transport handoff

## Validation
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-targets -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command bash BUILD in code/packages/rust/board-vm-targets
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command bash BUILD in code/packages/rust/board-vm-arduino
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core
- /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Generated build-plan.json and code/packages/rust/Cargo.lock were removed before committing.