### PR TITLE
[codex] Add Board VM TCP endpoint metadata

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -57,9 +57,10 @@ CLI `--baud` and `--timeout-ms` overrides before touching the OS port. That
 keeps DTR/open-settle, stale-byte clearing, endpoint metadata, and wire
 protocol ownership in the Rust target layer while this crate performs the
 platform-specific open/read/write call. The endpoint path accepts Rust-owned
-serial endpoint metadata (`serial://...`) plus TCP sockets and Board VM
-Bluetooth endpoints (`ble://`, `btspp://`, or `rfcomm://`) through the
-Rust-owned transport adapters. The smoke report starts with a stable
+serial endpoint metadata (`serial://...`), TCP endpoint metadata (`tcp://...` or
+bare `host:port`), and Board VM Bluetooth endpoints (`ble://`, `btspp://`, or
+`rfcomm://`) through the Rust-owned transport adapters. The smoke report starts
+with a stable
 `connection transport=...` field so hardware logs can distinguish serial, TCP
 socket, BLE GATT, and RFCOMM runs without parsing endpoint strings. The default
 run budget is intentionally small because the current firmware executes

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -23,7 +23,8 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_transact_wire_frame, parse_bluetooth_endpoint as parse_language_bluetooth_endpoint,
-    parse_serial_endpoint as parse_language_serial_endpoint, serial_runtime_open_plan_for_target,
+    parse_serial_endpoint as parse_language_serial_endpoint,
+    parse_tcp_endpoint as parse_language_tcp_endpoint, serial_runtime_open_plan_for_target,
     LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
 };
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
@@ -1802,7 +1803,15 @@ fn endpoint_connection_label(
 
 fn endpoint_transport(endpoint: &str) -> Result<SessionEndpointTransport, CliError> {
     match endpoint.split_once("://").map(|(scheme, _)| scheme) {
-        None | Some("tcp") => Ok(SessionEndpointTransport::Tcp),
+        None | Some("tcp") => {
+            if parse_language_tcp_endpoint(endpoint).is_some() {
+                Ok(SessionEndpointTransport::Tcp)
+            } else {
+                Err(CliError::DeviceSelection(format!(
+                    "invalid Board VM TCP endpoint: {endpoint}"
+                )))
+            }
+        }
         Some("serial") => {
             if parse_language_serial_endpoint(endpoint).is_some() {
                 Ok(SessionEndpointTransport::Serial)
@@ -2767,6 +2776,10 @@ mod tests {
                 host_nonce: DEFAULT_HOST_NONCE,
             })
         );
+        assert_eq!(
+            endpoint_transport("tcp://board-vm.local:4170").unwrap(),
+            SessionEndpointTransport::Tcp
+        );
     }
 
     #[test]
@@ -2785,6 +2798,10 @@ mod tests {
                 instruction_budget: DEFAULT_INSTRUCTION_BUDGET,
                 host_nonce: DEFAULT_HOST_NONCE,
             })
+        );
+        assert_eq!(
+            endpoint_transport("127.0.0.1:4170").unwrap(),
+            SessionEndpointTransport::Tcp
         );
     }
 
@@ -2912,6 +2929,16 @@ mod tests {
         assert_eq!(
             error,
             CliError::DeviceSelection("invalid Board VM serial endpoint: serial://".to_owned())
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_tcp_endpoint() {
+        let error = endpoint_transport("tcp://   ").unwrap_err();
+
+        assert_eq!(
+            error,
+            CliError::DeviceSelection("invalid Board VM TCP endpoint: tcp://   ".to_owned())
         );
     }
 

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -74,6 +74,9 @@ external-adapter targets reuse the selected port.
 transport open contract for language adapters: baud rate, timeout, stale-byte
 clearing, open-settle delay, endpoint scheme, and Board VM wire protocol. The
 actual OS serial open still belongs to the frontend adapter or CLI.
+`parse_serial_endpoint`, `parse_tcp_endpoint`, and `parse_bluetooth_endpoint`
+keep endpoint scheme and transport metadata in the same Rust-owned boundary so
+frontends do not need parallel endpoint tables.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -389,6 +389,15 @@ pub struct LanguageSerialEndpoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageTcpEndpoint {
+    pub endpoint: String,
+    pub transport: LanguageConnectionTransport,
+    pub endpoint_transport: LanguageHostEndpointTransport,
+    pub endpoint_scheme: String,
+    pub authority: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageBluetoothEndpoint {
     pub endpoint: String,
     pub transport: LanguageConnectionTransport,
@@ -1534,6 +1543,25 @@ pub fn parse_serial_endpoint(endpoint: &str) -> Option<LanguageSerialEndpoint> {
         endpoint_transport: LanguageHostEndpointTransport::SerialPort,
         endpoint_scheme: scheme.to_owned(),
         port: port.to_owned(),
+    })
+}
+
+pub fn parse_tcp_endpoint(endpoint: &str) -> Option<LanguageTcpEndpoint> {
+    let (scheme, authority) = match endpoint.split_once("://") {
+        Some(("tcp", authority)) => ("tcp", authority),
+        Some(_) => return None,
+        None => ("tcp", endpoint),
+    };
+    let authority = authority.trim();
+    if authority.is_empty() {
+        return None;
+    }
+    Some(LanguageTcpEndpoint {
+        endpoint: endpoint.to_owned(),
+        transport: LanguageConnectionTransport::Wifi,
+        endpoint_transport: LanguageHostEndpointTransport::TcpSocket,
+        endpoint_scheme: scheme.to_owned(),
+        authority: authority.to_owned(),
     })
 }
 
@@ -5656,6 +5684,27 @@ mod tests {
         assert!(parse_serial_endpoint("serial://   ").is_none());
         assert!(serial_runtime_open_plan_for_target("uno-r4-wifi", "   ").is_none());
         assert!(serial_runtime_open_plan_for_target("not-a-board", "COM7").is_none());
+    }
+
+    #[test]
+    fn tcp_endpoint_metadata_is_owned_by_rust_language_core() {
+        let endpoint = parse_tcp_endpoint("tcp://board-vm.local:4170").unwrap();
+        assert_eq!(endpoint.endpoint, "tcp://board-vm.local:4170");
+        assert_eq!(endpoint.transport, LanguageConnectionTransport::Wifi);
+        assert_eq!(
+            endpoint.endpoint_transport,
+            LanguageHostEndpointTransport::TcpSocket
+        );
+        assert_eq!(endpoint.endpoint_scheme, "tcp");
+        assert_eq!(endpoint.authority, "board-vm.local:4170");
+
+        let bare_endpoint = parse_tcp_endpoint("127.0.0.1:4170").unwrap();
+        assert_eq!(bare_endpoint.endpoint, "127.0.0.1:4170");
+        assert_eq!(bare_endpoint.endpoint_scheme, "tcp");
+        assert_eq!(bare_endpoint.authority, "127.0.0.1:4170");
+
+        assert!(parse_tcp_endpoint("serial:///dev/cu.usbmodem1101").is_none());
+        assert!(parse_tcp_endpoint("tcp://   ").is_none());
     }
 
     #[test]

--- a/code/specs/BVM04-board-vm-host-sdks.md
+++ b/code/specs/BVM04-board-vm-host-sdks.md
@@ -228,6 +228,9 @@ When a frontend receives a `serial://...` endpoint string from that plan or from
 a user-facing CLI surface, it should parse the endpoint through the Rust-owned
 serial endpoint helper and then apply the same serial open plan instead of
 maintaining a parallel endpoint scheme table.
+TCP endpoint strings should follow the same boundary: frontends should ask Rust
+for `tcp://...` or bare `host:port` endpoint metadata and keep their local code
+to the platform-specific socket open/read/write call.
 
 Selector handling follows the same ownership boundary. If a frontend receives
 an Arduino CLI FQBN such as `arduino:renesas_uno:nanor4`, it should ask the Rust


### PR DESCRIPTION
## Summary
- add `LanguageTcpEndpoint` and `parse_tcp_endpoint` in `board-vm-language-core` for `tcp://...` and bare `host:port` endpoint metadata
- have `board-vm-cli` validate TCP endpoints through language-core before selecting TCP transport
- document the Rust-owned TCP endpoint metadata boundary for host SDKs and CLI users

## Validation
- `cargo fmt -p board-vm-cli -p board-vm-language-core`
- `cargo test -p board-vm-cli -p board-vm-language-core`
- `bash BUILD` in `code/packages/rust/board-vm-cli`
- `bash BUILD` in `code/packages/rust/board-vm-language-core`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli`
- `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool -root . -diff-base origin/main -validate-build-files -detect-languages -emit-plan build-plan.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed before committing.