### PR TITLE
feat(ml-framework-core): MX10 Phase 4b — Rust fast path for SigmoidFunction

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,94 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 4b: optional Rust fast path for `SigmoidFunction` via a 4-op composed graph
+
+Extends Phase 4's activation dispatch from `TanhFunction` +
+`ReLUFunction` to also cover `SigmoidFunction`.  GELU and Softmax
+remain deferred — see "What's NOT in Phase 4b" below.
+
+Sigmoid is the first activation in the dispatch helpers that's built
+from a **multi-op composed graph** rather than a direct unary op or
+the two-input Max trick ReLU uses.  The graph topology is:
+
+```
+input(0) ──Neg──> neg(1) ──Exp──> exp_neg(2) ─┐
+                                               ├Add──> one_plus(4) ──Recip──> out(5)
+                          ones-const(3) ──────┘
+```
+
+All four ops (Neg, Exp, Add, Recip) ship in a single FFI envelope so
+the per-call overhead (bytes-pack + JSON-build + planner-plan +
+executor-dispatch + bytes-unpack) is paid once, not four times.  The
+executor sees one graph, plans it once, and dispatches the ops
+back-to-back internally.
+
+Like ReLU's zero-tensor, the `1` in `1 + exp(-x)` must be materialised
+as a full ones-tensor of `a.shape` because matrix-cpu's `Add` op
+doesn't broadcast scalars.  The constant ships in the graph's
+`constants[]` array (same pattern as ReLU's zero-tensor and matmul's
+weight/bias buffers).
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds:
+    - `sigmoid_via_rust(a)` — ~80 LOC.  Reuses the existing
+      `should_use_rust_for_activation` predicate from Phase 4 (same
+      `_ELEMENTWISE_RUST_THRESHOLD = 100_000`).  Builds the 6-tensor
+      4-op envelope above, ships the ones-constant via `constants[]`,
+      and validates output length before unpacking.
+    - Updates the Phase 4 module-level comment to flip Sigmoid from
+      "deferred" to "shipped in Phase 4b".
+
+- **`functions.py`** — `SigmoidFunction.forward` gains a 4-line
+  dispatch block that mirrors `TanhFunction`'s shape: both must
+  populate `self.saved_metadata["output"]` (backward formula
+  `g * y * (1 - y)` depends only on the output, not the input).
+  The pure-Python `1.0 / (1.0 + math.exp(-x))` kernel is unchanged
+  in the fallback branch.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, numel ≥ 100_000 | **Rust** (4-op composed graph) |
+| Extension installed, numel < 100_000 | Pure-Python `1/(1+exp(-x))` |
+| Extension NOT installed | Pure-Python `1/(1+exp(-x))` |
+| Activation outside {Tanh, ReLU, Sigmoid} | Pure-Python (always) |
+
+#### Tests (48 total MX10 tests, was 45)
+
+- **`ActivationParityTests.test_sigmoid_parity`** (1 case, skip if
+  extension missing): random `(500, 200)` tensor in `[-3, 3]` (same
+  range as Tanh — covers the saturation tails), compares Rust vs
+  pure-Python with the standard `rtol=1e-3, atol=1e-4` f32-vs-double
+  tolerance.  Tighter would risk false failures from f32 drift
+  across 4 ops; looser would miss real numerical bugs.
+- **`SigmoidFallbackTests`** (3 cases, always run): direct-call
+  `RuntimeError` from `sigmoid_via_rust` when unavailable, pure-Python
+  correctness for `[0, 1, -1]` against `math.exp`, plus a
+  `saved_metadata["output"]` handshake test that runs backward and
+  checks `g * y * (1 - y)`.
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**350 passed + 18 skipped (parity-tests that need the extension)**;
+the same `test_device.py` pre-existing failure on main is unrelated.
+
+### What's NOT in Phase 4b
+
+- GELU.  The tanh-approximation form
+  (`0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))`) needs an
+  8-op composition plus a scalar `Pow(3)`; the latter is still
+  deferred from Phase 2 pending a scalar-exponent Pow variant in
+  matrix-cpu.  Composing `x * x * x` via three Muls works but adds
+  more graph nodes than warranted before profiling.
+- Softmax.  Needs `exp(x - max(x))` followed by per-axis broadcast
+  and divide; the broadcast dimension overlaps with Phase 3b
+  (axis-specific reductions) and warrants their joint design.
+- No backward-path Rust dispatch for Sigmoid (formula is two scalar
+  Muls per cell on the saved output — pure-Python is fast enough
+  that the FFI round-trip would lose).
+
 ### Added — MX10 Phase 4: optional Rust fast path for `TanhFunction` + `ReLUFunction` activations
 
 Extends the per-op conditional dispatch to two members of the

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -570,21 +570,19 @@ def mean_via_rust(a: Tensor) -> Tensor:
 #
 # The other classic activations are deferred:
 #
