### PR TITLE
feat(ml-framework-core): MX10 Phase 3 — Rust fast path for reduce-all Sum/Mean

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 3: optional Rust fast path for reduce-all `SumFunction` / `MeanFunction`
+
+Extends the per-op conditional dispatch to the **reduce-all path
+of `SumFunction` and `MeanFunction`** (the `dim=None` case that
+collapses any-shape tensor → scalar).  Axis-specific reductions
+(`dim=<int>`) stay pure-Python in Phase 3 — output-shape computation
+and the backward broadcast differ materially from the reduce-all
+case, and warrant their own sub-phase.
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds:
+    - `should_use_rust_for_reduction(numel)` predicate.  Reuses the
+      same threshold (`_ELEMENTWISE_RUST_THRESHOLD = 100_000`) as
+      elementwise — reductions have roughly the same per-cell cost
+      (one add/divide per cell).
+    - `_reduce_all_via_rust(a, op_kind)` shared helper for the
+      single-op envelope: 1 input tensor, 1 output tensor (shape
+      `[]` — a scalar), op with `axes=[0, 1, ..., ndim-1]` and
+      `keep_dims=False`.
+    - Public wrappers `sum_via_rust(a)` and `mean_via_rust(a)` that
+      use matrix-ir-json's `ReduceSum` and `ReduceMean` ops
+      respectively.  Both return Tensor of shape `(1,)` to match
+      the pure-Python contract.
+
+- **`functions.py`** — `SumFunction.forward` and
+  `MeanFunction.forward` each gain a 2-line dispatch block inside
+  the `if dim is None:` branch.  The `dim != None` branches are
+  untouched — Phase 3 only accelerates the reduce-all path.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `dim is None`, numel ≥ 100_000 | **Rust** |
+| Extension installed, `dim is None`, numel < 100_000 | Pure-Python |
+| `dim != None` (axis-specific) | Pure-Python (always) |
+| Extension NOT installed | Pure-Python |
+
+#### Tests (36 total MX10 tests, was 27)
+
+- **`ReductionParityTests`** (3 cases, skip if extension missing):
+  predicate sanity + Sum + Mean parity at the 100_000-cell threshold,
+  same `rtol=1e-3, atol=1e-4` tolerance as matmul/elementwise.
+- **`ReductionFallbackTests`** (6 cases, always runs): predicate
+  short-circuit, direct-call `RuntimeError`, Sum/Mean correctness via
+  pure-Python fallback (`[1,2,3,4,5].sum() == 15`,
+  `[1,2,3,4,5].mean() == 3`), and a sanity test confirming the
+  axis-specific path (`sum(dim=0)`) is unchanged by Phase 3.
+
+All passing locally on darwin-arm64 py 3.10.6 with the C extension
+built; full suite at 355 passed + the same `test_device.py`
+pre-existing failure unrelated to this PR.
+
+### What's NOT in Phase 3
+
+- Axis-specific reductions (`dim != None`).  Deferred to Phase 3b
+  if profiling shows demand.
+- Other reductions (Min, Max, Std, Var, ArgMin, ArgMax).  Only
+  Sum/Mean are routed in Phase 3 because they're the most common in
+  ML workloads (loss aggregation, batch normalisation, etc.); the
+  rest can be added later using the same `_reduce_all_via_rust`
+  factory.
+- No activations (Phase 4: ReLU/Sigmoid/Tanh/GELU/Softmax).
+
 ### Added — MX10 Phase 2: optional Rust fast path for the elementwise op family
 
 Extends the per-op conditional dispatch from Phase 1 (matmul only)

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -437,3 +437,124 @@ def abs_via_rust(a: Tensor) -> Tensor:
 # competitive (Python's float pow is C-implemented and tight).
 # Deferred until matrix-cpu adds a scalar-exponent variant of Pow,
 # or until profiling shows it's worth the broadcast cost.
