### PR TITLE
[codex] Accept Board VM serial endpoints in CLI

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -17,6 +17,14 @@ cargo run -p board-vm-cli --bin board-vm -- smoke \
 
 ```sh
 cargo run -p board-vm-cli --bin board-vm -- smoke \
+  --endpoint serial:///dev/cu.usbmodem... \
+  --board uno-r4-wifi \
+  --baud 115200 \
+  --timeout-ms 1000
+```
+
+```sh
+cargo run -p board-vm-cli --bin board-vm -- smoke \
   --endpoint tcp://board-vm.local:4170 \
   --timeout-ms 1000
 ```
@@ -48,9 +56,10 @@ asks `board-vm-language-core` for the runtime serial open plan, then applies
 CLI `--baud` and `--timeout-ms` overrides before touching the OS port. That
 keeps DTR/open-settle, stale-byte clearing, endpoint metadata, and wire
 protocol ownership in the Rust target layer while this crate performs the
-platform-specific open/read/write call. The endpoint path supports TCP sockets
-and Board VM Bluetooth endpoints (`ble://`, `btspp://`, or `rfcomm://`) through
-the Rust-owned transport adapters. The smoke report starts with a stable
+platform-specific open/read/write call. The endpoint path accepts Rust-owned
+serial endpoint metadata (`serial://...`) plus TCP sockets and Board VM
+Bluetooth endpoints (`ble://`, `btspp://`, or `rfcomm://`) through the
+Rust-owned transport adapters. The smoke report starts with a stable
 `connection transport=...` field so hardware logs can distinguish serial, TCP
 socket, BLE GATT, and RFCOMM runs without parsing endpoint strings. The default
 run budget is intentionally small because the current firmware executes
@@ -64,8 +73,9 @@ This is the first language-agnostic host shell: it drives the binary protocol
 through the shared client library, while future frontend packages can put
 richer syntax on top of the same transport calls. `gpio-read` and `time-now`
 print Rust-decoded run-report return values from the board. The endpoint path
