### PR TITLE
Check HTML fixture case identities

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -107,6 +107,9 @@ binary while production code continues to link only static Rust source.
 - `check_whatwg_lexer_fixture_metadata.py`: checker that keeps the generated
   WHATWG lexer fixture files, generator pairs, metadata formats, and
   stale-check manifest wiring aligned
+- `check_html_fixture_case_ids.py`: checker that keeps checked-in lexer and
+  parser fixture case identities unique, stable, and aligned with parser audit
+  count metadata
 - `check_whatwg_lexer_rust_tests.py`: checker that keeps every focused WHATWG
   lexer fixture paired with a Rust test that parses the fixture and exercises
   the lexer harness
@@ -183,6 +186,8 @@ Verify local WHATWG lexer fixture metadata and manifest coverage with:
 
 ```bash
 python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py \
+  --check
+python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py \
   --check
 python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py \
   --check

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -108,6 +108,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "html-fixture-case-identities",
+            (
+                str(FIXTURE_DIR / "check_html_fixture_case_ids.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "html5lib-tokenizer-normalized",
             (
                 str(FIXTURE_DIR / "normalize_html5lib_fixtures.py"),

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+"""Check stable case identities in checked-in HTML lexer/parser fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+RUST_DIR = FIXTURE_DIR.parents[2]
+PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
+NUMERIC_REFERENCE_FIXTURE = "whatwg-numeric-references.json"
+
+
+@dataclass(frozen=True)
+class FixtureStats:
+    fixture_count: int
+    case_count: int
+
+
+def main() -> int:
+    parse_args()
+    errors, stats = check_fixture_case_ids()
+
+    print("HTML fixture case identities")
+    print(f"fixture files: {stats.fixture_count}")
+    print(f"cases: {stats.case_count}")
+
+    if errors:
+        raise SystemExit("\n\n".join(errors))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check stable, unique case identity fields in checked-in HTML "
+            "lexer/parser JSON fixtures."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compatibility flag for generated-fixture stale-check manifests.",
+    )
+    return parser.parse_args()
+
+
+def check_fixture_case_ids() -> tuple[list[str], FixtureStats]:
+    errors: list[str] = []
+    fixture_count = 0
+    case_count = 0
+
+    for fixture_path in fixture_json_files():
+        relative_path = relative_fixture(fixture_path)
+        data = read_json_object(fixture_path, errors)
+        if data is None or "cases" not in data:
+            continue
+
+        cases = data["cases"]
+        fixture_count += 1
+        if not isinstance(cases, list):
+            errors.append(f"{relative_path}: cases must be a list")
+            continue
+
+        case_count += len(cases)
+        identity_errors = check_case_identities(relative_path, fixture_path.name, cases)
+        audit_errors = check_parser_audit_counts(relative_path, data, cases)
+        errors.extend(identity_errors)
+        errors.extend(audit_errors)
+
+    return errors, FixtureStats(fixture_count=fixture_count, case_count=case_count)
+
+
+def fixture_json_files() -> list[Path]:
+    fixture_dirs = (FIXTURE_DIR, PARSER_FIXTURE_DIR)
+    return sorted(
+        fixture_path
+        for fixture_dir in fixture_dirs
+        for fixture_path in fixture_dir.glob("*.json")
+        if fixture_path.is_file()
+    )
+
+
+def read_json_object(fixture_path: Path, errors: list[str]) -> dict[str, Any] | None:
+    relative_path = relative_fixture(fixture_path)
+    try:
+        data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{relative_path}: invalid JSON: {exc}")
+        return None
+
+    if not isinstance(data, dict):
+        errors.append(f"{relative_path}: fixture must be a JSON object")
+        return None
+    return data
+
+
+def check_case_identities(
+    relative_path: str,
+    fixture_name: str,
+    cases: list[Any],
+) -> list[str]:
+    errors: list[str] = []
+    identities: list[str | int] = []
+
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            errors.append(f"{relative_path}: cases[{index}] must be an object")
+            continue
+
+        identity = case_identity(relative_path, fixture_name, index, case, errors)
+        if identity is not None:
+            identities.append(identity)
+
+    duplicate_identities = [
+        identity for identity, count in Counter(identities).items() if count > 1
+    ]
+    if duplicate_identities:
+        formatted = ", ".join(str(identity) for identity in sorted(duplicate_identities))
+        errors.append(f"{relative_path}: duplicate case identities: {formatted}")
+
+    return errors
+
+
+def case_identity(
+    relative_path: str,
+    fixture_name: str,
+    index: int,
+    case: dict[str, Any],
+    errors: list[str],
+) -> str | int | None:
+    if fixture_name == NUMERIC_REFERENCE_FIXTURE:
+        value = case.get("value")
+        if isinstance(value, int):
+            return value
+        errors.append(f"{relative_path}: cases[{index}].value must be an integer")
+        return None
+
+    case_id = case.get("id")
+    if isinstance(case_id, str) and case_id:
+        return case_id
+    errors.append(f"{relative_path}: cases[{index}].id must be a non-empty string")
+    return None
+
+
+def check_parser_audit_counts(
+    relative_path: str,
+    data: dict[str, Any],
+    cases: list[Any],
+) -> list[str]:
+    errors: list[str] = []
+
+    if "case_count" in data and data["case_count"] != len(cases):
+        errors.append(
+            f"{relative_path}: case_count={data['case_count']!r} "
+            f"does not match {len(cases)} cases"
+        )
+
+    if "counts_by_axis" in data:
+        expected_counts = data["counts_by_axis"]
+        if not isinstance(expected_counts, dict):
+            errors.append(f"{relative_path}: counts_by_axis must be an object")
+            return errors
+
+        axis_counts = Counter(
+            case.get("axis")
+            for case in cases
+            if isinstance(case, dict) and isinstance(case.get("axis"), str)
+        )
+        actual_counts = dict(sorted(axis_counts.items()))
+        if expected_counts != actual_counts:
+            errors.append(
+                f"{relative_path}: counts_by_axis={expected_counts!r} "
+                f"does not match {actual_counts!r}"
+            )
+
+    return errors
+
+
+def relative_fixture(path: Path) -> str:
+    try:
+        return str(path.relative_to(RUST_DIR))
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/html-fixture-scripts.txt
+++ b/code/packages/rust/html-lexer/tests/fixtures/html-fixture-scripts.txt
@@ -2,6 +2,7 @@
 # Relative to code/packages/rust.
 html-lexer/tests/fixtures/check_generated_html_fixtures.py
 html-lexer/tests/fixtures/check_html5lib_tokenizer_coverage.py
+html-lexer/tests/fixtures/check_html_fixture_case_ids.py
 html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py
 html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py
 html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py
@@ -24,6 +25,7 @@ html-lexer/tests/fixtures/generate_whatwg_text_mode_delimiters_fixture.py
 html-lexer/tests/fixtures/generated_fixture_io.py
 html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
 html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+html-lexer/tests/fixtures/test_html_fixture_case_ids.py
 html-lexer/tests/fixtures/test_html_fixture_scripts_compile.py
 html-parser/tests/fixtures/audit_html5lib_coverage.py
 html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py

--- a/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
@@ -38,6 +38,7 @@ class GeneratedHtmlFixtureManifestTest(unittest.TestCase):
         }
 
         self.assertIn("check_html_fixture_scripts_compile.py", checked_scripts)
+        self.assertIn("check_html_fixture_case_ids.py", checked_scripts)
         self.assertIn("normalize_html5lib_fixtures.py", checked_scripts)
         self.assertIn("check_html5lib_tokenizer_coverage.py", checked_scripts)
         self.assertIn("check_whatwg_lexer_fixture_metadata.py", checked_scripts)

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""Regression tests for the HTML fixture case identity checker."""
+
+from __future__ import annotations
+
+import unittest
+
+import check_html_fixture_case_ids as case_id_check
+
+
+class HtmlFixtureCaseIdsTest(unittest.TestCase):
+    def test_checked_in_fixtures_have_valid_case_identities(self) -> None:
+        errors, stats = case_id_check.check_fixture_case_ids()
+
+        self.assertEqual(errors, [])
+        self.assertGreater(stats.fixture_count, 0)
+        self.assertGreater(stats.case_count, 0)
+
+    def test_numeric_reference_fixture_uses_integer_values_as_identities(self) -> None:
+        numeric_fixture = (
+            case_id_check.FIXTURE_DIR / case_id_check.NUMERIC_REFERENCE_FIXTURE
+        )
+        numeric_cases = case_id_check.read_json_object(numeric_fixture, [])["cases"]
+
+        self.assertTrue(all("id" not in case for case in numeric_cases))
+        self.assertTrue(all(isinstance(case["value"], int) for case in numeric_cases))
+
+    def test_parser_audit_counts_match_case_axes(self) -> None:
+        audit_fixture = (
+            case_id_check.PARSER_FIXTURE_DIR / "whatwg-table-audit.json"
+        )
+        audit_data = case_id_check.read_json_object(audit_fixture, [])
+        audit_cases = audit_data["cases"]
+
+        self.assertEqual(audit_data["case_count"], len(audit_cases))
+        self.assertEqual(
+            case_id_check.check_parser_audit_counts(
+                "html-parser/tests/fixtures/whatwg-table-audit.json",
+                audit_data,
+                audit_cases,
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python guard for stable case identities across checked-in HTML lexer/parser JSON fixtures
- validate numeric-reference cases by integer value while other case fixtures use string IDs
- check parser audit case_count and counts_by_axis metadata, then wire the guard into the generated fixture manifest

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_scripts_compile.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_scripts_compile.py code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_construction_smoke.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py code/packages/rust/html-lexer/tests/fixtures/check_html5lib_tokenizer_coverage.py code/packages/rust/html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser