### PR TITLE
feat(moslayout,resolver): U29-1-G/R — HostDialog primitive

### DIFF
--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -86,8 +86,13 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     "Text", "Image", "Spacer", "Divider", "Icon",
     // Control flow (§3)
     "If", "Else", "For",
-    // Host primitives (§2.1 "Host*" rows)
-    "HostInput", "HostButton", "HostTable", "HostScroll",
+    // Host primitives (§2.1 "Host*" rows + UI29-1's HostDialog).
+    // HostDialog was added in UI29-1 after mosaic-pkg-dialog v0.1.0
+    // demonstrated that composing a dialog from Box+Column+Text loses
+    // modal/focus/top-layer/accessibility semantics that only the
+    // host's native dialog primitive (DOM <dialog>, Qt Popup, SwiftUI
+    // .sheet, XAML ContentDialog) provides.
+    "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
 ];
 
 // ---------------------------------------------------------------------------
@@ -645,14 +650,16 @@ version = "1"
 
     #[test]
     fn kernel_set_covers_ui29_section_2_1() {
-        // The fifteen primitives explicitly listed in the §2.1 table.
-        let expected_15 = [
+        // The sixteen primitives — fifteen from UI29 §2.1 plus
+        // HostDialog added in UI29-1 (#3846).
+        let expected_16 = [
             "Box", "Row", "Column", "Stack", "Text", "Image",
             "Spacer", "Divider", "Icon",
             "If", "For",
             "HostInput", "HostButton", "HostTable", "HostScroll",
+            "HostDialog",
         ];
-        for name in &expected_15 {
+        for name in &expected_16 {
             assert!(
                 KERNEL_PRIMITIVES.contains(name),
                 "kernel must include `{name}`"

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -100,6 +100,13 @@ const PRIMITIVES: &[&str] = &[
     // (currently both nodes coexist as siblings in `children`).
     "If",
     "Else",
+    // UI29 §2.1 / UI29-1 — host primitives. Each lowers to the host
+    // platform's native widget (DOM <input>, SwiftUI TextField, Qt
+    // TextInput, etc.). HostDialog (UI29-1) is the 16th kernel
+    // primitive, added after mosaic-pkg-dialog v0.1.0 exposed the need
+    // for a native dialog primitive with modal/focus/top-layer/
+    // accessibility semantics that composition cannot provide.
+    "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
 ];
 
 fn is_primitive(tag: &str) -> bool {
@@ -2063,6 +2070,23 @@ mod tests {
     fn if_and_else_are_in_primitives() {
         assert!(PRIMITIVES.contains(&"If"));
         assert!(PRIMITIVES.contains(&"Else"));
+    }
+
+    /// UI29-1 — HostDialog joined the kernel as the 16th primitive after
+    /// `mosaic-pkg-dialog` v0.1.0 demonstrated that composed dialogs lose
+    /// modal/focus/top-layer/accessibility semantics. PRIMITIVES is the
+    /// canonical roster every backend looks at; pin the entry so future
+    /// refactors that mistakenly drop it are caught at test time.
+    #[test]
+    fn host_dialog_and_friends_in_primitives() {
+        assert!(PRIMITIVES.contains(&"HostInput"));
+        assert!(PRIMITIVES.contains(&"HostButton"));
+        assert!(PRIMITIVES.contains(&"HostTable"));
+        assert!(PRIMITIVES.contains(&"HostScroll"));
+        assert!(
+            PRIMITIVES.contains(&"HostDialog"),
+            "UI29-1 added HostDialog as the 16th kernel primitive"
+        );
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary

Adds \`HostDialog\` to the kernel primitive lists in two crates:

- **moslayout-compiler**'s \`PRIMITIVES\` const — also caught a latent bug: the four already-merged Host* primitives (HostInput/HostButton/HostTable/HostScroll) had never been added to PRIMITIVES; this PR fixes that.
- **mosaic-package-resolver**'s \`KERNEL_PRIMITIVES\` — updates the §2.1 coverage test from \`expected_15\` → \`expected_16\`.

Per UI29-1 spec (#3846).

## Test plan
- [x] cargo test -p moslayout-compiler: 55 pass
- [x] cargo test -p mosaic-package-resolver: 13 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)