### PR TITLE
feat(ml-framework-core): MX10 Phase 4 — Rust fast path for Tanh + ReLU activations

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,97 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 4: optional Rust fast path for `TanhFunction` + `ReLUFunction` activations
+
+Extends the per-op conditional dispatch to two members of the
+**activation op family**: `TanhFunction` and `ReLUFunction`.  The
+remaining three activations (`SigmoidFunction`, `GELUFunction`,
+`SoftmaxFunction`) are intentionally deferred — see "What's NOT in
+Phase 4" below.
+
+#### Scope rationale
+
+| Activation | Phase 4 status | Why |
+|-----------|---------------|-----|
+| **Tanh** | **Shipped** | matrix-ir-json has a direct unary `Tanh` op — single-op graph, reuses the same `_elementwise_unary_via_rust` factory as Neg/Abs. |
+| **ReLU** | **Shipped** | Composed as `max(x, 0)` via the existing binary `Max` op + a zero-constant tensor of shape `a.shape`.  First time the dispatch helpers use matrix-ir-json's `constants[]` array (same pattern matrix-cpu uses for MatMul weights/biases). |
+| Sigmoid | Deferred (Phase 4b) | Needs a 4-op composition: `Neg → Exp → Add(scalar 1) → Recip`.  Each intermediate tensor adds a graph node; the round-trip cost makes the threshold non-obvious. |
+| GELU | Deferred (Phase 4b) | The standard tanh-approximation form needs `Mul, Pow(3), Add, Mul, Tanh, Add, Mul, Mul` — 8 ops plus a scalar Pow (Pow itself is still deferred from Phase 2 — see the Phase 2 "What's NOT" section). |
+| Softmax | Deferred (Phase 4b) | Per-axis broadcast + numerical-stability max-subtract make this not a pure elementwise composition.  Wants its own dispatch design. |
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds:
+    - `should_use_rust_for_activation(numel)` predicate.  Reuses the
+      same threshold (`_ELEMENTWISE_RUST_THRESHOLD = 100_000`) as
+      elementwise/reduction — activations have roughly the same
+      per-cell cost (one transcendental or one compare per cell).
+    - `tanh_via_rust(a)` — thin wrapper that calls the existing
+      `_elementwise_unary_via_rust` factory with `op_kind="Tanh"`.
+      No new graph-building code needed — Tanh is a direct unary op
+      in matrix-ir-json.
+    - `relu_via_rust(a)` — the only genuinely new helper.  Builds a
+      3-tensor graph (input + zero-constant + output), with a single
+      `Max` op that compares each input cell to the corresponding
+      zero-constant cell.  The zero-constant tensor is shipped in
+      the `constants[]` array of the graph definition (as
+      `bytes_hex = "00" * numel * 4`), not as a runtime input.  This
+      pattern matches how matrix-cpu MatMul tests ship weights.
+
+- **`functions.py`**:
+    - Imports: `relu_via_rust`, `should_use_rust_for_activation`,
+      `tanh_via_rust`.
+    - `ReLUFunction.forward` gains the standard 2-line dispatch
+      block before the existing `[max(0.0, x) for x in a.data]`
+      list comprehension.
+    - `TanhFunction.forward` gains a slightly longer 4-line dispatch
+      because it must populate `self.saved_metadata["output"] =
+      result.data` for backward (which uses `d/dx tanh = 1 -
+      tanh(x)^2`).  Both paths populate the same key so backward
+      is path-agnostic.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, numel ≥ 100_000 | **Rust** (matrix-cpu via matrix-rust-python) |
+| Extension installed, numel < 100_000 | Pure-Python kernel |
+| Extension NOT installed | Pure-Python kernel |
+| Activation outside the {Tanh, ReLU} set | Pure-Python (always) |
+
+#### Tests (45 total MX10 tests, was 36)
+
+- **`ActivationParityTests`** (3 cases, skip if extension missing):
+  predicate sanity + Tanh parity (range [-3, 3] so the function
+  saturates at both tails) + ReLU parity at the `(500, 200) =
+  100_000`-cell threshold.  Tolerance: same `rtol=1e-3, atol=1e-4`
+  as matmul/elementwise/reduction (f32 vs double).
+- **`ActivationFallbackTests`** (6 cases, always run): predicate
+  short-circuit, direct-call `RuntimeError` for both helpers,
+  ReLU correctness via fallback (`[-2,-1,0,1,2] → [0,0,0,1,2]`),
+  Tanh correctness via fallback (compared to `math.tanh`), plus a
+  `saved_metadata["output"]` handshake test that verifies the
+  fallback path still populates the key backward needs (gradient
+  of tanh via `1 - tanh(x)^2`).
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite at
+**347 passed + 17 skipped (parity-tests that need the extension)**;
+the same `test_device.py` failure that's on main without these
+changes is unrelated.
+
+### What's NOT in Phase 4
+
+- Sigmoid, GELU, Softmax (deferred to Phase 4b — see scope table).
+- Backward-path Rust dispatch for ReLU/Tanh.  ReLU's backward
+  is `grad * (x > 0)` and Tanh's is `grad * (1 - output^2)`,
+  both implemented as pure-Python list comprehensions.  Routing
+  these to Rust would need a Mul + Max/Comparison composition;
+  deferred pending profiling demand.
+- PowFunction Rust path (still deferred from Phase 2 — needs
+  scalar-exponent variant in matrix-cpu).
+- Axis-specific reductions (still deferred from Phase 3 to
+  Phase 3b).
+
 ### Added — MX10 Phase 3: optional Rust fast path for reduce-all `SumFunction` / `MeanFunction`
 
 Extends the per-op conditional dispatch to the **reduce-all path

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -558,3 +558,124 @@ def sum_via_rust(a: Tensor) -> Tensor:
 def mean_via_rust(a: Tensor) -> Tensor:
     """``a.mean()`` (reduce-all) via Rust.  Returns Tensor of shape ``(1,)``."""
     return _reduce_all_via_rust(a, "ReduceMean")
+
+
+# ──────────────────────────────────────────────────────────────────
+# Activation fast paths (MX10 Phase 4)
+#
+# matrix-ir-json supports Tanh, Sqrt, Exp, Log, Recip directly as
+# unary ops (same shape as Neg/Abs in Phase 2).  For ReLU we
+# compose: ReLU(x) = max(x, 0) — Max op with a zero-valued
+# constant tensor.
+#
+# The other classic activations are deferred:
+#
+# * Sigmoid = 1 / (1 + exp(-x)) — needs Exp + Neg + Add (with
+#   1-const) + Recip in a 4-op graph.  Doable but adds enough
+#   complexity that profiling should justify the FFI overhead
+#   first.
+# * GELU = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+#   — multi-op composition with constants and Pow.  Deferred until
+#   matrix-cpu adds scalar-exponent Pow (would simplify the
+#   ``x^3`` term).
+# * Softmax = exp(x - max(x)) / sum(exp(...)) — needs per-axis
+#   broadcast which Phase 3b territory; deferred to coincide.
+#
+# So Phase 4 ships **Tanh** and **ReLU** — the two most common
+# activations in modern ML workloads (Tanh in older RNN architectures
+# and GLU gates; ReLU in every CNN/transformer feed-forward block).
+# Sigmoid/GELU/Softmax wait for Phase 4b.
+# ──────────────────────────────────────────────────────────────────
+
+
+# Activations share the elementwise cost profile (one transcendental
+# or comparison per cell), so the same threshold applies.
+def should_use_rust_for_activation(numel: int) -> bool:
+    """Decide whether to dispatch an activation (Tanh / ReLU) to
+    Rust.  Reuses the elementwise threshold (100_000 cells)."""
+    if not _RUST_AVAILABLE:
+        return False
+    return numel >= _ELEMENTWISE_RUST_THRESHOLD
+
+
+def tanh_via_rust(a: Tensor) -> Tensor:
+    """``tanh(a)`` via the unary Tanh op.  Same envelope shape as
+    Neg/Abs in Phase 2."""
+    return _elementwise_unary_via_rust(a, "Tanh")
+
+
+def relu_via_rust(a: Tensor) -> Tensor:
+    """``ReLU(a) = max(a, 0)`` via Max with a zero-valued constant
+    tensor of shape ``a.shape``.
+
+    Differs from the elementwise binary helper because the second
+    "input" isn't a real input — it's a constant we ship as part of
+    the graph's ``constants[]`` array, then reference from the Max
+    op like any other tensor.  The matrix-ir-json schema supports
+    this naturally: ``constants[]`` entries become buffer-uploaded
+    automatically by the executor.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "relu_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_activation() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(a.data)
+    shape_list = list(a.shape)
+
+    a_bytes = struct.pack(f"<{numel}f", *a.data)
+    # Zero constant of the same shape — bytes are all-zero.  We
+    # ship the bytes_hex inline in the graph definition rather than
+    # as an envelope input (constants live in the graph, inputs in
+    # the envelope).
+    zero_bytes_hex = ("00" * numel * 4)  # 4 bytes per f32 cell, all zero
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    # tensor 0 = input x
+                    {"id": 0, "dtype": "f32", "shape": shape_list},
+                    # tensor 1 = zero constant (also same shape — matrix-cpu's
+                    # Max doesn't broadcast scalars, so we materialise a full
+                    # zero tensor)
+                    {"id": 1, "dtype": "f32", "shape": shape_list},
+                    # tensor 2 = output
+                    {"id": 2, "dtype": "f32", "shape": shape_list},
+                ],
+                "inputs": [0],
+                "outputs": [2],
+                "ops": [
+                    {"kind": "Max", "lhs": 0, "rhs": 1, "output": 2}
+                ],
+                "constants": [
+                    {
+                        "tensor_id": 1,
+                        "dtype": "f32",
+                        "shape": shape_list,
+                        "bytes_hex": zero_bytes_hex,
+                    }
+                ],
+            },
+            "inputs": [a_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    expected_bytes = numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"relu_via_rust: expected {expected_bytes} output bytes "
+            f"({numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
+
+    return _Tensor(out_floats, a.shape, device=a.device)

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -51,11 +51,14 @@ from ._rust_backend import (
     mean_via_rust,
     mul_via_rust,
     neg_via_rust,
+    relu_via_rust,
+    should_use_rust_for_activation,
     should_use_rust_for_elementwise,
     should_use_rust_for_matmul,
     should_use_rust_for_reduction,
     sub_via_rust,
     sum_via_rust,
+    tanh_via_rust,
 )
 from .autograd import Function
 from .tensor import Tensor, _compute_strides, _numel
@@ -704,6 +707,11 @@ class ReLUFunction(Function):
 
     def forward(self, a: Tensor) -> Tensor:
         self.save_for_backward(a)
+        # MX10 Phase 4 — optional Rust fast path.  ReLU is composed
+        # as max(x, 0) via matrix-cpu's Max op with a zero-constant
+        # tensor of the same shape.
+        if should_use_rust_for_activation(len(a.data)):
+            return relu_via_rust(a)
         data = [max(0.0, x) for x in a.data]
         return Tensor(data, a.shape, device=a.device)
 
@@ -761,6 +769,13 @@ class TanhFunction(Function):
 
     def forward(self, a: Tensor) -> Tensor:
         self.save_for_backward(a)
+        # MX10 Phase 4 — optional Rust fast path (direct unary Tanh).
+        # The output is saved into saved_metadata for backward; we
+        # extract it from the returned Tensor either way.
+        if should_use_rust_for_activation(len(a.data)):
+            result = tanh_via_rust(a)
+            self.saved_metadata["output"] = result.data
+            return result
         data = [math.tanh(x) for x in a.data]
         self.saved_metadata["output"] = data
         return Tensor(data, a.shape, device=a.device)

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -25,8 +25,11 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
+import math
+
 from ml_framework_core import Tensor
 from ml_framework_core import _rust_backend
+from ml_framework_core.functions import ReLUFunction, TanhFunction
 
 
 class MatMulFallbackTests(unittest.TestCase):
@@ -313,6 +316,93 @@ class ReductionFallbackTests(unittest.TestCase):
         result = a.sum(dim=0)
         # Column sums: [1+4, 2+5, 3+6] = [5, 7, 9]
         self.assertEqual(result.data, [5.0, 7.0, 9.0])
+
+
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 4 — activation fallback tests
+#
+# Same pattern as elementwise/reduction: monkey-patch
+# ``_RUST_AVAILABLE = False`` and confirm the pure-Python kernel
+# still produces correct results for the two Phase 4 activations
+# (Tanh, ReLU).  Sigmoid/GELU/Softmax are deferred to Phase 4b and
+# never reach the dispatch path in Phase 4, so they are not tested
+# here.
+# ──────────────────────────────────────────────────────────────────
+
+
+class ActivationFallbackTests(unittest.TestCase):
+    """Confirm Tanh + ReLU still work when the Rust path is disabled."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_predicate_returns_false_for_activation_when_unavailable(self) -> None:
+        """Even a giant tensor must fall back when the extension is missing."""
+        self.assertFalse(
+            _rust_backend.should_use_rust_for_activation(10_000_000)
+        )
+
+    def test_tanh_via_rust_raises_when_unavailable(self) -> None:
+        """``tanh_via_rust`` must raise rather than silently produce wrong data."""
+        a = Tensor([0.0, 1.0, -1.0], (3,))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.tanh_via_rust(a)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_relu_via_rust_raises_when_unavailable(self) -> None:
+        """``relu_via_rust`` must raise (defence-in-depth for ungated callers)."""
+        a = Tensor([-1.0, 0.0, 1.0], (3,))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.relu_via_rust(a)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_tanh_correct_via_fallback(self) -> None:
+        """``TanhFunction.apply(a)`` falls back to ``math.tanh`` per element.
+
+        Hand-computed: tanh(0) = 0; tanh(1) ≈ 0.7615941559;
+        tanh(-1) ≈ -0.7615941559.  Using ``assertAlmostEqual`` with
+        ``places=12`` because the pure-Python path uses double-precision
+        math.tanh — the result must be bit-equivalent to ``math.tanh``.
+        """
+        a = Tensor([0.0, 1.0, -1.0], (3,))
+        result = TanhFunction.apply(a)
+        self.assertEqual(result.shape, (3,))
+        self.assertAlmostEqual(result.data[0], 0.0, places=12)
+        self.assertAlmostEqual(result.data[1], math.tanh(1.0), places=12)
+        self.assertAlmostEqual(result.data[2], math.tanh(-1.0), places=12)
+
+    def test_relu_correct_via_fallback(self) -> None:
+        """``ReLUFunction.apply(a)`` falls back to ``max(0, x)`` per element.
+
+        Hand-computed: ReLU([-2,-1,0,1,2]) = [0,0,0,1,2].
+        """
+        a = Tensor([-2.0, -1.0, 0.0, 1.0, 2.0], (5,))
+        result = ReLUFunction.apply(a)
+        self.assertEqual(result.shape, (5,))
+        self.assertEqual(result.data, [0.0, 0.0, 0.0, 1.0, 2.0])
+
+    def test_tanh_saved_metadata_populated_via_fallback(self) -> None:
+        """The pure-Python ``TanhFunction.forward`` saves the output in
+        ``saved_metadata["output"]`` so that backward can reuse it.
+        Confirm this contract still holds when the Rust path is disabled
+        (the dispatch block also saves output via the same key, so both
+        paths must be observationally identical from backward's POV).
+        """
+        a = Tensor([0.5, -0.5], (2,), requires_grad=True)
+        result = TanhFunction.apply(a)
+        # Backward should succeed without raising; this exercises the
+        # saved_metadata["output"] handshake end-to-end.
+        result.backward(Tensor([1.0, 1.0], (2,)))
+        self.assertIsNotNone(a.grad)
+        # d/dx tanh(x) = 1 - tanh(x)^2
+        expected_grad_0 = 1.0 - math.tanh(0.5) ** 2
+        expected_grad_1 = 1.0 - math.tanh(-0.5) ** 2
+        self.assertAlmostEqual(a.grad.data[0], expected_grad_0, places=10)
+        self.assertAlmostEqual(a.grad.data[1], expected_grad_1, places=10)
 
 
 if __name__ == "__main__":

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -470,5 +470,110 @@ class ReductionParityTests(unittest.TestCase):
         self._assert_close_scalar(rust_result.data[0], python_result.data[0])
 
 
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 4 — activation parity tests (Tanh + ReLU)
+#
+# Tanh is a direct unary op (matches Neg/Abs envelope shape from
+# Phase 2).  ReLU is composed as max(x, 0) via the Max op with a
+# zero-valued constant tensor shipped in the graph's constants[].
+# ──────────────────────────────────────────────────────────────────
+
+
+@unittest.skipUnless(
+    EXTENSION_AVAILABLE,
+    "matrix_rust_python C extension not installed; see parity-tests skip-reason.",
+)
+class ActivationParityTests(unittest.TestCase):
+    """Compare Tanh / ReLU Rust and pure-Python kernels head-to-head."""
+
+    SHAPE = (500, 200)  # 100_000 cells
+
+    def _make_tensor(self, seed: int):
+        import random
+
+        from ml_framework_core import Tensor
+
+        rng = random.Random(seed)
+        # Use range [-3, 3] so tanh saturates at both ends (any bug
+        # in the f32 vs double path would show in the saturated
+        # region where small input differences produce ~0 output
+        # differences) and ReLU exercises both halves.
+        data = [rng.uniform(-3.0, 3.0) for _ in range(500 * 200)]
+        return Tensor(data, self.SHAPE)
+
+    def _assert_close(
+        self,
+        actual: list[float],
+        expected: list[float],
+        rtol: float = 1e-3,
+        atol: float = 1e-4,
+    ) -> None:
+        """Same f32-vs-double tolerance as matmul/elementwise/reduction."""
+        self.assertEqual(len(actual), len(expected))
+        for i, (a, e) in enumerate(zip(actual, expected, strict=False)):
+            denom = max(abs(a), abs(e), atol)
+            err = abs(a - e) / denom
+            self.assertLess(
+                err,
+                rtol,
+                f"index {i}: rust={a!r}, python={e!r}, relative error {err:.2e}",
+            )
+
+    def test_activation_dispatch_predicate_fires_at_threshold(self) -> None:
+        """``should_use_rust_for_activation(100_000)`` returns True."""
+        from ml_framework_core._rust_backend import should_use_rust_for_activation
+
+        self.assertTrue(
+            should_use_rust_for_activation(500 * 200),
+            "MX10 Phase 4 threshold should let 100_000 cells use Rust",
+        )
+
+    def test_tanh_parity(self) -> None:
+        """``TanhFunction.apply(t)`` Rust matches pure-Python."""
+        from ml_framework_core import TanhFunction, _rust_backend
+
+        a = self._make_tensor(seed=42)
+
+        rust_result = TanhFunction.apply(a)
+        self.assertEqual(rust_result.shape, self.SHAPE)
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = TanhFunction.apply(a)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_result.data, python_result.data)
+
+    def test_relu_parity(self) -> None:
+        """``ReLUFunction.apply(t)`` Rust matches pure-Python.
+
+        ReLU is the only activation in Phase 4 that's not a direct
+        unary op — it's composed as Max(x, zero_const).  Verifying
+        the composed graph produces the same numerical result as
+        the trivial ``max(0.0, x)`` Python loop catches any bug in
+        the constant-buffer plumbing.
+        """
+        from ml_framework_core import ReLUFunction, _rust_backend
+
+        a = self._make_tensor(seed=7)
+
+        rust_result = ReLUFunction.apply(a)
+        self.assertEqual(rust_result.shape, self.SHAPE)
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = ReLUFunction.apply(a)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        # ReLU has no f32 accumulation (it's a single comparison +
+        # passthrough), so tolerance can be tighter.  Use the
+        # default rtol=1e-3 anyway for consistency.
+        self._assert_close(rust_result.data, python_result.data)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Extends MX10 per-op conditional dispatch to **Tanh** (direct unary op) and **ReLU** (composed as `max(x, zero_const)` via the Max op + a zero-constant tensor shipped in `constants[]`).
- Sigmoid, GELU, Softmax are intentionally deferred to Phase 4b (each needs its own dispatch design — 4-to-8-op compositions plus per-axis broadcasts).
- Same `_ELEMENTWISE_RUST_THRESHOLD = 100_000` predicate as Phases 2/3. Pure-Python fallback unchanged for `numel < threshold` or when the extension isn't installed.
- +9 tests (3 parity skip-if-no-extension, 6 fallback always-run). Full suite: 347 passed + 17 skipped + the pre-existing unrelated `test_device.py` failure.
- Security review: PASSED (no vulnerabilities — `json.dumps`/`struct.pack`/`bytes.fromhex` only; no eval/exec/pickle/subprocess; format strings built from integers not strings; output length validated before unpack).

## Test plan

- [x] `python3 -m pytest tests/` passes (347/348 with the 1 pre-existing failure)
- [x] New `ActivationParityTests` (3 cases) skip gracefully without the C extension
- [x] New `ActivationFallbackTests` (6 cases) always run and pass
- [x] `TanhFunction.backward` still works (verified via `test_tanh_saved_metadata_populated_via_fallback`)
- [ ] CI green on full repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)