### PR TITLE
Add HTML fixture Python compile check

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -529,6 +529,14 @@ python3 code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures
   --check
 ```
 
+To check that all lexer/parser fixture helper and generator Python scripts still
+compile without writing bytecode into the worktree:
+
+```bash
+python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py \
+  --check
+```
+
 Planned flow:
 
 1. Import or mirror selected upstream tokenizer cases into a generator script.

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -101,6 +101,13 @@ def parse_args() -> argparse.Namespace:
 def default_checks() -> list[FixtureCheck]:
     return [
         FixtureCheck(
+            "html-fixture-python-scripts-compile",
+            (
+                str(FIXTURE_DIR / "check_html_fixture_scripts_compile.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "html5lib-tokenizer-normalized",
             (
                 str(FIXTURE_DIR / "normalize_html5lib_fixtures.py"),

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+"""Check that HTML lexer/parser fixture Python scripts compile."""
+
+from __future__ import annotations
+
+import argparse
+import py_compile
+import tempfile
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+RUST_DIR = FIXTURE_DIR.parents[2]
+PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
+SCRIPT_GLOB = "*.py"
+
+
+def main() -> int:
+    parse_args()
+    script_paths = fixture_scripts()
+
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="html-fixture-pycompile-") as temp_dir:
+        temp_path = Path(temp_dir)
+        for script_path in script_paths:
+            target = temp_path / f"{script_path.stem}.pyc"
+            try:
+                py_compile.compile(
+                    str(script_path),
+                    cfile=str(target),
+                    doraise=True,
+                )
+            except py_compile.PyCompileError as exc:
+                errors.append(f"{relative_script(script_path)}: {exc.msg}")
+
+    print("HTML fixture Python scripts")
+    print(f"scripts: {len(script_paths)}")
+
+    if errors:
+        raise SystemExit("\n\n".join(errors))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compile all checked-in Python fixture helpers and generators for "
+            "the Rust HTML lexer/parser conformance corpora."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compatibility flag for generated-fixture stale-check manifests.",
+    )
+    return parser.parse_args()
+
+
+def fixture_scripts() -> list[Path]:
+    fixture_dirs = (FIXTURE_DIR, PARSER_FIXTURE_DIR)
+    return sorted(
+        script_path
+        for fixture_dir in fixture_dirs
+        for script_path in fixture_dir.glob(SCRIPT_GLOB)
+        if script_path.is_file()
+    )
+
+
+def relative_script(path: Path) -> str:
+    try:
+        return str(path.relative_to(RUST_DIR))
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
@@ -37,6 +37,7 @@ class GeneratedHtmlFixtureManifestTest(unittest.TestCase):
             for path in manifest.PARSER_FIXTURE_DIR.glob("generate_whatwg_*_fixture.py")
         }
 
+        self.assertIn("check_html_fixture_scripts_compile.py", checked_scripts)
         self.assertIn("normalize_html5lib_fixtures.py", checked_scripts)
         self.assertIn("check_html5lib_tokenizer_coverage.py", checked_scripts)
         self.assertIn("check_whatwg_lexer_fixture_metadata.py", checked_scripts)


### PR DESCRIPTION
## Summary
- add a fixture-tooling compile checker covering HTML lexer and parser fixture Python scripts
- wire the checker into the generated HTML fixture manifest and manifest regression test
- document the new checker in the lexer fixture README

## Tests
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit`
- `python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py code/packages/rust/html-lexer/tests/fixtures/check_html5lib_tokenizer_coverage.py code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py`
- `cargo test -p coding-adventures-html-lexer normalized_html5lib`
- `cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