-# * Sigmoid = 1 / (1 + exp(-x)) — needs Exp + Neg + Add (with
-#   1-const) + Recip in a 4-op graph.  Doable but adds enough
-#   complexity that profiling should justify the FFI overhead
-#   first.
+# * Sigmoid = 1 / (1 + exp(-x)) — composed as a 4-op graph (Neg →
+#   Exp → Add(1-const) → Recip).  **Shipped in Phase 4b** via
+#   ``sigmoid_via_rust`` below.
 # * GELU = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 #   — multi-op composition with constants and Pow.  Deferred until
 #   matrix-cpu adds scalar-exponent Pow (would simplify the
 #   ``x^3`` term).
 # * Softmax = exp(x - max(x)) / sum(exp(...)) — needs per-axis
-#   broadcast which Phase 3b territory; deferred to coincide.
+#   broadcast which is Phase 3b territory; deferred to coincide.
 #
-# So Phase 4 ships **Tanh** and **ReLU** — the two most common
-# activations in modern ML workloads (Tanh in older RNN architectures
-# and GLU gates; ReLU in every CNN/transformer feed-forward block).
-# Sigmoid/GELU/Softmax wait for Phase 4b.
+# Phase 4 shipped Tanh + ReLU; Phase 4b adds Sigmoid via the 4-op
+# graph factory ``_sigmoid_via_rust_composed`` below.  GELU and
+# Softmax wait for later sub-phases.
 # ──────────────────────────────────────────────────────────────────
 
 
