### PR TITLE
Flatten drain count-drift summary flag

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this package will be documented in this file.
 - Flattened idle, progress, and continuation flags in supervisor drain run
   summaries.
 - Count-drift presence flags for supervisor drain run reports and summaries.
+- Flattened aggregate count-drift flags for supervisor drain run summaries.
 - Stable count-drift classifications for supervisor drain run reports and
   summaries.
 - Flattened count-drift and host-investigation labels in supervisor drain run

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -88,6 +88,8 @@ The crate keeps the boundary narrow:
   for host log entries
 - supervisor drain run summaries expose count-drift presence flags beside
   signed deltas for host logs
+- supervisor drain run summaries flatten aggregate count-drift flags for
+  payload-free host logs
 - supervisor drain run summaries expose stable count-drift classifications so
   hosts can distinguish row, follow-up pressure, and combined drift
 - supervisor drain run summaries flatten stable count-drift and

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1225,6 +1225,7 @@ impl ToolAuditSupervisorDrainRunReport {
             follow_up_record_count_delta: self.follow_up_record_count_delta(),
             has_record_count_drift: self.has_record_count_drift(),
             has_follow_up_record_count_drift: self.has_follow_up_record_count_drift(),
+            has_count_drift: self.has_count_drift(),
             count_drift_kind: self.count_drift_kind(),
             count_drift_label: self.count_drift_label(),
             is_no_count_drift: self.is_no_count_drift(),
@@ -1451,6 +1452,8 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub has_record_count_drift: bool,
     /// Whether follow-up pressure count drift was observed.
     pub has_follow_up_record_count_drift: bool,
+    /// Whether any planned-vs-actual count drift was observed.
+    pub has_count_drift: bool,
     /// Stable classification of observed planned-vs-actual count drift.
     pub count_drift_kind: ToolAuditSupervisorDrainCountDriftKind,
     /// Stable count-drift classification label for host logs.
@@ -1662,7 +1665,7 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return whether any planned-vs-actual count drift was observed.
     pub fn has_count_drift(&self) -> bool {
-        self.has_record_count_drift() || self.has_follow_up_record_count_drift()
+        self.has_count_drift
     }
 
     /// Return whether planned and replayed counts stayed aligned.
@@ -4398,6 +4401,7 @@ mod tests {
         assert_eq!(summary.follow_up_record_count_delta(), 0);
         assert!(!summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
+        assert!(!summary.has_count_drift);
         assert!(!summary.has_count_drift());
         assert!(summary.is_no_count_drift);
         assert!(summary.is_no_count_drift());
@@ -4523,6 +4527,7 @@ mod tests {
         assert!(summary.has_record_count_drift());
         assert!(!summary.has_follow_up_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift());
+        assert!(summary.has_count_drift);
         assert!(summary.has_count_drift());
         assert!(!summary.is_no_count_drift);
         assert!(!summary.is_no_count_drift());
@@ -4603,6 +4608,7 @@ mod tests {
         assert!(!summary.matches_record_count());
         assert!(summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
+        assert!(summary.has_count_drift);
         assert!(summary.has_count_drift());
         assert!(!summary.is_no_count_drift);
         assert!(!summary.is_no_count_drift());
@@ -4683,6 +4689,7 @@ mod tests {
         assert!(!summary.has_record_count_drift());
         assert!(summary.has_follow_up_record_count_drift);
         assert!(summary.has_follow_up_record_count_drift());
+        assert!(summary.has_count_drift);
         assert!(summary.has_count_drift());
         assert!(!summary.is_no_count_drift);
         assert!(!summary.is_no_count_drift());


### PR DESCRIPTION
Summary:
- Flatten aggregate has_count_drift onto ToolAuditSupervisorDrainRunSummary for host log consumers
- Wire the summary accessor to the flattened field and cover raw/accessor values in drift tests
- Document the new flattened aggregate flag in README/CHANGELOG

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-has-count-summary-flag/mise.toml cargo test -p chief-of-staff-tool-audit-store
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-has-count-summary-flag/mise.toml sh BUILD