### PR TITLE
feat(ml-framework-core): MX10 Phase 3b — Rust fast path for axis-specific Sum/Mean (dim != None)

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 3b: optional Rust fast path for axis-specific `SumFunction` / `MeanFunction` (`dim != None`)
+
+Closes the gap Phase 3 explicitly deferred — the `dim != None`
+branch of `SumFunction.forward` and `MeanFunction.forward` now also
+dispatches through Rust when the extension is installed and the
+input is at or above the threshold.  Phase 3 only covered the
+reduce-all (`dim=None`) case; this PR makes axis-specific reductions
+get the same speedup using the same `_ELEMENTWISE_RUST_THRESHOLD =
+100_000` predicate.
+
+#### Why this is its own helper rather than reusing `_reduce_all_via_rust`
+
+- Output shape changes based on `dim` and `keepdim`.  Reduce-all
+  always produces a scalar; axis reductions can be any shape with
+  one dimension collapsed (`keep_dims=True`) or removed
+  (`keep_dims=False`).
+- Output `numel` varies — `input_numel / shape[dim]` rather than 1.
+- The `shape (1,) when result_shape is empty` fallback for rank-0
+  outputs matches a contract unique to `SumFunction` / `MeanFunction`.
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds:
+    - `_reduce_axis_via_rust(a, op_kind, dim, keepdim)` generic
+      helper for `ReduceSum` / `ReduceMean` along a single axis.
+      Computes the matrix-ir-json output shape from `(input_shape,
+      dim, keepdim)`, ships `axes=[dim]` and `keep_dims=keepdim` in
+      the op, then unpacks `product(output_shape)` f32 cells.
+      Caller normalises negative dims because matrix-ir-json's
+      `axes` field is unsigned.
+    - Public wrappers `sum_axis_via_rust(a, dim, keepdim)` and
+      `mean_axis_via_rust(a, dim, keepdim)`.  Mean dispatches
+      directly to `ReduceMean` (rather than composing `ReduceSum`
+      + divide) so the division happens inside matrix-cpu in f32
+      throughout, and we don't need to ship the divisor as a
+      constant.
+
+- **`functions.py`**:
+    - Imports `sum_axis_via_rust`, `mean_axis_via_rust`.
+    - `SumFunction.forward` (`dim != None` branch) gains a 2-line
+      dispatch block after the negative-dim normalisation; the
+      pure-Python axis loop below is the fallback.
+    - `MeanFunction.forward` (`dim != None` branch) gains a 3-line
+      dispatch block.  Bypasses the existing `SumFunction.apply +
+      divide` composition when going through Rust — avoids creating
+      a spurious `SumFunction` autograd node in the graph and lets
+      matrix-cpu do the f32 division.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `numel ≥ 100_000` | **Rust** (ReduceSum/ReduceMean with `axes=[dim]`) |
+| Extension installed, `numel < 100_000` | Pure-Python axis loop |
+| Extension NOT installed | Pure-Python axis loop |
+| `dim is None` | Phase 3 reduce-all path (unchanged) |
+
+#### Tests (57 total MX10 tests, was 48)
+
+- **`ReductionAxisParityTests`** (4 cases, skip if extension
+  missing): four parity tests covering the four
+  `{Sum, Mean} × {keepdim=True, keepdim=False}` combinations on a
+  `(500, 200) = 100_000`-cell tensor, comparing Rust vs pure-Python
+  at the standard `rtol=1e-3, atol=1e-4` tolerance.  Axis reductions
+  sum up to 500 cells in f32 (for `dim=0`), well within the rtol
+  budget but not as forgiving as the 100_000-cell reduce-all sum.
+- **`ReductionAxisFallbackTests`** (5 cases, always run):
+  defence-in-depth `RuntimeError` from `sum_axis_via_rust` and
+  `mean_axis_via_rust` when unavailable, plus correctness via the
+  pure-Python axis loop for `sum(dim=0)`, `sum(dim=0, keepdim=True)`,
+  and `mean(dim=1)` on a 2x3 tensor.
+- **Renamed**: `test_axis_specific_reduction_unchanged_by_phase_3`
+  → `test_axis_specific_reduction_below_threshold_stays_pure_python`,
+  with updated docstring to reflect that Phase 3b changed *what
+  dispatches when* — small tensors still bypass Rust even with the
+  extension installed, but for the new reason (sub-threshold rather
+  than `dim != None` blanket).
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**355 passed + 22 skipped (parity-tests that need the extension)**;
+the pre-existing `test_device.py` failure on main is unrelated.
+
+### What's NOT in Phase 3b
+
+- Multi-axis reductions (e.g. `dim=(0, 2)`).  `SumFunction` /
+  `MeanFunction` don't expose a multi-axis API at this layer
+  (they accept `int | None`); matrix-ir-json's `axes` field would
+  support it, but the change is API-shaped, not dispatch-shaped.
+- Other reductions (`Min`, `Max`, `Std`, `Var`, `ArgMin`, `ArgMax`).
+  Same story as Phase 3 — Sum/Mean are the most common in ML
+  workloads (loss, batch norm); others can be added using the same
+  `_reduce_axis_via_rust` factory.
+- Backward-path Rust dispatch.  The Sum/Mean backward broadcasts
+  the gradient back to the input shape; doable as a `Broadcast` op
+  in matrix-cpu but currently pure-Python.
+
 ### Added — MX10 Phase 4b: optional Rust fast path for `SigmoidFunction` via a 4-op composed graph
 
 Extends Phase 4's activation dispatch from `TanhFunction` +

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -561,6 +561,139 @@ def mean_via_rust(a: Tensor) -> Tensor:
 
 
 # ──────────────────────────────────────────────────────────────────