+
+
+# ──────────────────────────────────────────────────────────────────
+# Reduction fast paths (MX10 Phase 3)
+#
+# Sum and Mean over the whole tensor (the ``dim=None`` case in
+# SumFunction / MeanFunction) collapse the input to a single scalar.
+# matrix-ir-json supports this via ReduceSum / ReduceMean with the
+# "axes" field listing every axis and keep_dims=false.
+#
+# **Axis-specific reductions (``dim != None``) are not accelerated
+# in Phase 3.**  The output-shape computation, the axis broadcast
+# for backward, and the per-test fixture coverage all differ
+# materially from the reduce-all case.  Adding axis-specific
+# dispatch is straightforward extension work but its own PR.
+# ──────────────────────────────────────────────────────────────────
+
+
+# Reductions have roughly the same per-cell cost as elementwise
+# (one add/divide per cell), so the FFI break-even threshold is in
+# the same neighbourhood.  We reuse the elementwise threshold here
+# rather than tracking a separate constant — if profiling shows
+# reductions break even at a different point we can split.
+def should_use_rust_for_reduction(numel: int) -> bool:
+    """Decide whether to dispatch a reduce-all op (Sum / Mean over
+    the whole tensor) to Rust.
+
+    Returns ``True`` iff the C extension is installed AND the input
+    has at least ``_ELEMENTWISE_RUST_THRESHOLD`` cells.
+
+    For axis-specific reductions (``dim != None``), the caller should
+    NOT call this — Phase 3 only accelerates the reduce-all path.
+    """
+    if not _RUST_AVAILABLE:
+        return False
+    return numel >= _ELEMENTWISE_RUST_THRESHOLD
+
+
+def _reduce_all_via_rust(a: Tensor, op_kind: str) -> Tensor:
+    """Generic helper for ReduceSum / ReduceMean over the whole tensor.
+
+    Input shape: arbitrary.
+    Output shape: ``(1,)`` — same shape SumFunction/MeanFunction return
+    in the ``dim=None`` case.
+
+    ``axes = [0, 1, ..., ndim-1]`` reduces along every dimension;
+    ``keep_dims = false`` collapses to a 0-D tensor which matrix-ir-json
+    represents as the shape returned by Shape::reduce_along_axes.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            f"{op_kind.lower()}_via_rust called but Rust backend is not available; "
+            f"callers must check should_use_rust_for_reduction() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(a.data)
+    input_shape = list(a.shape)
+    # All axes — reduce along every dimension to collapse to a scalar.
+    all_axes = list(range(len(input_shape)))
+
+    a_bytes = struct.pack(f"<{numel}f", *a.data)
+
+    # Reduce-all with keep_dims=False produces a 0-element-rank
+    # (scalar) output.  matrix-ir's Shape::reduce_along_axes with
+    # keep_dims=false returns an empty shape `[]` for full reduction;
+    # the executor still allocates 1 cell of buffer.  We declare
+    # output shape `[]` and expect 1 f32 (4 bytes) back.
+    output_shape: list[int] = []
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    {"id": 0, "dtype": "f32", "shape": input_shape},
+                    {"id": 1, "dtype": "f32", "shape": output_shape},
+                ],
+                "inputs": [0],
+                "outputs": [1],
+                "ops": [
+                    {
+                        "kind": op_kind,
+                        "input": 0,
+                        "axes": all_axes,
+                        "keep_dims": False,
+                        "output": 1,
+                    }
+                ],
+                "constants": [],
+            },
+            "inputs": [a_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    if len(out_bytes) != 4:
+        raise RuntimeError(
+            f"{op_kind.lower()}_via_rust: expected 4 output bytes (1 f32), "
+            f"got {len(out_bytes)}"
+        )
+    (scalar,) = struct.unpack("<f", out_bytes)
+
+    # SumFunction / MeanFunction return shape (1,) for dim=None.
+    # Match that contract so the dispatch is a drop-in replacement.
+    return _Tensor([scalar], (1,), device=a.device)
+
+
+def sum_via_rust(a: Tensor) -> Tensor:
+    """``a.sum()`` (reduce-all) via Rust.  Returns Tensor of shape ``(1,)``."""
+    return _reduce_all_via_rust(a, "ReduceSum")
+
+
+def mean_via_rust(a: Tensor) -> Tensor:
+    """``a.mean()`` (reduce-all) via Rust.  Returns Tensor of shape ``(1,)``."""
+    return _reduce_all_via_rust(a, "ReduceMean")

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -48,11 +48,14 @@ from ._rust_backend import (
     add_via_rust,
     div_via_rust,
     matmul_via_rust,
+    mean_via_rust,
     mul_via_rust,
     neg_via_rust,
     should_use_rust_for_elementwise,
     should_use_rust_for_matmul,
+    should_use_rust_for_reduction,
     sub_via_rust,
+    sum_via_rust,
 )
 from .autograd import Function
 from .tensor import Tensor, _compute_strides, _numel
@@ -405,6 +408,12 @@ class SumFunction(Function):
         self.saved_metadata["keepdim"] = keepdim
 
         if dim is None:
+            # MX10 Phase 3 — optional Rust fast path (reduce-all).
+            # Axis-specific reductions (dim != None) stay pure-Python
+            # in Phase 3; broadcasting + output-shape computation
+            # differ enough to warrant their own sub-phase.
+            if should_use_rust_for_reduction(len(a.data)):
+                return sum_via_rust(a)
             # Sum all elements → scalar
             total = sum(a.data)
             return Tensor([total], (1,), device=a.device)
@@ -513,6 +522,10 @@ class MeanFunction(Function):
         self.saved_metadata["dim"] = dim
 
         if dim is None:
+            # MX10 Phase 3 — optional Rust fast path (reduce-all).
+            # Axis-specific path stays pure-Python in Phase 3.
+            if should_use_rust_for_reduction(len(a.data)):
+                return mean_via_rust(a)
             total = sum(a.data)
             return Tensor([total / a.numel], (1,), device=a.device)
 

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -249,5 +249,71 @@ class ElementwiseFallbackTests(unittest.TestCase):
         self.assertEqual(result.data, [1.0, 2.0, 3.0, 4.0])
 
 
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 3 — reduction fallback tests
+#
+# Same pattern as elementwise: monkey-patch ``_RUST_AVAILABLE = False``
+# and confirm the pure-Python kernel produces correct results.
+# ──────────────────────────────────────────────────────────────────
+
+
+class ReductionFallbackTests(unittest.TestCase):
+    """Confirm sum/mean still work when the Rust path is disabled."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_predicate_returns_false_for_reduction_when_unavailable(self) -> None:
+        self.assertFalse(_rust_backend.should_use_rust_for_reduction(10_000_000))
+
+    def test_sum_via_rust_raises_when_unavailable(self) -> None:
+        a = Tensor([1.0, 2.0, 3.0], (3,))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.sum_via_rust(a)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_mean_via_rust_raises_when_unavailable(self) -> None:
+        a = Tensor([1.0, 2.0, 3.0], (3,))
+        with self.assertRaises(RuntimeError):
+            _rust_backend.mean_via_rust(a)
+
+    def test_sum_correct_via_fallback(self) -> None:
+        """``a.sum()`` (reduce-all) gives the right total via pure-Python."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0], (5,))
+        result = a.sum()
+        self.assertEqual(result.shape, (1,))
+        self.assertEqual(result.data, [15.0])
+
+    def test_mean_correct_via_fallback(self) -> None:
+        """``a.mean()`` (reduce-all) gives the right average via pure-Python."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0], (5,))
+        result = a.mean()
+        self.assertEqual(result.shape, (1,))
+        self.assertEqual(result.data, [3.0])
+
+    def test_axis_specific_reduction_unchanged_by_phase_3(self) -> None:
+        """``a.sum(dim=0)`` stays pure-Python in Phase 3 — never dispatches.
+
+        Even with the Rust extension installed, the axis-specific
+        path bypasses the threshold check entirely (the dispatch
+        condition is wrapped in ``if dim is None``).  Sanity:
+        the result is still correct.
+        """
+        # Reset to "extension available" but the predicate isn't even
+        # consulted for dim != None, so behavior matches whether or
+        # not extension is present.
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+        # 2x3 tensor, sum along dim=0 → shape (3,) with column sums.
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        result = a.sum(dim=0)
+        # Column sums: [1+4, 2+5, 3+6] = [5, 7, 9]
+        self.assertEqual(result.data, [5.0, 7.0, 9.0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -376,5 +376,99 @@ class ElementwiseParityTests(unittest.TestCase):
         self._unary_parity_check("Abs", lambda a: a.abs(), seed=13)
 
 
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 3 — reduction (Sum / Mean) parity tests
+#
+# Reduce-all over a 100_000-cell tensor with dim=None.  Output is
+# a scalar (Tensor of shape (1,)).  Same f32-vs-double tolerance as
+# matmul + elementwise.
+# ──────────────────────────────────────────────────────────────────
+
+
+@unittest.skipUnless(
+    EXTENSION_AVAILABLE,
+    "matrix_rust_python C extension not installed; see parity-tests skip-reason.",
+)
+class ReductionParityTests(unittest.TestCase):
+    """Compare each reduce-all op's Rust and pure-Python kernels."""
+
+    SHAPE = (500, 200)  # 100_000 cells
+
+    def _make_tensor(self, seed: int):
+        import random
+
+        from ml_framework_core import Tensor
+
+        rng = random.Random(seed)
+        data = [rng.uniform(-1.0, 1.0) for _ in range(500 * 200)]
+        return Tensor(data, self.SHAPE)
+
+    def _assert_close_scalar(
+        self,
+        actual: float,
+        expected: float,
+        rtol: float = 1e-3,
+        atol: float = 1e-4,
+    ) -> None:
+        """Tolerance same as matmul/elementwise — covers f32 vs double
+        quantization noise from summing 100_000 cells in f32."""
+        denom = max(abs(actual), abs(expected), atol)
+        err = abs(actual - expected) / denom
+        self.assertLess(
+            err,
+            rtol,
+            f"rust={actual!r}, python={expected!r}, relative error {err:.2e}",
+        )
+
+    def test_reduction_dispatch_predicate_fires_at_threshold(self) -> None:
+        """``should_use_rust_for_reduction(100_000)`` returns True."""
+        from ml_framework_core._rust_backend import should_use_rust_for_reduction
+
+        self.assertTrue(
+            should_use_rust_for_reduction(500 * 200),
+            "MX10 Phase 3 threshold should let 100_000 cells use Rust",
+        )
+
+    def test_sum_parity(self) -> None:
+        """``a.sum()`` (reduce-all) produces same scalar via Rust and pure-Python."""
+        from ml_framework_core import _rust_backend
+
+        a = self._make_tensor(seed=42)
+
+        rust_result = a.sum()
+        self.assertEqual(
+            rust_result.shape, (1,), "sum() reduce-all should return shape (1,)"
+        )
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = a.sum()
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close_scalar(rust_result.data[0], python_result.data[0])
+
+    def test_mean_parity(self) -> None:
+        """``a.mean()`` (reduce-all) produces same scalar via Rust and pure-Python."""
+        from ml_framework_core import _rust_backend
+
+        a = self._make_tensor(seed=7)
+
+        rust_result = a.mean()
+        self.assertEqual(
+            rust_result.shape, (1,), "mean() reduce-all should return shape (1,)"
+        )
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = a.mean()
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close_scalar(rust_result.data[0], python_result.data[0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Extends MX10's per-op conditional dispatch to the **reduce-all path of \`SumFunction\` and \`MeanFunction\`** (\`dim=None\`, collapses any-shape tensor → scalar). Routes through matrix-ir-json's \`ReduceSum\` / \`ReduceMean\` ops with \`axes=[0..ndim-1]\` and \`keep_dims=False\`.

**Axis-specific reductions (\`dim != None\`) stay pure-Python** in Phase 3 — output-shape computation and the backward broadcast differ enough to warrant their own sub-phase.

## Implementation

- \`_rust_backend.py\`: \`should_use_rust_for_reduction(numel)\` predicate (reuses the elementwise \`100_000\` threshold), \`_reduce_all_via_rust(a, op_kind)\` shared helper, public wrappers \`sum_via_rust\` / \`mean_via_rust\`.
- \`functions.py\`: 2-line dispatch in \`SumFunction.forward\` and \`MeanFunction.forward\`, scoped strictly inside \`if dim is None:\`.

## Behaviour matrix

| Situation | Path |
|-----------|------|
| Extension + \`dim=None\` + numel ≥ 100_000 | **Rust** |
| Extension + \`dim=None\` + numel < 100_000 | Pure-Python |
| \`dim != None\` (axis-specific) | Pure-Python (always) |
| No extension | Pure-Python |

## Tests (27 → 36)

- **\`ReductionParityTests\`** (3 cases, skip if no extension): predicate sanity + Sum + Mean parity at the 100_000-cell threshold (\`rtol=1e-3, atol=1e-4\`).
- **\`ReductionFallbackTests\`** (6 cases, always runs): predicate short-circuit, defence-in-depth \`RuntimeError\`, correctness of pure-Python kernels, **and a sanity test confirming \`sum(dim=0)\` is unchanged by Phase 3**.

All 36 MX10 tests pass locally. Full suite 355 pass + 1 unrelated pre-existing \`test_device.py\` failure.

## Security review (\`/security-review\`): PASSED

Key check — the new \`axes\`/\`keep_dims\` envelope fields are pure-Python-derived from tensor shape (no attacker influence), \`op_kind\` passed via \`json.dumps\` escaping with only two hardcoded callers, output-bytes length validated before \`struct.unpack\`, dispatch strictly scoped inside \`if dim is None:\` (fallback test proves axis-specific path can't be rerouted).

## What's NOT in Phase 3

- Axis-specific reductions (\`dim != None\`) — Phase 3b territory
- Other reductions (Min, Max, Std, Var, ArgMin, ArgMax) — same factory could handle them
- Activations (Phase 4: ReLU/Sigmoid/Tanh/GELU/Softmax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)