### PR TITLE
feat(javascript-parser): plumb CV at Program root (CLOC03 Stage 2 v1)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.5.0] - 2026-05-21
+
+### Added
+- New dependencies on `coding_adventures_correlation_vector` (for `CVLog`, `Origin`) and `serde_json` (for contribution `meta` JSON values).
+- `pub struct ProgramWithCv { pub ast: GrammarASTNode, pub cv: String }` — packages a parsed AST with its program-root CV identifier.
+- `parse_javascript_with_cv(source, source_file, EsVersion, &mut CVLog) -> Result<ProgramWithCv, String>` — full CV-plumbed parse per CLOC03 §"Stage 2 — Parser" (v1: root-only). Behavior:
+  - Tokenizes via `tokenize_javascript_with_cv` so every token gets its own CV ID.
+  - Runs the underlying `GrammarParser` on the unwrapped tokens.
+  - Mints the program-root CV via `cv.merge(all_token_cv_ids, Origin{source: source_file, location: "0:0", …})` so the program CV has every token as an ancestor.
+  - Appends `Contribution { source: "parser", tag: "constructed", meta: { rule: <root rule name>, version: <es version> } }` per CLOC03.
+- Module docs added a "Correlation-vector plumbing" section linking to CLOC03 and noting that v1 is root-only.
+- 5 new tests:
+  - `parse_with_cv_assigns_a_program_id`
+  - `parse_with_cv_program_id_resolves_in_log` — `cv.get(id)` returns an entry whose `Origin.source = source_file` and `Origin.location = "0:0"`.
+  - `parse_with_cv_appends_constructed_contribution` — `cv.history(id)` contains a `(source="parser", tag="constructed")` entry whose meta carries the correct `rule` and `version`.
+  - `parse_with_cv_program_has_token_ancestors` — `cv.ancestors(id)` is non-empty (the merge step worked).
+  - `parse_with_cv_disabled_log_still_returns_ast` — `CVLog::new(false)` keeps the API shape; the parser does not panic and still returns a valid AST.
+
+### Notes
+- All existing APIs (string-based, typed, no-CV) are untouched. This PR is purely additive.
+- v1 is **root-only**: per-AST-node CV propagation requires deeper plumbing into `GrammarParser` (which today produces a generic `GrammarASTNode` tree, not the typed `javascript-ast::Program`). That work happens in a follow-up PR alongside the AST-typed parser output.
+- The merge approach (program CV inherits from all tokens) gives source-map generators a reasonable starting point even with root-only plumbing: every output byte that comes from the program node resolves to the leftmost token's `Origin`.
+
 ## [0.4.0] - 2026-05-21
 
 ### Added

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser."
+description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03."
 
 [dependencies]
 grammar-tools = { path = "../grammar-tools" }
@@ -10,3 +10,5 @@ lexer = { path = "../lexer" }
 parser = { path = "../parser" }
 coding-adventures-javascript-lexer = { path = "../javascript-lexer" }
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"

--- a/code/packages/rust/javascript-parser/src/lib.rs
+++ b/code/packages/rust/javascript-parser/src/lib.rs
@@ -1,8 +1,27 @@
 //! JavaScript parser backed by compiled ECMAScript parser grammars (es1 through es2025).
+//!
+//! # Correlation-vector plumbing
+//!
+//! Per [CLOC03](../../../specs/CLOC03-correlation-vector-plumbing.md)
+//! §"Stage 2 — Parser", when called via [`parse_javascript_with_cv`] the
+//! parser inherits the lexer's per-token CV IDs onto the AST via
+//! `CVLog::merge(token_ids, Origin{...})`.
+//!
+//! **v1 (this version):** stamps a single CV ID onto the `Program` root
+//! built from the merge of *all* token IDs, and appends one
+//! `Contribution { source: "parser", tag: "constructed", meta: { version, ... } }`.
+//! Per-AST-node CV propagation requires deeper plumbing into the
+//! underlying `GrammarParser` (which produces a generic `GrammarASTNode`
+//! tree, not the typed `javascript-ast::Program` yet) and is deferred to
+//! follow-up PRs alongside the AST-typed parser output.
 
-use coding_adventures_javascript_lexer::{tokenize_javascript, tokenize_javascript_typed};
+use coding_adventures_correlation_vector::{CVLog, Origin};
+use coding_adventures_javascript_lexer::{
+    tokenize_javascript, tokenize_javascript_typed, tokenize_javascript_with_cv,
+};
 use coding_adventures_javascript_tokens::EsVersion;
 use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+use std::collections::HashMap;
 
 /// Typed default version. New code should prefer this over the string form.
 pub const DEFAULT_ES_VERSION: EsVersion = EsVersion::Es2025;
@@ -62,6 +81,91 @@ pub fn parse_javascript_typed(
         .map_err(|e| format!("JavaScript parse failed: {e}"))
 }
 
+/// A parsed program paired with the correlation-vector ID assigned to its
+/// root by [`parse_javascript_with_cv`].
+///
+/// The CV ID is in `CVLog`'s standard string format (e.g. `"a3f1.1.4"`).
+/// Use it to look up the parser's contributions, the root `Origin`, or
+/// the merged parent token IDs.
+#[derive(Debug, Clone)]
+pub struct ProgramWithCv {
+    /// The parsed AST. v1 still uses the generic `GrammarASTNode` —
+    /// switching to `javascript-ast::Program` is a follow-up.
+    pub ast: GrammarASTNode,
+    /// The CV ID assigned to the program root.
+    pub cv: String,
+}
+
+/// Parse JavaScript source and plumb correlation vectors per CLOC03
+/// §"Stage 2 — Parser" (v1: root-only).
+///
+/// Behavior:
+///
+/// 1. Tokenize via [`tokenize_javascript_with_cv`] so every token gets
+///    its own CV ID anchored to the source file.
+/// 2. Run the existing `GrammarParser` over the tokens (stripping the
+///    CV-pairing wrapper, since the underlying parser doesn't carry CV
+///    information per-node yet — a follow-up PR plumbs CV deeper).
+/// 3. Compute the program-root CV via `cv.merge(all_token_cv_ids,
+///    Origin{ source: source_file, location: "0:0", ... })`. The
+///    `Origin` is the *program-as-a-whole* origin; individual tokens'
+///    own origins are still reachable via their per-token CVs.
+/// 4. Append a `Contribution { source: "parser", tag: "constructed",
+///    meta: { rule, version } }` to the program-root CV.
+///
+/// Returns `(ast, program_cv_id)` packaged in a [`ProgramWithCv`].
+pub fn parse_javascript_with_cv(
+    source: &str,
+    source_file: &str,
+    version: EsVersion,
+    cv: &mut CVLog,
+) -> Result<ProgramWithCv, String> {
+    // 1. Tokenize with CV plumbing.
+    let cv_tokens = tokenize_javascript_with_cv(source, source_file, version, cv)?;
+    let token_cv_ids: Vec<String> = cv_tokens.iter().map(|t| t.cv.clone()).collect();
+    let tokens: Vec<lexer::token::Token> = cv_tokens.into_iter().map(|t| t.token).collect();
+
+    // 2. Parse via the existing GrammarParser.
+    let grammar = _grammar::parser_grammar(version.as_str())
+        .expect("compiled JavaScript parser grammar missing supported version");
+    let mut parser = GrammarParser::new(tokens, grammar);
+    let ast = parser
+        .parse()
+        .map_err(|e| format!("JavaScript parse failed: {e}"))?;
+
+    // 3. Mint the program-root CV by merging every token's CV.
+    let parent_refs: Vec<&str> = token_cv_ids.iter().map(|s| s.as_str()).collect();
+    let program_cv = cv.merge(
+        &parent_refs,
+        Some(Origin {
+            source: source_file.to_string(),
+            location: "0:0".to_string(),
+            timestamp: None,
+            meta: HashMap::new(),
+        }),
+    );
+
+    // 4. Append the "constructed" contribution per CLOC03 §Stage 2.
+    let mut meta = HashMap::new();
+    meta.insert(
+        "rule".to_string(),
+        serde_json::Value::String(ast.rule_name.clone()),
+    );
+    meta.insert(
+        "version".to_string(),
+        serde_json::Value::String(version.as_str().to_string()),
+    );
+    // Ignore the Err path on `contribute` — the only error it can return is
+    // "contributing to a deleted entity," which can't happen here (we just
+    // created the entity).
+    let _ = cv.contribute(&program_cv, "parser", "constructed", meta);
+
+    Ok(ProgramWithCv {
+        ast,
+        cv: program_cv,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,5 +212,77 @@ mod tests {
     #[test]
     fn create_parser_typed() {
         let _parser = create_javascript_parser_typed("var x = 1;", EsVersion::Es5).unwrap();
+    }
+
+    // ----- CV-plumbed parser (CLOC03 Stage 2 v1) -----
+
+    #[test]
+    fn parse_with_cv_assigns_a_program_id() {
+        let mut cv = CVLog::new(true);
+        let pwc = parse_javascript_with_cv("var x = 1;", "src/test.js", EsVersion::Es5, &mut cv)
+            .unwrap();
+        assert_eq!(pwc.ast.rule_name, "program");
+        assert!(!pwc.cv.is_empty(), "expected a non-empty program CV id");
+    }
+
+    #[test]
+    fn parse_with_cv_program_id_resolves_in_log() {
+        let mut cv = CVLog::new(true);
+        let pwc = parse_javascript_with_cv("var x = 1;", "lookup.js", EsVersion::Es5, &mut cv)
+            .unwrap();
+        let entry = cv
+            .get(&pwc.cv)
+            .unwrap_or_else(|| panic!("program CV {:?} not found in log", pwc.cv));
+        let origin = entry
+            .origin
+            .as_ref()
+            .expect("program CV must have an Origin");
+        assert_eq!(origin.source, "lookup.js");
+        assert_eq!(origin.location, "0:0");
+    }
+
+    #[test]
+    fn parse_with_cv_appends_constructed_contribution() {
+        let mut cv = CVLog::new(true);
+        let pwc = parse_javascript_with_cv("var x = 1;", "src.js", EsVersion::Es5, &mut cv)
+            .unwrap();
+        let history = cv.history(&pwc.cv);
+        let constructed = history
+            .iter()
+            .find(|c| c.source == "parser" && c.tag == "constructed")
+            .expect("expected one parser/constructed contribution");
+        assert_eq!(
+            constructed.meta.get("rule").and_then(|v| v.as_str()),
+            Some("program")
+        );
+        assert_eq!(
+            constructed.meta.get("version").and_then(|v| v.as_str()),
+            Some("es5")
+        );
+    }
+
+    #[test]
+    fn parse_with_cv_program_has_token_ancestors() {
+        let mut cv = CVLog::new(true);
+        let pwc = parse_javascript_with_cv("var x = 1;", "anc.js", EsVersion::Es5, &mut cv)
+            .unwrap();
+        // The program CV was minted via cv.merge(token_ids, ...) so it
+        // should have at least one ancestor.
+        let ancestors = cv.ancestors(&pwc.cv);
+        assert!(
+            !ancestors.is_empty(),
+            "expected program CV to have token ancestors"
+        );
+    }
+
+    #[test]
+    fn parse_with_cv_disabled_log_still_returns_ast() {
+        // Disabled log keeps API shape but skips storage. The parser must
+        // not panic and must still return a valid AST.
+        let mut cv = CVLog::new(false);
+        let pwc = parse_javascript_with_cv("var x = 1;", "off.js", EsVersion::Es5, &mut cv)
+            .unwrap();
+        assert_eq!(pwc.ast.rule_name, "program");
+        assert!(!pwc.cv.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Continues the CLOC03 plumbing rollout. The lexer ([#3806](https://github.com/adhithyan15/coding-adventures/pull/3806))
assigns a CV ID to every token; this PR has the parser **inherit those
token IDs** onto a program-root CV via `cv.merge(...)`, records the
parser's stage with a `"constructed"` `Contribution`, and packages it
all as a `ProgramWithCv`.

### `javascript-parser` (`0.4.0` → `0.5.0`)

- New dependencies on `coding_adventures_correlation_vector` and
  `serde_json`.
- **`pub struct ProgramWithCv { pub ast: GrammarASTNode, pub cv: String }`**.
- **`parse_javascript_with_cv(source, source_file, EsVersion,
  &mut CVLog) -> Result<ProgramWithCv, String>`** — per CLOC03 §Stage 2
  (v1, root-only):
  1. Tokenize via `tokenize_javascript_with_cv` (lexer CV plumbing from #3806).
  2. Run the underlying `GrammarParser` on the bare tokens.
  3. Mint the program-root CV via `cv.merge(token_ids, Origin{ source:
     source_file, location: "0:0", … })` so every token is an ancestor.
  4. Append `Contribution { source: "parser", tag: "constructed",
     meta: { rule, version } }`.
- Module docs add a "Correlation-vector plumbing" section, including
  the v1-vs-future-PR scope note.

### What v1 deliberately does **not** do

Per-AST-node CV propagation. The underlying `GrammarParser` still emits
a generic `GrammarASTNode` tree, not the typed `javascript-ast::Program`
with `cv: CvId` on every node. Threading CV per-node requires
`GrammarParser` changes and the typed output, which is the natural
follow-up. Until then, root-only plumbing still gives source maps and
debuggers a usable signal (leftmost-ancestor resolution per CLOC07).

## Test plan

- [x] `cargo test -p coding-adventures-javascript-parser` — **12/12 pass**
      (7 existing + 5 new CV tests)
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      error unrelated)
- [ ] CI matrix

New tests:
- `parse_with_cv_assigns_a_program_id`
- `parse_with_cv_program_id_resolves_in_log` (Origin.source +
  location)
- `parse_with_cv_appends_constructed_contribution` (rule + version
  in meta)
- `parse_with_cv_program_has_token_ancestors` (`cv.ancestors(id)`
  non-empty)
- `parse_with_cv_disabled_log_still_returns_ast` (production fast path)

## What's next

1. **GrammarParser CV plumbing + typed AST output** — when the parser
   emits `javascript-ast::Program` directly, every node gets its own
   `CvId` per CLOC02. This is the deeper plumbing PR.
2. **Extend `javascript-tokens` with `TokenKind`** (deferred).
3. **Stage 2+** — `type-sidecar` crate, JSDoc grammar/crates, …

🤖 Generated with [Claude Code](https://claude.com/claude-code)