### PR TITLE
Flatten drain record-delta summary flags

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this package will be documented in this file.
 - Signed replayed-minus-planned row and follow-up pressure deltas in supervisor
   drain run summaries.
 - Delta-direction helpers for supervisor drain run reports.
+- Flattened row-count delta direction flags for supervisor drain run summaries.
 - Status aliases for supervisor drain run reports.
 - Row-count match helpers for supervisor drain run reports and summaries.
 - Planned-count match and drift flag accessors for supervisor drain run

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -88,6 +88,8 @@ The crate keeps the boundary narrow:
   for host log entries
 - supervisor drain run summaries expose count-drift presence flags beside
   signed deltas for host logs
+- supervisor drain run summaries flatten row-count delta direction flags beside
+  signed deltas for host logs
 - supervisor drain run summaries flatten aggregate count-drift flags for
   payload-free host logs
 - supervisor drain run summaries expose stable count-drift classifications so

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1222,6 +1222,8 @@ impl ToolAuditSupervisorDrainRunReport {
             planned_follow_up_records: self.planned_follow_up_records(),
             drained_follow_up_records: self.drained_follow_up_records(),
             record_count_delta: self.record_count_delta(),
+            replayed_extra_records: self.replayed_extra_records(),
+            missed_planned_records: self.missed_planned_records(),
             follow_up_record_count_delta: self.follow_up_record_count_delta(),
             has_record_count_drift: self.has_record_count_drift(),
             has_follow_up_record_count_drift: self.has_follow_up_record_count_drift(),
@@ -1446,6 +1448,10 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub drained_follow_up_records: usize,
     /// Replayed-minus-planned row count delta.
     pub record_count_delta: i128,
+    /// Whether more rows replayed than the preflight plan expected.
+    pub replayed_extra_records: bool,
+    /// Whether fewer rows replayed than the preflight plan expected.
+    pub missed_planned_records: bool,
     /// Replayed-minus-planned follow-up pressure count delta.
     pub follow_up_record_count_delta: i128,
     /// Whether row count drift was observed.
@@ -1720,12 +1726,12 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return whether the actual run replayed more rows than planned.
     pub fn replayed_extra_records(&self) -> bool {
-        self.record_count_delta > 0
+        self.replayed_extra_records
     }
 
     /// Return whether the actual run replayed fewer rows than planned.
     pub fn missed_planned_records(&self) -> bool {
-        self.record_count_delta < 0
+        self.missed_planned_records
     }
 
     /// Return whether the actual run replayed more follow-up pressure than planned.
@@ -4397,6 +4403,10 @@ mod tests {
         assert_eq!(summary.drained_follow_up_records(), 0);
         assert_eq!(summary.record_count_delta, 0);
         assert_eq!(summary.record_count_delta(), 0);
+        assert!(!summary.replayed_extra_records);
+        assert!(!summary.replayed_extra_records());
+        assert!(!summary.missed_planned_records);
+        assert!(!summary.missed_planned_records());
         assert_eq!(summary.follow_up_record_count_delta, 0);
         assert_eq!(summary.follow_up_record_count_delta(), 0);
         assert!(!summary.has_record_count_drift);
@@ -4523,6 +4533,10 @@ mod tests {
         assert!(report.replayed_extra_records());
         assert!(!report.missed_planned_records());
         assert_eq!(summary.record_count_delta, 1);
+        assert!(summary.replayed_extra_records);
+        assert!(summary.replayed_extra_records());
+        assert!(!summary.missed_planned_records);
+        assert!(!summary.missed_planned_records());
         assert!(summary.has_record_count_drift);
         assert!(summary.has_record_count_drift());
         assert!(!summary.has_follow_up_record_count_drift);
@@ -4605,6 +4619,10 @@ mod tests {
         assert!(report.requires_host_count_drift_investigation());
         assert!(!report.is_no_host_investigation());
         assert_eq!(summary.record_count_delta, -1);
+        assert!(!summary.replayed_extra_records);
+        assert!(!summary.replayed_extra_records());
+        assert!(summary.missed_planned_records);
+        assert!(summary.missed_planned_records());
         assert!(!summary.matches_record_count());
         assert!(summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
@@ -4684,6 +4702,10 @@ mod tests {
         assert!(report.requires_host_count_drift_investigation());
         assert!(!report.is_no_host_investigation());
         assert_eq!(summary.record_count_delta, 0);
+        assert!(!summary.replayed_extra_records);
+        assert!(!summary.replayed_extra_records());
+        assert!(!summary.missed_planned_records);
+        assert!(!summary.missed_planned_records());
         assert_eq!(summary.follow_up_record_count_delta, -1);
         assert!(!summary.has_record_count_drift);
         assert!(!summary.has_record_count_drift());


### PR DESCRIPTION
Summary:
- Flatten replayed_extra_records and missed_planned_records onto ToolAuditSupervisorDrainRunSummary for host log consumers
- Wire summary accessors to the flattened fields and cover raw/accessor values in drift tests
- Document the new flattened row-count delta direction flags in README/CHANGELOG

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-record-delta-summary-flags/mise.toml cargo test -p chief-of-staff-tool-audit-store
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-record-delta-summary-flags/mise.toml sh BUILD