### PR TITLE
[codex] Add Board VM endpoint parse diagnostics

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -61,8 +61,8 @@ serial endpoint metadata (`serial://...`), TCP endpoint metadata (`tcp://...` or
 bare `host:port`), and Board VM Bluetooth endpoints (`ble://`, `btspp://`, or
 `rfcomm://`) through the Rust-owned transport adapters. Endpoint transport
 classification comes from the shared `board-vm-language-core`
-`parse_host_endpoint` summary, so the CLI does not maintain its own endpoint
-scheme table. The smoke report starts with a stable
+`parse_host_endpoint_with_error` summary, so the CLI does not maintain its own
+endpoint scheme or parse-error tables. The smoke report starts with a stable
 `connection transport=...` field so hardware logs can distinguish serial, TCP
 socket, BLE GATT, and RFCOMM runs without parsing endpoint strings. The default
 run budget is intentionally small because the current firmware executes

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -22,8 +22,10 @@ use board_vm_host::{
     GpioReadProgram, TimeNowProgram, BLINK_MODULE_LEN, GPIO_READ_MODULE_LEN, TIME_NOW_MODULE_LEN,
 };
 use board_vm_language_core::{
-    bluetooth_transact_wire_frame, parse_host_endpoint as parse_language_host_endpoint,
+    bluetooth_transact_wire_frame,
+    parse_host_endpoint_with_error as parse_language_host_endpoint_with_error,
     parse_serial_endpoint as parse_language_serial_endpoint, serial_runtime_open_plan_for_target,
+    LanguageHostEndpointParseError, LanguageHostEndpointParseErrorKind,
     LanguageHostEndpointTransport, LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
 };
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
@@ -1812,24 +1814,27 @@ fn endpoint_connection_label(
 }
 
 fn endpoint_transport(endpoint: &str) -> Result<SessionEndpointTransport, CliError> {
-    parse_language_host_endpoint(endpoint)
+    parse_language_host_endpoint_with_error(endpoint)
         .map(|endpoint| endpoint.endpoint_transport.into())
-        .ok_or_else(|| endpoint_parse_error(endpoint))
+        .map_err(endpoint_parse_error)
 }
 
