### PR TITLE
feat(type-sidecar): scaffold crate with Record + Type lattice primitives (CLOC04 Phase 1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -487,6 +487,7 @@ members = [
     "x25519",
     "type-checker-protocol",
     "type-declarations",
+    "type-sidecar",
     "grammar-type-checker",
     "nib-lexer",
     "nib-parser",

--- a/code/packages/rust/type-sidecar/BUILD
+++ b/code/packages/rust/type-sidecar/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-type-sidecar -- --nocapture

--- a/code/packages/rust/type-sidecar/BUILD_windows
+++ b/code/packages/rust/type-sidecar/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-type-sidecar -- --nocapture

--- a/code/packages/rust/type-sidecar/CHANGELOG.md
+++ b/code/packages/rust/type-sidecar/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to the `coding-adventures-type-sidecar` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-21
+
+### Added
+- New crate scaffolded per [CLOC04](../../../specs/CLOC04-type-sidecar-format.md) — the producer-agnostic carrier for JS/TS type information.
+- `pub const FORMAT_VERSION: u32 = 1` — wire-format version.
+- `CvId` type alias for `String` matching the current `correlation-vector` representation (with module docs explaining the upgrade path to a real newtype).
+- `Sidecar` struct: `format_version: u32`, `records: HashMap<CvId, Record>`. `Sidecar::new()`, `default()`, `insert(record)`, plus `get`/`ty`/`attr`/`provenance` accessors.
+- `Record` struct: `cv`, `ty: Option<Type>`, `attributes: Attributes`, `provenance: Provenance`. `ty = None` distinguishes "no opinion" from "record absent."
+- `Type` enum (v1 scaffolding — primitives only):
+  - `Never`, `Unknown`, `Any` (three distinct lattice points per CLOC04).
+  - `Undefined`, `Null`, `Boolean`, `Number`, `BigInt`, `String`, `Symbol`.
+  - `Opaque { raw: String }` escape hatch for types the producer can't lower yet (typechecker treats this as `Unknown`). Encoded as a struct variant rather than a tuple because the `tag = "kind"` serde representation can't carry a newtype around a raw string.
+- `Attributes` struct: `TriState` fields (`nullable`, `readonly`, `pure`, `no_side_effects`, `idempotent`), `deprecated: Option<String>`, `extension: HashMap<String, serde_json::Value>` for keys that haven't been promoted to typed fields. `Default` impl returns all-`Unknown`.
+- `TriState` enum: `Unknown` / `True` / `False`. Three-valued because "no claim" is distinct from `False`.
+- `Provenance` struct: `producer: ProducerId`, `producer_version`, `source_file: Option<String>`, `source_location: Option<String>`, `generated_at: Option<String>`, `evidence: Vec<EvidenceStep>`.
+- `ProducerId(pub String)` newtype + `ProducerId::new()` constructor.
+- `EvidenceStep { stage, note, at }`.
+- All types derive `Debug, Clone, PartialEq, Serialize, Deserialize`. `Type` uses `serde(tag = "kind")` so on-disk values look like `{"kind": "Number"}`.
+- Module-level docs explain the role of this crate per CLOC01 + CLOC04 and document the dependency whitelist (no `javascript-ast`, no `closure-*`).
+- 12 tests covering: empty/default sidecar, insert + get, accessor short paths, `ty = None` distinction, primitive type round-trip through JSON (all 10 primitives), `Opaque` round-trip, `kind` discriminator on wire format, `Attributes::default()` is all-`Unknown`, `TriState` round-trip, full Sidecar serde round-trip with multiple records, provenance evidence chain growth, `ProducerId` equality.
+
+### Notes
+- Zero runtime dependencies beyond `serde` + `serde_json`. No `coding_adventures_correlation_vector` dep yet — `CvId` is a `String` alias here; the dep returns once that crate exposes a `CvId` newtype.
+- The full `Type` lattice (Object, Function, Class, Union, Intersection, generics, NamedRef, literals) ships in follow-up PRs to keep this scaffold small. Producers needing those today can encode them as `Type::Opaque` round-trips.
+- `SidecarBuilder` and `type-sidecar-merger` are deferred to follow-up PRs.

--- a/code/packages/rust/type-sidecar/Cargo.toml
+++ b/code/packages/rust/type-sidecar/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-type-sidecar"
+version = "0.1.0"
+edition = "2021"
+description = "Type sidecar — the producer-agnostic format that carries JS/TS type information into the Closure pipeline. Per CLOC04, JSDoc / TypeScript / hand-written annotations all emit the same shape; downstream typechecker and passes consume Sidecars without caring who wrote them."
+
+[dependencies]
+# Note: not depending on coding_adventures_correlation_vector for v1 — CvId
+# is a String alias here (matching the correlation-vector crate's current
+# representation). When CvId is promoted to a real newtype, this crate
+# will pick that up as a real dependency.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/code/packages/rust/type-sidecar/README.md
+++ b/code/packages/rust/type-sidecar/README.md
@@ -1,0 +1,72 @@
+# coding-adventures-type-sidecar
+
+The **producer-agnostic type-information carrier** for the JavaScript pipeline.
+Per [CLOC04](../../../specs/CLOC04-type-sidecar-format.md), JSDoc, TypeScript,
+and hand-written `.d.ts`-style annotations all emit the same sidecar shape;
+downstream consumers (`closure-typechecker`, optimization passes, the future
+V8 clone) read sidecars without knowing or caring which producer wrote them.
+
+## Why a separate crate
+
+The CLOC02 invariant is that the JS AST is **type-blind**. Types arrive as a
+parallel input keyed by the same `CvId`s the AST uses. Splitting that input
+into its own crate keeps:
+
+- AST consumers free of type-system imports.
+- Multiple type producers (JSDoc / TS / external) interchangeable behind one
+  shared format.
+- The merger between producers a separate, reviewable layer.
+
+## Dependency whitelist
+
+- `serde` + `serde_json` — for the JSON wire format.
+
+Deliberately **not**:
+- `javascript-ast` — the sidecar is AST-shape-agnostic.
+- Any `closure-*`, `jsdoc-*`, or `typescript-*` crate — those depend *on* this
+  crate, not the other way.
+
+A future dep on `coding_adventures_correlation_vector` will land once `CvId`
+becomes a true newtype there; for v1, `CvId` is a `String` alias defined
+here.
+
+## What's in v1
+
+- `Sidecar` — top-level `HashMap<CvId, Record>` + `format_version: u32`.
+- `Record` — `{ cv, ty: Option<Type>, attributes, provenance }`.
+- `Type` — primitive variants (`Never`, `Unknown`, `Any`, `Undefined`, `Null`,
+  `Boolean`, `Number`, `BigInt`, `String`, `Symbol`) plus an
+  `Opaque { raw: String }` escape hatch.
+- `Attributes` — `TriState` fields (`nullable`, `readonly`, `pure`,
+  `no_side_effects`, `idempotent`), `deprecated: Option<String>`, plus an
+  `extension: HashMap<String, serde_json::Value>` for keys that don't yet
+  have a typed slot.
+- `TriState` — `Unknown` / `True` / `False`.
+- `Provenance` — `producer`, `producer_version`, `source_file`,
+  `source_location`, `generated_at`, `evidence: Vec<EvidenceStep>`.
+- `Sidecar::new()` constructor plus `get`/`ty`/`attr`/`provenance`
+  accessors and `insert`.
+
+## What's coming (follow-up PRs)
+
+Per CLOC04 §"The `Type` lattice":
+- Object / Function / Class / Constructor / Instance variants.
+- Union / Intersection combinators.
+- Generics with `TypeParam` / `Generic { base, args }`.
+- `NamedRef` for nominal references.
+- Literal types (`LiteralString`, `LiteralNumber`, …).
+- `type-sidecar-merger` crate for combining sidecars from multiple producers
+  with a pluggable conflict policy.
+- `SidecarBuilder` for ergonomic producer-side construction.
+
+## Wire format
+
+JSON via serde. `Type` uses `serde(tag = "kind")` so on-disk values look
+like:
+
+```json
+{ "kind": "Number" }
+{ "kind": "Opaque", "raw": "future-syntax" }
+```
+
+The full envelope is at `format_version: 1` for everything this crate emits.

--- a/code/packages/rust/type-sidecar/required_capabilities.json
+++ b/code/packages/rust/type-sidecar/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/type-sidecar",
+  "capabilities": [],
+  "justification": "Pure data type definitions and JSON serde. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/type-sidecar/src/lib.rs
+++ b/code/packages/rust/type-sidecar/src/lib.rs
@@ -1,0 +1,496 @@
+//! Type sidecar — the producer-agnostic type-information carrier.
+//!
+//! # What this crate is for
+//!
+//! Per [CLOC01](../../../specs/CLOC01-closure-compiler-overview.md) and
+//! [CLOC04](../../../specs/CLOC04-type-sidecar-format.md), JavaScript types
+//! and the JS AST are kept **separate**. The AST is type-blind; types
+//! arrive in a parallel input — a *sidecar* — keyed by the same `CvId`s
+//! the AST uses.
+//!
+//! Multiple producers all emit the same sidecar shape:
+//!
+//! - **JSDoc extractor** (CLOC05): extracts types from `/** ... */`
+//!   comments and emits Records keyed by the JS-side `CvId` the comment
+//!   annotates.
+//! - **TypeScript extractor** (deferred): parses `.ts` source, runs type
+//!   inference, emits Records keyed by the equivalent JS-side `CvId`.
+//! - **Hand-written `.d.ts`-style external sidecars**: users write the
+//!   JSON directly.
+//!
+//! Downstream consumers (`closure-typechecker`, optimization passes, the
+//! future V8 clone) read sidecars without knowing or caring which
+//! producer wrote them.
+//!
+//! # Dependency whitelist (CLOC04 §"Dependency whitelist")
+//!
+//! - `coding_adventures_correlation_vector` — for the `CvId` representation.
+//! - `serde` + `serde_json` — for the JSON wire format.
+//!
+//! Explicitly **not**:
+//! - `javascript-ast` — the sidecar is AST-shape-agnostic; it just holds
+//!   `CvId` keys.
+//! - Any `closure-*`, `jsdoc-*`, or `typescript-*` crate — those depend
+//!   *on* this crate, not the other way.
+//!
+//! # What's here in v1 (this scaffolding PR)
+//!
+//! - The top-level [`Sidecar`] and [`Record`] structs.
+//! - The [`Type`] lattice, with primitive variants + the [`Type::Opaque`]
+//!   escape hatch. The full lattice from CLOC04 (Object, Function, Class,
+//!   Union, Intersection, generics, NamedRef, …) lands in follow-up PRs.
+//! - [`Attributes`] (TriState fields), [`TriState`].
+//! - [`Provenance`] with [`ProducerId`] and [`EvidenceStep`].
+//!
+//! Format version: `1`.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The wire-format version. Bumped on breaking shape changes per CLOC04.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// A correlation-vector identifier.
+///
+/// Aliased to `String` here for v1, matching the current
+/// `coding_adventures_correlation_vector` representation (where IDs are
+/// returned and consumed as `String`). The dependency on
+/// `correlation-vector` is kept in `Cargo.toml` so this alias can be
+/// upgraded to a real newtype later without a downstream churn — see
+/// CLOC02's `CvId` note for the migration plan.
+pub type CvId = std::string::String;
+
+// ============================================================================
+// Top level: Sidecar
+// ============================================================================
+
+/// A type sidecar: a map from `CvId` to a single [`Record`], plus the
+/// format-version tag downstream consumers use to reject incompatible
+/// inputs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Sidecar {
+    /// The wire-format version. Always [`FORMAT_VERSION`] for sidecars
+    /// produced by this crate.
+    pub format_version: u32,
+    /// One record per CvId. Exactly one — producers that hold multiple
+    /// beliefs about the same node encode them inside the record's
+    /// `evidence` chain, not as separate records.
+    pub records: HashMap<CvId, Record>,
+}
+
+impl Default for Sidecar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sidecar {
+    /// Construct an empty sidecar at the current [`FORMAT_VERSION`].
+    pub fn new() -> Self {
+        Self {
+            format_version: FORMAT_VERSION,
+            records: HashMap::new(),
+        }
+    }
+
+    /// Look up the full record for a CvId, if any. Returns `None` if the
+    /// producer has no record about that node.
+    pub fn get(&self, cv: &CvId) -> Option<&Record> {
+        self.records.get(cv)
+    }
+
+    /// Convenience: the resolved type for a CvId, if any.
+    pub fn ty(&self, cv: &CvId) -> Option<&Type> {
+        self.records.get(cv).and_then(|r| r.ty.as_ref())
+    }
+
+    /// Convenience: the attributes for a CvId, if any.
+    pub fn attr(&self, cv: &CvId) -> Option<&Attributes> {
+        self.records.get(cv).map(|r| &r.attributes)
+    }
+
+    /// Convenience: the provenance chain for a CvId, if any.
+    pub fn provenance(&self, cv: &CvId) -> Option<&Provenance> {
+        self.records.get(cv).map(|r| &r.provenance)
+    }
+
+    /// Insert (or overwrite) a record. Producers usually go through a
+    /// builder rather than calling this directly; merger crates use it.
+    pub fn insert(&mut self, record: Record) {
+        self.records.insert(record.cv.clone(), record);
+    }
+}
+
+// ============================================================================
+// Record
+// ============================================================================
+
+/// One sidecar entry: the type and attributes a producer believes about
+/// the CvId-keyed node, plus the audit chain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Record {
+    /// The CvId this record describes. Mirrors the map key.
+    pub cv: CvId,
+    /// The resolved type assertion. `None` means "this producer saw the
+    /// node but explicitly has no opinion about its type" — distinct
+    /// from the node being absent from the sidecar entirely.
+    pub ty: Option<Type>,
+    /// Auxiliary attributes that aren't part of the structural type but
+    /// matter for optimization (nullability, purity, deprecation, …).
+    pub attributes: Attributes,
+    /// Where this record came from and how it got here.
+    pub provenance: Provenance,
+}
+
+// ============================================================================
+// Type lattice
+// ============================================================================
+
+/// The structural type of a node.
+///
+/// v1 scaffolds the primitive variants plus [`Type::Opaque`]. The full
+/// lattice from CLOC04 §"The `Type` lattice" — Object, Function, Class,
+/// Union, Intersection, generics, NamedRef, literal types — lands in
+/// follow-up PRs to keep this scaffolding small and focused.
+///
+/// The `kind` discriminator on the wire is human-readable (`"Null"`,
+/// `"Number"`, etc.) per the CLOC04 JSON format.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum Type {
+    /// The empty set — a node typed `Never` is unreachable.
+    Never,
+    /// The universal set with no assumed operations. The typechecker
+    /// rejects any direct use; distinct from [`Type::Any`].
+    Unknown,
+    /// The universal set with all operations assumed valid. The opt-out
+    /// type — JSDoc `@type {*}` and TypeScript `any` both lower to this.
+    Any,
+    /// The literal `undefined` type.
+    Undefined,
+    /// The literal `null` type.
+    Null,
+    /// The primitive `boolean` type.
+    Boolean,
+    /// The primitive `number` type.
+    Number,
+    /// The `bigint` type (ES2020+).
+    BigInt,
+    /// The primitive `string` type.
+    String,
+    /// The `symbol` type (ES2015+).
+    Symbol,
+    /// Escape hatch for types the producer cannot lower yet. The `raw`
+    /// field is the producer-emitted raw form for debug purposes; the
+    /// typechecker treats `Opaque` exactly like [`Type::Unknown`] (no
+    /// claim) so the framework degrades gracefully.
+    ///
+    /// Encoded as a struct variant rather than a tuple variant because
+    /// the `tag = "kind"` serde representation can't carry a tagged
+    /// newtype around a raw string.
+    Opaque { raw: std::string::String },
+}
+
+// ============================================================================
+// Attributes
+// ============================================================================
+
+/// Per-node attributes that affect optimization but aren't part of the
+/// structural type itself. Each field uses [`TriState`] so producers can
+/// distinguish "we know it's true" from "we know it's false" from "we
+/// have no opinion."
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Attributes {
+    /// Whether the node's value can be `null` / `undefined`.
+    pub nullable: TriState,
+    /// Whether the node is a read-only binding or property.
+    pub readonly: TriState,
+    /// Whether a function/expression is pure (no side effects, output
+    /// determined by inputs only).
+    pub pure: TriState,
+    /// Weaker than `pure`: depends on inputs but does not mutate state.
+    pub no_side_effects: TriState,
+    /// Whether a function is idempotent (calling twice equals calling
+    /// once).
+    pub idempotent: TriState,
+    /// Optional deprecation message. `Some(_)` means deprecated.
+    pub deprecated: Option<std::string::String>,
+    /// Free-form attribute extension space. Lets producers communicate
+    /// attributes that don't yet have a typed slot here; once a key
+    /// gains broad adoption, it gets promoted into a real field with a
+    /// format-version bump.
+    #[serde(default)]
+    pub extension: HashMap<std::string::String, serde_json::Value>,
+}
+
+impl Default for Attributes {
+    fn default() -> Self {
+        Self {
+            nullable: TriState::Unknown,
+            readonly: TriState::Unknown,
+            pure: TriState::Unknown,
+            no_side_effects: TriState::Unknown,
+            idempotent: TriState::Unknown,
+            deprecated: None,
+            extension: HashMap::new(),
+        }
+    }
+}
+
+/// A three-valued boolean for attributes. The three states have distinct
+/// meanings: a producer that doesn't speak about an attribute emits
+/// [`Unknown`](TriState::Unknown), which the merger then treats as "no
+/// claim" and lets other producers fill in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TriState {
+    /// No claim either way.
+    Unknown,
+    /// Known to be true.
+    True,
+    /// Known to be false.
+    False,
+}
+
+// ============================================================================
+// Provenance
+// ============================================================================
+
+/// The chain of where a record came from. Always present so a debugger
+/// can answer "*why* does the typechecker believe this?"
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Who emitted this record.
+    pub producer: ProducerId,
+    /// Version string of the producer (free-form; SemVer-ish).
+    pub producer_version: std::string::String,
+    /// The source file the type came from, if any (e.g. the `.ts` file
+    /// or the `.js` file containing the JSDoc comment).
+    pub source_file: Option<std::string::String>,
+    /// Free-form location string within `source_file`, e.g. `"42:1"`.
+    pub source_location: Option<std::string::String>,
+    /// Optional ISO 8601 timestamp the record was produced.
+    pub generated_at: Option<std::string::String>,
+    /// The audit chain. Grows as the record passes through stages
+    /// (extractor → merger → typechecker contributions).
+    #[serde(default)]
+    pub evidence: Vec<EvidenceStep>,
+}
+
+/// An identifier for a sidecar producer. Conventional values:
+/// `"jsdoc"`, `"tsc-5.8"`, `"manual"`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProducerId(pub std::string::String);
+
+impl ProducerId {
+    /// Convenience constructor.
+    pub fn new(id: impl Into<std::string::String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// One step in a [`Provenance::evidence`] chain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceStep {
+    /// The stage that recorded this step (`"parse"`, `"infer"`,
+    /// `"merge"`, …).
+    pub stage: std::string::String,
+    /// Free-text note about what happened at this stage.
+    pub note: std::string::String,
+    /// Optional location string anchoring the step (e.g. `"42:1"`).
+    pub at: Option<std::string::String>,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_provenance() -> Provenance {
+        Provenance {
+            producer: ProducerId::new("jsdoc"),
+            producer_version: "1.0.0".into(),
+            source_file: Some("src/api.js".into()),
+            source_location: Some("42:1".into()),
+            generated_at: None,
+            evidence: vec![EvidenceStep {
+                stage: "extract".into(),
+                note: "from @type tag".into(),
+                at: Some("42:1".into()),
+            }],
+        }
+    }
+
+    fn sample_record(cv: &str) -> Record {
+        Record {
+            cv: cv.to_string(),
+            ty: Some(Type::Number),
+            attributes: Attributes {
+                nullable: TriState::False,
+                pure: TriState::True,
+                ..Attributes::default()
+            },
+            provenance: sample_provenance(),
+        }
+    }
+
+    #[test]
+    fn sidecar_new_is_empty_at_format_version_1() {
+        let s = Sidecar::new();
+        assert_eq!(s.format_version, FORMAT_VERSION);
+        assert_eq!(s.format_version, 1);
+        assert!(s.records.is_empty());
+    }
+
+    #[test]
+    fn sidecar_default_matches_new() {
+        let a = Sidecar::default();
+        let b = Sidecar::new();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn sidecar_insert_and_get() {
+        let mut s = Sidecar::new();
+        let rec = sample_record("a3f1.1");
+        s.insert(rec.clone());
+
+        assert_eq!(s.get(&"a3f1.1".to_string()), Some(&rec));
+        assert_eq!(s.get(&"nope.1".to_string()), None);
+    }
+
+    #[test]
+    fn sidecar_accessors_short_paths() {
+        let mut s = Sidecar::new();
+        s.insert(sample_record("a3f1.1"));
+        let id = "a3f1.1".to_string();
+
+        assert_eq!(s.ty(&id), Some(&Type::Number));
+        assert!(matches!(s.attr(&id).unwrap().pure, TriState::True));
+        assert_eq!(s.provenance(&id).unwrap().producer, ProducerId::new("jsdoc"));
+
+        let missing = "missing.1".to_string();
+        assert!(s.ty(&missing).is_none());
+        assert!(s.attr(&missing).is_none());
+        assert!(s.provenance(&missing).is_none());
+    }
+
+    #[test]
+    fn record_with_no_opinion_has_ty_none() {
+        // CLOC04: ty = None means "producer saw the node but has no
+        // opinion" — distinct from the node being absent entirely.
+        let rec = Record {
+            cv: "x.1".into(),
+            ty: None,
+            attributes: Attributes::default(),
+            provenance: sample_provenance(),
+        };
+
+        let mut s = Sidecar::new();
+        s.insert(rec);
+        let id = "x.1".to_string();
+
+        assert!(s.get(&id).is_some());
+        assert!(s.ty(&id).is_none());
+    }
+
+    #[test]
+    fn type_primitives_round_trip_through_json() {
+        // The full primitive set should serialize/deserialize cleanly via
+        // the `tag = "kind"` discriminator.
+        let primitives = [
+            Type::Never,
+            Type::Unknown,
+            Type::Any,
+            Type::Undefined,
+            Type::Null,
+            Type::Boolean,
+            Type::Number,
+            Type::BigInt,
+            Type::String,
+            Type::Symbol,
+        ];
+        for t in primitives {
+            let j = serde_json::to_string(&t).unwrap();
+            let back: Type = serde_json::from_str(&j).unwrap();
+            assert_eq!(t, back, "round-trip failed for {:?}", t);
+        }
+    }
+
+    #[test]
+    fn type_opaque_round_trips_with_raw_string() {
+        let t = Type::Opaque { raw: "MappedType<keyof Foo>".into() };
+        let j = serde_json::to_string(&t).unwrap();
+        let back: Type = serde_json::from_str(&j).unwrap();
+        assert_eq!(t, back);
+    }
+
+    #[test]
+    fn type_serializes_with_kind_discriminator() {
+        let json = serde_json::to_value(Type::Number).unwrap();
+        // Per CLOC04 wire format, the kind field is the discriminator.
+        assert_eq!(json["kind"], "Number");
+    }
+
+    #[test]
+    fn attributes_default_is_all_unknown() {
+        let a = Attributes::default();
+        assert_eq!(a.nullable, TriState::Unknown);
+        assert_eq!(a.readonly, TriState::Unknown);
+        assert_eq!(a.pure, TriState::Unknown);
+        assert_eq!(a.no_side_effects, TriState::Unknown);
+        assert_eq!(a.idempotent, TriState::Unknown);
+        assert_eq!(a.deprecated, None);
+        assert!(a.extension.is_empty());
+    }
+
+    #[test]
+    fn tristate_round_trips() {
+        for t in [TriState::Unknown, TriState::True, TriState::False] {
+            let j = serde_json::to_string(&t).unwrap();
+            let back: TriState = serde_json::from_str(&j).unwrap();
+            assert_eq!(t, back);
+        }
+    }
+
+    #[test]
+    fn sidecar_serde_round_trip() {
+        // End-to-end: insert a record, serialize the whole sidecar, parse
+        // it back, get identical contents.
+        let mut s = Sidecar::new();
+        s.insert(sample_record("a3f1.1"));
+        s.insert(Record {
+            cv: "b2c4.7".into(),
+            ty: Some(Type::Opaque { raw: "future-syntax".into() }),
+            attributes: Attributes::default(),
+            provenance: sample_provenance(),
+        });
+
+        let json = serde_json::to_string(&s).unwrap();
+        let back: Sidecar = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
+        assert_eq!(back.format_version, 1);
+        assert_eq!(back.records.len(), 2);
+    }
+
+    #[test]
+    fn provenance_evidence_grows_as_vec() {
+        let mut p = sample_provenance();
+        let before = p.evidence.len();
+        p.evidence.push(EvidenceStep {
+            stage: "merge".into(),
+            note: "combined with tsc-5.8 record".into(),
+            at: None,
+        });
+        assert_eq!(p.evidence.len(), before + 1);
+    }
+
+    #[test]
+    fn producer_id_equality_by_inner_string() {
+        assert_eq!(ProducerId::new("jsdoc"), ProducerId::new("jsdoc"));
+        assert_ne!(ProducerId::new("jsdoc"), ProducerId::new("tsc-5.8"));
+    }
+}


### PR DESCRIPTION
## Summary

**Stage 2 begins.** First new-crate PR after the foundational
JavaScript-frontend work. Scaffolds
`coding-adventures-type-sidecar` — the **producer-agnostic** carrier for
JS/TS type information per CLOC04.

Per CLOC02 the AST is type-blind. Types arrive in a parallel input — a
*sidecar* — keyed by the same `CvId`s the AST uses. Multiple producers
(JSDoc extractor, future TS extractor, hand-written external
annotations) all emit this same shape; downstream consumers
(`closure-typechecker`, optimization passes, future V8 clone) read
sidecars without caring who wrote them.

### What's here (v1)

- **`Sidecar`** — `HashMap<CvId, Record>` + `format_version: u32`.
  `new()`, `default()`, `insert()`, `get`/`ty`/`attr`/`provenance`
  accessors.
- **`Record`** — `cv + ty: Option<Type> + attributes + provenance`.
  `ty = None` distinguishes "no opinion" from "absent."
- **`Type`** — primitive variants (`Never`, `Unknown`, `Any` —
  three distinct lattice points per CLOC04 — `Undefined`, `Null`,
  `Boolean`, `Number`, `BigInt`, `String`, `Symbol`) plus
  `Opaque { raw: String }` as the escape hatch.
- **`Attributes`** — `TriState` fields (`nullable`, `readonly`,
  `pure`, `no_side_effects`, `idempotent`), `deprecated`, plus
  `extension` for unpromoted keys.
- **`TriState`** — `Unknown` / `True` / `False`. Three-valued because
  "no claim" is distinct from `False`.
- **`Provenance`** — full audit chain with `ProducerId`,
  `producer_version`, `source_file`/`location`, `generated_at`, and
  `evidence: Vec<EvidenceStep>`.

### Dependency whitelist (CLOC04)

- `serde` + `serde_json` only. No `coding_adventures_correlation_vector`
  dep yet — `CvId` is a `String` alias here; the dep returns when the
  CV crate exposes a true newtype.
- Explicitly **not** `javascript-ast` or any `closure-*` / `jsdoc-*` /
  `typescript-*` crate. The sidecar is AST-shape-agnostic; those crates
  depend on this one, not the other way.

### What's deferred (follow-up PRs)

- Full `Type` lattice: Object / Function / Class / Constructor /
  Instance / Union / Intersection / generics (`TypeParam`,
  `Generic { base, args }`) / `NamedRef` / literal types. Producers
  needing those today encode them via `Type::Opaque` round-trips.
- `SidecarBuilder` for ergonomic producer-side construction.
- `type-sidecar-merger` crate combining sidecars from multiple
  producers with a pluggable conflict policy.

## Test plan

- [x] `cargo test -p coding-adventures-type-sidecar` — **13/13 pass**
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      error unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

Public-API coverage:
- Empty/default sidecar at `format_version: 1`
- `insert` + `get` round-trip
- All accessor short paths (`ty`/`attr`/`provenance`)
- `ty = None` distinguishes "no opinion" from "absent"
- Every primitive `Type` variant round-trips through JSON
- `Opaque { raw }` round-trips with its raw string
- Wire format uses the `kind` discriminator
- `Attributes::default()` is all-`Unknown`
- `TriState` round-trips
- End-to-end `Sidecar` serde round-trip with multiple records
- `Provenance.evidence` chain growth
- `ProducerId` equality by inner string

## What's next

Stage 2 continues:

1. **`type-sidecar-merger` crate** — combines sidecars from multiple
   producers per CLOC04 §"Merging policy".
2. **JSDoc grammar + crates** per CLOC05.

Then Stage 3 (`closure-typechecker` + the `closure-pass-*` family) and
Stage 4 (`closure-emitter`, `closure-source-map`, `closure-cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)