@@ -674,6 +672,101 @@ def relu_via_rust(a: Tensor) -> Tensor:
     if len(out_bytes) != expected_bytes:
         raise RuntimeError(
             f"relu_via_rust: expected {expected_bytes} output bytes "
+            f"({numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
+
+    return _Tensor(out_floats, a.shape, device=a.device)
+
+
+def sigmoid_via_rust(a: Tensor) -> Tensor:
+    """``Sigmoid(a) = 1 / (1 + exp(-a))`` composed as a 4-op graph.
+
+    Topology::
+
+        input(0) ──Neg──> neg(1) ──Exp──> exp_neg(2) ─┐
+                                                       ├Add──> one_plus(4) ──Recip──> out(5)
+                                  ones-const(3) ──────┘
+
+    matrix-cpu doesn't broadcast scalars (the same constraint that
+    forces ReLU's zero-tensor materialisation), so the ``1`` in
+    ``1 + exp(-x)`` is materialised as a full ones-tensor of shape
+    ``a.shape`` and shipped via the graph's ``constants[]`` array.
+
+    Why 4 ops in one envelope rather than 4 separate envelopes:
+    each FFI round-trip pays the bytes-pack + JSON-build +
+    planner-plan + executor-dispatch + bytes-unpack cost.  Bundling
+    the entire composition into one envelope amortises that
+    overhead — the executor sees a single graph, plans it once,
+    and dispatches the ops back-to-back in the same call.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "sigmoid_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_activation() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(a.data)
+    shape_list = list(a.shape)
+
+    a_bytes = struct.pack(f"<{numel}f", *a.data)
+    # All-ones constant of shape a.shape — same pattern as the
+    # zero-tensor in relu_via_rust, but with 1.0 in every cell.
+    # We pack via struct rather than computing the hex literal
+    # ("0000803f" per cell) so the code stays readable.
+    ones_bytes = struct.pack(f"<{numel}f", *([1.0] * numel))
+    ones_hex = ones_bytes.hex()
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    # tensor 0 = input x
+                    {"id": 0, "dtype": "f32", "shape": shape_list},
+                    # tensor 1 = -x
+                    {"id": 1, "dtype": "f32", "shape": shape_list},
+                    # tensor 2 = exp(-x)
+                    {"id": 2, "dtype": "f32", "shape": shape_list},
+                    # tensor 3 = ones constant (one per cell)
+                    {"id": 3, "dtype": "f32", "shape": shape_list},
+                    # tensor 4 = 1 + exp(-x)
+                    {"id": 4, "dtype": "f32", "shape": shape_list},
+                    # tensor 5 = 1 / (1 + exp(-x)) — output
+                    {"id": 5, "dtype": "f32", "shape": shape_list},
+                ],
+                "inputs": [0],
+                "outputs": [5],
+                "ops": [
+                    {"kind": "Neg", "input": 0, "output": 1},
+                    {"kind": "Exp", "input": 1, "output": 2},
+                    {"kind": "Add", "lhs": 2, "rhs": 3, "output": 4},
+                    {"kind": "Recip", "input": 4, "output": 5},
+                ],
+                "constants": [
+                    {
+                        "tensor_id": 3,
+                        "dtype": "f32",
+                        "shape": shape_list,
+                        "bytes_hex": ones_hex,
+                    }
+                ],
+            },
+            "inputs": [a_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    expected_bytes = numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"sigmoid_via_rust: expected {expected_bytes} output bytes "
             f"({numel} f32), got {len(out_bytes)}"
         )
     out_floats = list(struct.unpack(f"<{numel}f", out_bytes))

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -56,6 +56,7 @@ from ._rust_backend import (
     should_use_rust_for_elementwise,
     should_use_rust_for_matmul,
     should_use_rust_for_reduction,
+    sigmoid_via_rust,
     sub_via_rust,
     sum_via_rust,
     tanh_via_rust,
@@ -740,6 +741,17 @@ class SigmoidFunction(Function):
 
     def forward(self, a: Tensor) -> Tensor:
         self.save_for_backward(a)
+        # MX10 Phase 4b — optional Rust fast path.  Sigmoid is
+        # composed as a 4-op graph (Neg → Exp → Add(1) → Recip)
+        # in matrix-cpu; the entire composition is bundled into one
+        # FFI envelope so we pay the per-call overhead just once.
+        # Output is saved for backward via the same metadata key the
+        # pure-Python path uses (backward formula: y * (1 - y) only
+        # depends on the output, not the input).
+        if should_use_rust_for_activation(len(a.data)):
+            result = sigmoid_via_rust(a)
+            self.saved_metadata["output"] = result.data
+            return result
         data = [1.0 / (1.0 + math.exp(-x)) for x in a.data]
         self.saved_metadata["output"] = data
         return Tensor(data, a.shape, device=a.device)

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -29,7 +29,11 @@ import math
 
 from ml_framework_core import Tensor
 from ml_framework_core import _rust_backend
-from ml_framework_core.functions import ReLUFunction, TanhFunction
+from ml_framework_core.functions import (
+    ReLUFunction,
+    SigmoidFunction,
+    TanhFunction,
+)
 
 
 class MatMulFallbackTests(unittest.TestCase):
@@ -403,6 +407,69 @@ class ActivationFallbackTests(unittest.TestCase):
         expected_grad_1 = 1.0 - math.tanh(-0.5) ** 2
         self.assertAlmostEqual(a.grad.data[0], expected_grad_0, places=10)
         self.assertAlmostEqual(a.grad.data[1], expected_grad_1, places=10)
+
+
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 4b — Sigmoid fallback tests
+#
+# Sigmoid joins the activation family in Phase 4b via a 4-op composed
+# graph (Neg → Exp → Add(1) → Recip).  Same fallback pattern: when
+# ``_RUST_AVAILABLE = False``, dispatch must short-circuit and the
+# pure-Python ``1 / (1 + exp(-x))`` kernel must produce the right
+# answer.
+# ──────────────────────────────────────────────────────────────────
+
+
+class SigmoidFallbackTests(unittest.TestCase):
+    """Confirm Sigmoid still works when the Rust path is disabled."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_sigmoid_via_rust_raises_when_unavailable(self) -> None:
+        """``sigmoid_via_rust`` must raise (defence-in-depth)."""
+        a = Tensor([0.0, 1.0, -1.0], (3,))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.sigmoid_via_rust(a)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_sigmoid_correct_via_fallback(self) -> None:
+        """``SigmoidFunction.apply(a)`` falls back to ``1/(1+exp(-x))``.
+
+        Hand-computed: sigmoid(0) = 0.5; sigmoid(1) ≈ 0.7310585786;
+        sigmoid(-1) ≈ 0.2689414214.  ``assertAlmostEqual`` with
+        ``places=12`` because the pure-Python path uses
+        double-precision ``math.exp``.
+        """
+        a = Tensor([0.0, 1.0, -1.0], (3,))
+        result = SigmoidFunction.apply(a)
+        self.assertEqual(result.shape, (3,))
+        self.assertAlmostEqual(result.data[0], 0.5, places=12)
+        self.assertAlmostEqual(
+            result.data[1], 1.0 / (1.0 + math.exp(-1.0)), places=12
+        )
+        self.assertAlmostEqual(
+            result.data[2], 1.0 / (1.0 + math.exp(1.0)), places=12
+        )
+
+    def test_sigmoid_saved_metadata_populated_via_fallback(self) -> None:
+        """Backward needs ``saved_metadata["output"]`` (formula
+        ``g * y * (1 - y)`` is in terms of the output, not the input).
+        Confirm the contract holds via the fallback path.
+        """
+        a = Tensor([0.0, 2.0], (2,), requires_grad=True)
+        result = SigmoidFunction.apply(a)
+        result.backward(Tensor([1.0, 1.0], (2,)))
+        self.assertIsNotNone(a.grad)
+        # d/dx sigmoid(x) = sigmoid(x) * (1 - sigmoid(x))
+        y0 = 1.0 / (1.0 + math.exp(-0.0))  # 0.5
+        y1 = 1.0 / (1.0 + math.exp(-2.0))
+        self.assertAlmostEqual(a.grad.data[0], y0 * (1.0 - y0), places=10)
+        self.assertAlmostEqual(a.grad.data[1], y1 * (1.0 - y1), places=10)
 
 
 if __name__ == "__main__":

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -574,6 +574,34 @@ class ActivationParityTests(unittest.TestCase):
         # default rtol=1e-3 anyway for consistency.
         self._assert_close(rust_result.data, python_result.data)
 
+    def test_sigmoid_parity(self) -> None:
+        """``SigmoidFunction.apply(t)`` Rust matches pure-Python.
+
+        Phase 4b — Sigmoid is the first activation built from a
+        4-op composed graph (Neg → Exp → Add(1-const) → Recip)
+        rather than a direct unary op.  Numerical drift between
+        the f32 Rust path and the double pure-Python path
+        accumulates across the four ops, so we keep the same
+        ``rtol=1e-3, atol=1e-4`` tolerance the other parity tests
+        use — strict enough to catch a real bug, loose enough to
+        accept f32 quantisation.
+        """
+        from ml_framework_core import SigmoidFunction, _rust_backend
+
+        a = self._make_tensor(seed=99)
+
+        rust_result = SigmoidFunction.apply(a)
+        self.assertEqual(rust_result.shape, self.SHAPE)
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = SigmoidFunction.apply(a)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_result.data, python_result.data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Extends MX10 per-op conditional dispatch from Phase 4's {Tanh, ReLU} to also cover **Sigmoid** via a 4-op composed graph (`Neg → Exp → Add(1-const) → Recip`), bundled in a single FFI envelope.
- Like ReLU's zero-tensor, the `1` in `1 + exp(-x)` ships as a full ones-tensor via the graph's `constants[]` array (matrix-cpu's `Add` doesn't broadcast scalars).
- `SigmoidFunction.forward` gets a 4-line dispatch that mirrors `TanhFunction`'s shape (both must populate `saved_metadata["output"]` because backward `g * y * (1 - y)` depends only on the output).
- GELU and Softmax still deferred: GELU needs 8-op composition + scalar Pow (still deferred from Phase 2); Softmax needs per-axis broadcast (overlaps with Phase 3b territory).
- +4 tests (1 parity skip-if-no-extension, 3 fallback always-run). Full suite: 350 passed + 18 skipped + the pre-existing unrelated `test_device.py` failure.
- Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes (350/351 with the 1 pre-existing failure)
- [x] New `ActivationParityTests.test_sigmoid_parity` (1 case) skips gracefully without the C extension
- [x] New `SigmoidFallbackTests` (3 cases) always run and pass, including `saved_metadata["output"]` handshake
- [ ] CI green on full repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)