-fn endpoint_parse_error(endpoint: &str) -> CliError {
-    match endpoint.split_once("://").map(|(scheme, _)| scheme) {
-        Some("serial") => {
-            CliError::DeviceSelection(format!("invalid Board VM serial endpoint: {endpoint}"))
+fn endpoint_parse_error(error: LanguageHostEndpointParseError) -> CliError {
+    match error.kind {
+        LanguageHostEndpointParseErrorKind::InvalidSerialEndpoint => CliError::DeviceSelection(
+            format!("invalid Board VM serial endpoint: {}", error.endpoint),
+        ),
+        LanguageHostEndpointParseErrorKind::InvalidTcpEndpoint => {
+            CliError::DeviceSelection(format!("invalid Board VM TCP endpoint: {}", error.endpoint))
         }
-        None | Some("tcp") => {
-            CliError::DeviceSelection(format!("invalid Board VM TCP endpoint: {endpoint}"))
-        }
-        Some("ble") | Some("btspp") | Some("rfcomm") => {
-            CliError::DeviceSelection(format!("invalid Board VM Bluetooth endpoint: {endpoint}"))
-        }
-        Some(scheme) => {
-            CliError::DeviceSelection(format!("unsupported --endpoint scheme: {scheme}"))
+        LanguageHostEndpointParseErrorKind::InvalidBluetoothEndpoint => CliError::DeviceSelection(
+            format!("invalid Board VM Bluetooth endpoint: {}", error.endpoint),
+        ),
+        LanguageHostEndpointParseErrorKind::UnsupportedScheme => {
+            CliError::DeviceSelection(format!(
+                "unsupported --endpoint scheme: {}",
+                error.scheme.as_deref().unwrap_or("")
+            ))
         }
     }
 }

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -79,7 +79,10 @@ keep endpoint scheme and transport metadata in the same Rust-owned boundary so
 frontends do not need parallel endpoint tables. `parse_host_endpoint` provides
 the transport-classification summary over all supported endpoint forms, letting
 CLI consumers and language adapters route serial, TCP, BLE GATT, and RFCOMM
-without duplicating scheme dispatch.
+without duplicating scheme dispatch. `parse_host_endpoint_with_error` returns
+the same summary with a Rust-owned parse error kind for malformed endpoint
+input, so frontends can present native messages without inventing their own
+endpoint failure taxonomy.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -405,6 +405,21 @@ pub struct LanguageHostEndpointSummary {
     pub endpoint_scheme: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageHostEndpointParseErrorKind {
+    InvalidSerialEndpoint,
+    InvalidTcpEndpoint,
+    InvalidBluetoothEndpoint,
+    UnsupportedScheme,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageHostEndpointParseError {
+    pub endpoint: String,
+    pub kind: LanguageHostEndpointParseErrorKind,
+    pub scheme: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageBluetoothEndpoint {
     pub endpoint: String,
@@ -1601,6 +1616,29 @@ pub fn parse_host_endpoint(endpoint: &str) -> Option<LanguageHostEndpointSummary
         endpoint_transport: endpoint.endpoint_transport,
         endpoint_scheme: endpoint.endpoint_scheme,
     })
+}
+
+pub fn parse_host_endpoint_with_error(
+    endpoint: &str,
+) -> Result<LanguageHostEndpointSummary, LanguageHostEndpointParseError> {
+    parse_host_endpoint(endpoint).ok_or_else(|| host_endpoint_parse_error(endpoint))
+}
+
+pub fn host_endpoint_parse_error(endpoint: &str) -> LanguageHostEndpointParseError {
+    let scheme = endpoint.split_once("://").map(|(scheme, _)| scheme);
+    let kind = match scheme {
+        Some("serial") => LanguageHostEndpointParseErrorKind::InvalidSerialEndpoint,
+        None | Some("tcp") => LanguageHostEndpointParseErrorKind::InvalidTcpEndpoint,
+        Some("ble") | Some("btspp") | Some("rfcomm") => {
+            LanguageHostEndpointParseErrorKind::InvalidBluetoothEndpoint
+        }
+        Some(_) => LanguageHostEndpointParseErrorKind::UnsupportedScheme,
+    };
+    LanguageHostEndpointParseError {
+        endpoint: endpoint.to_owned(),
+        kind,
+        scheme: scheme.map(str::to_owned),
+    }
 }
 
 pub fn bluetooth_endpoint_candidates_from_devices(
@@ -5814,6 +5852,48 @@ mod tests {
         assert!(parse_host_endpoint("tcp://   ").is_none());
         assert!(parse_host_endpoint("ble://").is_none());
         assert!(parse_host_endpoint("ws://board-vm.local:4170").is_none());
+
+        assert_eq!(
+            parse_host_endpoint_with_error("tcp://board-vm.local:4170")
+                .unwrap()
+                .endpoint_transport,
+            LanguageHostEndpointTransport::TcpSocket
+        );
+    }
+
+    #[test]
+    fn host_endpoint_parse_errors_are_classified_by_rust_language_core() {
+        let serial = parse_host_endpoint_with_error("serial://   ").unwrap_err();
+        let tcp = parse_host_endpoint_with_error("tcp://   ").unwrap_err();
+        let bare_tcp = parse_host_endpoint_with_error("").unwrap_err();
+        let bluetooth = parse_host_endpoint_with_error("ble://").unwrap_err();
+        let unsupported = parse_host_endpoint_with_error("ws://board-vm.local:4170").unwrap_err();
+
+        assert_eq!(
+            serial.kind,
+            LanguageHostEndpointParseErrorKind::InvalidSerialEndpoint
+        );
+        assert_eq!(serial.scheme.as_deref(), Some("serial"));
+        assert_eq!(
+            tcp.kind,
+            LanguageHostEndpointParseErrorKind::InvalidTcpEndpoint
+        );
+        assert_eq!(tcp.scheme.as_deref(), Some("tcp"));
+        assert_eq!(
+            bare_tcp.kind,
+            LanguageHostEndpointParseErrorKind::InvalidTcpEndpoint
+        );
+        assert_eq!(bare_tcp.scheme, None);
+        assert_eq!(
+            bluetooth.kind,
+            LanguageHostEndpointParseErrorKind::InvalidBluetoothEndpoint
+        );
+        assert_eq!(bluetooth.scheme.as_deref(), Some("ble"));
+        assert_eq!(
+            unsupported.kind,
+            LanguageHostEndpointParseErrorKind::UnsupportedScheme
+        );
+        assert_eq!(unsupported.scheme.as_deref(), Some("ws"));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add Rust-owned endpoint parse diagnostics in board-vm-language-core
- expose parse_host_endpoint_with_error and host_endpoint_parse_error with transport-specific error kinds
- make board-vm-cli consume typed core diagnostics while preserving existing endpoint error messages
- document the typed endpoint parse surface in the CLI and language-core READMEs

Validation:
- cargo fmt -p board-vm-cli -p board-vm-language-core
- cargo test -p board-vm-cli -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-cli
- bash BUILD in code/packages/rust/board-vm-language-core
- cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes:
- Generated build-plan.json and code/packages/rust/Cargo.lock were removed before committing.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool currently panics on latest origin/main while loading code/packages/starlark/library-rules/rust_library.star before evaluating this diff.