-uses the same TCP socket and Bluetooth wire transports as `smoke`, with loopback
-coverage for interactive upload/run flows over TCP, BLE GATT, and RFCOMM.
+uses the same serial, TCP socket, and Bluetooth wire transports as `smoke`,
+with loopback coverage for interactive upload/run flows over serial endpoint
+metadata, TCP, BLE GATT, and RFCOMM.
 
 `eject blink` writes the current blink MVP as embeddable Rust constants with a
 program id, slot, boot policy, bytecode CRC, and BVM module bytes. That output

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -23,8 +23,8 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_transact_wire_frame, parse_bluetooth_endpoint as parse_language_bluetooth_endpoint,
-    serial_runtime_open_plan_for_target, LanguageSerialRuntimeOpenPlan,
-    LANGUAGE_SERIAL_OPEN_SETTLE_MS,
+    parse_serial_endpoint as parse_language_serial_endpoint, serial_runtime_open_plan_for_target,
+    LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
 };
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
 use board_vm_protocol::{
@@ -1548,7 +1548,11 @@ where
 #[cfg(test)]
 fn repl_connection_label(options: &ReplOptions) -> String {
     if let Some(endpoint) = options.endpoint.as_deref() {
-        return format!("endpoint={endpoint}");
+        return endpoint_connection_label(
+            endpoint,
+            endpoint_transport(endpoint).expect("test repl endpoint should be valid"),
+            options.baud_rate,
+        );
     }
     match options.port.as_deref() {
         Some(port) => format!("port={port} baud={}", options.baud_rate),
@@ -1569,7 +1573,11 @@ fn smoke_connection_transport(options: &SmokeOptions) -> SmokeConnectionTranspor
 #[cfg(test)]
 fn smoke_connection_label(options: &SmokeOptions) -> String {
     if let Some(endpoint) = options.endpoint.as_deref() {
-        return format!("endpoint={endpoint}");
+        return endpoint_connection_label(
+            endpoint,
+            endpoint_transport(endpoint).expect("test smoke endpoint should be valid"),
+            options.baud_rate,
+        );
     }
     match options.port.as_deref() {
         Some(port) => format!("port={port} baud={}", options.baud_rate),
@@ -1592,7 +1600,11 @@ fn bootloader_reboot_connection_transport(
 #[cfg(test)]
 fn bootloader_reboot_connection_label(options: &BootloaderRebootOptions) -> String {
     if let Some(endpoint) = options.endpoint.as_deref() {
-        return format!("endpoint={endpoint}");
+        return endpoint_connection_label(
+            endpoint,
+            endpoint_transport(endpoint).expect("test bootloader endpoint should be valid"),
+            options.baud_rate,
+        );
     }
     match options.port.as_deref() {
         Some(port) => format!("port={port} baud={}", options.baud_rate),
@@ -1605,11 +1617,19 @@ fn open_smoke_transport(
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let connection_transport = SmokeConnectionTransport::from(endpoint_transport(endpoint)?);
-        let transport = open_endpoint_transport(endpoint, &options.tcp_config(endpoint))?;
+        let endpoint_transport = endpoint_transport(endpoint)?;
+        let connection_transport = SmokeConnectionTransport::from(endpoint_transport);
+        let transport = open_endpoint_transport(
+            endpoint,
+            endpoint_transport,
+            &options.board,
+            options.baud_rate,
+            options.timeout_ms,
+            &options.tcp_config(endpoint),
+        )?;
         return Ok((
             connection_transport,
-            format!("endpoint={endpoint}"),
+            endpoint_connection_label(endpoint, endpoint_transport, options.baud_rate),
             transport,
         ));
     }
@@ -1632,11 +1652,19 @@ fn open_bootloader_reboot_transport(
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let connection_transport = SmokeConnectionTransport::from(endpoint_transport(endpoint)?);
-        let transport = open_endpoint_transport(endpoint, &options.tcp_config(endpoint))?;
+        let endpoint_transport = endpoint_transport(endpoint)?;
+        let connection_transport = SmokeConnectionTransport::from(endpoint_transport);
+        let transport = open_endpoint_transport(
+            endpoint,
+            endpoint_transport,
+            &options.board,
+            options.baud_rate,
+            options.timeout_ms,
+            &options.tcp_config(endpoint),
+        )?;
         return Ok((
             connection_transport,
-            format!("endpoint={endpoint}"),
+            endpoint_connection_label(endpoint, endpoint_transport, options.baud_rate),
             transport,
         ));
     }
@@ -1657,8 +1685,19 @@ fn open_bootloader_reboot_transport(
 fn open_repl_transport(options: &ReplOptions) -> Result<(String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let transport = open_endpoint_transport(endpoint, &options.tcp_config(endpoint))?;
-        return Ok((format!("endpoint={endpoint}"), transport));
+        let endpoint_transport = endpoint_transport(endpoint)?;
+        let transport = open_endpoint_transport(
+            endpoint,
+            endpoint_transport,
+            &options.board,
+            options.baud_rate,
+            options.timeout_ms,
+            &options.tcp_config(endpoint),
+        )?;
+        return Ok((
+            endpoint_connection_label(endpoint, endpoint_transport, options.baud_rate),
+            transport,
+        ));
     }
 
     open_serial_session_transport(
@@ -1700,9 +1739,25 @@ fn ensure_endpoint_not_mixed_with_port(port: Option<&str>) -> Result<(), CliErro
 
 fn open_endpoint_transport(
     endpoint: &str,
+    endpoint_transport: SessionEndpointTransport,
+    board: &str,
+    baud_rate: u32,
+    timeout_ms: u64,
     tcp_config: &TcpConfig,
 ) -> Result<SessionTransport, CliError> {
-    match endpoint_transport(endpoint)? {
+    match endpoint_transport {
+        SessionEndpointTransport::Serial => {
+            let serial_endpoint = parse_language_serial_endpoint(endpoint).ok_or_else(|| {
+                CliError::DeviceSelection(format!("invalid Board VM serial endpoint: {endpoint}"))
+            })?;
+            let (_, transport) = open_serial_session_transport(
+                Some(&serial_endpoint.port),
+                board,
+                baud_rate,
+                timeout_ms,
+            )?;
+            Ok(transport)
+        }
         SessionEndpointTransport::Tcp => Ok(SessionTransport::Tcp(
             BoardTcpTransport::<_, 1024>::connect(tcp_config)?,
         )),
@@ -1715,6 +1770,7 @@ fn open_endpoint_transport(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SessionEndpointTransport {
+    Serial,
     Tcp,
     BluetoothLeGatt,
     BluetoothClassicRfcomm,
@@ -1723,6 +1779,7 @@ enum SessionEndpointTransport {
 impl From<SessionEndpointTransport> for SmokeConnectionTransport {
     fn from(value: SessionEndpointTransport) -> Self {
         match value {
+            SessionEndpointTransport::Serial => Self::SerialPort,
             SessionEndpointTransport::Tcp => Self::TcpSocket,
             SessionEndpointTransport::BluetoothLeGatt => Self::BluetoothLeGatt,
             SessionEndpointTransport::BluetoothClassicRfcomm => Self::BluetoothClassicRfcomm,
@@ -1730,9 +1787,31 @@ impl From<SessionEndpointTransport> for SmokeConnectionTransport {
     }
 }
 
+fn endpoint_connection_label(
+    endpoint: &str,
+    endpoint_transport: SessionEndpointTransport,
+    baud_rate: u32,
+) -> String {
+    match endpoint_transport {
+        SessionEndpointTransport::Serial => format!("endpoint={endpoint} baud={baud_rate}"),
+        SessionEndpointTransport::Tcp
+        | SessionEndpointTransport::BluetoothLeGatt
+        | SessionEndpointTransport::BluetoothClassicRfcomm => format!("endpoint={endpoint}"),
+    }
+}
+
 fn endpoint_transport(endpoint: &str) -> Result<SessionEndpointTransport, CliError> {
     match endpoint.split_once("://").map(|(scheme, _)| scheme) {
         None | Some("tcp") => Ok(SessionEndpointTransport::Tcp),
+        Some("serial") => {
+            if parse_language_serial_endpoint(endpoint).is_some() {
+                Ok(SessionEndpointTransport::Serial)
+            } else {
+                Err(CliError::DeviceSelection(format!(
+                    "invalid Board VM serial endpoint: {endpoint}"
+                )))
+            }
+        }
         Some("ble") => {
             if parse_language_bluetooth_endpoint(endpoint).is_some() {
                 Ok(SessionEndpointTransport::BluetoothLeGatt)
@@ -2108,7 +2187,7 @@ pub fn format_onboard_led(led: Option<OnboardLed>) -> String {
 }
 
 pub fn usage() -> &'static str {
-    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm bootloader-reboot [--port <path>|--endpoint tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
+    "usage:\n  board-vm list-ports\n  board-vm list-targets\n  board-vm esp-detect --port <path> [--baud <rate>] [--timeout-ms <ms>] [--no-reset]\n  board-vm esp-upload --port <path> --image <path> [--offset <addr>] [--block-size <bytes>] [--flash-size <bytes>] [--baud <rate>] [--timeout-ms <ms>] [--no-reset] [--no-verify] [--stay-in-bootloader]\n  board-vm pico-uf2 --image <path.uf2> [--mount <RPI-RP2 mount>]\n  board-vm pico-uf2 --list\n  board-vm smoke [--port <path>|--endpoint serial://path|tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm repl [--port <path>|--endpoint serial://path|tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--program-id <id>] [--budget <instructions>] [--host-nonce <u32>]\n  board-vm bootloader-reboot [--port <path>|--endpoint serial://path|tcp://host:port|ble://device?...|btspp://device:channel] [--board <selector>] [--baud <rate>] [--timeout-ms <ms>] [--host-nonce <u32>]\n  board-vm eject blink --out <path> [--program-id <id>] [--slot <slot>] [--boot-policy store-only|run-at-boot|run-if-no-host|<u8>]"
 }
 
 #[cfg(test)]
@@ -2763,6 +2842,35 @@ mod tests {
     }
 
     #[test]
+    fn parses_smoke_serial_endpoint() {
+        let endpoint = "serial:///dev/cu.usbmodem-test";
+        let command =
+            parse_args(["smoke", "--endpoint", endpoint, "--board", "uno-r4-wifi"]).unwrap();
+
+        assert_eq!(
+            command,
+            CliCommand::Smoke(SmokeOptions {
+                port: None,
+                endpoint: Some(endpoint.to_owned()),
+                board: "uno-r4-wifi".to_owned(),
+                baud_rate: DEFAULT_BAUD_RATE,
+                timeout_ms: DEFAULT_TIMEOUT_MS,
+                program_id: DEFAULT_PROGRAM_ID,
+                instruction_budget: DEFAULT_INSTRUCTION_BUDGET,
+                host_nonce: DEFAULT_HOST_NONCE,
+            })
+        );
+        assert_eq!(
+            endpoint_transport(endpoint).unwrap(),
+            SessionEndpointTransport::Serial
+        );
+        assert_eq!(
+            endpoint_connection_label(endpoint, SessionEndpointTransport::Serial, 57_600),
+            "endpoint=serial:///dev/cu.usbmodem-test baud=57600"
+        );
+    }
+
+    #[test]
     fn parses_repl_rfcomm_endpoint() {
         let command = parse_args(["repl", "--endpoint", "btspp://uno-r4-wifi:1"]).unwrap();
 
@@ -2794,6 +2902,16 @@ mod tests {
             CliError::DeviceSelection(
                 "invalid Board VM Bluetooth endpoint: ble://AA:BB:CC:DD:EE:FF".to_owned()
             )
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_serial_endpoint() {
+        let error = endpoint_transport("serial://").unwrap_err();
+
+        assert_eq!(
+            error,
+            CliError::DeviceSelection("invalid Board VM serial endpoint: serial://".to_owned())
         );
     }
 
@@ -3042,6 +3160,34 @@ mod tests {
         assert!(report.run.instructions_executed > 0);
         assert_eq!(report.run.open_handles, 1);
         assert!(report.run.returns.is_empty());
+    }
+
+    #[test]
+    fn smoke_serial_endpoint_reports_serial_transport_metadata() {
+        let endpoint = "serial:///dev/cu.usbmodem-test";
+        let options = SmokeOptions {
+            port: None,
+            endpoint: Some(endpoint.to_owned()),
+            board: "uno-r4-wifi".to_owned(),
+            baud_rate: 57_600,
+            timeout_ms: 250,
+            program_id: 7,
+            instruction_budget: 200,
+            host_nonce: 0x1234_5678,
+        };
+
+        let report = run_smoke_with_transport(&options, LoopbackSmokeTransport::new()).unwrap();
+
+        assert_eq!(
+            report.connection.transport,
+            SmokeConnectionTransport::SerialPort
+        );
+        assert_eq!(
+            report.connection.label,
+            "endpoint=serial:///dev/cu.usbmodem-test baud=57600"
+        );
+        assert_eq!(report.connection.timeout_ms, 250);
+        assert_eq!(report.hello.host_nonce, 0x1234_5678);
     }
 
     #[test]

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -380,6 +380,15 @@ pub struct LanguageConnectionOption {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageSerialEndpoint {
+    pub endpoint: String,
+    pub transport: LanguageConnectionTransport,
+    pub endpoint_transport: LanguageHostEndpointTransport,
+    pub endpoint_scheme: String,
+    pub port: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageBluetoothEndpoint {
     pub endpoint: String,
     pub transport: LanguageConnectionTransport,
@@ -1508,6 +1517,24 @@ pub fn serial_runtime_open_plan_from_upload_handoff(
 ) -> Option<LanguageSerialRuntimeOpenPlan> {
     let target = known_target(&handoff.board_id)?;
     language_serial_runtime_open_plan(&target, &handoff.runtime_port, &handoff.runtime_port_source)
+}
+
+pub fn parse_serial_endpoint(endpoint: &str) -> Option<LanguageSerialEndpoint> {
+    let (scheme, port) = endpoint.split_once("://")?;
+    if scheme != "serial" {
+        return None;
+    }
+    let port = port.trim();
+    if port.is_empty() {
+        return None;
+    }
+    Some(LanguageSerialEndpoint {
+        endpoint: endpoint.to_owned(),
+        transport: LanguageConnectionTransport::Serial,
+        endpoint_transport: LanguageHostEndpointTransport::SerialPort,
+        endpoint_scheme: scheme.to_owned(),
+        port: port.to_owned(),
+    })
 }
 
 pub fn parse_bluetooth_endpoint(endpoint: &str) -> Option<LanguageBluetoothEndpoint> {
@@ -5592,6 +5619,15 @@ mod tests {
         assert_eq!(plan.upload_port_hint.as_deref(), Some("native_usb"));
         assert!(plan.notes.contains("runtime CDC serial port"));
 
+        let endpoint = parse_serial_endpoint(&plan.endpoint).unwrap();
+        assert_eq!(endpoint.transport, LanguageConnectionTransport::Serial);
+        assert_eq!(
+            endpoint.endpoint_transport,
+            LanguageHostEndpointTransport::SerialPort
+        );
+        assert_eq!(endpoint.endpoint_scheme, "serial");
+        assert_eq!(endpoint.port, "/dev/cu.usbmodem1101");
+
         let handoff = arduino_cli_upload_runtime_handoff_for_execution_plan(
             &arduino_cli_upload_execution_plan_for_target(
                 "arduino-nano-r4",
@@ -5616,6 +5652,8 @@ mod tests {
         assert_eq!(esp.upload_port_hint.as_deref(), Some("esp_rom_serial"));
         assert!(esp.notes.contains("ESP runtime serial port"));
 
+        assert!(parse_serial_endpoint("tcp://board-vm.local:4170").is_none());
+        assert!(parse_serial_endpoint("serial://   ").is_none());
         assert!(serial_runtime_open_plan_for_target("uno-r4-wifi", "   ").is_none());
         assert!(serial_runtime_open_plan_for_target("not-a-board", "COM7").is_none());
     }

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -224,6 +224,10 @@ before touching the OS port. That plan keeps baud rate, timeout, stale-byte
 clearing, DTR/open-settle behavior, endpoint scheme, and Board VM wire protocol
 shared across CLI, Ruby, Python, Lua, Java, JS, and future frontends while the
 language adapter still performs the platform-specific open/read/write call.
+When a frontend receives a `serial://...` endpoint string from that plan or from
+a user-facing CLI surface, it should parse the endpoint through the Rust-owned
+serial endpoint helper and then apply the same serial open plan instead of
+maintaining a parallel endpoint scheme table.
 
 Selector handling follows the same ownership boundary. If a frontend receives
 an Arduino CLI FQBN such as `arduino:renesas_uno:nanor4`, it should ask the Rust


### PR DESCRIPTION
## Summary
- adds Rust-owned `serial://...` endpoint parsing to `board-vm-language-core`
- lets `board-vm-cli` accept serial endpoints for smoke/repl/bootloader reboot and open them through the existing serial runtime open-plan path
- keeps endpoint reports explicit as serial transport metadata while preserving CLI baud/timeout overrides
- documents the serial endpoint ownership boundary in the CLI README and host SDK spec

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo fmt -p board-vm-cli -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-cli -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command bash BUILD` in `code/packages/rust/board-vm-cli`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-arduino-cli-upload-command cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.
