### PR TITLE
fix(toml-parser): use precompiled grammar; drop fs:read capability

### DIFF
--- a/code/packages/typescript/toml-parser/CHANGELOG.md
+++ b/code/packages/typescript/toml-parser/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the TOML Parser package will be documented in this file.
 
+## [0.1.1] — 2026-05-21
+
+### Changed
+
+- **Use the precompiled grammar at runtime instead of `readFileSync`-ing
+  `toml.grammar`.**  `src/_grammar.ts` (auto-generated from
+  `code/grammars/toml.grammar` via `grammar-tools compile-grammar`) was
+  already present in the repo but unused — `parser.ts` was still loading
+  the grammar text from disk and re-parsing it on every `parseTOML` call.
+  We now import `PARSER_GRAMMAR` directly from `_grammar.ts`.
+
+  **Capability impact**: `required_capabilities.json` drops from
+  `[{ fs:read → ../../grammars/toml.grammar }]` to `[]`.  Every
+  downstream consumer that imports `@coding-adventures/toml-parser`
+  now keeps its own `[]` capabilities (previously, any TS package
+  that called `parseTOML` transitively required `fs:read`).
+
+  **Performance impact**: first-call latency improves (no fs round-trip,
+  no grammar text re-parsing).  Subsequent calls are unchanged.
+
+  **No API change**: `parseTOML(source)` returns the same `ASTNode`.
+  All 34 existing tests pass with no modifications.
+
+### Removed
+
+- `fileURLToPath`, `dirname`, `join`, `readFileSync` imports
+  (no longer needed).
+- The `GRAMMARS_DIR` / `TOML_GRAMMAR_PATH` constants.
+- The `parseParserGrammar` import (the grammar arrives pre-parsed).
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/typescript/toml-parser/README.md
+++ b/code/packages/typescript/toml-parser/README.md
@@ -4,7 +4,9 @@ Parses TOML text (v1.0.0) into abstract syntax trees using the grammar-driven pa
 
 ## What It Does
 
-This package is a **thin wrapper** around the generic `GrammarParser` from `@coding-adventures/parser`. It loads the `toml.grammar` file and delegates all parsing work to the generic engine.
+This package is a **thin wrapper** around the generic `GrammarParser` from `@coding-adventures/parser`. It imports the precompiled TOML grammar (auto-generated from `code/grammars/toml.grammar` via `grammar-tools compile-grammar` into `src/_grammar.ts`) and delegates all parsing work to the generic engine.
+
+The grammar lives in source as a TypeScript object literal — no `readFileSync` happens at parse time, so this package's runtime capabilities are `[]` (pure transform). Every downstream consumer keeps its own pure-transform status.
 
 TOML has ~12 grammar rules -- significantly more than JSON's 4 rules. The additional complexity comes from newline-delimited expressions, table headers, array-of-tables headers, dotted keys, bare keys, inline tables, and multi-line arrays.
 

--- a/code/packages/typescript/toml-parser/package-lock.json
+++ b/code/packages/typescript/toml-parser/package-lock.json
@@ -35,6 +35,12 @@
       "name": "@coding-adventures/grammar-tools",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cli-builder": "file:../cli-builder"
+      },
+      "bin": {
+        "grammar-tools": "program/index.ts"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.0",

--- a/code/packages/typescript/toml-parser/package.json
+++ b/code/packages/typescript/toml-parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coding-adventures/toml-parser",
-  "version": "0.1.0",
-  "description": "Parses TOML text into ASTs using the grammar-driven parser — a thin wrapper that loads toml.grammar",
+  "version": "0.1.1",
+  "description": "Parses TOML text into ASTs using the grammar-driven parser.  Pure transform (no fs:read): the parser grammar is precompiled at build time into src/_grammar.ts and embedded as a TypeScript object literal.",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/code/packages/typescript/toml-parser/required_capabilities.json
+++ b/code/packages/typescript/toml-parser/required_capabilities.json
@@ -2,13 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
   "version": 1,
   "package": "typescript/toml-parser",
-  "capabilities": [
-    {
-      "category": "fs",
-      "action": "read",
-      "target": "../../grammars/toml.grammar",
-      "justification": "Reads parser grammar definition file to build parse tables at initialization time."
-    }
-  ],
-  "justification": "Reads grammar definition files. No write, network, or process access needed."
+  "capabilities": [],
+  "justification": "Pure transform: TOML source text → ASTNode tree. The parser grammar is precompiled at build time (src/_grammar.ts is auto-generated from code/grammars/toml.grammar via `grammar-tools compile-grammar`) and embedded as a TypeScript object literal, so no fs read happens at parse time. No I/O, no network, no shell, no env."
 }

--- a/code/packages/typescript/toml-parser/src/parser.ts
+++ b/code/packages/typescript/toml-parser/src/parser.ts
@@ -78,34 +78,29 @@
  *     src/ -> toml-parser/ -> typescript/ -> packages/ -> code/ -> grammars/
  */
 
-import { fileURLToPath } from "url";
-import { dirname, join } from "path";
-import { readFileSync } from "fs";
-
-import { parseParserGrammar } from "@coding-adventures/grammar-tools";
 import { GrammarParser } from "@coding-adventures/parser";
 import type { ASTNode } from "@coding-adventures/parser";
 import { tokenizeTOML } from "@coding-adventures/toml-lexer";
 
-/**
- * Resolve __dirname for ESM modules.
- * See the toml-lexer tokenizer.ts for a detailed explanation.
- */
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { PARSER_GRAMMAR } from "./_grammar.js";
 
 /**
- * Navigate from src/ up to the grammars/ directory.
+ * The TOML grammar, embedded as a TypeScript object literal at build time.
  *
- * The path traversal:
- *   __dirname  = .../toml-parser/src/
- *   ..          = .../toml-parser/
- *   ../..       = .../typescript/
- *   ../../..    = .../packages/
- *   ../../../.. = .../code/
- *   + grammars  = .../code/grammars/
+ * `_grammar.ts` is auto-generated from `code/grammars/toml.grammar` via:
+ *
+ *     grammar-tools compile-grammar code/grammars/toml.grammar \
+ *         --out code/packages/typescript/toml-parser/src/_grammar.ts
+ *
+ * Importing the precompiled grammar (instead of `readFileSync`-ing the
+ * `.grammar` file at parse time) keeps this package's runtime capabilities
+ * to `[]` — no `fs:read` required.  That matters for every downstream
+ * consumer (e.g. `forme-doc-frontmatter`) that wants to stay
+ * pure-transform.
+ *
+ * If you change `toml.grammar`, regenerate `_grammar.ts` and ship the
+ * regenerated file as part of the same commit.
  */
-const GRAMMARS_DIR = join(__dirname, "..", "..", "..", "..", "grammars");
-const TOML_GRAMMAR_PATH = join(GRAMMARS_DIR, "toml.grammar");
 
 /**
  * Parse TOML text and return an AST.
@@ -142,21 +137,14 @@ export function parseTOML(source: string): ASTNode {
   const tokens = tokenizeTOML(source);
 
   /**
-   * Step 2: Load the grammar.
-   * The grammar file defines the syntax rules in EBNF-like notation.
-   * parseParserGrammar converts the text into a structured object that
-   * the GrammarParser can use for recursive descent.
+   * Step 2: Parse.
+   * The grammar is already structured (precompiled at build time) — no
+   * file I/O or grammar-text parsing happens here.  GrammarParser takes
+   * the token array and rules, then performs recursive descent with
+   * backtracking to produce an AST.  The starting rule is "document"
+   * (the first rule in toml.grammar), which expects a sequence of
+   * expressions separated by newlines.
    */
-  const grammarText = readFileSync(TOML_GRAMMAR_PATH, "utf-8");
-  const grammar = parseParserGrammar(grammarText);
-
-  /**
-   * Step 3: Parse.
-   * The GrammarParser takes the token array and grammar rules, then
-   * performs recursive descent with backtracking to produce an AST.
-   * The starting rule is "document" (the first rule in toml.grammar),
-   * which expects a sequence of expressions separated by newlines.
-   */
-  const parser = new GrammarParser(tokens, grammar);
+  const parser = new GrammarParser(tokens, PARSER_GRAMMAR);
   return parser.parse();
 }


### PR DESCRIPTION
## Summary

- `src/_grammar.ts` (auto-generated from `code/grammars/toml.grammar` via `grammar-tools compile-grammar`) was already present in the repo but unused.
- `parser.ts` was still doing `readFileSync(TOML_GRAMMAR_PATH)` + `parseParserGrammar(text)` on every `parseTOML` call.
- Switch the parser to import `PARSER_GRAMMAR` directly from `_grammar.ts`.
- All 34 existing tests pass with **no modifications**. Coverage: 99.33% line / 100% branch.

## Capability impact

`required_capabilities.json` drops from:

```json
[{ "category": "fs", "action": "read", "target": "../../grammars/toml.grammar" }]
```

to:

```json
[]
```

**This matters for downstream consumers.** Any TypeScript package that calls `parseTOML` previously inherited the `fs:read` transitively, breaking the pure-transform contract for any package that wanted `capabilities: []`.

The motivating case is `@coding-adventures/forme-doc-frontmatter` (PR #3781): when discussing whether it should use this parser instead of its in-house TOML implementation, the deciding constraint was the `fs:read` transitivity. Removing it unblocks the dedup. Same logic applies to every future TS package that needs TOML parsing.

## Performance impact

First-call latency improves — no fs round-trip, no grammar-text re-parsing. Subsequent calls are unchanged.

## No API change

`parseTOML(source)` returns the same `ASTNode`. The 34 existing tests pass without any test modifications, which is the cleanest possible confirmation of compatibility.

## Removed

- `fileURLToPath`, `dirname`, `join`, `readFileSync` imports.
- `parseParserGrammar` import (the grammar arrives pre-parsed).
- `GRAMMARS_DIR` / `TOML_GRAMMAR_PATH` constants.

## Version

Bumped to `0.1.1`.

## Test plan

- [x] All 34 vitest tests pass locally (unchanged test suite)
- [x] Coverage stays at 99.33% line / 100% branch
- [x] `required_capabilities.json` updated to `[]` with justification
- [x] CHANGELOG entry under `[0.1.1] — 2026-05-21` documents the capability drop + rationale
- [x] README and package.json description updated to reflect the precompiled-grammar architecture
- [ ] CI green on ubuntu / macos / windows
- [ ] CodeQL JS/TS analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)