### PR TITLE
[codex] Add Board VM endpoint session summary

### DIFF
--- a/code/packages/rust/board-vm-cli/README.md
+++ b/code/packages/rust/board-vm-cli/README.md
@@ -64,11 +64,14 @@ classification comes from the shared `board-vm-language-core`
 `parse_host_endpoint_with_error` summary, so the CLI does not maintain its own
 endpoint scheme or parse-error tables. Endpoint connection labels also come
 from `host_endpoint_connection_label`, which keeps the serial-only baud label
-policy in the shared Rust layer. The smoke report starts with a stable
-`connection transport=...` field so hardware logs can distinguish serial, TCP
-socket, BLE GATT, and RFCOMM runs without parsing endpoint strings. The default
-run budget is intentionally small because the current firmware executes blink
-bytecode synchronously while it prepares the run report.
+policy in the shared Rust layer. Endpoint open paths consume
+`host_endpoint_session_summary`, so the parsed endpoint metadata and display
+label arrive together before this crate touches platform transport APIs. The
+smoke report starts with a stable `connection transport=...` field so hardware
+logs can distinguish serial, TCP socket, BLE GATT, and RFCOMM runs without
+parsing endpoint strings. The default run budget is intentionally small because
+the current firmware executes blink bytecode synchronously while it prepares
+the run report.
 
 `repl` opens the same serial-plan-backed transport, sends `HELLO`, and then
 accepts a small interactive command set: `caps`, `upload-blink`, `upload-gpio-read <pin>

--- a/code/packages/rust/board-vm-cli/src/lib.rs
+++ b/code/packages/rust/board-vm-cli/src/lib.rs
@@ -23,12 +23,11 @@ use board_vm_host::{
 };
 use board_vm_language_core::{
     bluetooth_transact_wire_frame,
-    host_endpoint_connection_label as language_host_endpoint_connection_label,
-    parse_host_endpoint_with_error as parse_language_host_endpoint_with_error,
+    host_endpoint_session_summary as language_host_endpoint_session_summary,
     parse_serial_endpoint as parse_language_serial_endpoint, serial_runtime_open_plan_for_target,
     LanguageHostEndpointParseError, LanguageHostEndpointParseErrorKind,
-    LanguageHostEndpointSummary, LanguageHostEndpointTransport, LanguageSerialRuntimeOpenPlan,
-    LANGUAGE_SERIAL_OPEN_SETTLE_MS,
+    LanguageHostEndpointSessionSummary, LanguageHostEndpointTransport,
+    LanguageSerialRuntimeOpenPlan, LANGUAGE_SERIAL_OPEN_SETTLE_MS,
 };
 use board_vm_language_core::{detect_target, discover_devices, LanguageHostDevice};
 use board_vm_protocol::{
@@ -1612,9 +1611,9 @@ fn open_smoke_transport(
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let endpoint_summary = endpoint_summary(endpoint)?;
+        let endpoint_summary = endpoint_session_summary(endpoint, options.baud_rate)?;
         let endpoint_transport =
-            SessionEndpointTransport::from(endpoint_summary.endpoint_transport);
+            SessionEndpointTransport::from(endpoint_summary.endpoint.endpoint_transport);
         let connection_transport = SmokeConnectionTransport::from(endpoint_transport);
         let transport = open_endpoint_transport(
             endpoint,
@@ -1626,7 +1625,7 @@ fn open_smoke_transport(
         )?;
         return Ok((
             connection_transport,
-            language_host_endpoint_connection_label(&endpoint_summary, options.baud_rate),
+            endpoint_summary.connection_label,
             transport,
         ));
     }
@@ -1649,9 +1648,9 @@ fn open_bootloader_reboot_transport(
 ) -> Result<(SmokeConnectionTransport, String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let endpoint_summary = endpoint_summary(endpoint)?;
+        let endpoint_summary = endpoint_session_summary(endpoint, options.baud_rate)?;
         let endpoint_transport =
-            SessionEndpointTransport::from(endpoint_summary.endpoint_transport);
+            SessionEndpointTransport::from(endpoint_summary.endpoint.endpoint_transport);
         let connection_transport = SmokeConnectionTransport::from(endpoint_transport);
         let transport = open_endpoint_transport(
             endpoint,
@@ -1663,7 +1662,7 @@ fn open_bootloader_reboot_transport(
         )?;
         return Ok((
             connection_transport,
-            language_host_endpoint_connection_label(&endpoint_summary, options.baud_rate),
+            endpoint_summary.connection_label,
             transport,
         ));
     }
@@ -1684,9 +1683,9 @@ fn open_bootloader_reboot_transport(
 fn open_repl_transport(options: &ReplOptions) -> Result<(String, SessionTransport), CliError> {
     if let Some(endpoint) = options.endpoint.as_deref() {
         ensure_endpoint_not_mixed_with_port(options.port.as_deref())?;
-        let endpoint_summary = endpoint_summary(endpoint)?;
+        let endpoint_summary = endpoint_session_summary(endpoint, options.baud_rate)?;
         let endpoint_transport =
-            SessionEndpointTransport::from(endpoint_summary.endpoint_transport);
+            SessionEndpointTransport::from(endpoint_summary.endpoint.endpoint_transport);
         let transport = open_endpoint_transport(
             endpoint,
             endpoint_transport,
@@ -1695,10 +1694,7 @@ fn open_repl_transport(options: &ReplOptions) -> Result<(String, SessionTranspor
             options.timeout_ms,
             &options.tcp_config(endpoint),
         )?;
-        return Ok((
-            language_host_endpoint_connection_label(&endpoint_summary, options.baud_rate),
-            transport,
-        ));
+        return Ok((endpoint_summary.connection_label, transport));
     }
 
     open_serial_session_transport(
@@ -1801,17 +1797,20 @@ impl From<SessionEndpointTransport> for SmokeConnectionTransport {
 
 #[cfg(test)]
 fn endpoint_connection_label(endpoint: &str, baud_rate: u32) -> Result<String, CliError> {
-    endpoint_summary(endpoint)
-        .map(|endpoint| language_host_endpoint_connection_label(&endpoint, baud_rate))
+    endpoint_session_summary(endpoint, baud_rate).map(|endpoint| endpoint.connection_label)
 }
 
 #[cfg(test)]
 fn endpoint_transport(endpoint: &str) -> Result<SessionEndpointTransport, CliError> {
-    endpoint_summary(endpoint).map(|endpoint| endpoint.endpoint_transport.into())
+    endpoint_session_summary(endpoint, DEFAULT_BAUD_RATE)
+        .map(|endpoint| endpoint.endpoint.endpoint_transport.into())
 }
 
-fn endpoint_summary(endpoint: &str) -> Result<LanguageHostEndpointSummary, CliError> {
-    parse_language_host_endpoint_with_error(endpoint).map_err(endpoint_parse_error)
+fn endpoint_session_summary(
+    endpoint: &str,
+    baud_rate: u32,
+) -> Result<LanguageHostEndpointSessionSummary, CliError> {
+    language_host_endpoint_session_summary(endpoint, baud_rate).map_err(endpoint_parse_error)
 }
 
 fn endpoint_parse_error(error: LanguageHostEndpointParseError) -> CliError {

--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -85,7 +85,9 @@ input, so frontends can present native messages without inventing their own
 endpoint failure taxonomy. `host_endpoint_connection_label` also keeps the
 cross-transport display policy in Rust: serial endpoints carry the runtime baud
 rate in host logs, while TCP and Bluetooth endpoints use the endpoint string
-alone.
+alone. `host_endpoint_session_summary` packages the parsed endpoint metadata
+with that connection label so CLI consumers and language adapters can open a
+session without recombining transport and display policy.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -405,6 +405,12 @@ pub struct LanguageHostEndpointSummary {
     pub endpoint_scheme: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageHostEndpointSessionSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageHostEndpointParseErrorKind {
     InvalidSerialEndpoint,
@@ -988,6 +994,18 @@ pub fn host_endpoint_connection_label(
     } else {
         format!("endpoint={}", endpoint.endpoint)
     }
+}
+
+pub fn host_endpoint_session_summary(
+    endpoint: &str,
+    baud_rate: u32,
+) -> Result<LanguageHostEndpointSessionSummary, LanguageHostEndpointParseError> {
+    let endpoint = parse_host_endpoint_with_error(endpoint)?;
+    let connection_label = host_endpoint_connection_label(&endpoint, baud_rate);
+    Ok(LanguageHostEndpointSessionSummary {
+        endpoint,
+        connection_label,
+    })
 }
 
 pub const fn upload_adapter_name(adapter: TargetUploadAdapter) -> &'static str {
@@ -5892,6 +5910,27 @@ mod tests {
         assert_eq!(
             host_endpoint_connection_label(&rfcomm, 57_600),
             "endpoint=rfcomm://ESP32-BoardVM:3"
+        );
+
+        let session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session summary");
+        assert_eq!(
+            session.endpoint.endpoint_transport,
+            LanguageHostEndpointTransport::SerialPort
+        );
+        assert_eq!(
+            session.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        let session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session summary");
+        assert_eq!(
+            session.endpoint.endpoint_transport,
+            LanguageHostEndpointTransport::TcpSocket
+        );
+        assert_eq!(
+            session.connection_label,
+            "endpoint=tcp://board-vm.local:4170"
         );
     }
 


### PR DESCRIPTION
Summary:
- add Rust-owned LanguageHostEndpointSessionSummary in board-vm-language-core
- expose host_endpoint_session_summary to package parsed endpoint metadata with the connection label
- make board-vm-cli consume the shared session summary before opening endpoint transports
- document the endpoint session summary surface in the CLI and language-core READMEs

Validation:
- cargo fmt -p board-vm-cli -p board-vm-language-core
- cargo test -p board-vm-cli -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-cli
- bash BUILD in code/packages/rust/board-vm-language-core
- cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes:
- Generated build-plan.json and code/packages/rust/Cargo.lock were removed before committing.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool still panics on latest origin/main while loading code/packages/starlark/library-rules/rust_library.star before evaluating this diff.