### PR TITLE
feat(ml-framework-core): MX10 Phase 4d — Rust fast path for SoftmaxFunction (7-op composed graph)

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,114 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 4d: optional Rust fast path for `SoftmaxFunction` via a 7-op composed graph
+
+Extends the activation dispatch from Phase 4/4b's {Tanh, ReLU,
+Sigmoid} to also cover `SoftmaxFunction` — the last of the
+classic 5-activation set the Phase 4 family targets.  GELU remains
+deferred (its 8-op tanh-approximation composition still warrants
+its own sub-phase).
+
+This phase was unblocked by **two prerequisites that landed earlier
+in MX10**:
+- Phase 3b's axis-reduction helpers (`ReduceSum` / `ReduceMax` with
+  `axes=[dim]` and `keep_dims=True`) for the per-axis max-subtract
+  and sum-exp steps.
+- matrix-cpu's existing `Broadcast` op (with `target_shape`) for
+  expanding the keepdim-shaped intermediates back to the input
+  shape before the elementwise subtract and divide.
+
+#### Numerical stability
+
+The shift-by-max step is essential: if any element of the input is
+large (say 1000), `exp(1000)` overflows f32 to `+inf` and the
+output is `NaN`.  Subtracting the per-axis max forces the largest
+argument to `exp` to be `0`, so the sum of exps is always `>= 1.0`
+and the division is well-conditioned.  This is the standard
+"numerically stable softmax" recipe, and both the pure-Python and
+Rust paths implement it identically.
+
+#### Graph topology
+
+For a 2-D input of shape `(N, K)` with `dim = 1`::
+
+    input(0) ──ReduceMax(axes=[dim], keep_dims=True)──> max(1)        shape (N, 1)
+    max(1) ──Broadcast(target=input_shape)──> max_bcast(2)             shape (N, K)
+    Sub(input(0), max_bcast(2)) ──> shifted(3)                         shape (N, K)
+    shifted(3) ──Exp──> exp_shifted(4)                                  shape (N, K)
+    exp_shifted(4) ──ReduceSum(axes=[dim], keep_dims=True)──> denom(5) shape (N, 1)
+    denom(5) ──Broadcast(target=input_shape)──> denom_bcast(6)         shape (N, K)
+    Div(exp_shifted(4), denom_bcast(6)) ──> out(7)                     shape (N, K)
+
+All seven ops ship in **one** FFI envelope so the per-call overhead
+is paid once.  matrix-cpu's `Sub` and `Div` don't broadcast scalars,
+so the two explicit `Broadcast` ops are required to expand the
+keepdim-shaped reduction outputs back to the input shape before
+the elementwise subtract/divide.
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds `softmax_via_rust(a, dim)`:
+    - Builds the 8-tensor 7-op envelope above.
+    - Reuses the existing `should_use_rust_for_activation` predicate
+      from Phase 4 (same `_ELEMENTWISE_RUST_THRESHOLD = 100_000`) —
+      softmax has roughly the same per-cell cost as other
+      activations (one exp + one max + one divide per cell).
+    - Caller normalises negative dims before passing in (matches
+      the contract for `_reduce_axis_via_rust`).
+    - Updates the Phase 4 module-level comment to flip Softmax from
+      "deferred" to "shipped in Phase 4d".
+
+- **`functions.py`** — `SoftmaxFunction.forward` gains a dispatch
+  block before the existing 1-D / n-D pure-Python branches.  The
+  Rust path normalises `dim` first, populates
+  `self.saved_metadata["output"]` (backward formula
+  `y * (grad - sum(grad * y))` depends on output), then returns.
+  The pure-Python branches are byte-for-byte unchanged in the
+  fallback path.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `numel ≥ 100_000` | **Rust** (7-op composed graph in one FFI call) |
+| Extension installed, `numel < 100_000` | Pure-Python softmax kernel |
+| Extension NOT installed | Pure-Python softmax kernel |
+
+#### Tests (61 total MX10 tests, was 57)
+
+- **`ActivationParityTests.test_softmax_dim0_parity`** and
+  **`test_softmax_dim1_parity`** (2 cases, skip if extension
+  missing): random `(500, 200)` tensor in `[-3, 3]`, compares Rust
+  vs pure-Python at the standard `rtol=1e-3, atol=1e-4` tolerance.
+  Tests both `dim=0` (non-contiguous stride access in pure-Python)
+  and `dim=1` (contiguous) to catch any axis-handling bugs.
+- **`SoftmaxFallbackTests`** (4 cases, always run):
+  defence-in-depth `RuntimeError` for `softmax_via_rust`,
+  1-D correctness for `[1, 2, 3]` against hand-computed values,
+  2-D `dim=1` row-sum-to-1 invariant for a 2x3 tensor, plus a
+  `saved_metadata["output"]` handshake test that exercises
+  uniform-input → uniform-output → zero-gradient (a nice
+  closed-form property of softmax backward).
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**359 passed + 24 skipped (parity tests that need the extension)**;
+the pre-existing `test_device.py` failure on main is unrelated.
+
+### What's NOT in Phase 4d
+
+- GELU.  Tanh-approximation form is 8 ops + scalar `Pow(3)` (or
+  three `Mul`s instead).  Doable now, but the right place for it is
+  Phase 4c — a separate PR — because it's an isolated composition
+  with no overlap with the Softmax design.
+- Backward-path Rust dispatch for Softmax.  The formula
+  `y * (grad - sum(grad * y))` is itself a small composed graph
+  (one Mul + one ReduceSum + one Broadcast + one Sub + one Mul);
+  doable as a Phase 4d-back follow-up if profiling shows demand.
+- Higher-arity softmax variants (per-row vs per-column with
+  different normalisation conventions, log-softmax, etc.).  Only
+  the standard along-axis softmax is in scope here.
+
 ### Added — MX10 Phase 3b: optional Rust fast path for axis-specific `SumFunction` / `MeanFunction` (`dim != None`)
 
 Closes the gap Phase 3 explicitly deferred — the `dim != None`

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -710,12 +710,16 @@ def mean_axis_via_rust(a: Tensor, dim: int, keepdim: bool) -> Tensor:
 #   — multi-op composition with constants and Pow.  Deferred until
 #   matrix-cpu adds scalar-exponent Pow (would simplify the
 #   ``x^3`` term).
-# * Softmax = exp(x - max(x)) / sum(exp(...)) — needs per-axis
-#   broadcast which is Phase 3b territory; deferred to coincide.
+# * Softmax = exp(x - max(x)) / sum(exp(...)) — composed as a 7-op
+#   graph (ReduceMax → Broadcast → Sub → Exp → ReduceSum → Broadcast
+#   → Div) now that Phase 3b's axis-reduction helpers and matrix-cpu
+#   ``Broadcast`` exist as building blocks.  **Shipped in Phase 4d**
+#   via ``softmax_via_rust`` below.
 #
 # Phase 4 shipped Tanh + ReLU; Phase 4b adds Sigmoid via the 4-op
-# graph factory ``_sigmoid_via_rust_composed`` below.  GELU and
-# Softmax wait for later sub-phases.
+# graph below; Phase 4d adds Softmax via the 7-op graph below.
+# GELU still waits — its tanh-approximation form (8-op composition
+# with x^3 via three Muls) is doable but warrants its own sub-phase.
 # ──────────────────────────────────────────────────────────────────
 
 
@@ -900,6 +904,129 @@ def sigmoid_via_rust(a: Tensor) -> Tensor:
     if len(out_bytes) != expected_bytes:
         raise RuntimeError(
             f"sigmoid_via_rust: expected {expected_bytes} output bytes "
+            f"({numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
+
+    return _Tensor(out_floats, a.shape, device=a.device)
+
+
+def softmax_via_rust(a: Tensor, dim: int) -> Tensor:
+    """``Softmax(a, dim) = exp(a - max(a, dim)) / sum(exp(...), dim)``
+    as a 7-op composed graph.
+
+    Topology (with axis-reduction shapes shown for a 2-D input
+    of shape ``(N, K)`` and ``dim = 1``)::
+
+        input(0) ──ReduceMax(axes=[dim], keep_dims=True)──> max(1)        shape (N, 1)
+        max(1) ──Broadcast(target=input_shape)──> max_bcast(2)             shape (N, K)
+        Sub(input(0), max_bcast(2)) ──> shifted(3)                         shape (N, K)
+        shifted(3) ──Exp──> exp_shifted(4)                                  shape (N, K)
+        exp_shifted(4) ──ReduceSum(axes=[dim], keep_dims=True)──> denom(5) shape (N, 1)
+        denom(5) ──Broadcast(target=input_shape)──> denom_bcast(6)         shape (N, K)
+        Div(exp_shifted(4), denom_bcast(6)) ──> out(7)                     shape (N, K)
+
+    All seven ops ship in one envelope so the FFI overhead is paid
+    once.  matrix-cpu's ``Sub`` and ``Div`` don't broadcast scalars,
+    so we explicitly insert two ``Broadcast`` ops to expand the
+    reduce-with-keepdim results back to the input shape before the
+    elementwise subtract/divide.
+
+    The shift-by-max step is essential for **numerical stability** —
+    if any element of ``a`` is large (say 1000), ``exp(1000)``
+    overflows f32 to +inf and you get NaN.  Subtracting the per-axis
+    max forces the largest argument to ``exp`` to be 0, so the
+    sum of exps is always ``>= 1.0`` and the division is well-conditioned.
+
+    Caller must normalise negative dims before calling.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "softmax_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_activation() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(a.data)
+    input_shape = list(a.shape)
+
+    # Axis-reduction output shape: dim becomes size 1 (keep_dims=True).
+    reduced_shape = list(input_shape)
+    reduced_shape[dim] = 1
+
+    a_bytes = struct.pack(f"<{numel}f", *a.data)
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    # tensor 0 = input x
+                    {"id": 0, "dtype": "f32", "shape": input_shape},
+                    # tensor 1 = max(x, dim, keepdim=True)
+                    {"id": 1, "dtype": "f32", "shape": reduced_shape},
+                    # tensor 2 = broadcast(max, target=input_shape)
+                    {"id": 2, "dtype": "f32", "shape": input_shape},
+                    # tensor 3 = x - max_bcast
+                    {"id": 3, "dtype": "f32", "shape": input_shape},
+                    # tensor 4 = exp(shifted)
+                    {"id": 4, "dtype": "f32", "shape": input_shape},
+                    # tensor 5 = sum(exp_shifted, dim, keepdim=True)
+                    {"id": 5, "dtype": "f32", "shape": reduced_shape},
+                    # tensor 6 = broadcast(denom, target=input_shape)
+                    {"id": 6, "dtype": "f32", "shape": input_shape},
+                    # tensor 7 = output = exp_shifted / denom_bcast
+                    {"id": 7, "dtype": "f32", "shape": input_shape},
+                ],
+                "inputs": [0],
+                "outputs": [7],
+                "ops": [
+                    {
+                        "kind": "ReduceMax",
+                        "input": 0,
+                        "axes": [dim],
+                        "keep_dims": True,
+                        "output": 1,
+                    },
+                    {
+                        "kind": "Broadcast",
+                        "input": 1,
+                        "target_shape": input_shape,
+                        "output": 2,
+                    },
+                    {"kind": "Sub", "lhs": 0, "rhs": 2, "output": 3},
+                    {"kind": "Exp", "input": 3, "output": 4},
+                    {
+                        "kind": "ReduceSum",
+                        "input": 4,
+                        "axes": [dim],
+                        "keep_dims": True,
+                        "output": 5,
+                    },
+                    {
+                        "kind": "Broadcast",
+                        "input": 5,
+                        "target_shape": input_shape,
+                        "output": 6,
+                    },
+                    {"kind": "Div", "lhs": 4, "rhs": 6, "output": 7},
+                ],
+                "constants": [],
+            },
+            "inputs": [a_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    expected_bytes = numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"softmax_via_rust: expected {expected_bytes} output bytes "
             f"({numel} f32), got {len(out_bytes)}"
         )
     out_floats = list(struct.unpack(f"<{numel}f", out_bytes))

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -58,6 +58,7 @@ from ._rust_backend import (
     should_use_rust_for_matmul,
     should_use_rust_for_reduction,
     sigmoid_via_rust,
+    softmax_via_rust,
     sub_via_rust,
     sum_axis_via_rust,
     sum_via_rust,
@@ -876,6 +877,22 @@ class SoftmaxFunction(Function):
 
         if dim < 0:
             dim = a.ndim + dim
+
+        # MX10 Phase 4d — optional Rust fast path.  Softmax composes
+        # as a 7-op graph (ReduceMax → Broadcast → Sub → Exp →
+        # ReduceSum → Broadcast → Div) in a single FFI envelope.
+        # All seven ops share the input tensor's element-cost
+        # profile, so the same threshold as elementwise/activation
+        # applies.  Backward needs ``saved_metadata["output"]``;
+        # populate it from the Rust result the same way TanhFunction
+        # / SigmoidFunction do.
+        #
+        # The 1-D and n-D pure-Python branches below are byte-for-byte
+        # unchanged in the fallback path.
+        if should_use_rust_for_activation(len(a.data)):
+            result = softmax_via_rust(a, dim)
+            self.saved_metadata["output"] = result.data
+            return result
 
         if a.ndim == 1:
             max_val = max(a.data)

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -32,6 +32,7 @@ from ml_framework_core import _rust_backend
 from ml_framework_core.functions import (
     ReLUFunction,
     SigmoidFunction,
+    SoftmaxFunction,
     TanhFunction,
 )
 
@@ -527,6 +528,89 @@ class SigmoidFallbackTests(unittest.TestCase):
         y1 = 1.0 / (1.0 + math.exp(-2.0))
         self.assertAlmostEqual(a.grad.data[0], y0 * (1.0 - y0), places=10)
         self.assertAlmostEqual(a.grad.data[1], y1 * (1.0 - y1), places=10)
+
+
+# ──────────────────────────────────────────────────────────────────
+# MX10 Phase 4d — Softmax fallback tests
+#
+# Softmax joins the activation family via a 7-op composed graph
+# (ReduceMax → Broadcast → Sub → Exp → ReduceSum → Broadcast → Div).
+# Same fallback pattern: when ``_RUST_AVAILABLE = False``, dispatch
+# must short-circuit and the pure-Python softmax kernel must produce
+# the right answer.
+# ──────────────────────────────────────────────────────────────────
+
+
+class SoftmaxFallbackTests(unittest.TestCase):
+    """Confirm Softmax still works when the Rust path is disabled."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_softmax_via_rust_raises_when_unavailable(self) -> None:
+        """``softmax_via_rust`` must raise (defence-in-depth)."""
+        a = Tensor([1.0, 2.0, 3.0], (3,))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.softmax_via_rust(a, dim=0)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_softmax_1d_correct_via_fallback(self) -> None:
+        """``SoftmaxFunction.apply(a, 0)`` on a 1-D tensor sums to ~1.
+
+        Softmax is a probability distribution, so the output values
+        must sum to 1.0 (within float tolerance).  Hand-computed for
+        ``[1, 2, 3]``: ``exp([1,2,3] - 3) = [exp(-2), exp(-1), 1]``,
+        normalised by their sum.
+        """
+        a = Tensor([1.0, 2.0, 3.0], (3,))
+        result = SoftmaxFunction.apply(a, 0)
+        self.assertEqual(result.shape, (3,))
+
+        # Hand computation
+        exps = [math.exp(-2.0), math.exp(-1.0), 1.0]
+        total = sum(exps)
+        expected = [e / total for e in exps]
+        for got, want in zip(result.data, expected, strict=False):
+            self.assertAlmostEqual(got, want, places=12)
+
+        # Probability-distribution invariant
+        self.assertAlmostEqual(sum(result.data), 1.0, places=12)
+
+    def test_softmax_2d_dim1_correct_via_fallback(self) -> None:
+        """``a.softmax(dim=1)`` on a 2x3 tensor — each row sums to ~1."""
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3))
+        result = SoftmaxFunction.apply(a, 1)
+        self.assertEqual(result.shape, (2, 3))
+
+        # Each row sums to 1
+        self.assertAlmostEqual(sum(result.data[0:3]), 1.0, places=12)
+        self.assertAlmostEqual(sum(result.data[3:6]), 1.0, places=12)
+
+    def test_softmax_saved_metadata_populated_via_fallback(self) -> None:
+        """Backward needs ``saved_metadata["output"]``.  Confirm the
+        fallback path populates it and the gradient lands correctly.
+
+        Softmax backward: ``y * (grad - sum(grad * y))``.  For a
+        uniform input the softmax output is uniform and backward
+        with grad=ones gives zero (because ``grad == sum(grad * y)``
+        for uniform y).
+        """
+        a = Tensor([1.0, 1.0, 1.0], (3,), requires_grad=True)
+        result = SoftmaxFunction.apply(a, 0)
+        # Uniform input → uniform softmax → all 1/3
+        for v in result.data:
+            self.assertAlmostEqual(v, 1.0 / 3.0, places=12)
+
+        # Backward with ones-grad
+        result.backward(Tensor([1.0, 1.0, 1.0], (3,)))
+        self.assertIsNotNone(a.grad)
+        # For uniform softmax, ones-grad backward is zero
+        for g in a.grad.data:
+            self.assertAlmostEqual(g, 0.0, places=12)
 
 
 if __name__ == "__main__":

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -698,6 +698,56 @@ class ActivationParityTests(unittest.TestCase):
         # default rtol=1e-3 anyway for consistency.
         self._assert_close(rust_result.data, python_result.data)
 
+    def test_softmax_dim0_parity(self) -> None:
+        """``SoftmaxFunction.apply(t, dim=0)`` Rust matches pure-Python.
+
+        Phase 4d — Softmax is the first activation built from a 7-op
+        composed graph (ReduceMax → Broadcast → Sub → Exp → ReduceSum
+        → Broadcast → Div).  The shift-by-max step is essential for
+        numerical stability; the random inputs in ``[-3, 3]`` stay well
+        within f32 range without it, but the test still exercises the
+        full graph including both Broadcast ops.
+
+        Each output column should sum to ~1.0 (softmax is a
+        probability distribution along the reduced axis).
+        """
+        from ml_framework_core import SoftmaxFunction, _rust_backend
+
+        a = self._make_tensor(seed=55)
+
+        rust_result = SoftmaxFunction.apply(a, 0)
+        self.assertEqual(rust_result.shape, self.SHAPE)
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = SoftmaxFunction.apply(a, 0)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_result.data, python_result.data)
+
+    def test_softmax_dim1_parity(self) -> None:
+        """``SoftmaxFunction.apply(t, dim=1)`` — softmax along the
+        contiguous (last) dimension. Different stride access pattern
+        than dim=0.
+        """
+        from ml_framework_core import SoftmaxFunction, _rust_backend
+
+        a = self._make_tensor(seed=66)
+
+        rust_result = SoftmaxFunction.apply(a, 1)
+        self.assertEqual(rust_result.shape, self.SHAPE)
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = SoftmaxFunction.apply(a, 1)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_result.data, python_result.data)
+
     def test_sigmoid_parity(self) -> None:
         """``SigmoidFunction.apply(t)`` Rust matches pure-Python.
 


### PR DESCRIPTION
## Summary

- Extends activation dispatch to **Softmax** via a 7-op composed graph: `ReduceMax → Broadcast → Sub → Exp → ReduceSum → Broadcast → Div`, all bundled in one FFI envelope.
- Unblocked by Phase 3b's axis-reduction helpers (ReduceMax/ReduceSum with `axes=[dim]` + `keep_dims=True`) plus matrix-cpu's existing `Broadcast` op (needed because `Sub`/`Div` don't broadcast scalars).
- Numerical stability: standard shift-by-max recipe — both Rust and pure-Python paths implement it identically.
- `SoftmaxFunction.forward` gets a dispatch block that normalises `dim`, populates `saved_metadata["output"]` (backward `y * (grad - sum(grad * y))` depends on output), and returns.
- GELU still deferred (Phase 4c); backward-path Rust dispatch for softmax also deferred.
- +6 tests (2 parity covering dim=0 and dim=1, 4 fallback including 1-D correctness, 2-D row-sum invariant, and the uniform-input/zero-gradient backward handshake).
- Full suite: **359 passed + 24 skipped + 1 pre-existing unrelated failure**.
- Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes (359/360 with the 1 pre-existing failure)
- [x] New `ActivationParityTests.test_softmax_dim{0,1}_parity` (2 cases) skip gracefully without the C extension
- [x] New `SoftmaxFallbackTests` (4 cases) always run and pass; row-sum-to-1 invariant verified
- [x] Backward handshake confirmed via uniform-input → zero-gradient closed-form property
- [ ] CI green on full repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)