### PR TITLE
Add read checkpoint scalar accessors

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file.
 - JSON encoding/decoding for payload-free `ToolAuditRecord` rows.
 - Query and inventory helpers over persisted audit records.
 - Deterministic checkpoint pages for incremental audit replay.
+- Timestamp and call-id scalar accessors for replay checkpoints.
 - Durable named checkpoint state for supervisors that resume audit replay.
 - Next-checkpoint timestamp and call-id scalar accessors for checkpoint pages.
 - Timestamp and call-id scalar accessors for stored checkpoint state.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -15,6 +15,8 @@ The crate keeps the boundary narrow:
   payload-free read-model rebuilds
 - hosts can flush batches of audit rows and get a payload-free write summary
   with call-id-level storage failures
+- replay checkpoints expose timestamp and call-id scalar accessors for host
+  checkpoint logs
 - supervisors can read deterministic checkpoint pages to resume audit replay
   after restarts without reprocessing the whole store
 - checkpoint pages expose next-checkpoint timestamp and call-id scalar

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -533,6 +533,16 @@ impl ToolAuditReadCheckpoint {
         }
     }
 
+    /// Return this checkpoint's timestamp for host checkpoint logs.
+    pub fn checkpoint_timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+
+    /// Return this checkpoint's call id for host checkpoint logs.
+    pub fn checkpoint_call_id(&self) -> &str {
+        &self.call_id
+    }
+
     /// Return whether this checkpoint is after another checkpoint.
     pub fn is_after(&self, other: &Self) -> bool {
         (self.timestamp_ms, self.call_id.as_str()) > (other.timestamp_ms, other.call_id.as_str())
@@ -563,12 +573,12 @@ impl ToolAuditCheckpointPage {
 
     /// Return the checkpoint timestamp to use for the next read.
     pub fn next_checkpoint_timestamp_ms(&self) -> u64 {
-        self.next_checkpoint.timestamp_ms
+        self.next_checkpoint.checkpoint_timestamp_ms()
     }
 
     /// Return the checkpoint call id to use for the next read.
     pub fn next_checkpoint_call_id(&self) -> &str {
-        &self.next_checkpoint.call_id
+        self.next_checkpoint.checkpoint_call_id()
     }
 }
 
@@ -2727,6 +2737,17 @@ mod tests {
             .expect_err("call ids are append-only audit keys");
 
         assert!(matches!(error, StorageError::Conflict { .. }));
+    }
+
+    #[test]
+    fn read_checkpoints_expose_scalar_accessors() {
+        let beginning = ToolAuditReadCheckpoint::beginning();
+        assert_eq!(beginning.checkpoint_timestamp_ms(), 0);
+        assert_eq!(beginning.checkpoint_call_id(), "");
+
+        let checkpoint = ToolAuditReadCheckpoint::new(151, "call_2");
+        assert_eq!(checkpoint.checkpoint_timestamp_ms(), 151);
+        assert_eq!(checkpoint.checkpoint_call_id(), "call_2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add timestamp and call-id scalar accessors on ToolAuditReadCheckpoint
- route checkpoint page scalar helpers through the read checkpoint accessors
- document the host checkpoint log accessors

## Validation
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD