### PR TITLE
Add drain outcome scheduler intent helpers

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this package will be documented in this file.
   continuation, follow-up, and plan-divergence states.
 - Stable, parseable supervisor drain outcome labels and action flags for host
   schedulers.
+- Scheduler-action labels and intent helpers on supervisor drain outcomes.
 - Flattened supervisor drain run summaries for host logs and scheduler loops.
 - Typed classifier accessors for supervisor drain run summaries.
 - Workload accessors for supervisor drain run reports.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -47,6 +47,8 @@ The crate keeps the boundary narrow:
   needing continuation, needing follow-up, or diverged from preflight
 - supervisor drain outcomes expose stable, parseable snake_case labels and
   action flags for host logs and scheduling decisions
+- supervisor drain outcomes expose scheduler-action labels and typed intent
+  helpers for host scheduling decisions
 - supervisor drain reports can emit flattened payload-free run summaries for
   host logs, schedulers, and continuation decisions
 - supervisor drain run summaries expose typed classifier accessors for host

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1746,6 +1746,11 @@ impl ToolAuditSupervisorDrainRunOutcome {
         self.scheduler_action().requires_scheduler_action()
     }
 
+    /// Return whether this outcome intentionally leaves the scheduler idle.
+    pub fn is_no_scheduler_action(self) -> bool {
+        self.scheduler_action().is_no_action()
+    }
+
     /// Return the recommended scheduler action for this outcome.
     pub fn scheduler_action(self) -> ToolAuditSupervisorDrainSchedulerAction {
         match self {
@@ -1756,6 +1761,26 @@ impl ToolAuditSupervisorDrainRunOutcome {
             Self::NeedsFollowUp => ToolAuditSupervisorDrainSchedulerAction::RouteFollowUp,
             Self::PlanDiverged => ToolAuditSupervisorDrainSchedulerAction::InvestigatePlanDrift,
         }
+    }
+
+    /// Return the stable scheduler-action label for this outcome.
+    pub fn scheduler_action_label(self) -> &'static str {
+        self.scheduler_action().as_str()
+    }
+
+    /// Return whether this outcome asks the host to schedule another drain pass.
+    pub fn requests_continuation(self) -> bool {
+        self.scheduler_action().requests_continuation()
+    }
+
+    /// Return whether this outcome routes follow-up pressure to the host.
+    pub fn routes_follow_up(self) -> bool {
+        self.scheduler_action().routes_follow_up()
+    }
+
+    /// Return whether this outcome asks the host to investigate plan drift.
+    pub fn requires_plan_drift_investigation(self) -> bool {
+        self.scheduler_action().requires_plan_drift_investigation()
     }
 }
 
@@ -3760,35 +3785,71 @@ mod tests {
                 ToolAuditSupervisorDrainRunOutcome::Idle,
                 "idle",
                 ToolAuditSupervisorDrainSchedulerAction::NoAction,
+                "no_action",
+                false,
+                true,
+                false,
+                false,
                 false,
             ),
             (
                 ToolAuditSupervisorDrainRunOutcome::CaughtUp,
                 "caught_up",
                 ToolAuditSupervisorDrainSchedulerAction::NoAction,
+                "no_action",
+                false,
+                true,
+                false,
+                false,
                 false,
             ),
             (
                 ToolAuditSupervisorDrainRunOutcome::NeedsContinuation,
                 "needs_continuation",
                 ToolAuditSupervisorDrainSchedulerAction::ScheduleContinuation,
+                "schedule_continuation",
                 true,
+                false,
+                true,
+                false,
+                false,
             ),
             (
                 ToolAuditSupervisorDrainRunOutcome::NeedsFollowUp,
                 "needs_follow_up",
                 ToolAuditSupervisorDrainSchedulerAction::RouteFollowUp,
+                "route_follow_up",
                 true,
+                false,
+                false,
+                true,
+                false,
             ),
             (
                 ToolAuditSupervisorDrainRunOutcome::PlanDiverged,
                 "plan_diverged",
                 ToolAuditSupervisorDrainSchedulerAction::InvestigatePlanDrift,
+                "investigate_plan_drift",
+                true,
+                false,
+                false,
+                false,
                 true,
             ),
         ];
 
-        for (outcome, label, scheduler_action, requires_action) in cases {
+        for (
+            outcome,
+            label,
+            scheduler_action,
+            scheduler_action_label,
+            requires_action,
+            is_no_action,
+            requests_continuation,
+            routes_follow_up,
+            requires_plan_drift_investigation,
+        ) in cases
+        {
             assert_eq!(outcome.as_str(), label);
             assert_eq!(outcome.to_string(), label);
             assert_eq!(
@@ -3796,7 +3857,15 @@ mod tests {
                 Some(outcome)
             );
             assert_eq!(outcome.scheduler_action(), scheduler_action);
+            assert_eq!(outcome.scheduler_action_label(), scheduler_action_label);
             assert_eq!(outcome.requires_scheduler_action(), requires_action);
+            assert_eq!(outcome.is_no_scheduler_action(), is_no_action);
+            assert_eq!(outcome.requests_continuation(), requests_continuation);
+            assert_eq!(outcome.routes_follow_up(), routes_follow_up);
+            assert_eq!(
+                outcome.requires_plan_drift_investigation(),
+                requires_plan_drift_investigation
+            );
         }
         assert_eq!(
             ToolAuditSupervisorDrainRunOutcome::from_label("needs_attention"),


### PR DESCRIPTION
## Summary
- Add scheduler-action label and intent helpers on `ToolAuditSupervisorDrainRunOutcome`.
- Extend stable outcome label coverage for host scheduler branching.
- Document the helper surface in the package README and changelog.

## Tests
- `cargo test -p chief-of-staff-tool-audit-store`
- `sh BUILD`
