### PR TITLE
[codex] Add Board VM endpoint display metadata

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -62,11 +62,13 @@ bare `host:port`), and Board VM Bluetooth endpoints (`ble://`, `btspp://`, or
 `rfcomm://`) through the Rust-owned transport adapters. Endpoint transport
 classification comes from the shared `board-vm-language-core`
 `parse_host_endpoint_with_error` summary, so the CLI does not maintain its own
-endpoint scheme or parse-error tables. The smoke report starts with a stable
+endpoint scheme or parse-error tables. Endpoint connection labels also come
+from `host_endpoint_connection_label`, which keeps the serial-only baud label
+policy in the shared Rust layer. The smoke report starts with a stable
 `connection transport=...` field so hardware logs can distinguish serial, TCP
 socket, BLE GATT, and RFCOMM runs without parsing endpoint strings. The default
-run budget is intentionally small because the current firmware executes
-blink bytecode synchronously while it prepares the run report.
+run budget is intentionally small because the current firmware executes blink
+bytecode synchronously while it prepares the run report.
 
 `repl` opens the same serial-plan-backed transport, sends `HELLO`, and then
 accepts a small interactive command set: `caps`, `upload-blink`, `upload-gpio-read <pin>

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -23,10 +23,12 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_transact_wire_frame,
+    host_endpoint_connection_label as language_host_endpoint_connection_label,
     parse_host_endpoint_with_error as parse_language_host_endpoint_with_error,
     parse_serial_endpoint as parse_language_serial_endpoint, serial_runtime_open_plan_for_target,
     LanguageHostEndpointParseError, LanguageHostEndpointParseErrorKind,
-    LanguageHostEndpointTransport, LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
+    LanguageHostEndpointSummary, LanguageHostEndpointTransport, LanguageSerialRuntimeOpenPlan,
+    LANGUAGE_SERIAL_OPEN_SETTLE_MS,
 };
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
 use board_vm_protocol::{
@@ -1550,11 +1552,8 @@ where
 #[cfg(test)]
 fn repl_connection_label(options: &ReplOptions) -> String {
     if let Some(endpoint) = options.endpoint.as_deref() {
-        return endpoint_connection_label(
-            endpoint,
-            endpoint_transport(endpoint).expect("test repl endpoint should be valid"),
-            options.baud_rate,
-        );
+        return endpoint_connection_label(endpoint, options.baud_rate)
+            .expect("test repl endpoint should be valid");
     }
     match options.port.as_deref() {
         Some(port) => format!("port={port} baud={}", options.baud_rate),
@@ -1575,11 +1574,8 @@ fn smoke_connection_transport(options: &SmokeOptions) -> SmokeConnectionTranspor
 #[cfg(test)]
 fn smoke_connection_label(options: &SmokeOptions) -> String {
     if let Some(endpoint) = options.endpoint.as_deref() {
-        return endpoint_connection_label(
-            endpoint,
-            endpoint_transport(endpoint).expect("test smoke endpoint should be valid"),
-            options.baud_rate,
-        );
+        return endpoint_connection_label(endpoint, options.baud_rate)
+            .expect("test smoke endpoint should be valid");
     }
     match options.port.as_deref() {
         Some(port) => format!("port={port} baud={}", options.baud_rate),
@@ -1602,11 +1598,8 @@ fn bootloader_reboot_connection_transport(
 #[cfg(test)]
 fn bootloader_reboot_connection_label(options: &BootloaderRebootOptions) -> String {
     if let Some(endpoint) = options.endpoint.as_deref() {
-        return endpoint_connection_label(
-            endpoint,
-            endpoint_transport(endpoint).expect("test bootloader endpoint should be valid"),
-            options.baud_rate,
-        );
+        return endpoint_connection_label(endpoint, options.baud_rate)
+            .expect("test bootloader endpoint should be valid");
     }
     match options.port.as_deref() {
         Some(port) => format!("port={port} baud={}", options.baud_rate),
@@ -1619,7 +1612,9 @@ fn open_smoke_transport(
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let endpoint_transport = endpoint_transport(endpoint)?;
+        let endpoint_summary = endpoint_summary(endpoint)?;
+        let endpoint_transport =
+            SessionEndpointTransport::from(endpoint_summary.endpoint_transport);
         let connection_transport = SmokeConnectionTransport::from(endpoint_transport);
         let transport = open_endpoint_transport(
             endpoint,
@@ -1631,7 +1626,7 @@ fn open_smoke_transport(
         )?;
         return Ok((
             connection_transport,
-            endpoint_connection_label(endpoint, endpoint_transport, options.baud_rate),
+            language_host_endpoint_connection_label(&endpoint_summary, options.baud_rate),
             transport,
         ));
     }
@@ -1654,7 +1649,9 @@ fn open_bootloader_reboot_transport(
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let endpoint_transport = endpoint_transport(endpoint)?;
+        let endpoint_summary = endpoint_summary(endpoint)?;
+        let endpoint_transport =
+            SessionEndpointTransport::from(endpoint_summary.endpoint_transport);
         let connection_transport = SmokeConnectionTransport::from(endpoint_transport);
         let transport = open_endpoint_transport(
             endpoint,
@@ -1666,7 +1663,7 @@ fn open_bootloader_reboot_transport(
         )?;
         return Ok((
             connection_transport,
-            endpoint_connection_label(endpoint, endpoint_transport, options.baud_rate),
+            language_host_endpoint_connection_label(&endpoint_summary, options.baud_rate),
             transport,
         ));
     }
@@ -1687,7 +1684,9 @@ fn open_bootloader_reboot_transport(
 fn open_repl_transport(options: &ReplOptions) -> Result<(String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let endpoint_transport = endpoint_transport(endpoint)?;
+        let endpoint_summary = endpoint_summary(endpoint)?;
+        let endpoint_transport =
+            SessionEndpointTransport::from(endpoint_summary.endpoint_transport);
         let transport = open_endpoint_transport(
             endpoint,
             endpoint_transport,
@@ -1697,7 +1696,7 @@ fn open_repl_transport(options: &ReplOptions) -> Result<(String, SessionTranspor
             &options.tcp_config(endpoint),
         )?;
         return Ok((
-            endpoint_connection_label(endpoint, endpoint_transport, options.baud_rate),
+            language_host_endpoint_connection_label(&endpoint_summary, options.baud_rate),
             transport,
         ));
     }
@@ -1800,23 +1799,19 @@ impl From<SessionEndpointTransport> for SmokeConnectionTransport {
     }
 }
 
-fn endpoint_connection_label(
-    endpoint: &str,
-    endpoint_transport: SessionEndpointTransport,
-    baud_rate: u32,
-) -> String {
-    match endpoint_transport {
-        SessionEndpointTransport::Serial => format!("endpoint={endpoint} baud={baud_rate}"),
-        SessionEndpointTransport::Tcp
-        | SessionEndpointTransport::BluetoothLeGatt
-        | SessionEndpointTransport::BluetoothClassicRfcomm => format!("endpoint={endpoint}"),
-    }
+#[cfg(test)]
+fn endpoint_connection_label(endpoint: &str, baud_rate: u32) -> Result<String, CliError> {
+    endpoint_summary(endpoint)
+        .map(|endpoint| language_host_endpoint_connection_label(&endpoint, baud_rate))
 }
 
+#[cfg(test)]
 fn endpoint_transport(endpoint: &str) -> Result<SessionEndpointTransport, CliError> {
-    parse_language_host_endpoint_with_error(endpoint)
-        .map(|endpoint| endpoint.endpoint_transport.into())
-        .map_err(endpoint_parse_error)
+    endpoint_summary(endpoint).map(|endpoint| endpoint.endpoint_transport.into())
+}
+
+fn endpoint_summary(endpoint: &str) -> Result<LanguageHostEndpointSummary, CliError> {
+    parse_language_host_endpoint_with_error(endpoint).map_err(endpoint_parse_error)
 }
 
 fn endpoint_parse_error(error: LanguageHostEndpointParseError) -> CliError {
@@ -2876,7 +2871,7 @@ mod tests {
             SessionEndpointTransport::Serial
         );
         assert_eq!(
-            endpoint_connection_label(endpoint, SessionEndpointTransport::Serial, 57_600),
+            endpoint_connection_label(endpoint, 57_600).unwrap(),
             "endpoint=serial:///dev/cu.usbmodem-test baud=57600"
         );
     }

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -82,7 +82,10 @@ CLI consumers and language adapters route serial, TCP, BLE GATT, and RFCOMM
 without duplicating scheme dispatch. `parse_host_endpoint_with_error` returns
 the same summary with a Rust-owned parse error kind for malformed endpoint
 input, so frontends can present native messages without inventing their own
-endpoint failure taxonomy.
+endpoint failure taxonomy. `host_endpoint_connection_label` also keeps the
+cross-transport display policy in Rust: serial endpoints carry the runtime baud
+rate in host logs, while TCP and Bluetooth endpoints use the endpoint string
+alone.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -973,6 +973,23 @@ pub const fn host_endpoint_transport_name(
     }
 }
 
+pub const fn host_endpoint_transport_uses_baud_rate(
+    transport: LanguageHostEndpointTransport,
+) -> bool {
+    matches!(transport, LanguageHostEndpointTransport::SerialPort)
+}
+
+pub fn host_endpoint_connection_label(
+    endpoint: &LanguageHostEndpointSummary,
+    baud_rate: u32,
+) -> String {
+    if host_endpoint_transport_uses_baud_rate(endpoint.endpoint_transport) {
+        format!("endpoint={} baud={baud_rate}", endpoint.endpoint)
+    } else {
+        format!("endpoint={}", endpoint.endpoint)
+    }
+}
+
 pub const fn upload_adapter_name(adapter: TargetUploadAdapter) -> &'static str {
     match adapter {
         TargetUploadAdapter::ArduinoCli => "arduino_cli",
@@ -5858,6 +5875,23 @@ mod tests {
                 .unwrap()
                 .endpoint_transport,
             LanguageHostEndpointTransport::TcpSocket
+        );
+
+        assert_eq!(
+            host_endpoint_connection_label(&serial, 57_600),
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            host_endpoint_connection_label(&tcp, 57_600),
+            "endpoint=127.0.0.1:4170"
+        );
+        assert_eq!(
+            host_endpoint_connection_label(&ble, 57_600),
+            "endpoint=ble://uno-r4-wifi/180f/2a19/2a1a"
+        );
+        assert_eq!(
+            host_endpoint_connection_label(&rfcomm, 57_600),
+            "endpoint=rfcomm://ESP32-BoardVM:3"
         );
     }
 


### PR DESCRIPTION
Summary:
- add Rust-owned host endpoint connection label metadata in board-vm-language-core
- keep the serial-only baud label policy beside endpoint transport classification
- make board-vm-cli consume the shared label helper after parsing endpoint summaries
- document the shared endpoint display surface in the CLI and language-core READMEs

Validation:
- cargo fmt -p board-vm-cli -p board-vm-language-core
- cargo test -p board-vm-cli -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-cli
- bash BUILD in code/packages/rust/board-vm-language-core
- cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes:
- Generated build-plan.json and code/packages/rust/Cargo.lock were removed before committing.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool still panics on latest origin/main while loading code/packages/starlark/library-rules/rust_library.star before evaluating this diff.