### PR TITLE
[codex] Add Board VM host endpoint summary

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -59,8 +59,10 @@ protocol ownership in the Rust target layer while this crate performs the
 platform-specific open/read/write call. The endpoint path accepts Rust-owned
 serial endpoint metadata (`serial://...`), TCP endpoint metadata (`tcp://...` or
 bare `host:port`), and Board VM Bluetooth endpoints (`ble://`, `btspp://`, or
-`rfcomm://`) through the Rust-owned transport adapters. The smoke report starts
-with a stable
+`rfcomm://`) through the Rust-owned transport adapters. Endpoint transport
+classification comes from the shared `board-vm-language-core`
+`parse_host_endpoint` summary, so the CLI does not maintain its own endpoint
+scheme table. The smoke report starts with a stable
 `connection transport=...` field so hardware logs can distinguish serial, TCP
 socket, BLE GATT, and RFCOMM runs without parsing endpoint strings. The default
 run budget is intentionally small because the current firmware executes

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -22,10 +22,9 @@ use board_vm_host::{
     GpioReadProgram, TimeNowProgram, BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, TIME_NOW_MODULE_LEN,
 };
 use board_vm_language_core::{
-    bluetooth_transact_wire_frame, parse_bluetooth_endpoint as parse_language_bluetooth_endpoint,
-    parse_serial_endpoint as parse_language_serial_endpoint,
-    parse_tcp_endpoint as parse_language_tcp_endpoint, serial_runtime_open_plan_for_target,
-    LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
+    bluetooth_transact_wire_frame, parse_host_endpoint as parse_language_host_endpoint,
+    parse_serial_endpoint as parse_language_serial_endpoint, serial_runtime_open_plan_for_target,
+    LanguageHostEndpointTransport, LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
 };
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
 use board_vm_protocol::{
@@ -1777,6 +1776,17 @@ enum SessionEndpointTransport {
     BluetoothClassicRfcomm,
 }
 
+impl From<LanguageHostEndpointTransport> for SessionEndpointTransport {
+    fn from(value: LanguageHostEndpointTransport) -> Self {
+        match value {
+            LanguageHostEndpointTransport::SerialPort => Self::Serial,
+            LanguageHostEndpointTransport::TcpSocket => Self::Tcp,
+            LanguageHostEndpointTransport::BluetoothLeGatt => Self::BluetoothLeGatt,
+            LanguageHostEndpointTransport::BluetoothClassicRfcomm => Self::BluetoothClassicRfcomm,
+        }
+    }
+}
+
 impl From<SessionEndpointTransport> for SmokeConnectionTransport {
     fn from(value: SessionEndpointTransport) -> Self {
         match value {
@@ -1802,46 +1812,25 @@ fn endpoint_connection_label(
 }
 
 fn endpoint_transport(endpoint: &str) -> Result<SessionEndpointTransport, CliError> {
+    parse_language_host_endpoint(endpoint)
+        .map(|endpoint| endpoint.endpoint_transport.into())
+        .ok_or_else(|| endpoint_parse_error(endpoint))
+}
+
+fn endpoint_parse_error(endpoint: &str) -> CliError {
     match endpoint.split_once("://").map(|(scheme, _)| scheme) {
-        None | Some("tcp") => {
-            if parse_language_tcp_endpoint(endpoint).is_some() {
-                Ok(SessionEndpointTransport::Tcp)
-            } else {
-                Err(CliError::DeviceSelection(format!(
-                    "invalid Board VM TCP endpoint: {endpoint}"
-                )))
-            }
-        }
         Some("serial") => {
-            if parse_language_serial_endpoint(endpoint).is_some() {
-                Ok(SessionEndpointTransport::Serial)
-            } else {
-                Err(CliError::DeviceSelection(format!(
-                    "invalid Board VM serial endpoint: {endpoint}"
-                )))
-            }
+            CliError::DeviceSelection(format!("invalid Board VM serial endpoint: {endpoint}"))
         }
-        Some("ble") => {
-            if parse_language_bluetooth_endpoint(endpoint).is_some() {
-                Ok(SessionEndpointTransport::BluetoothLeGatt)
-            } else {
-                Err(CliError::DeviceSelection(format!(
-                    "invalid Board VM Bluetooth endpoint: {endpoint}"
-                )))
-            }
+        None | Some("tcp") => {
+            CliError::DeviceSelection(format!("invalid Board VM TCP endpoint: {endpoint}"))
         }
-        Some("btspp") | Some("rfcomm") => {
-            if parse_language_bluetooth_endpoint(endpoint).is_some() {
-                Ok(SessionEndpointTransport::BluetoothClassicRfcomm)
-            } else {
-                Err(CliError::DeviceSelection(format!(
-                    "invalid Board VM Bluetooth endpoint: {endpoint}"
-                )))
-            }
+        Some("ble") | Some("btspp") | Some("rfcomm") => {
+            CliError::DeviceSelection(format!("invalid Board VM Bluetooth endpoint: {endpoint}"))
         }
-        Some(scheme) => Err(CliError::DeviceSelection(format!(
-            "unsupported --endpoint scheme: {scheme}"
-        ))),
+        Some(scheme) => {
+            CliError::DeviceSelection(format!("unsupported --endpoint scheme: {scheme}"))
+        }
     }
 }
 

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -76,7 +76,10 @@ clearing, open-settle delay, endpoint scheme, and Board VM wire protocol. The
 actual OS serial open still belongs to the frontend adapter or CLI.
 `parse_serial_endpoint`, `parse_tcp_endpoint`, and `parse_bluetooth_endpoint`
 keep endpoint scheme and transport metadata in the same Rust-owned boundary so
-frontends do not need parallel endpoint tables.
+frontends do not need parallel endpoint tables. `parse_host_endpoint` provides
+the transport-classification summary over all supported endpoint forms, letting
+CLI consumers and language adapters route serial, TCP, BLE GATT, and RFCOMM
+without duplicating scheme dispatch.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -398,6 +398,14 @@ pub struct LanguageTcpEndpoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageHostEndpointSummary {
+    pub endpoint: String,
+    pub transport: LanguageConnectionTransport,
+    pub endpoint_transport: LanguageHostEndpointTransport,
+    pub endpoint_scheme: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageBluetoothEndpoint {
     pub endpoint: String,
     pub transport: LanguageConnectionTransport,
@@ -1567,6 +1575,32 @@ pub fn parse_tcp_endpoint(endpoint: &str) -> Option<LanguageTcpEndpoint> {
 
 pub fn parse_bluetooth_endpoint(endpoint: &str) -> Option<LanguageBluetoothEndpoint> {
     language_bluetooth_endpoint(parse_board_vm_bluetooth_endpoint(endpoint).ok()?)
+}
+
+pub fn parse_host_endpoint(endpoint: &str) -> Option<LanguageHostEndpointSummary> {
+    if let Some(endpoint) = parse_serial_endpoint(endpoint) {
+        return Some(LanguageHostEndpointSummary {
+            endpoint: endpoint.endpoint,
+            transport: endpoint.transport,
+            endpoint_transport: endpoint.endpoint_transport,
+            endpoint_scheme: endpoint.endpoint_scheme,
+        });
+    }
+    if let Some(endpoint) = parse_tcp_endpoint(endpoint) {
+        return Some(LanguageHostEndpointSummary {
+            endpoint: endpoint.endpoint,
+            transport: endpoint.transport,
+            endpoint_transport: endpoint.endpoint_transport,
+            endpoint_scheme: endpoint.endpoint_scheme,
+        });
+    }
+    let endpoint = parse_bluetooth_endpoint(endpoint)?;
+    Some(LanguageHostEndpointSummary {
+        endpoint: endpoint.endpoint,
+        transport: endpoint.transport,
+        endpoint_transport: endpoint.endpoint_transport,
+        endpoint_scheme: endpoint.endpoint_scheme,
+    })
 }
 
 pub fn bluetooth_endpoint_candidates_from_devices(
@@ -5736,6 +5770,50 @@ mod tests {
         assert_eq!(rfcomm.device, "ESP32-BoardVM");
         assert_eq!(rfcomm.channel, Some(3));
         assert!(parse_bluetooth_endpoint("tcp://board-vm.local:4170").is_none());
+    }
+
+    #[test]
+    fn host_endpoint_summary_classifies_all_supported_transports() {
+        let serial = parse_host_endpoint("serial:///dev/cu.usbmodem1101").unwrap();
+        let tcp = parse_host_endpoint("127.0.0.1:4170").unwrap();
+        let ble = parse_host_endpoint("ble://uno-r4-wifi/180f/2a19/2a1a").unwrap();
+        let rfcomm = parse_host_endpoint("rfcomm://ESP32-BoardVM:3").unwrap();
+
+        assert_eq!(serial.transport, LanguageConnectionTransport::Serial);
+        assert_eq!(
+            serial.endpoint_transport,
+            LanguageHostEndpointTransport::SerialPort
+        );
+        assert_eq!(serial.endpoint_scheme, "serial");
+
+        assert_eq!(tcp.transport, LanguageConnectionTransport::Wifi);
+        assert_eq!(
+            tcp.endpoint_transport,
+            LanguageHostEndpointTransport::TcpSocket
+        );
+        assert_eq!(tcp.endpoint_scheme, "tcp");
+
+        assert_eq!(ble.transport, LanguageConnectionTransport::BluetoothLe);
+        assert_eq!(
+            ble.endpoint_transport,
+            LanguageHostEndpointTransport::BluetoothLeGatt
+        );
+        assert_eq!(ble.endpoint_scheme, "ble");
+
+        assert_eq!(
+            rfcomm.transport,
+            LanguageConnectionTransport::BluetoothClassic
+        );
+        assert_eq!(
+            rfcomm.endpoint_transport,
+            LanguageHostEndpointTransport::BluetoothClassicRfcomm
+        );
+        assert_eq!(rfcomm.endpoint_scheme, "rfcomm");
+
+        assert!(parse_host_endpoint("serial://   ").is_none());
+        assert!(parse_host_endpoint("tcp://   ").is_none());
+        assert!(parse_host_endpoint("ble://").is_none());
+        assert!(parse_host_endpoint("ws://board-vm.local:4170").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a Rust-owned `parse_host_endpoint` summary over serial, TCP, BLE GATT, and RFCOMM endpoint forms
- make `board-vm-cli` consume that language-core summary instead of maintaining endpoint scheme dispatch locally
- document the shared endpoint classification boundary for CLI consumers and language adapters

## Validation
- `cargo fmt -p board-vm-cli -p board-vm-language-core`
- `cargo test -p board-vm-cli -p board-vm-language-core`
- `bash BUILD` in `code/packages/rust/board-vm-cli`
- `bash BUILD` in `code/packages/rust/board-vm-language-core`
- `cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

Note: the external `coding-adventures-target-detect/build-tool` currently panics on latest `origin/main` while loading `code/packages/starlark/library-rules/rust_library.star`, before this diff is evaluated. Generated `build-plan.json` and `code/packages/rust/Cargo.lock` were removed.