### PR TITLE
feat(javascript-lexer): plumb CV through tokenization (CLOC03 Stage 1)

### DIFF
--- a/code/packages/rust/javascript-lexer/CHANGELOG.md
+++ b/code/packages/rust/javascript-lexer/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-javascript-lexer` crate will be documented in this file.
 
+## [0.5.0] - 2026-05-21
+
+### Added
+- New dependency on `coding_adventures_correlation_vector` for `CVLog` and `Origin` types.
+- `pub struct TokenWithCv { pub token: Token, pub cv: String }` — token paired with its CV identifier.
+- `tokenize_javascript_with_cv(source, source_file, EsVersion, &mut CVLog) -> Result<Vec<TokenWithCv>, String>` — tokenize and assign a CV ID per token per CLOC03 §"Stage 1 — Lexer".
+- Per-token `Origin` records: `source = source_file`, `location = "line:col"` from `Token.line` and `Token.column`. No `Contribution` appended (lexing is creation, not modification — per CLOC03).
+- Module docs added a CV plumbing section linking to CLOC03.
+- 4 new tests:
+  - `tokenize_with_cv_assigns_an_id_per_token` — every token gets a non-empty CV.
+  - `tokenize_with_cv_ids_are_unique` — uniqueness across the full token stream.
+  - `tokenize_with_cv_entries_resolvable_in_log` — `cv.get(id)` returns an entry whose `Origin.source` matches the requested `source_file` and whose `location` is `"line:col"`.
+  - `tokenize_with_cv_disabled_log_still_returns_tokens` — `CVLog::new(false)` keeps the API shape but skips storage (per CLOC03's production fast path).
+
+### Notes
+- The string-based and typed APIs from prior versions remain untouched; this PR is purely additive.
+- The `cv` field on `TokenWithCv` is `String` because `correlation-vector` represents IDs as `String` today.
+- This is the first concrete CLOC03 plumbing — the parser will consume `TokenWithCv` and inherit CV IDs onto AST nodes in a follow-up PR.
+
 ## [0.4.0] - 2026-05-21
 
 ### Added

--- a/code/packages/rust/javascript-lexer/Cargo.toml
+++ b/code/packages/rust/javascript-lexer/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "coding-adventures-javascript-lexer"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "JavaScript lexer — tokenizes JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven lexer."
+description = "JavaScript lexer — tokenizes JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven lexer. Includes correlation-vector plumbing per CLOC03."
 
 [dependencies]
 grammar-tools = { path = "../grammar-tools" }
 lexer = { path = "../lexer" }
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/javascript-lexer/src/lib.rs
+++ b/code/packages/rust/javascript-lexer/src/lib.rs
@@ -1,8 +1,21 @@
 //! JavaScript lexer backed by compiled ECMAScript token grammars (es1 through es2025).
+//!
+//! # Correlation-vector plumbing
+//!
+//! Per [CLOC03](../../../specs/CLOC03-correlation-vector-plumbing.md)
+//! §"Stage 1 — Lexer," when called via [`tokenize_javascript_with_cv`] the
+//! lexer assigns a fresh correlation-vector ID to every emitted token via
+//! `CVLog::create(Some(Origin{ ... }))`. The `Origin` records the source
+//! filename and a `line:column` location string built from the token's
+//! own positional info. No `Contribution` is appended at this stage —
+//! lexing is the act of *creation*, and there is nothing yet to contribute
+//! about.
 
+use coding_adventures_correlation_vector::{CVLog, Origin};
 use coding_adventures_javascript_tokens::EsVersion;
 use lexer::grammar_lexer::GrammarLexer;
 use lexer::token::Token;
+use std::collections::HashMap;
 
 mod _grammar;
 
@@ -73,6 +86,60 @@ pub fn tokenize_javascript_typed(
         .map_err(|e| format!("JavaScript tokenization failed: {e}"))
 }
 
+/// A token paired with the correlation-vector ID assigned to it by
+/// [`tokenize_javascript_with_cv`].
+///
+/// The CV ID is a string in the same format that
+/// [`CVLog`](coding_adventures_correlation_vector::CVLog) returns — e.g.
+/// `"a3f1.1"`. Downstream consumers (the parser, the AST) can look it up
+/// in the same `CVLog` they passed in.
+#[derive(Debug, Clone)]
+pub struct TokenWithCv {
+    /// The token as produced by [`tokenize_javascript_typed`]. Fields are
+    /// unchanged; nothing about the token itself depends on CV plumbing.
+    pub token: Token,
+    /// The CV ID assigned to this token. Use it to look up the
+    /// `CVEntry` (origin, contributions, parents) in the same `CVLog`.
+    pub cv: String,
+}
+
+/// Tokenize and assign a fresh correlation-vector ID to every emitted token.
+///
+/// Per CLOC03 §"Stage 1 — Lexer", every token gets exactly one
+/// `CVLog::create(Some(Origin{ ... }))` call with an `Origin` whose
+/// `source` is `source_file` and whose `location` is `"line:col"` built
+/// from the token's own `line` and `column` fields. No `Contribution` is
+/// appended; lexing is creation, not modification.
+///
+/// `source_file` should be the path or display name of the input file
+/// (e.g. `"src/api.js"`). For stdin input, conventions vary — the existing
+/// repo uses `"stdin"`. The string ends up in `Origin.source` and is what
+/// the source-map generator resolves back to.
+///
+/// The `cv` log is borrowed mutably for the duration of the call. The same
+/// log is then handed to the parser, typechecker, and every downstream
+/// pass — see CLOC03 for the full lifecycle.
+pub fn tokenize_javascript_with_cv(
+    source: &str,
+    source_file: &str,
+    version: EsVersion,
+    cv: &mut CVLog,
+) -> Result<Vec<TokenWithCv>, String> {
+    let tokens = tokenize_javascript_typed(source, version)?;
+    let mut out = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        let origin = Origin {
+            source: source_file.to_string(),
+            location: format!("{}:{}", token.line, token.column),
+            timestamp: None,
+            meta: HashMap::new(),
+        };
+        let id = cv.create(Some(origin));
+        out.push(TokenWithCv { token, cv: id });
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,5 +200,70 @@ mod tests {
     fn create_lexer_typed_returns_grammar_lexer() {
         // Constructor returns infallibly (no unknown-version path).
         let _lexer = create_javascript_lexer_typed("var x = 1;", EsVersion::Es5);
+    }
+
+    // ----- CV-plumbed tokenization (CLOC03 Stage 1) -----
+
+    #[test]
+    fn tokenize_with_cv_assigns_an_id_per_token() {
+        let mut cv = CVLog::new(true);
+        let tokens =
+            tokenize_javascript_with_cv("var x = 1;", "src/test.js", EsVersion::Es5, &mut cv)
+                .unwrap();
+        assert!(!tokens.is_empty(), "expected at least one token");
+        for t in &tokens {
+            assert!(!t.cv.is_empty(), "expected a non-empty CV id");
+        }
+    }
+
+    #[test]
+    fn tokenize_with_cv_ids_are_unique() {
+        let mut cv = CVLog::new(true);
+        let tokens =
+            tokenize_javascript_with_cv("var x = 1; var y = 2;", "u.js", EsVersion::Es5, &mut cv)
+                .unwrap();
+        let mut ids: Vec<&str> = tokens.iter().map(|t| t.cv.as_str()).collect();
+        let len = ids.len();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), len, "all CV ids should be unique");
+    }
+
+    #[test]
+    fn tokenize_with_cv_entries_resolvable_in_log() {
+        let mut cv = CVLog::new(true);
+        let tokens =
+            tokenize_javascript_with_cv("var x = 1;", "lookup.js", EsVersion::Es5, &mut cv)
+                .unwrap();
+        for t in &tokens {
+            let entry = cv
+                .get(&t.cv)
+                .unwrap_or_else(|| panic!("CV id {:?} not found in log", t.cv));
+            let origin = entry
+                .origin
+                .as_ref()
+                .expect("token CV must have an Origin");
+            assert_eq!(origin.source, "lookup.js");
+            // location is "line:col" — must contain a colon.
+            assert!(
+                origin.location.contains(':'),
+                "expected line:col location, got {:?}",
+                origin.location
+            );
+        }
+    }
+
+    #[test]
+    fn tokenize_with_cv_disabled_log_still_returns_tokens() {
+        // Per CLOC03, when the log is disabled, create() still returns IDs
+        // (so call sites stay shape-identical) but no entries get stored.
+        let mut cv = CVLog::new(false);
+        let tokens =
+            tokenize_javascript_with_cv("var x = 1;", "off.js", EsVersion::Es5, &mut cv).unwrap();
+        assert!(!tokens.is_empty());
+        // Log has no entries, but tokens do have (synthetic) IDs.
+        for t in &tokens {
+            assert!(!t.cv.is_empty());
+        }
     }
 }


### PR DESCRIPTION
## Summary

First concrete CLOC03 plumbing PR. Adds the ability to tokenize JavaScript
source **and** assign a correlation-vector ID to every emitted token, with
an `Origin` record that captures the source filename and `line:col`
location.

### `javascript-lexer` (`0.4.0` → `0.5.0`)

- New dependency on `coding_adventures_correlation_vector` for `CVLog`
  and `Origin`.
- **`pub struct TokenWithCv { pub token: Token, pub cv: String }`** —
  token paired with its CV identifier.
- **`tokenize_javascript_with_cv(source, source_file, EsVersion,
  &mut CVLog) -> Result<Vec<TokenWithCv>, String>`** — tokenize and assign
  a CV ID per token per CLOC03 §"Stage 1 — Lexer". Per-token `Origin`
  records: `source = source_file`, `location = "line:col"` from
  `Token.line` and `Token.column`. **No `Contribution` appended** —
  lexing is creation, not modification (per CLOC03).
- Module-level docs gain a "Correlation-vector plumbing" section.

### What stays unchanged

All existing APIs (string-based and typed) plus existing tests are
untouched. This PR is purely additive.

## Test plan

- [x] `cargo test -p coding-adventures-javascript-lexer` — **12/12 pass**
      (8 existing + 4 new CV tests)
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      error unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

New tests:
- `tokenize_with_cv_assigns_an_id_per_token`
- `tokenize_with_cv_ids_are_unique`
- `tokenize_with_cv_entries_resolvable_in_log` — `cv.get(id)` returns an
  entry whose `Origin.source` matches and `location` is `"line:col"`
- `tokenize_with_cv_disabled_log_still_returns_tokens` — `CVLog::new(false)`
  keeps API shape but skips storage (CLOC03 production fast path)

## What's next

1. **CV plumbing through `javascript-parser`** — consume `TokenWithCv`,
   inherit CV IDs onto AST nodes via `cv.merge(parents, Origin{...})`,
   append `"constructed"` contribution per CLOC03 §"Stage 2 — Parser".
2. Switch parser output to `javascript-ast::Program`.
3. Extend `javascript-tokens` with `TokenKind` enum (deferred).
4. Stage 2+ (type-sidecar crate, JSDoc grammar/crates, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)