### PR TITLE
Add HTML fixture README inventory check

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/README.md
+++ b/code/packages/rust/html-lexer/tests/fixtures/README.md
@@ -59,6 +59,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-character-reference-boundaries.json`: generated HTML tokenizer
   character-reference boundary cases used by Rust tests to pin text,
   attribute, RCDATA, and seeded named/numeric continuation recovery
+- `whatwg-attribute-boundaries.json`: generated HTML tokenizer attribute
+  boundary cases used by Rust tests to pin seeded start-tag and
+  current-attribute continuation recovery
 - `whatwg-input-stream.json`: generated HTML Standard input-stream
   preprocessing cases used by Rust tests to exercise CRLF and bare-CR
   normalization across tokenizer contexts and chunk boundaries
@@ -71,6 +74,9 @@ binary while production code continues to link only static Rust source.
 - `whatwg-text-mode-delimiters.json`: generated HTML tokenizer text-mode
   delimiter cases used by Rust tests to pin RCDATA, RAWTEXT, script-data,
   escaped-script, and seeded end-tag continuation recovery
+- `whatwg-text-mode-boundaries.json`: generated HTML tokenizer text-mode
+  boundary cases used by Rust tests to pin parser-seeded RCDATA, RAWTEXT,
+  PLAINTEXT, and text-mode continuation recovery
 - `whatwg-script-escape-boundaries.json`: generated HTML tokenizer script
   escape boundary cases used by Rust tests to pin escaped/double-escaped
   script data, NULL, EOF, and seeded continuation recovery
@@ -116,6 +122,9 @@ binary while production code continues to link only static Rust source.
 - `check_html_fixture_format_registry.py`: checker that keeps every
   format-bearing lexer/parser fixture JSON file explicitly registered with its
   expected format string and fixture category
+- `check_html_fixture_readme_inventory.py`: checker that keeps the lexer and
+  parser fixture READMEs aligned with user-facing fixture data and command
+  scripts
 - `check_whatwg_lexer_rust_tests.py`: checker that keeps every focused WHATWG
   lexer fixture paired with a Rust test that parses the fixture and exercises
   the lexer harness
@@ -138,6 +147,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_character_reference_boundaries_fixture.py`: importer that
   generates focused character-reference boundary cases for the checked-in
   `whatwg-character-reference-boundaries.json` fixture
+- `generate_whatwg_attribute_boundaries_fixture.py`: importer that generates
+  focused attribute boundary cases for the checked-in
+  `whatwg-attribute-boundaries.json` fixture
 - `generate_whatwg_input_stream_fixture.py`: importer that generates finite
   CRLF/bare-CR preprocessing cases for the checked-in
   `whatwg-input-stream.json` fixture
@@ -149,6 +161,9 @@ binary while production code continues to link only static Rust source.
 - `generate_whatwg_text_mode_delimiters_fixture.py`: importer that generates
   text-mode end-tag delimiter cases for the checked-in
   `whatwg-text-mode-delimiters.json` fixture
+- `generate_whatwg_text_mode_boundaries_fixture.py`: importer that generates
+  focused text-mode boundary cases for the checked-in
+  `whatwg-text-mode-boundaries.json` fixture
 - `generate_whatwg_script_escape_boundaries_fixture.py`: importer that
   generates focused script escape boundary cases for the checked-in
   `whatwg-script-escape-boundaries.json` fixture
@@ -198,6 +213,8 @@ python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids
 python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py \
   --check
 python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py \
+  --check
+python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py \
   --check
 python3 code/packages/rust/html-lexer/tests/fixtures/check_whatwg_lexer_rust_tests.py \
   --check

