### PR TITLE
feat(sql-planner,mini-sqlite): UNION / INTERSECT / EXCEPT in derived tables

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.75.0] - 2026-05-21
+
+### Added
+
+- **Compound queries as derived tables** (via ``sql-planner 0.34.0``).
+  ``SELECT * FROM (SELECT 1 UNION SELECT 2) AS t``, INTERSECT, EXCEPT,
+  and chained variants are now accepted both in FROM and JOIN positions.
+  Previously the adapter raised ``derived table must be a plain SELECT,
+  not a set operation``.  Alias is still required (optional-alias is a
+  separate change).
+
+  16 oracle tests in ``test_tier3_union_in_derived.py`` cover UNION /
+  UNION ALL / INTERSECT / EXCEPT in derived tables, set-op chaining,
+  JOIN with compound right sides, real-tables-providing-rows pipelines,
+  and a regression guard for plain SELECT.
+
 ## [1.74.0] - 2026-05-20
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.74.0"
+version = "1.75.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -445,8 +445,17 @@ def _table_ref(
     q = _maybe_child(node, "query_stmt")
     if q is not None:
         inner_stmt = _query_stmt(q, ctes=ctes, view_defs=view_defs)
-        if not isinstance(inner_stmt, SelectStmt):
-            raise ProgrammingError("derived table must be a plain SELECT, not a set operation")
+        # SQLite allows the inner query of a derived table to be a compound
+        # query (UNION / INTERSECT / EXCEPT), not just a plain SELECT.  The
+        # planner's :func:`_plan_derived_inner` dispatches on the statement
+        # type, so we can pass through any of the four typed forms.  We
+        # still reject anything else (INSERT, UPDATE, DDL, etc.) because the
+        # surrounding ``FROM`` context only makes sense for query-producing
+        # statements.
+        if not isinstance(inner_stmt, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt):
+            raise ProgrammingError(
+                "derived table inner query must be a SELECT or set operation"
+            )
         # The alias is the first NAME token AFTER the closing parenthesis,
         # optionally preceded by an AS keyword.  Walk the children and grab
         # the NAME once we're past the ")" token.

--- a/code/packages/python/mini-sqlite/tests/test_tier3_union_in_derived.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_union_in_derived.py
@@ -1,0 +1,187 @@
+"""Compound queries (UNION / INTERSECT / EXCEPT) as derived tables.
+
+SQLite allows the inner query of a derived table to be any compound
+query, not just a plain SELECT.  Before this PR mini-sqlite raised
+``derived table must be a plain SELECT, not a set operation`` for
+queries like ``SELECT * FROM (SELECT 1 UNION SELECT 2) AS u``.
+
+The fix spans three layers:
+
+1. **AST** (``sql_planner.ast.DerivedTableRef.select``) — widened from
+   ``SelectStmt`` to ``SelectStmt | UnionStmt | IntersectStmt | ExceptStmt``.
+
+2. **Adapter** — the rejection check now allows any of the four typed
+   query-producing statement forms.
+
+3. **Planner** — a new ``_plan_derived_inner`` helper dispatches by
+   statement type so the inner of a derived table can be planned the
+   same way as a top-level query.  ``_output_columns`` and
+   ``_source_columns`` learn to descend through ``Union`` / ``Intersect``
+   / ``Except`` nodes (inheriting column names from the left side, per
+   SQLite's documented rule).
+
+The alias is still mandatory — the optional-alias relaxation is a
+separate change.
+
+These tests pair every interesting case against reference ``sqlite3``
+byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = mini_sqlite.connect(":memory:").execute(query).fetchall()
+    r = sqlite3.connect(":memory:").execute(query).fetchall()
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# UNION as the derived table inner query
+# ---------------------------------------------------------------------------
+
+
+class TestUnionDerivedTable:
+    def test_two_value_union(self) -> None:
+        _check("SELECT * FROM (SELECT 1 AS x UNION SELECT 2) AS t ORDER BY x")
+
+    def test_union_all_preserves_duplicates(self) -> None:
+        _check("SELECT * FROM (SELECT 1 AS x UNION ALL SELECT 1) AS u ORDER BY 1")
+
+    def test_three_way_union(self) -> None:
+        _check(
+            "SELECT count(*) FROM (SELECT 1 UNION SELECT 2 UNION SELECT 3) AS s"
+        )
+
+    def test_union_with_outer_where(self) -> None:
+        _check(
+            "SELECT x FROM (SELECT 1 AS x UNION SELECT 2 UNION SELECT 3) AS t "
+            "WHERE x > 1 ORDER BY x"
+        )
+
+    def test_union_with_outer_aggregate(self) -> None:
+        _check(
+            "SELECT sum(x) FROM (SELECT 10 AS x UNION SELECT 20 UNION SELECT 30) AS t"
+        )
+
+
+# ---------------------------------------------------------------------------
+# INTERSECT as the derived table inner query
+# ---------------------------------------------------------------------------
+
+
+class TestIntersectDerivedTable:
+    def test_simple_intersect(self) -> None:
+        _check(
+            "SELECT * FROM (SELECT 1 AS x INTERSECT SELECT 1) AS i ORDER BY x"
+        )
+
+    def test_intersect_disjoint(self) -> None:
+        # No overlap → empty result.
+        _check("SELECT count(*) FROM (SELECT 1 INTERSECT SELECT 2) AS i")
+
+    def test_mixed_intersect_then_union(self) -> None:
+        # Set-op chaining inside the derived table.
+        _check(
+            "SELECT x FROM (SELECT 1 AS x INTERSECT SELECT 1 UNION SELECT 2) "
+            "AS s ORDER BY x"
+        )
+
+
+# ---------------------------------------------------------------------------
+# EXCEPT as the derived table inner query
+# ---------------------------------------------------------------------------
+
+
+class TestExceptDerivedTable:
+    def test_simple_except(self) -> None:
+        _check("SELECT * FROM (SELECT 1 AS x EXCEPT SELECT 2) AS e")
+
+    def test_except_removes_overlap(self) -> None:
+        _check(
+            "SELECT * FROM (SELECT 1 AS x UNION SELECT 2 UNION SELECT 3 EXCEPT SELECT 2) "
+            "AS e ORDER BY x"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Compound queries in JOIN positions
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundJoin:
+    def test_join_left_plain_right_union(self) -> None:
+        _check(
+            "SELECT a.x, b.y FROM (SELECT 1 AS x) AS a "
+            "JOIN (SELECT 1 AS y UNION SELECT 2) AS b ON 1=1 ORDER BY b.y"
+        )
+
+    def test_join_both_union(self) -> None:
+        _check(
+            "SELECT a.x, b.y "
+            "FROM (SELECT 1 AS x UNION SELECT 2) AS a "
+            "JOIN (SELECT 10 AS y UNION SELECT 20) AS b ON 1=1 "
+            "ORDER BY a.x, b.y"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tables provide rows for the inner queries — exercises full pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestUnionDerivedWithRealTables:
+    SETUP = [
+        "CREATE TABLE odds (n INTEGER)",
+        "INSERT INTO odds VALUES (1), (3), (5)",
+        "CREATE TABLE evens (n INTEGER)",
+        "INSERT INTO evens VALUES (2), (4), (6)",
+    ]
+
+    def test_union_of_two_tables_in_derived(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        m = conn_m.execute(
+            "SELECT n FROM (SELECT n FROM odds UNION SELECT n FROM evens) "
+            "AS combined ORDER BY n"
+        ).fetchall()
+        r = conn_r.execute(
+            "SELECT n FROM (SELECT n FROM odds UNION SELECT n FROM evens) "
+            "AS combined ORDER BY n"
+        ).fetchall()
+        assert m == r
+
+    def test_count_distinct_via_union(self) -> None:
+        conn_m = mini_sqlite.connect(":memory:")
+        conn_r = sqlite3.connect(":memory:")
+        for s in self.SETUP:
+            conn_m.execute(s)
+            conn_r.execute(s)
+        # UNION dedups; UNION ALL keeps duplicates.
+        m = conn_m.execute(
+            "SELECT count(*) FROM (SELECT n FROM odds UNION ALL SELECT n FROM evens) AS u"
+        ).fetchall()
+        r = conn_r.execute(
+            "SELECT count(*) FROM (SELECT n FROM odds UNION ALL SELECT n FROM evens) AS u"
+        ).fetchall()
+        assert m == r
+
+
+# ---------------------------------------------------------------------------
+# Regression — plain SELECT in derived table still works
+# ---------------------------------------------------------------------------
+
+
+class TestPlainSelectStillWorks:
+    def test_plain_select(self) -> None:
+        _check("SELECT * FROM (SELECT 1 AS x) AS t")
+
+    def test_plain_select_with_filter(self) -> None:
+        _check("SELECT x FROM (SELECT 1 AS x WHERE 1=1) AS t")

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.34.0] - 2026-05-21
+
+### Added
+
+- **Compound queries (UNION / INTERSECT / EXCEPT) as derived tables.**
+  ``DerivedTableRef.select`` is widened from ``SelectStmt`` to
+  ``SelectStmt | UnionStmt | IntersectStmt | ExceptStmt`` and a new
+  ``_plan_derived_inner`` helper dispatches by statement type so the
+  inner of a ``(query) AS alias`` source can be any of the four
+  query-producing statement forms — matching SQLite.
+  ``_output_columns`` and ``_source_columns`` learn to descend through
+  ``Union`` / ``Intersect`` / ``Except`` nodes, inheriting column
+  names from the left side per SQLite's documented rule.
+
 ## [0.33.0] - 2026-05-19
 
 ### Fixed

--- a/code/packages/python/sql-planner/pyproject.toml
+++ b/code/packages/python/sql-planner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-planner"
-version = "0.33.0"
+version = "0.34.0"
 description = "Translates a structured SQL AST into a Logical Plan Tree of relational-algebra nodes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-planner/src/sql_planner/ast.py
+++ b/code/packages/python/sql-planner/src/sql_planner/ast.py
@@ -82,11 +82,16 @@ class TableRef:
 
 @dataclass(frozen=True, slots=True)
 class DerivedTableRef:
-    """A subquery used as a table source — ``(SELECT ...) AS alias``.
+    """A subquery used as a table source — ``(query) AS alias``.
 
-    The ``select`` is the inner query statement (already a typed SelectStmt,
-    not a raw parse node).  The ``alias`` is mandatory — SQL requires an
-    alias for every derived table.
+    The ``select`` is the inner query statement (already a typed statement
+    node, not a raw parse node).  It may be a plain ``SelectStmt`` or any
+    of the set-operation wrappers — SQLite allows derived tables to wrap a
+    compound query such as ``(SELECT … UNION SELECT …)`` and exposes its
+    output columns to the outer scope just like a plain SELECT would.
+
+    The ``alias`` is mandatory in our implementation (SQLite makes it
+    optional; that relaxation is a separate change).
 
     Example::
 
@@ -97,9 +102,18 @@ class DerivedTableRef:
                               from_=TableRef('orders')),
             alias='dt',
         )
+
+    UNION example::
+
+        SELECT * FROM (SELECT 1 UNION SELECT 2) AS u
+        ↓
+        DerivedTableRef(
+            select=UnionStmt(left=SelectStmt(...), right=SelectStmt(...)),
+            alias='u',
+        )
     """
 
