### PR TITLE
feat(mini-sqlite): set-op in CTE bodies + MATERIALIZED hint tests

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [1.79.0] - 2026-05-21
+
+### Added
+
+- **UNION / INTERSECT / EXCEPT in non-recursive CTE bodies.**  Closes
+  the same gap PR #3817 fixed for derived tables, but for *named*
+  CTEs.  Previously the adapter raised
+  `"CTE 'x' body must be a plain SELECT, not a set operation"`
+  even though the parser accepts the syntax.  Now the body of a
+  ``WITH x AS (SELECT … UNION SELECT …)`` plays through the same set-
+  op tree that derived tables use.
+- CTE column aliases on a set-op body — `WITH u(label) AS (SELECT 'a'
+  UNION SELECT 'b') …` — work too.  The aliases apply to the
+  *leftmost* SelectStmt in the set-op tree (matching SQLite, which
+  derives output column names from the leftmost operand of a set-op
+  chain).
+- 21 oracle tests in `tests/test_tier3_materialized_cte.py` that pin
+  both behaviours: the `[NOT] MATERIALIZED` parse-and-ignore contract
+  (existing behaviour, previously untested) and the new set-op-in-CTE
+  support, including column aliases and 4-way UNION chains.
+
+### Changed
+
+- `_apply_cte_col_aliases` now walks down the `.left` spine of a
+  set-op tree until it reaches the leftmost SelectStmt, then rewrites
+  its items.  Returns the same tree shape on the way back out.
+- `ctes` dict type widened from
+  `dict[str, SelectStmt | RecursiveCTERef]` to
+  `dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef]`
+  across the adapter so set-op bodies can be stored and substituted
+  into FROM clauses via the existing `DerivedTableRef.select` union
+  type.
+
 ## [1.78.0] - 2026-05-21
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.78.0"
+version = "1.79.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -220,7 +220,7 @@ def _stmt_dispatch(
 
 def _query_stmt(
     node: ASTNode,
-    ctes: dict[str, SelectStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> Statement:
     """Translate ``query_stmt = [ with_clause ] select_stmt { set_op_clause }`` to a Statement.
@@ -236,7 +236,7 @@ def _query_stmt(
     set-operation tree.
     """
     # Accumulate CTEs: outer dict (if any) merged with any new WITH clause.
-    active_ctes: dict[str, SelectStmt | RecursiveCTERef] = dict(ctes) if ctes else {}
+    active_ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] = dict(ctes) if ctes else {}
     with_node = _maybe_child(node, "with_clause")
     if with_node is not None:
         # Check whether the WITH clause carries the RECURSIVE keyword.
@@ -289,12 +289,13 @@ def _query_stmt(
                 )
             else:
                 inner_stmt = _query_stmt(inner_q, ctes=active_ctes, view_defs=view_defs)
-                if not isinstance(inner_stmt, SelectStmt):
-                    raise ProgrammingError(
-                        f"CTE '{cte_name}' body must be a plain SELECT, not a set operation"
-                    )
-                # Apply column aliases to the non-recursive CTE's SELECT items.
-                if col_aliases and isinstance(inner_stmt, SelectStmt):
+                # The body may be a plain SelectStmt or a set-op tree
+                # (UnionStmt / IntersectStmt / ExceptStmt) — both are
+                # accepted, matching SQLite.  Column aliases on the CTE
+                # name are applied to the *leftmost* SelectStmt in the
+                # tree (set-op output column names inherit from the
+                # left operand, matching SQLite).
+                if col_aliases:
                     inner_stmt = _apply_cte_col_aliases(inner_stmt, col_aliases)
                 # Make this CTE visible to subsequent CTEs and the main query.
                 active_ctes[cte_name] = inner_stmt
@@ -345,7 +346,7 @@ def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode]:
 
 def _select(
     node: ASTNode,
-    ctes: dict[str, SelectStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> SelectStmt:
     state = _PlaceholderCounter()
@@ -416,7 +417,7 @@ def _select_item(node: ASTNode, state: _PlaceholderCounter) -> SelectItem:
 
 def _table_ref(
     node: ASTNode,
-    ctes: dict[str, SelectStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> TableRef | DerivedTableRef | RecursiveCTERef:
     """Translate a table_ref node.
@@ -528,7 +529,7 @@ def _table_ref(
 def _join_clause(
     node: ASTNode,
     state: _PlaceholderCounter,
-    ctes: dict[str, SelectStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> JoinClause:
     # join_clause has two forms (grammar):
@@ -2391,8 +2392,11 @@ def _cte_col_aliases(cte_node: ASTNode) -> list[str]:
     return aliases
 
 
-def _apply_cte_col_aliases(stmt: SelectStmt, aliases: list[str]) -> SelectStmt:
-    """Apply column aliases declared in a CTE definition to the CTE's SELECT items.
+def _apply_cte_col_aliases(
+    stmt: SelectStmt | UnionStmt | IntersectStmt | ExceptStmt,
+    aliases: list[str],
+) -> SelectStmt | UnionStmt | IntersectStmt | ExceptStmt:
+    """Apply column aliases declared in a CTE definition to the CTE's body.
 
     When a CTE is declared with an explicit column list::
 
@@ -2402,15 +2406,30 @@ def _apply_cte_col_aliases(stmt: SelectStmt, aliases: list[str]) -> SelectStmt:
     name is ``"1"`` (the literal).  The column alias list ``(n)`` says the
     output column should be named ``n``.
 
-    This helper adds ``alias=<declared_name>`` to each :class:`SelectItem` in
-    the anchor query's SELECT list, ensuring the planner sees the right
-    column names when it derives the CTE's output schema.
+    For a plain ``SelectStmt`` body, we add ``alias=<declared_name>`` to
+    each :class:`SelectItem`.  For a set-op tree (``a UNION b``,
+    ``a INTERSECT b``, ``a EXCEPT b``) we walk down the *left* spine
+    until we reach the leftmost :class:`SelectStmt` and rewrite that
+    one's items.  SQLite (and the SQL standard) derives the output
+    column names of a set-op chain entirely from the leftmost operand,
+    so renaming the leftmost SELECT is sufficient to make the planner
+    see the right schema.
 
-    If ``aliases`` is shorter than ``stmt.items`` the trailing items keep their
-    current aliases (the same behaviour as SQLite).  If ``aliases`` is empty,
-    ``stmt`` is returned unchanged.
+    If ``aliases`` is shorter than the SELECT list the trailing items
+    keep their current aliases (matches SQLite).  If ``aliases`` is
+    empty, ``stmt`` is returned unchanged.
     """
-    if not aliases or not stmt.items:
+    if not aliases:
+        return stmt
+    if isinstance(stmt, (UnionStmt, IntersectStmt, ExceptStmt)):
+        # Recursively rewrite the left side; right side is left alone.
+        new_left = _apply_cte_col_aliases(stmt.left, aliases)  # type: ignore[arg-type]
+        if isinstance(stmt, UnionStmt):
+            return UnionStmt(left=new_left, right=stmt.right, all=stmt.all)  # type: ignore[arg-type]
+        if isinstance(stmt, IntersectStmt):
+            return IntersectStmt(left=new_left, right=stmt.right, all=stmt.all)  # type: ignore[arg-type]
+        return ExceptStmt(left=new_left, right=stmt.right, all=stmt.all)  # type: ignore[arg-type]
+    if not stmt.items:
         return stmt
     new_items_list: list[SelectItem] = []
     for i, item in enumerate(stmt.items):

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -218,9 +218,18 @@ def _stmt_dispatch(
 # --------------------------------------------------------------------------
 
 
+# Shorthand for the value type of the active-CTE dict.  A named CTE's
+# body can be a plain SELECT, a set-op tree (UNION/INTERSECT/EXCEPT
+# anywhere on the left spine), or a recursive reference token; all
+# three plug into ``DerivedTableRef.select`` at substitution time.
+# Aliased here purely so the dozen function signatures threading this
+# dict around don't blow past the 100-column ruff limit.
+_CTEBody = SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef
+
+
 def _query_stmt(
     node: ASTNode,
-    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, _CTEBody] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> Statement:
     """Translate ``query_stmt = [ with_clause ] select_stmt { set_op_clause }`` to a Statement.
@@ -236,7 +245,7 @@ def _query_stmt(
     set-operation tree.
     """
     # Accumulate CTEs: outer dict (if any) merged with any new WITH clause.
-    active_ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] = dict(ctes) if ctes else {}
+    active_ctes: dict[str, _CTEBody] = dict(ctes) if ctes else {}
     with_node = _maybe_child(node, "with_clause")
     if with_node is not None:
         # Check whether the WITH clause carries the RECURSIVE keyword.
@@ -346,7 +355,7 @@ def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode]:
 
 def _select(
     node: ASTNode,
-    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, _CTEBody] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> SelectStmt:
     state = _PlaceholderCounter()
@@ -417,7 +426,7 @@ def _select_item(node: ASTNode, state: _PlaceholderCounter) -> SelectItem:
 
 def _table_ref(
     node: ASTNode,
-    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, _CTEBody] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> TableRef | DerivedTableRef | RecursiveCTERef:
     """Translate a table_ref node.
@@ -529,7 +538,7 @@ def _table_ref(
 def _join_clause(
     node: ASTNode,
     state: _PlaceholderCounter,
-    ctes: dict[str, SelectStmt | UnionStmt | IntersectStmt | ExceptStmt | RecursiveCTERef] | None = None,
+    ctes: dict[str, _CTEBody] | None = None,
     view_defs: dict[str, SelectStmt] | None = None,
 ) -> JoinClause:
     # join_clause has two forms (grammar):

--- a/code/packages/python/mini-sqlite/tests/test_tier3_materialized_cte.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_materialized_cte.py
@@ -1,0 +1,239 @@
+"""``[NOT] MATERIALIZED`` CTE hints — parse-and-ignore semantics.
+
+SQLite 3.35+ accepts an optional hint on every CTE definition:
+
+    WITH x AS [NOT] MATERIALIZED (SELECT …) …
+
+The hint tells SQLite's cost-based optimizer whether to materialize the
+CTE into a temporary table (MATERIALIZED) or inline it like a view (NOT
+MATERIALIZED).  Without the hint SQLite chooses based on its own
+heuristics.
+
+Mini-sqlite has *no* cost-based optimizer — CTEs are always inlined as
+subqueries by the planner — so the hint is purely advisory.  We parse it
+to stay byte-compatible with applications that use it for portability
+with real SQLite, then silently discard it.
+
+This test file pins the parse-and-ignore contract: every query is run
+through both ``mini_sqlite`` and stdlib ``sqlite3`` and must return
+identical rows.  A regression that, say, started raising on the
+keyword, or worse, that produced *different* rows when the hint is
+present versus absent, would be caught here.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = list(mini_sqlite.connect(":memory:").execute(query))
+    r = list(sqlite3.connect(":memory:").execute(query))
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+def _check_with_table(setup: list[str], query: str) -> None:
+    mc = mini_sqlite.connect(":memory:")
+    rc = sqlite3.connect(":memory:")
+    for s in setup:
+        mc.execute(s)
+        rc.execute(s)
+    m = list(mc.execute(query))
+    r = list(rc.execute(query))
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Single-CTE forms.
+# ---------------------------------------------------------------------------
+
+
+class TestSingleCTE:
+    def test_materialized(self) -> None:
+        _check("WITH x AS MATERIALIZED (SELECT 1 AS n) SELECT * FROM x")
+
+    def test_not_materialized(self) -> None:
+        _check("WITH x AS NOT MATERIALIZED (SELECT 1 AS n) SELECT * FROM x")
+
+    def test_no_hint_baseline(self) -> None:
+        _check("WITH x AS (SELECT 1 AS n) SELECT * FROM x")
+
+    def test_materialized_with_column_alias(self) -> None:
+        _check("WITH x(a) AS MATERIALIZED (SELECT 42) SELECT a FROM x")
+
+    def test_not_materialized_with_column_alias(self) -> None:
+        _check("WITH x(a) AS NOT MATERIALIZED (SELECT 42) SELECT a FROM x")
+
+
+# ---------------------------------------------------------------------------
+# Multiple CTEs in one WITH clause, mixed hints.
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleCTEs:
+    def test_both_materialized(self) -> None:
+        _check(
+            "WITH a AS MATERIALIZED (SELECT 1 AS x),"
+            "     b AS MATERIALIZED (SELECT 2 AS y) "
+            "SELECT a.x, b.y FROM a, b"
+        )
+
+    def test_mixed_hints(self) -> None:
+        _check(
+            "WITH a AS MATERIALIZED (SELECT 1 AS x),"
+            "     b AS NOT MATERIALIZED (SELECT x*2 AS y FROM a) "
+            "SELECT * FROM b"
+        )
+
+    def test_hint_then_no_hint(self) -> None:
+        _check(
+            "WITH a AS MATERIALIZED (SELECT 1 AS x),"
+            "     b AS (SELECT x+1 AS y FROM a) "
+            "SELECT y FROM b"
+        )
+
+    def test_no_hint_then_hint(self) -> None:
+        _check(
+            "WITH a AS (SELECT 10 AS x),"
+            "     b AS NOT MATERIALIZED (SELECT x FROM a) "
+            "SELECT * FROM b"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Recursive CTEs with MATERIALIZED — the hint is parsed but the recursion
+# semantics must still work end-to-end.
+# ---------------------------------------------------------------------------
+
+
+class TestRecursiveMaterialized:
+    def test_recursive_materialized(self) -> None:
+        _check(
+            "WITH RECURSIVE c(n) AS MATERIALIZED "
+            "(SELECT 1 UNION ALL SELECT n+1 FROM c WHERE n < 5) "
+            "SELECT n FROM c"
+        )
+
+    def test_recursive_not_materialized(self) -> None:
+        _check(
+            "WITH RECURSIVE c(n) AS NOT MATERIALIZED "
+            "(SELECT 1 UNION ALL SELECT n+1 FROM c WHERE n < 3) "
+            "SELECT n FROM c"
+        )
+
+    def test_recursive_two_columns_materialized(self) -> None:
+        _check(
+            "WITH RECURSIVE p(n, sq) AS MATERIALIZED "
+            "(SELECT 1, 1 UNION ALL SELECT n+1, (n+1)*(n+1) FROM p WHERE n < 4) "
+            "SELECT * FROM p"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Equivalence: query-with-hint == query-without-hint.  This is the
+# strongest expression of "parse and ignore" — any divergence between
+# these pairs would be a bug.
+# ---------------------------------------------------------------------------
+
+
+class TestHintIsAdvisory:
+    """The hint never changes results, only the planner's strategy."""
+
+    setup = [
+        "CREATE TABLE t(id INTEGER, v INTEGER)",
+        "INSERT INTO t VALUES (1, 10), (2, 20), (3, 30), (4, 40)",
+    ]
+
+    def _both(self, with_hint: str, without_hint: str) -> None:
+        # Both spellings must agree with sqlite3 AND with each other.
+        _check_with_table(self.setup, with_hint)
+        _check_with_table(self.setup, without_hint)
+
+        mc = mini_sqlite.connect(":memory:")
+        for s in self.setup:
+            mc.execute(s)
+        a = list(mc.execute(with_hint))
+        b = list(mc.execute(without_hint))
+        assert a == b, f"hint changed results!\n  with: {a}\n  without: {b}"
+
+    def test_filter_then_join(self) -> None:
+        self._both(
+            "WITH big AS MATERIALIZED (SELECT * FROM t WHERE v >= 20) "
+            "SELECT id, v FROM big ORDER BY id",
+            "WITH big AS (SELECT * FROM t WHERE v >= 20) "
+            "SELECT id, v FROM big ORDER BY id",
+        )
+
+    def test_aggregation_inside_cte(self) -> None:
+        self._both(
+            "WITH agg AS NOT MATERIALIZED (SELECT SUM(v) AS s FROM t) "
+            "SELECT s FROM agg",
+            "WITH agg AS (SELECT SUM(v) AS s FROM t) "
+            "SELECT s FROM agg",
+        )
+
+    def test_self_join_via_cte(self) -> None:
+        self._both(
+            "WITH base AS MATERIALIZED (SELECT id, v FROM t) "
+            "SELECT a.id, a.v, b.v FROM base a JOIN base b ON a.id = b.id ORDER BY a.id",
+            "WITH base AS (SELECT id, v FROM t) "
+            "SELECT a.id, a.v, b.v FROM base a JOIN base b ON a.id = b.id ORDER BY a.id",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Set operations inside a CTE body — both with and without the
+# MATERIALIZED hint.  This was a known gap until this PR; the parser
+# accepted the syntax but the adapter raised
+# "CTE body must be a plain SELECT, not a set operation".  PR #3817
+# fixed the same gap for *derived tables* (anonymous subqueries in
+# FROM); this commit extends the fix to *named* CTEs.
+# ---------------------------------------------------------------------------
+
+
+class TestSetOpInsideCTE:
+    def test_union_in_materialized(self) -> None:
+        _check(
+            "WITH u AS MATERIALIZED "
+            "(SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3) "
+            "SELECT n FROM u ORDER BY n"
+        )
+
+    def test_intersect_in_not_materialized(self) -> None:
+        _check(
+            "WITH i AS NOT MATERIALIZED "
+            "(SELECT 1 AS n UNION SELECT 2 INTERSECT SELECT 2) "
+            "SELECT n FROM i"
+        )
+
+    def test_union_in_plain_cte_no_hint(self) -> None:
+        # The fix applies regardless of MATERIALIZED — the original gap
+        # affected hint-less CTEs too.
+        _check(
+            "WITH u AS (SELECT 1 AS n UNION SELECT 2 UNION SELECT 3) "
+            "SELECT n FROM u ORDER BY n"
+        )
+
+    def test_except_in_cte(self) -> None:
+        _check(
+            "WITH e AS (SELECT 1 AS n UNION SELECT 2 UNION SELECT 3 EXCEPT SELECT 2) "
+            "SELECT n FROM e ORDER BY n"
+        )
+
+    def test_union_with_column_aliases(self) -> None:
+        # CTE column aliases on a set-op body — applied to the LEFTMOST
+        # SelectStmt of the set-op tree (SQLite derives output column
+        # names from the leftmost operand).
+        _check(
+            "WITH u(label) AS (SELECT 'a' UNION ALL SELECT 'b') "
+            "SELECT label FROM u ORDER BY label"
+        )
+
+    def test_chain_of_union_in_cte(self) -> None:
+        _check(
+            "WITH u AS ("
+            "  SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4"
+            ") SELECT n FROM u WHERE n > 2 ORDER BY n"
+        )


### PR DESCRIPTION
## Summary

- Closes the **UNION/INTERSECT/EXCEPT-in-named-CTE-body** gap (parser
  already accepted the syntax; adapter was raising). Symmetrical with
  the same fix PR #3817 made for *anonymous* derived tables.
- Locks in the existing `[NOT] MATERIALIZED` CTE hint parse-and-ignore
  contract with 15 oracle tests (previously untested).
- 6 additional tests cover the new set-op-in-CTE support including
  column aliases on set-op bodies and 4-way UNION chains.

## Adapter changes

- Removed the raise on set-op CTE bodies — the body now flows through
  the same `DerivedTableRef.select` union type (`SelectStmt | UnionStmt | IntersectStmt | ExceptStmt`) that anonymous derived tables already use.
- `_apply_cte_col_aliases` walks down the `.left` spine of a set-op tree until it reaches the leftmost SelectStmt, then rewrites its items. Matches SQLite — set-op chains derive output column names from the leftmost operand.
- `ctes` dict type widened across every adapter function that threads a CTE table down.

## Test plan

- [x] 21 new oracle tests pass (`test_tier3_materialized_cte.py`)
- [x] All 1943 mini-sqlite tests pass at 91.26% coverage
- [x] Security review passed (no new SQL injection or DoS surface; recursion is bounded by parser tree depth which already applied)

## Pipeline changes (version)

| Package | Change |
|---|---|
| mini-sqlite 1.78 → 1.79 | Adapter set-op CTE fix + MATERIALIZED test coverage |

🤖 Generated with [Claude Code](https://claude.com/claude-code)