+# Axis-specific reduction fast paths (MX10 Phase 3b)
+#
+# Phase 3 shipped reduce-all (dim=None) only.  Phase 3b adds the
+# dim != None branch — reducing along a single named axis with
+# either keep_dims=True (axis becomes size 1) or keep_dims=False
+# (axis is dropped).
+#
+# The same matrix-ir-json ReduceSum / ReduceMean ops are used as
+# Phase 3; the only difference is the ``axes`` list contains one
+# element (the named dim) instead of every dim, and ``keep_dims``
+# follows the user-supplied keepdim flag.
+#
+# Why this is its own helper rather than reusing _reduce_all_via_rust:
+#   - output shape changes based on dim and keepdim (not always (1,))
+#   - output numel varies (input numel / shape[dim])
+#   - the ``(1,) when empty`` fallback for rank-0 reductions matches
+#     a contract that's unique to SumFunction/MeanFunction
+# ──────────────────────────────────────────────────────────────────
+
+
+def _reduce_axis_via_rust(
+    a: Tensor, op_kind: str, dim: int, keepdim: bool
+) -> Tensor:
+    """Generic helper for ReduceSum / ReduceMean along a single axis.
+
+    Args:
+        a: input tensor.
+        op_kind: "ReduceSum" or "ReduceMean" (matrix-ir-json op name).
+        dim: non-negative axis index (caller must normalise negatives).
+        keepdim: if True, output shape preserves the axis as size 1;
+            if False, the axis is dropped.
+
+    Output-shape convention matches SumFunction's pure-Python path:
+      - shape[dim] becomes 1 (keepdim) or is removed (not keepdim)
+      - if removing the axis leaves an empty shape (e.g. 1-D input
+        with dim=0 keepdim=False), we return shape ``(1,)`` to match
+        the existing user-facing contract.
+
+    For matrix-cpu the requested output shape is whatever shape we
+    declare on the output tensor; the executor allocates exactly
+    ``product(output_shape)`` cells (clamped to 1 for rank-0).
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            f"{op_kind.lower()}_axis_via_rust called but Rust backend is "
+            f"not available; callers must check "
+            f"should_use_rust_for_reduction() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(a.data)
+    input_shape = list(a.shape)
+
+    # Compute the matrix-ir-json output shape (sent to the executor):
+    # keep_dims=True → axis becomes 1; keep_dims=False → axis dropped.
+    if keepdim:
+        ir_output_shape = list(input_shape)
+        ir_output_shape[dim] = 1
+    else:
+        ir_output_shape = [s for i, s in enumerate(input_shape) if i != dim]
+
+    # Output numel: product of remaining dims (after axis collapse).
+    # For a rank-0 result (1-D input reduced without keepdim) the IR
+    # shape is [] but the executor still writes 1 f32 cell.
+    output_numel = 1
+    for s in ir_output_shape:
+        output_numel *= s
+
+    a_bytes = struct.pack(f"<{numel}f", *a.data)
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    {"id": 0, "dtype": "f32", "shape": input_shape},
+                    {"id": 1, "dtype": "f32", "shape": ir_output_shape},
+                ],
+                "inputs": [0],
+                "outputs": [1],
+                "ops": [
+                    {
+                        "kind": op_kind,
+                        "input": 0,
+                        "axes": [dim],
+                        "keep_dims": keepdim,
+                        "output": 1,
+                    }
+                ],
+                "constants": [],
+            },
+            "inputs": [a_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    expected_bytes = output_numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"{op_kind.lower()}_axis_via_rust: expected {expected_bytes} "
+            f"output bytes ({output_numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{output_numel}f", out_bytes))
+
+    # Match SumFunction's user-facing contract: rank-0 outputs are
+    # presented as shape (1,) rather than ().
+    user_shape = tuple(ir_output_shape) if ir_output_shape else (1,)
+
+    return _Tensor(out_floats, user_shape, device=a.device)
+
+
+def sum_axis_via_rust(a: Tensor, dim: int, keepdim: bool) -> Tensor:
+    """``a.sum(dim=dim, keepdim=keepdim)`` via Rust ReduceSum."""
+    return _reduce_axis_via_rust(a, "ReduceSum", dim, keepdim)
+
+
+def mean_axis_via_rust(a: Tensor, dim: int, keepdim: bool) -> Tensor:
+    """``a.mean(dim=dim, keepdim=keepdim)`` via Rust ReduceMean.
+
+    Note: We dispatch directly to ReduceMean rather than composing
+    ``ReduceSum`` + divide, so the division happens inside matrix-cpu
+    (one f32 multiply by ``1/count``) and we don't have to ship the
+    divisor as a constant.
+    """
+    return _reduce_axis_via_rust(a, "ReduceMean", dim, keepdim)
+
+
+# ──────────────────────────────────────────────────────────────────
 # Activation fast paths (MX10 Phase 4)
 #
 # matrix-ir-json supports Tanh, Sqrt, Exp, Log, Recip directly as

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -48,6 +48,7 @@ from ._rust_backend import (
     add_via_rust,
     div_via_rust,
     matmul_via_rust,
+    mean_axis_via_rust,
     mean_via_rust,
     mul_via_rust,
     neg_via_rust,
@@ -58,6 +59,7 @@ from ._rust_backend import (
     should_use_rust_for_reduction,
     sigmoid_via_rust,
     sub_via_rust,
+    sum_axis_via_rust,
     sum_via_rust,
     tanh_via_rust,
 )
@@ -425,6 +427,15 @@ class SumFunction(Function):
         if dim < 0:
             dim = a.ndim + dim
 
+        # MX10 Phase 3b — optional Rust fast path (axis-specific).
+        # Same threshold as reduce-all (per-cell cost is similar);
+        # matrix-cpu's ReduceSum takes an ``axes=[dim]`` list and
+        # ``keep_dims=keepdim`` flag.  Pure-Python axis loop below
+        # is the fallback for small tensors or when the extension
+        # isn't installed.
+        if should_use_rust_for_reduction(len(a.data)):
+            return sum_axis_via_rust(a, dim, keepdim)
+
         # Sum along a specific dimension
         list(a.shape)
         stride = _compute_strides(a.shape)
@@ -532,6 +543,17 @@ class MeanFunction(Function):
                 return mean_via_rust(a)
             total = sum(a.data)
             return Tensor([total / a.numel], (1,), device=a.device)
+
+        # MX10 Phase 3b — optional Rust fast path (axis-specific).
+        # We dispatch directly to ReduceMean (rather than reusing the
+        # ReduceSum-then-divide composition below) so the division
+        # happens inside matrix-cpu in f32 throughout, and we skip
+        # creating a spurious SumFunction autograd node.  Normalise
+        # the dim to non-negative first because matrix-ir-json's
+        # axes are unsigned.
+        norm_dim = dim if dim >= 0 else a.ndim + dim
+        if should_use_rust_for_reduction(len(a.data)):
+            return mean_axis_via_rust(a, norm_dim, keepdim)
 
         # Use SumFunction then divide
         sum_result = SumFunction.apply(a, dim, keepdim)

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -302,17 +302,17 @@ class ReductionFallbackTests(unittest.TestCase):
         self.assertEqual(result.shape, (1,))
         self.assertEqual(result.data, [3.0])
 
-    def test_axis_specific_reduction_unchanged_by_phase_3(self) -> None:
-        """``a.sum(dim=0)`` stays pure-Python in Phase 3 — never dispatches.
+    def test_axis_specific_reduction_below_threshold_stays_pure_python(self) -> None:
+        """``a.sum(dim=0)`` on a tiny tensor uses pure-Python regardless.
 
-        Even with the Rust extension installed, the axis-specific
-        path bypasses the threshold check entirely (the dispatch
-        condition is wrapped in ``if dim is None``).  Sanity:
-        the result is still correct.
+        Phase 3b (axis-specific reductions) reuses the same
+        ``should_use_rust_for_reduction`` predicate as reduce-all, so
+        small tensors below the threshold fall back to the pure-Python
+        axis loop even when the extension is installed.  The 2x3
+        tensor here has 6 cells — well below the 100_000 threshold.
         """
-        # Reset to "extension available" but the predicate isn't even
-        # consulted for dim != None, so behavior matches whether or
-        # not extension is present.
+        # Reset to "extension available" so we exercise the
+        # threshold-gated dispatch (not the unavailable short-circuit).
         _rust_backend._RUST_AVAILABLE = self._saved_available
 
         # 2x3 tensor, sum along dim=0 → shape (3,) with column sums.
@@ -320,6 +320,63 @@ class ReductionFallbackTests(unittest.TestCase):
         result = a.sum(dim=0)
         # Column sums: [1+4, 2+5, 3+6] = [5, 7, 9]
         self.assertEqual(result.data, [5.0, 7.0, 9.0])
+
+
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 3b — axis-specific reduction fallback tests
+#
+# Phase 3 covered the dim=None case; Phase 3b adds dim != None.
+# The same predicate gates both, so the only new fallback assertions
+# are: defence-in-depth RuntimeError from the new helpers, and
+# correctness of the pure-Python axis loop when _RUST_AVAILABLE=False.
+# ──────────────────────────────────────────────────────────────────
+
+
+class ReductionAxisFallbackTests(unittest.TestCase):
+    """Confirm axis-specific sum/mean still work when Rust is disabled."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_sum_axis_via_rust_raises_when_unavailable(self) -> None:
+        """``sum_axis_via_rust`` must raise (defence-in-depth)."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.sum_axis_via_rust(a, dim=0, keepdim=False)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_mean_axis_via_rust_raises_when_unavailable(self) -> None:
+        """``mean_axis_via_rust`` must raise (defence-in-depth)."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        with self.assertRaises(RuntimeError):
+            _rust_backend.mean_axis_via_rust(a, dim=0, keepdim=False)
+
+    def test_sum_axis_keepdim_false_correct_via_fallback(self) -> None:
+        """``a.sum(dim=0)`` shape (3,): column sums of 2x3 tensor."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        result = a.sum(dim=0)
+        self.assertEqual(result.shape, (3,))
+        # Columns: [1+4, 2+5, 3+6] = [5, 7, 9]
+        self.assertEqual(result.data, [5.0, 7.0, 9.0])
+
+    def test_sum_axis_keepdim_true_correct_via_fallback(self) -> None:
+        """``a.sum(dim=0, keepdim=True)`` keeps the axis as size 1."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        result = a.sum(dim=0, keepdim=True)
+        self.assertEqual(result.shape, (1, 3))
+        self.assertEqual(result.data, [5.0, 7.0, 9.0])
+
+    def test_mean_axis_keepdim_false_correct_via_fallback(self) -> None:
+        """``a.mean(dim=1)`` shape (2,): row means of 2x3 tensor."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        result = a.mean(dim=1)
+        self.assertEqual(result.shape, (2,))
+        # Row means: [(1+2+3)/3, (4+5+6)/3] = [2.0, 5.0]
+        self.assertEqual(result.data, [2.0, 5.0])
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -471,6 +471,130 @@ class ReductionParityTests(unittest.TestCase):
 
 
 # ──────────────────────────────────────────────────────────────────
+# MX10 Phase 3b — axis-specific reduction parity tests
+#
+# Phase 3 covered dim=None.  Phase 3b adds the dim != None branch.
+# Output shape varies based on dim and keepdim, so we test both
+# keepdim=True (axis becomes 1) and keepdim=False (axis dropped),
+# plus both Sum and Mean.
+# ──────────────────────────────────────────────────────────────────
+
+
+@unittest.skipUnless(
+    EXTENSION_AVAILABLE,
+    "matrix_rust_python C extension not installed; see parity-tests skip-reason.",
+)
+class ReductionAxisParityTests(unittest.TestCase):
+    """Compare axis-specific Sum/Mean Rust and pure-Python kernels."""
+
+    SHAPE = (500, 200)  # 100_000 cells
+
+    def _make_tensor(self, seed: int):
+        import random
+
+        from ml_framework_core import Tensor
+
+        rng = random.Random(seed)
+        data = [rng.uniform(-1.0, 1.0) for _ in range(500 * 200)]
+        return Tensor(data, self.SHAPE)
+
+    def _assert_close_vec(
+        self,
+        actual: list[float],
+        expected: list[float],
+        rtol: float = 1e-3,
+        atol: float = 1e-4,
+    ) -> None:
+        """Same f32-vs-double tolerance as the other parity tests.
+
+        Axis reductions sum up to 500 cells in f32 (for dim=0 over a
+        500x200 tensor) — well within the rtol budget but not as
+        forgiving as the 100_000-cell reduce-all sum.
+        """
+        self.assertEqual(len(actual), len(expected))
+        for i, (a, e) in enumerate(zip(actual, expected, strict=False)):
+            denom = max(abs(a), abs(e), atol)
+            err = abs(a - e) / denom
+            self.assertLess(
+                err,
+                rtol,
+                f"index {i}: rust={a!r}, python={e!r}, relative error {err:.2e}",
+            )
+
+    def test_sum_axis_dim0_keepdim_false_parity(self) -> None:
+        """``a.sum(dim=0)`` (column sums) — Rust vs pure-Python."""
+        from ml_framework_core import _rust_backend
+
+        a = self._make_tensor(seed=11)
+
+        rust_result = a.sum(dim=0)
+        self.assertEqual(rust_result.shape, (200,))
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = a.sum(dim=0)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close_vec(rust_result.data, python_result.data)
+
+    def test_sum_axis_dim1_keepdim_true_parity(self) -> None:
+        """``a.sum(dim=1, keepdim=True)`` (row sums, axis kept as 1)."""
+        from ml_framework_core import _rust_backend
+
+        a = self._make_tensor(seed=22)
+
+        rust_result = a.sum(dim=1, keepdim=True)
+        self.assertEqual(rust_result.shape, (500, 1))
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = a.sum(dim=1, keepdim=True)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close_vec(rust_result.data, python_result.data)
+
+    def test_mean_axis_dim0_keepdim_false_parity(self) -> None:
+        """``a.mean(dim=0)`` (column means) — Rust vs pure-Python."""
+        from ml_framework_core import _rust_backend
+
+        a = self._make_tensor(seed=33)
+
+        rust_result = a.mean(dim=0)
+        self.assertEqual(rust_result.shape, (200,))
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = a.mean(dim=0)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close_vec(rust_result.data, python_result.data)
+
+    def test_mean_axis_dim1_keepdim_true_parity(self) -> None:
+        """``a.mean(dim=1, keepdim=True)`` (row means, axis kept as 1)."""
+        from ml_framework_core import _rust_backend
+
+        a = self._make_tensor(seed=44)
+
+        rust_result = a.mean(dim=1, keepdim=True)
+        self.assertEqual(rust_result.shape, (500, 1))
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = a.mean(dim=1, keepdim=True)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close_vec(rust_result.data, python_result.data)
+
+
+# ──────────────────────────────────────────────────────────────────
 # MX10 Phase 4 — activation parity tests (Tanh + ReLU)
 #
 # Tanh is a direct unary op (matches Neg/Abs envelope shape from


### PR DESCRIPTION
## Summary

- Closes the gap Phase 3 explicitly deferred — `SumFunction.forward` and `MeanFunction.forward` now dispatch through Rust for the `dim != None` branch using the same `_ELEMENTWISE_RUST_THRESHOLD = 100_000` predicate.
- New `_reduce_axis_via_rust` factory ships `axes=[dim]` + `keep_dims=keepdim` in the matrix-ir-json envelope; output shape varies based on `(dim, keepdim)`, output numel = `input_numel / shape[dim]`.
- `MeanFunction` dispatches directly to `ReduceMean` rather than reusing `SumFunction.apply + divide` so the division stays in f32 inside matrix-cpu and we avoid creating a spurious autograd node.
- Multi-axis reductions, Min/Max/Std/Var/ArgMin/ArgMax axis variants, and backward-path Rust dispatch all deferred.
- +9 tests (4 parity, 5 fallback); +1 rename (`..._unchanged_by_phase_3` → `..._below_threshold_stays_pure_python`).
- Full suite: 355 passed + 22 skipped + the pre-existing unrelated `test_device.py` failure.
- Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes (355/356 with the 1 pre-existing failure)
- [x] New `ReductionAxisParityTests` (4 cases) skip gracefully without the C extension
- [x] New `ReductionAxisFallbackTests` (5 cases) always run and pass
- [x] Renamed/updated existing axis-stays-pure-Python test reflects Phase 3b's new threshold semantics
- [ ] CI green on full repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)