-    select: SelectStmt
+    select: SelectStmt | UnionStmt | IntersectStmt | ExceptStmt
     alias: str
 
 

--- a/code/packages/python/sql-planner/src/sql_planner/planner.py
+++ b/code/packages/python/sql-planner/src/sql_planner/planner.py
@@ -270,7 +270,7 @@ def _plan_select(
         having_raw = _substitute_aliases(having_raw, select_aliases)
     having = _resolve(having_raw, scope, schema, outer_scope) if having_raw is not None else None
 
-    def _resolve_order_key(k: "AstSortKey") -> "P.SortKey":
+    def _resolve_order_key(k: AstSortKey) -> P.SortKey:
         """Resolve an ORDER BY sort key to a planner ``SortKey``.
 
         SQL (and SQLite) allow ORDER BY to reference output columns in two
@@ -480,6 +480,34 @@ def _win_spec_columns(spec: P.WindowFuncSpec) -> list[Column]:
     return cols
 
 
+def _plan_derived_inner(
+    stmt: SelectStmt | UnionStmt | IntersectStmt | ExceptStmt,
+    schema: SchemaProvider,
+) -> P.LogicalPlan:
+    """Plan the inner query of a derived table.
+
+    SQLite allows derived tables to wrap any compound query, not just a
+    plain SELECT — ``(SELECT 1 UNION SELECT 2) AS u`` is legal and the
+    outer scope sees the unioned column.  Dispatch on the statement
+    type the same way the top-level :func:`plan` does.
+
+    Centralising this dispatch avoids duplicating the four-way ``match``
+    at both the FROM-root site and the join-right site in
+    :func:`_build_from_tree`.
+    """
+    if isinstance(stmt, SelectStmt):
+        return _plan_select(stmt, schema)
+    if isinstance(stmt, UnionStmt):
+        return _plan_union(stmt, schema)
+    if isinstance(stmt, IntersectStmt):
+        return _plan_intersect(stmt, schema)
+    if isinstance(stmt, ExceptStmt):
+        return _plan_except(stmt, schema)
+    raise TypeError(
+        f"unexpected derived-table inner statement type: {type(stmt).__name__}"
+    )
+
+
 def _build_from_tree(
     root: TableRef | DerivedTableRef | RecursiveCTERef,
     joins: tuple[JoinClause, ...],
@@ -512,7 +540,7 @@ def _build_from_tree(
             union_all=root.union_all,
         )
     elif isinstance(root, DerivedTableRef):
-        inner_plan = _plan_select(root.select, schema)
+        inner_plan = _plan_derived_inner(root.select, schema)
         cols = _output_columns(inner_plan, schema)
         _add_to_scope(scope, root.alias, list(cols))
         tree = P.DerivedTable(
@@ -531,7 +559,7 @@ def _build_from_tree(
 
     for j in joins:
         if isinstance(j.right, DerivedTableRef):
-            inner_plan = _plan_select(j.right.select, schema)
+            inner_plan = _plan_derived_inner(j.right.select, schema)
             cols = _output_columns(inner_plan, schema)
             _add_to_scope(scope, j.right.alias, list(cols))
             right_node: P.LogicalPlan = P.DerivedTable(
@@ -717,6 +745,15 @@ def _output_columns(
     while isinstance(node, (P.Sort, P.Limit, P.Distinct, P.Having)):
         node = node.input  # type: ignore[union-attr]
 
+    # Set-operation nodes (Union / Intersect / Except) inherit the column
+    # names of their *left* side — this matches SQLite's documented rule
+    # and is required for derived tables that wrap a compound query
+    # (``(SELECT a UNION SELECT b) AS t``).  Without this branch, the
+    # ``_output_columns`` walker would hit the final ``raise`` and emit a
+    # confusing "SELECT * in derived table" error.
+    if isinstance(node, (P.Union, P.Intersect, P.Except)):
+        return _output_columns(node.left, schema)
+
     if isinstance(node, P.Project):
         cols: list[str] = []
         for i, item in enumerate(node.items, start=1):
@@ -792,10 +829,15 @@ def _source_columns(
     if isinstance(node, P.Project):
         return list(_output_columns(node, schema))
 
-    # Aggregate, Union, Intersect, Except, IndexScan, etc. — fall through to
-    # the same logic that _output_columns uses for non-Project top-levels.
-    # These should not normally be the direct input of another Project without
-    # an intervening explicit column list.
+    if isinstance(node, (P.Union, P.Intersect, P.Except)):
+        # Set-operation output schema follows the left side — same rule as
+        # :func:`_output_columns`.  Needed when a derived table wraps a
+        # compound query and the outer SELECT then says ``SELECT * FROM …``.
+        return list(_output_columns(node, schema))
+
+    # Aggregate, IndexScan, etc. — fall through.  These should not normally
+    # be the direct input of another Project without an intervening explicit
+    # column list.
     raise UnsupportedStatement(
         kind=f"SELECT * over {type(node).__name__} in derived table"
     )


### PR DESCRIPTION
## Summary

SQLite allows compound queries inside derived tables. Mini-sqlite was rejecting them with `derived table must be a plain SELECT, not a set operation`:

```sql
SELECT * FROM (SELECT 1 UNION SELECT 2) AS t       -- now works
SELECT count(*) FROM (a INTERSECT b) AS i          -- now works
SELECT a, b FROM x JOIN (a EXCEPT b) AS e ON …     -- now works
```

Three-layer fix:
1. **AST** (`sql_planner.ast.DerivedTableRef.select`) widened from `SelectStmt` to `SelectStmt | UnionStmt | IntersectStmt | ExceptStmt`.
2. **Adapter** relaxes the rejection check.
3. **Planner** gets a new `_plan_derived_inner` dispatch helper, and `_output_columns` / `_source_columns` learn to descend through `Union`/`Intersect`/`Except` (inheriting left-side column names per SQLite's rule).

Alias is still mandatory — making it optional is a separate change.

16 oracle tests; version bumps sql-planner 0.33.0 → 0.34.0, mini-sqlite 1.74.0 → 1.75.0.

## Test plan

- [x] `pytest sql-planner/tests/` — 210 passed
- [x] `pytest mini-sqlite/tests/test_tier3_union_in_derived.py` — 16/16
- [x] mini-sqlite full suite — 1831 passed
- [x] All cases match `sqlite3` byte-for-byte
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)