--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -129,6 +129,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "html-fixture-readme-inventory",
+            (
+                str(FIXTURE_DIR / "check_html_fixture_readme_inventory.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "html5lib-tokenizer-normalized",
             (
                 str(FIXTURE_DIR / "normalize_html5lib_fixtures.py"),

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+"""Check that HTML fixture READMEs mention the user-facing fixture artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+RUST_DIR = FIXTURE_DIR.parents[2]
+PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
+SCRIPT_INVENTORY = FIXTURE_DIR / "html-fixture-scripts.txt"
+
+DATA_SUFFIXES = {".dat", ".json", ".test"}
+SCRIPT_PREFIXES = ("audit_", "check_", "generate_", "normalize_")
+IGNORED_SCRIPT_PREFIXES = ("test_",)
+IGNORED_SCRIPT_NAMES = {"generated_fixture_io.py"}
+
+
+@dataclass(frozen=True)
+class ReadmeInventoryStats:
+    documented_artifact_count: int
+
+
+def main() -> int:
+    parse_args()
+    errors, stats = check_readme_inventory()
+
+    print("HTML fixture README inventory")
+    print(f"documented artifacts: {stats.documented_artifact_count}")
+
+    if errors:
+        raise SystemExit("\n\n".join(errors))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check that checked-in HTML lexer/parser fixture artifacts that users "
+            "run, regenerate, or inspect are mentioned in their package README."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compatibility flag for generated-fixture stale-check manifests.",
+    )
+    return parser.parse_args()
+
+
+def check_readme_inventory() -> tuple[list[str], ReadmeInventoryStats]:
+    errors: list[str] = []
+    artifacts = readme_artifacts()
+    seen = set()
+
+    for readme_path, artifact_name in artifacts:
+        key = (readme_path, artifact_name)
+        if key in seen:
+            errors.append(f"{relative_fixture(readme_path)}: duplicate README inventory target {artifact_name}")
+            continue
+        seen.add(key)
+
+        readme_text = readme_path.read_text(encoding="utf-8")
+        if artifact_name not in readme_text:
+            errors.append(
+                f"{relative_fixture(readme_path)}: missing README mention for {artifact_name}"
+            )
+
+    stats = ReadmeInventoryStats(documented_artifact_count=len(artifacts))
+    return errors, stats
+
+
+def readme_artifacts() -> list[tuple[Path, str]]:
+    return sorted(
+        [
+            *readme_data_artifacts(FIXTURE_DIR),
+            *readme_data_artifacts(PARSER_FIXTURE_DIR),
+            *readme_script_artifacts(),
+        ],
+        key=lambda item: (relative_fixture(item[0]), item[1]),
+    )
+
+
+def readme_data_artifacts(fixture_dir: Path) -> list[tuple[Path, str]]:
+    readme_path = fixture_dir / "README.md"
+    return [
+        (readme_path, fixture_path.name)
+        for fixture_path in fixture_dir.iterdir()
+        if fixture_path.is_file()
+        and fixture_path.suffix in DATA_SUFFIXES
+        and fixture_path.name != readme_path.name
+    ]
+
+
+def readme_script_artifacts() -> list[tuple[Path, str]]:
+    artifacts: list[tuple[Path, str]] = []
+    for relative_path in read_script_inventory():
+        script_path = RUST_DIR / relative_path
+        if not script_path.exists():
+            continue
+        if not is_user_facing_fixture_script(script_path.name):
+            continue
+
+        if script_path.parent == FIXTURE_DIR:
+            artifacts.append((FIXTURE_DIR / "README.md", script_path.name))
+        elif script_path.parent == PARSER_FIXTURE_DIR:
+            artifacts.append((PARSER_FIXTURE_DIR / "README.md", script_path.name))
+    return artifacts
+
+
+def read_script_inventory() -> list[Path]:
+    return [
+        Path(line.strip())
+        for line in SCRIPT_INVENTORY.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+
+def is_user_facing_fixture_script(script_name: str) -> bool:
+    if script_name in IGNORED_SCRIPT_NAMES:
+        return False
+    if script_name.startswith(IGNORED_SCRIPT_PREFIXES):
+        return False
+    return script_name.startswith(SCRIPT_PREFIXES)
+
+
+def relative_fixture(path: Path) -> str:
+    try:
+        return str(path.relative_to(RUST_DIR))
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-lexer/tests/fixtures/html-fixture-scripts.txt
+++ b/code/packages/rust/html-lexer/tests/fixtures/html-fixture-scripts.txt
@@ -4,6 +4,7 @@ html-lexer/tests/fixtures/check_generated_html_fixtures.py
 html-lexer/tests/fixtures/check_html5lib_tokenizer_coverage.py
 html-lexer/tests/fixtures/check_html_fixture_case_ids.py
 html-lexer/tests/fixtures/check_html_fixture_format_registry.py
+html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
 html-lexer/tests/fixtures/check_html_fixture_schemas.py
 html-lexer/tests/fixtures/check_html_fixture_scripts_compile.py
 html-lexer/tests/fixtures/check_whatwg_lexer_fixture_metadata.py
@@ -29,6 +30,7 @@ html-lexer/tests/fixtures/normalize_html5lib_fixtures.py
 html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
 html-lexer/tests/fixtures/test_html_fixture_case_ids.py
 html-lexer/tests/fixtures/test_html_fixture_format_registry.py
+html-lexer/tests/fixtures/test_html_fixture_readme_inventory.py
 html-lexer/tests/fixtures/test_html_fixture_schemas.py
 html-lexer/tests/fixtures/test_html_fixture_scripts_compile.py
 html-parser/tests/fixtures/audit_html5lib_coverage.py

--- a/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_generated_html_fixture_manifest.py
@@ -41,6 +41,7 @@ class GeneratedHtmlFixtureManifestTest(unittest.TestCase):
         self.assertIn("check_html_fixture_case_ids.py", checked_scripts)
         self.assertIn("check_html_fixture_schemas.py", checked_scripts)
         self.assertIn("check_html_fixture_format_registry.py", checked_scripts)
+        self.assertIn("check_html_fixture_readme_inventory.py", checked_scripts)
         self.assertIn("normalize_html5lib_fixtures.py", checked_scripts)
         self.assertIn("check_html5lib_tokenizer_coverage.py", checked_scripts)
         self.assertIn("check_whatwg_lexer_fixture_metadata.py", checked_scripts)

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_readme_inventory.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_readme_inventory.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+"""Regression tests for the HTML fixture README inventory check."""
+
+from __future__ import annotations
+
+import unittest
+
+import check_html_fixture_readme_inventory as readme_check
+
+
+class HtmlFixtureReadmeInventoryTest(unittest.TestCase):
+    def test_readme_inventory_is_current(self) -> None:
+        errors, _stats = readme_check.check_readme_inventory()
+
+        self.assertEqual(errors, [])
+
+    def test_inventory_covers_fixture_data_and_user_facing_scripts(self) -> None:
+        artifacts = readme_check.readme_artifacts()
+        artifact_names = {artifact_name for _readme_path, artifact_name in artifacts}
+
+        self.assertIn("whatwg-attribute-boundaries.json", artifact_names)
+        self.assertIn("whatwg-text-mode-boundaries.json", artifact_names)
+        self.assertIn("html5lib-tree-construction-smoke.dat", artifact_names)
+        self.assertIn("check_html_fixture_readme_inventory.py", artifact_names)
+        self.assertIn("audit_html5lib_coverage.py", artifact_names)
+        self.assertNotIn("generated_fixture_io.py", artifact_names)
+        self.assertNotIn("test_html_fixture_readme_inventory.py", artifact_names)
+
+    def test_inventory_targets_are_sorted_and_unique(self) -> None:
+        artifacts = readme_check.readme_artifacts()
+
+        self.assertEqual(artifacts, sorted(artifacts, key=lambda item: (str(item[0]), item[1])))
+        self.assertEqual(len(artifacts), len(set(artifacts)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a README inventory checker for user-facing HTML lexer/parser fixture artifacts
- wire the checker into the generated fixture manifest and script inventory
- document the missing attribute-boundary and text-mode-boundary lexer fixture families

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_readme_inventory.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile ... fixture checker/test scripts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser