### PR TITLE
Add WHATWG lexer Rust test coverage check

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -107,6 +107,9 @@ binary while production code continues to link only static Rust source.
 - `check_whatwg_lexer_fixture_metadata.py`: checker that keeps the generated
   WHATWG lexer fixture files, generator pairs, metadata formats, and
   stale-check manifest wiring aligned
+- `check_whatwg_lexer_rust_tests.py`: checker that keeps every focused WHATWG
+  lexer fixture paired with a Rust test that parses the fixture and exercises
+  the lexer harness
 - `check_generated_html_fixtures.py`: manifest check that runs every
   self-contained generated lexer/parser fixture stale check from checked-in
   inputs, with optional flags for upstream-only source inputs
@@ -180,6 +183,8 @@ Verify local WHATWG lexer fixture metadata and manifest coverage with:
 
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py \
+  --check
+python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py \
   --check
 ```
 

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -123,6 +123,13 @@ def default_checks() -> list[FixtureCheck]:
                 "--check",
             ),
         ),
+        FixtureCheck(
+            "whatwg-lexer-rust-tests",
+            (
+                str(FIXTURE_DIR / "check_whatwg_lexer_rust_tests.py"),
+                "--check",
+            ),
+        ),
         *lexer_fixture_checks(),
         FixtureCheck(
             "whatwg-tree-insertion-audit",

--- a/code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+"""Check Rust test coverage for focused WHATWG lexer fixtures."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+TEST_DIR = FIXTURE_DIR.parent
+FIXTURE_GLOB = "whatwg-*.json"
+
+
+LEXER_EXECUTION_SNIPPETS = (
+    "common::assert_lexer_case(",
+    "common::assert_default_lexer_case(",
+    "create_html_lexer()",
+    "create_html_lexer_with_context(",
+)
+
+CASE_ITERATION_SNIPPETS = (
+    "for case in &suite.cases",
+    "for case in &suite.position_cases",
+    "for entity in &suite.entities",
+    "for entity in suite.entities.iter()",
+)
+
+
+def main() -> int:
+    parse_args()
+    fixture_paths = sorted(FIXTURE_DIR.glob(FIXTURE_GLOB))
+    test_paths = sorted(TEST_DIR.glob("whatwg_*_test.rs"))
+
+    errors: list[str] = []
+    errors.extend(check_test_pairs(fixture_paths, test_paths))
+    for fixture_path in fixture_paths:
+        errors.extend(check_test_file(fixture_path))
+
+    print("WHATWG lexer Rust tests")
+    print(f"fixture files: {len(fixture_paths)}")
+    print(f"rust tests:    {len(test_paths)}")
+
+    if errors:
+        raise SystemExit("\n\n".join(errors))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check that every focused WHATWG lexer fixture has a matching Rust "
+            "test that includes and parses the fixture, iterates over fixture "
+            "cases, and exercises the HTML lexer harness."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compatibility flag for the generated fixture manifest.",
+    )
+    return parser.parse_args()
+
+
+def check_test_pairs(fixture_paths: list[Path], test_paths: list[Path]) -> list[str]:
+    fixture_names = {fixture_name(path) for path in fixture_paths}
+    test_names = {test_name(path) for path in test_paths}
+
+    errors: list[str] = []
+    missing_tests = sorted(fixture_names - test_names)
+    stale_tests = sorted(test_names - fixture_names)
+    if missing_tests:
+        errors.append(
+            "WHATWG lexer fixtures without matching Rust tests:\n"
+            + "\n".join(f"  {name}" for name in missing_tests)
+        )
+    if stale_tests:
+        errors.append(
+            "Rust WHATWG lexer tests without matching fixtures:\n"
+            + "\n".join(f"  {name}" for name in stale_tests)
+        )
+    return errors
+
+
+def check_test_file(fixture_path: Path) -> list[str]:
+    name = fixture_name(fixture_path)
+    test_path = TEST_DIR / f"whatwg_{name.replace('-', '_')}_test.rs"
+    if not test_path.exists():
+        return []
+
+    text = test_path.read_text()
+    errors: list[str] = []
+
+    required_snippets = {
+        "fixture include": f'include_str!("fixtures/{fixture_path.name}")',
+        "fixture parser": "serde_json::from_str(",
+        "load_suite helper": "fn load_suite()",
+        "Rust test": "#[test]",
+        "fixture parse expectation": "fixture should parse",
+    }
+    for label, snippet in required_snippets.items():
+        if snippet not in text:
+            errors.append(f"{test_path.name} is missing {label}: {snippet}")
+
+    if not any(snippet in text for snippet in LEXER_EXECUTION_SNIPPETS):
+        errors.append(
+            f"{test_path.name} does not exercise the HTML lexer harness; "
+            "expected one of: "
+            + ", ".join(LEXER_EXECUTION_SNIPPETS)
+        )
+
+    if not any(snippet in text for snippet in CASE_ITERATION_SNIPPETS):
+        errors.append(
+            f"{test_path.name} does not iterate over fixture cases; "
+            "expected one of: "
+            + ", ".join(CASE_ITERATION_SNIPPETS)
+        )
+
+    return errors
+
+
+def fixture_name(path: Path) -> str:
+    return path.name.removeprefix("whatwg-").removesuffix(".json")
+
+
+def test_name(path: Path) -> str:
+    return path.name.removeprefix("whatwg_").removesuffix("_test.rs").replace("_", "-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
@@ -40,6 +40,7 @@ class GeneratedHtmlFixtureManifestTest(unittest.TestCase):
         self.assertIn("normalize_html5lib_fixtures.py", checked_scripts)
         self.assertIn("check_html5lib_tokenizer_coverage.py", checked_scripts)
         self.assertIn("check_whatwg_lexer_fixture_metadata.py", checked_scripts)
+        self.assertIn("check_whatwg_lexer_rust_tests.py", checked_scripts)
         self.assertIn("check_whatwg_audit_manifest.py", checked_scripts)
         self.assertIn("check_html5lib_tree_construction_smoke.py", checked_scripts)
         self.assertIn("check_whatwg_audit_rust_tests.py", checked_scripts)


### PR DESCRIPTION
## Summary
- add a lexer-side checker that pairs every focused WHATWG lexer fixture with a Rust test
- verify each paired test includes/parses its fixture, iterates the corpus, and exercises the lexer harness
- wire the checker into the generated fixture manifest and fixture docs

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py code/packages/rust/html-lexer/tests/fixtures/check_html5lib_tokenizer_coverage.py code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser