### PR TITLE
Flatten drain follow-up delta summary flags

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this package will be documented in this file.
   drain run summaries.
 - Delta-direction helpers for supervisor drain run reports.
 - Flattened row-count delta direction flags for supervisor drain run summaries.
+- Flattened follow-up pressure delta direction flags for supervisor drain run
+  summaries.
 - Status aliases for supervisor drain run reports.
 - Row-count match helpers for supervisor drain run reports and summaries.
 - Planned-count match and drift flag accessors for supervisor drain run

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -90,6 +90,8 @@ The crate keeps the boundary narrow:
   signed deltas for host logs
 - supervisor drain run summaries flatten row-count delta direction flags beside
   signed deltas for host logs
+- supervisor drain run summaries flatten follow-up pressure delta direction
+  flags beside signed deltas for host logs
 - supervisor drain run summaries flatten aggregate count-drift flags for
   payload-free host logs
 - supervisor drain run summaries expose stable count-drift classifications so

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1225,6 +1225,8 @@ impl ToolAuditSupervisorDrainRunReport {
             replayed_extra_records: self.replayed_extra_records(),
             missed_planned_records: self.missed_planned_records(),
             follow_up_record_count_delta: self.follow_up_record_count_delta(),
+            replayed_extra_follow_up_records: self.replayed_extra_follow_up_records(),
+            missed_planned_follow_up_records: self.missed_planned_follow_up_records(),
             has_record_count_drift: self.has_record_count_drift(),
             has_follow_up_record_count_drift: self.has_follow_up_record_count_drift(),
             has_count_drift: self.has_count_drift(),
@@ -1454,6 +1456,10 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub missed_planned_records: bool,
     /// Replayed-minus-planned follow-up pressure count delta.
     pub follow_up_record_count_delta: i128,
+    /// Whether more follow-up pressure rows replayed than the preflight plan expected.
+    pub replayed_extra_follow_up_records: bool,
+    /// Whether fewer follow-up pressure rows replayed than the preflight plan expected.
+    pub missed_planned_follow_up_records: bool,
     /// Whether row count drift was observed.
     pub has_record_count_drift: bool,
     /// Whether follow-up pressure count drift was observed.
@@ -1736,12 +1742,12 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return whether the actual run replayed more follow-up pressure than planned.
     pub fn replayed_extra_follow_up_records(&self) -> bool {
-        self.follow_up_record_count_delta > 0
+        self.replayed_extra_follow_up_records
     }
 
     /// Return whether the actual run replayed less follow-up pressure than planned.
     pub fn missed_planned_follow_up_records(&self) -> bool {
-        self.follow_up_record_count_delta < 0
+        self.missed_planned_follow_up_records
     }
 
     /// Return the stable scheduler-action label for host logs.
@@ -4409,6 +4415,10 @@ mod tests {
         assert!(!summary.missed_planned_records());
         assert_eq!(summary.follow_up_record_count_delta, 0);
         assert_eq!(summary.follow_up_record_count_delta(), 0);
+        assert!(!summary.replayed_extra_follow_up_records);
+        assert!(!summary.replayed_extra_follow_up_records());
+        assert!(!summary.missed_planned_follow_up_records);
+        assert!(!summary.missed_planned_follow_up_records());
         assert!(!summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
         assert!(!summary.has_count_drift);
@@ -4707,6 +4717,10 @@ mod tests {
         assert!(!summary.missed_planned_records);
         assert!(!summary.missed_planned_records());
         assert_eq!(summary.follow_up_record_count_delta, -1);
+        assert!(!summary.replayed_extra_follow_up_records);
+        assert!(!summary.replayed_extra_follow_up_records());
+        assert!(summary.missed_planned_follow_up_records);
+        assert!(summary.missed_planned_follow_up_records());
         assert!(!summary.has_record_count_drift);
         assert!(!summary.has_record_count_drift());
         assert!(summary.has_follow_up_record_count_drift);
@@ -4760,10 +4774,16 @@ mod tests {
             .drain_supervisor_checkpoint_loop_with_plan("supervisor", 10, 2, &mut sink)
             .unwrap();
         report.drain.ticks[0].replay.inventory.follow_up_records = 2;
+        let summary = report.summary();
 
         assert_eq!(report.follow_up_record_count_delta(), 1);
         assert!(report.replayed_extra_follow_up_records());
         assert!(!report.missed_planned_follow_up_records());
+        assert_eq!(summary.follow_up_record_count_delta, 1);
+        assert!(summary.replayed_extra_follow_up_records);
+        assert!(summary.replayed_extra_follow_up_records());
+        assert!(!summary.missed_planned_follow_up_records);
+        assert!(!summary.missed_planned_follow_up_records());
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Flatten replayed_extra_follow_up_records and missed_planned_follow_up_records onto ToolAuditSupervisorDrainRunSummary
- Wire summary accessors to the flattened follow-up direction fields and cover missed/extra follow-up drift in tests
- Document the new flattened follow-up pressure delta direction flags in README/CHANGELOG

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-follow-up-delta-summary-flags/mise.toml cargo test -p chief-of-staff-tool-audit-store
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-follow-up-delta-summary-flags/mise.toml sh BUILD