### PR TITLE
feat(javascript-tokens): add Span type (CLOC02 Phase 1)

### DIFF
--- a/code/packages/rust/javascript-tokens/CHANGELOG.md
+++ b/code/packages/rust/javascript-tokens/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-javascript-tokens` crate will be documented in this file.
 
+## [0.2.0] - 2026-05-21
+
+### Added
+- `Span { start: u32, end: u32 }` byte-offset range type per CLOC02. Half-open `[start, end)` semantics. `u32` chosen for cache-friendly node sizes; supports any practical source file size.
+- `Span::new(start, end) -> Self` — `const fn` constructor (callers maintain `start <= end` invariant).
+- `Span::len(self) -> u32` and `Span::is_empty(self) -> bool` — both `const fn`.
+- Derives: `Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord` — Ord is lexicographic on `(start, end)`.
+- Module-level docs updated to introduce `Span`.
+- 6 new tests: construction, len, is_empty edge cases (zero-length, non-zero), `Copy` + `PartialEq`, `const fn` usage in const context, lexicographic `Ord`.
+
+### Notes
+- Still zero runtime dependencies — `Span` is just two `u32`s.
+- Per CLOC02, AST nodes do NOT hold spans directly; spans live in correlation-vector `Origin` records, keyed by `CvId`. This type is what `Origin` producers (the lexer) embed.
+- A full `TokenKind` enum is still pending — it's much larger and gets its own PR.
+
 ## [0.1.0] - 2026-05-21
 
 ### Added

--- a/code/packages/rust/javascript-tokens/Cargo.toml
+++ b/code/packages/rust/javascript-tokens/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coding-adventures-javascript-tokens"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Shared JavaScript token kinds and ES version enum — backend-agnostic types reused by javascript-lexer, javascript-parser, javascript-ast, and any future JS consumer (Closure Compiler, V8 clone)."
+description = "Shared JavaScript token kinds, byte span, and ES version enum — backend-agnostic types reused by javascript-lexer, javascript-parser, javascript-ast, and any future JS consumer (Closure Compiler, V8 clone)."
 
 [dependencies]

--- a/code/packages/rust/javascript-tokens/README.md
+++ b/code/packages/rust/javascript-tokens/README.md
@@ -1,7 +1,7 @@
 # coding-adventures-javascript-tokens
 
 Backend-agnostic shared types for the JavaScript pipeline: ES version enum,
-and (in follow-up PRs) the cross-crate `TokenKind` enum and `Span` type.
+byte-range span, and (in a follow-up PR) the cross-crate `TokenKind` enum.
 
 This crate sits at the **bottom** of the JS-pipeline dependency graph. It has
 no dependencies (not even `serde`) so anything downstream — `javascript-lexer`,
@@ -14,15 +14,17 @@ future V8-in-Rust clone — can pull it in without creating cycles.
   `code/grammars/ecmascript/`: `Es1`, `Es3`, `Es5`, `Es2015` through `Es2025`.
   Includes `latest()`, `as_str()` that matches the grammar file basenames,
   `FromStr`, and `Display`.
+- `Span { start: u32, end: u32 }` — half-open `[start, end)` byte range.
+  `const fn` constructors and accessors. Used by the lexer to record where
+  tokens came from in the source, and by `correlation-vector` `Origin`
+  records to anchor everything back to bytes.
 
 ## What's coming
 
 Per [CLOC02](../../../specs/CLOC02-javascript-ast.md):
 
 - `TokenKind` — the union enum across every ES version's `.tokens` file.
-- `Span` — `{ start: u32, end: u32 }`, decoupled from the CV log.
-
-These ship in their own PRs to keep the diffs small.
+  Ships in its own PR (it's large enough on its own).
 
 ## Why this is a separate crate
 

--- a/code/packages/rust/javascript-tokens/src/lib.rs
+++ b/code/packages/rust/javascript-tokens/src/lib.rs
@@ -17,12 +17,16 @@
 //! Both backends consume the same parser AST, which in turn references the
 //! types here.
 //!
-//! # What's in v1
+//! # What's here
 //!
-//! Just [`EsVersion`] — the enum naming every ECMAScript edition that has a
-//! grammar file under `code/grammars/ecmascript/`. The lexer and parser
-//! today take version strings like `"es2025"`; this enum is the typed
-//! replacement that downstream crates will migrate to.
+//! - [`EsVersion`] — the enum naming every ECMAScript edition that has a
+//!   grammar file under `code/grammars/ecmascript/`. The lexer and parser
+//!   today still take version strings, but typed APIs that consume
+//!   `EsVersion` directly are also available (see `javascript-lexer` and
+//!   `javascript-parser` v0.4.0+).
+//! - [`Span`] — a `{ start, end }` byte-offset range. Used by the lexer to
+//!   record where each token came from in the source, and by the AST and
+//!   correlation-vector layers to anchor everything back to bytes.
 //!
 //! A full `TokenKind` enum (covering every token kind from `NAME` through
 //! `OPTIONAL_CHAIN` and the template-literal groups) is a follow-up PR; it
@@ -176,6 +180,52 @@ impl fmt::Display for UnknownEsVersion {
 
 impl std::error::Error for UnknownEsVersion {}
 
+/// A byte range within a single source file.
+///
+/// `start` and `end` are **byte offsets**, not character or column counts.
+/// They follow the half-open `[start, end)` convention — `end` is exclusive,
+/// so an empty span at position `n` is `Span { start: n, end: n }`.
+///
+/// `u32` is wide enough to address any practical JavaScript source file
+/// (4 GiB cap) and half the size of `usize` on 64-bit targets — important
+/// because every token and every AST node will carry one or more spans.
+///
+/// Per [CLOC02](../../specs/CLOC02-javascript-ast.md), AST nodes themselves
+/// do *not* hold spans directly — spans live in correlation-vector
+/// [`Origin`] records, keyed by `CvId`. The AST holds only the `CvId`. This
+/// type is what producers of those `Origin` records embed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Span {
+    /// Byte offset of the first byte in this range (inclusive).
+    pub start: u32,
+    /// Byte offset one past the last byte in this range (exclusive).
+    pub end: u32,
+}
+
+impl Span {
+    /// Construct a span from a half-open `[start, end)` byte range.
+    ///
+    /// Callers are expected to maintain `start <= end`. This invariant is
+    /// not enforced at construction time — making it a runtime check would
+    /// force every call site into `Result` territory for what is, in
+    /// practice, a static guarantee from the lexer. Debug builds may add
+    /// an assertion in a future revision.
+    pub const fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+
+    /// The number of bytes in this span. Always returns `end - start` as
+    /// a `u32`; callers responsible for the `start <= end` invariant.
+    pub const fn len(self) -> u32 {
+        self.end - self.start
+    }
+
+    /// Whether this span covers zero bytes.
+    pub const fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +294,62 @@ mod tests {
         assert!(EsVersion::Es1 < EsVersion::Es3);
         assert!(EsVersion::Es5 < EsVersion::Es2015);
         assert!(EsVersion::Es2015 < EsVersion::Es2025);
+    }
+
+    // ----- Span tests -----
+
+    #[test]
+    fn span_constructs_from_byte_range() {
+        let s = Span::new(10, 20);
+        assert_eq!(s.start, 10);
+        assert_eq!(s.end, 20);
+    }
+
+    #[test]
+    fn span_len_is_end_minus_start() {
+        assert_eq!(Span::new(10, 20).len(), 10);
+        assert_eq!(Span::new(0, 1).len(), 1);
+        assert_eq!(Span::new(42, 42).len(), 0);
+    }
+
+    #[test]
+    fn span_is_empty_when_start_equals_end() {
+        assert!(Span::new(0, 0).is_empty());
+        assert!(Span::new(99, 99).is_empty());
+        assert!(!Span::new(0, 1).is_empty());
+        assert!(!Span::new(10, 20).is_empty());
+    }
+
+    #[test]
+    fn span_is_copy_and_eq() {
+        // Compile-time assertion that Span is Copy.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<Span>();
+
+        // PartialEq + Eq work over both fields.
+        let a = Span::new(3, 7);
+        let b = Span::new(3, 7);
+        let c = Span::new(3, 8);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn span_supports_const_construction() {
+        // `new`, `len`, `is_empty` are all `const fn`, so a Span can live
+        // in const context — useful for compile-time fixtures.
+        const S: Span = Span::new(2, 5);
+        const LEN: u32 = S.len();
+        const EMPTY: bool = S.is_empty();
+        assert_eq!(LEN, 3);
+        assert!(!EMPTY);
+    }
+
+    #[test]
+    fn span_ord_is_lexicographic() {
+        // PartialOrd/Ord compares start first, then end.
+        assert!(Span::new(0, 5) < Span::new(0, 6));
+        assert!(Span::new(0, 5) < Span::new(1, 2));
+        assert!(Span::new(5, 10) > Span::new(5, 5));
     }
 }


### PR DESCRIPTION
## Summary

Adds the `Span` byte-range type to `javascript-tokens` per CLOC02 — the next
type the JS pipeline needs after `EsVersion`. The lexer uses it to record
where each token came from in the source; `correlation-vector` `Origin`
records embed it to anchor everything back to bytes.

Crate version: `0.1.0` → `0.2.0`.

### What's here

- **`Span { start: u32, end: u32 }`** — half-open `[start, end)` byte range.
  `u32` chosen so two `Span`s stay cache-friendly when embedded in every
  token/origin record; addresses any practical JS source (4 GiB cap).
- **`Span::new(start, end) -> Self`** — `const fn` constructor.
- **`Span::len(self) -> u32`** and **`Span::is_empty(self) -> bool`** —
  both `const fn` so spans can live in const context.
- Derives: `Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord`
  (lexicographic on `(start, end)`).

### Why span doesn't live on AST nodes

Per CLOC02 invariants, AST nodes carry only a `CvId`. Spans live in the
correlation-vector `Origin` records keyed by `CvId`. This type is what
those `Origin` producers (the lexer) embed. The AST stays small.

## Test plan

- [x] `cargo test -p coding-adventures-javascript-tokens` — **15/15 pass**
      (9 existing + 6 new Span tests)
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl` error
      unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

Public-API coverage for `Span`:
- `span_constructs_from_byte_range`
- `span_len_is_end_minus_start` (zero-length + non-zero)
- `span_is_empty_when_start_equals_end` (both branches)
- `span_is_copy_and_eq` (compile-time `Copy` assertion + `PartialEq` matrix)
- `span_supports_const_construction` (validates `const fn` via const context)
- `span_ord_is_lexicographic` (start first, end second)

## What's next

1. **`TokenKind` enum** — the large remaining piece. Its own PR.
2. **CV plumbing through `javascript-lexer`** — every token gets a `CvId`,
   embedding `Span` in its `Origin`.
3. **CV plumbing through `javascript-parser`** — switch output to
   `javascript-ast::Program`.
4. Stage 2+ (type-sidecar crate, JSDoc grammar/crates, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)