### PR TITLE
feat(symbolic-vm): Phase 40 — Apart + telescope composition (Python 0.64.0)

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## 0.64.0 — 2026-05-22
+
+**Phase 40 — Apart + telescope composition.**
+
+The `sum_handler` now composes the existing partial-fraction
+decomposition (`Apart`) with the Phase 39 telescoping detector so
+classic sums like `∑ 1/(k·(k+1))` close in one step.
+
+Pipeline:
+
+```
+∑ 1/(k·(k+1))  →  Apart → 1/k − 1/(k+1)
+                  → telescope → 1 − 1/(N+1)
+                  → eval → N/(N+1)
+```
+
+When the initial `evaluate_sum` call falls through to the unevaluated
+`Sum(...)` shape AND the summand has a `Div` head, the handler runs
+`Apart(f, k)` once.  If Apart actually changes the shape (i.e. the
+denominator factors over ℚ), the handler normalises the
+`Add(a, Neg(b))` output into a `Sub(a, b)` and deep-canonicalises ADD
+operand ordering, then re-runs `evaluate_sum`.  The Phase 39 telescope
+detector matches on the rewritten form and emits the closed sum.  When
+Apart doesn't change the shape (irreducible denominator), the retry is
+a no-op and the original unevaluated `Sum(...)` is returned.
+
+### Added
+
+- **`_normalise_add_neg_to_sub(node)`** in `cas_handlers.py` — rewrites
+  the two-term `Add(a, Neg(b))` / `Add(Neg(b), a)` shape into the
+  equivalent `Sub(a, b)` form.  Apart emits the negative half via
+  `Neg(...)`, but the Phase 39 telescope detector keys off the `Sub`
+  head, so the rewrite is required for the two phases to compose.
+- **`_canonicalise_add_operand_order(node)`** — recursive walker that
+  reorders each `Add`'s arguments so numeric literals appear *last*.
+  The symbolic VM doesn't impose a canonical operand order on `Add`,
+  so `Add(k, 1)` and `Add(1, k)` are structurally distinct; the
+  telescope detector's `==` comparison after `vm.eval` therefore needs
+  both halves to agree on operand order.
+
+### Changed
+
+- **`sum_handler`** (`cas_handlers.py`) — adds a Phase 40 retry block
+  between the initial `evaluate_sum` call and the unevaluated
+  fallback.  Guarded by `isinstance(f, IRApply) and f.head == DIV` so
+  non-rational summands (Sin/Log/etc.) skip the extra dispatch cost.
+
+### Added — tests
+
+`tests/test_phase25.py` — new `TestPhase40_ApartTelescope` class with
+6 cases:
+
+- `test_one_over_k_times_kp1_concrete` — `∑_{k=1}^{4} 1/(k(k+1)) = 4/5`.
+- `test_one_over_k_times_kp1_concrete_larger` —
+  `∑_{k=1}^{10} 1/(k(k+1)) = 10/11`.
+- `test_one_over_k_times_kp1_symbolic_upper` — symbolic `n` bound; the
+  result must not be the unevaluated `Sum(...)`.
+- `test_one_over_kp1_times_kp2_concrete` —
+  `∑_{k=1}^{4} 1/((k+1)(k+2)) = 1/3` (shifted-denominator telescope).
+- `test_apart_irreducible_quadratic_stays_unevaluated` — `1/(k²+1)`
+  has no rational roots, so Apart leaves the input unchanged and the
+  retry is a no-op; result stays unevaluated.
+- `test_non_div_summand_skips_apart_retry` — `sin(k)` summand never
+  reaches the Apart retry (non-`Div` head).
+
+Full sum test set: 45 passed (39 prior Phase 25 + 6 net new Phase 40).
+Broader symbolic-vm slice (Phase 25 / 34 / integrate / cas-handlers):
+295 passed, 8 skipped, no regressions.
+
+### Still deferred
+
+- Hypergeometric / closed-form telescoping that needs more than one
+  Apart pass (e.g. nested denominators).
+- Limit-aware infinite telescope (`∑_{k=1}^{∞} 1/(k(k+1)) = 1`).
+- Cross-language port to TypeScript / Rust (a separate sprint).
+
 ## 0.63.0 — 2026-05-20
 
 **Phase 38 — Weierstrass closed forms lifted to linear trig arguments

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.63.0"
+version = "0.64.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -4390,12 +4390,25 @@ def sum_handler(vm: VM, expr: IRApply) -> IRNode:
     1. Constant summand → ``f * (hi − lo + 1)``
     2. Geometric series (finite or infinite) → standard formula
     3. Power-of-index via Faulhaber's formula (k^m, m = 0…5)
-    4. Classic infinite series (Basel, Leibniz, Taylor for e/exp)
-    5. Numeric small range when bounds are concrete integers
-    6. Fallback: returns unevaluated ``Sum(f, k, lo, hi)``
+    4. Telescoping (Phase 39): ``f = g(k+1) − g(k)`` → ``g(hi+1) − g(lo)``
+    5. Classic infinite series (Basel, Leibniz, Taylor for e/exp)
+    6. Numeric small range when bounds are concrete integers
+    7. Fallback: returns unevaluated ``Sum(f, k, lo, hi)``
 
     The VM is passed through so the evaluator can invoke ``vm.eval`` on
     intermediate sub-expressions (e.g. constant-summand count).
+
+    Phase 40 — Apart-expanded telescope retry
+    -----------------------------------------
+    When the initial ``evaluate_sum`` call falls through to the unevaluated
+    ``Sum(...)`` shape AND the summand has the form ``Div(P(k), Q(k))``
+    that ``Apart`` can decompose into a sum of partial fractions, we
+    expand once via ``Apart(f, k)`` and retry ``evaluate_sum`` on the
+    decomposed shape.  The classic case is ``∑ 1/(k·(k+1))`` →
+    ``∑ [1/k − 1/(k+1)]`` (Phase 39 closes the latter as
+    ``1 − 1/(hi+1)``).  When Apart returns the integrand unchanged
+    (denominator not factorable or no partial-fraction structure) the
+    retry is a no-op cost and we return the original unevaluated form.
     """
     from cas_summation import evaluate_sum as _evaluate_sum
 
@@ -4408,10 +4421,109 @@ def sum_handler(vm: VM, expr: IRApply) -> IRNode:
     lo_ev = vm.eval(lo)
     hi_ev = vm.eval(hi)
     result = _evaluate_sum(f, k, lo_ev, hi_ev, vm)
-    # Avoid re-entering the handler if evaluate_sum fell back to unevaluated.
+    # Phase 40: if the dispatcher couldn't close the sum, try
+    # ``Apart(f, k)`` once (partial-fraction expansion) and re-run.
+    # This composes the existing Phase 39 telescope detection with the
+    # decomposition step needed to expose telescopes like ``1/(k(k+1))``.
     if isinstance(result, IRApply) and result.head == SUM:
+        # Only try Apart for rational-function shapes (Div head) — Apart
+        # leaves other shapes unchanged anyway, but skipping saves a
+        # round-trip through the handler dispatch.
+        if isinstance(f, IRApply) and f.head == DIV:
+            apart_attempt = vm.eval(IRApply(IRSymbol("Apart"), (f, k)))
+            # Only retry when Apart actually changed the shape — comparing
+            # to the original `f` catches the "not factorable" return path
+            # which returns the input unchanged.
+            if apart_attempt != f:
+                # Apart emits two-term partial fractions as
+                # ``Add(Neg(a), b)`` (or ``Add(a, Neg(b))``) rather than
+                # ``Sub(b, a)``.  The Phase 39 telescope detector matches
+                # ``Sub`` heads only, so normalise here before retrying.
+                normalised = _normalise_add_neg_to_sub(apart_attempt)
+                retry = _evaluate_sum(normalised, k, lo_ev, hi_ev, vm)
+                if not (isinstance(retry, IRApply) and retry.head == SUM):
+                    return vm.eval(retry)
         return result
     return vm.eval(result)
+
+
+def _canonicalise_add_operand_order(node: IRNode) -> IRNode:
+    """Deep-rewrite every ``Add`` so that numeric literals appear *last*
+    among its arguments, recursively.
+
+    The symbolic VM doesn't currently impose a canonical operand order on
+    ``Add``, so two structurally distinct trees can represent the same
+    mathematical expression — e.g. ``Add(k, 1)`` vs ``Add(1, k)``.  The
+    Phase 39 telescope detector relies on ``==`` after ``vm.eval``, so
+    these need to look identical for the Apart-rewritten summand to
+    match the substituted half.
+
+    This walker sorts each ``Add``'s arguments so that ``IRInteger`` /
+    ``IRRational`` / ``IRFloat`` literals come last, preserving the
+    relative order of non-literal children.  Other heads recurse into
+    their arguments unchanged.
+    """
+    if isinstance(node, IRApply):
+        new_args = tuple(_canonicalise_add_operand_order(a) for a in node.args)
+        if node.head == ADD and len(new_args) >= 2:
+            literals = [
+                a for a in new_args if isinstance(a, (IRInteger, IRRational, IRFloat))
+            ]
+            non_literals = [
+                a
+                for a in new_args
+                if not isinstance(a, (IRInteger, IRRational, IRFloat))
+            ]
+            if literals and non_literals:
+                # Only re-order when both kinds are present, otherwise
+                # leave the tuple alone (preserves all-literal folds and
+                # all-symbolic structures).
+                new_args = tuple(non_literals + literals)
+        if new_args != node.args:
+            return IRApply(node.head, new_args)
+        return node
+    return node
+
+
+def _normalise_add_neg_to_sub(node: IRNode) -> IRNode:
+    """Rewrite two-term ``Add`` nodes containing a ``Neg`` into the
+    equivalent ``Sub`` shape, then deep-canonicalise the operand order on
+    every remaining ``Add`` so downstream pattern matchers that key off
+    ``Sub`` (notably the Phase 39 telescope detector in ``cas_summation``)
+    can fire and structural ``==`` comparisons survive operand-order
+    differences between Apart's output and the substituted half.
+
+    +---------------------------------+----------------+
+    | Input shape                     | Output         |
+    +=================================+================+
+    | ``Add(a, Neg(b))``              | ``Sub(a, b)``  |
+    | ``Add(Neg(b), a)``              | ``Sub(a, b)``  |
+    | ``Add(Neg(a), Neg(b))``         | left untouched |
+    | other (Add with 3+ args, etc.)  | left untouched |
+    +---------------------------------+----------------+
+
+    Only the top-level ``Add`` is rewritten to ``Sub``; the deep ADD
+    operand canonicalisation runs everywhere underneath via
+    :func:`_canonicalise_add_operand_order`.
+    """
+    if not isinstance(node, IRApply) or node.head != ADD or len(node.args) != 2:
+        return _canonicalise_add_operand_order(node)
+    left, right = node.args
+    left_is_neg = isinstance(left, IRApply) and left.head == NEG and len(left.args) == 1
+    right_is_neg = (
+        isinstance(right, IRApply) and right.head == NEG and len(right.args) == 1
+    )
+    if left_is_neg and right_is_neg:
+        # ``Add(Neg(a), Neg(b))`` is genuinely negative on both sides;
+        # leaving it alone preserves the structural identity.
+        return _canonicalise_add_operand_order(node)
+    if right_is_neg:
+        rewritten = IRApply(SUB, (left, right.args[0]))
+        return _canonicalise_add_operand_order(rewritten)
+    if left_is_neg:
+        rewritten = IRApply(SUB, (right, left.args[0]))
+        return _canonicalise_add_operand_order(rewritten)
+    return _canonicalise_add_operand_order(node)
 
 
 def product_handler(vm: VM, expr: IRApply) -> IRNode:

--- a/code/packages/python/symbolic-vm/tests/test_phase25.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase25.py
@@ -467,6 +467,84 @@ class TestPhase25_SumUnevaluated:
 
 
 # ===========================================================================
+# Phase 40 — Apart + telescope composition
+#
+# The sum_handler first calls ``evaluate_sum`` on the original summand.
+# If that falls through to the unevaluated ``Sum(...)`` shape AND the
+# summand has a ``Div`` head, the handler retries once after expanding
+# via ``Apart(f, k)`` (partial-fraction decomposition).  Classic case:
+# ``∑_{k=1}^{N} 1/(k(k+1))`` → ``∑ [1/k − 1/(k+1)]`` (Phase 39 telescope
+# then closes it to ``1 − 1/(N+1)``).  When ``Apart`` returns the input
+# unchanged (denominator not factorable into simple roots over ℚ), the
+# retry is a no-op and the sum stays unevaluated.
+# ===========================================================================
+
+
+class TestPhase40_ApartTelescope:
+    def test_one_over_k_times_kp1_concrete(self):
+        """``∑_{k=1}^{4} 1/(k(k+1)) = 1/2 + 1/6 + 1/12 + 1/20 = 4/5``."""
+        denom = IRApply(MUL, (K, IRApply(ADD, (K, _int(1)))))
+        f = IRApply(DIV, (_int(1), denom))
+        result = _sum(f, _int(1), _int(4))
+        v = _as_frac(result)
+        assert v is not None and v == Fraction(4, 5), f"got {result!r}"
+
+    def test_one_over_k_times_kp1_concrete_larger(self):
+        """``∑_{k=1}^{10} 1/(k(k+1)) = 10/11`` — Apart → telescope
+        gives ``1 − 1/11 = 10/11``."""
+        denom = IRApply(MUL, (K, IRApply(ADD, (K, _int(1)))))
+        f = IRApply(DIV, (_int(1), denom))
+        result = _sum(f, _int(1), _int(10))
+        v = _as_frac(result)
+        assert v is not None and v == Fraction(10, 11), f"got {result!r}"
+
+    def test_one_over_k_times_kp1_symbolic_upper(self):
+        """``∑_{k=1}^{n} 1/(k(k+1))`` symbolic n: Phase 40 must not leave
+        the sum unevaluated.  The exact closed form is ``1 − 1/(n+1)``
+        or equivalently ``n/(n+1)``; we don't pin a specific IR shape."""
+        denom = IRApply(MUL, (K, IRApply(ADD, (K, _int(1)))))
+        f = IRApply(DIV, (_int(1), denom))
+        result = _sum(f, _int(1), N)
+        assert not _is_unevaluated_sum(result), (
+            f"Expected Phase 40 to close ∑ 1/(k(k+1)); got {result!r}"
+        )
+
+    def test_one_over_kp1_times_kp2_concrete(self):
+        """``∑_{k=1}^{4} 1/((k+1)(k+2)) = 1/6 + 1/12 + 1/20 + 1/30 = 1/3``.
+
+        Apart on a shifted denominator still exposes the telescope:
+        ``1/((k+1)(k+2)) = 1/(k+1) − 1/(k+2)`` so the closed form is
+        ``1/2 − 1/6 = 1/3``.
+        """
+        kp1 = IRApply(ADD, (K, _int(1)))
+        kp2 = IRApply(ADD, (K, _int(2)))
+        denom = IRApply(MUL, (kp1, kp2))
+        f = IRApply(DIV, (_int(1), denom))
+        result = _sum(f, _int(1), _int(4))
+        v = _as_frac(result)
+        assert v is not None and v == Fraction(1, 3), f"got {result!r}"
+
+    def test_apart_irreducible_quadratic_stays_unevaluated(self):
+        """``∑_{k=1}^{n} 1/(k² + 1)``: denominator has no rational roots,
+        so Apart returns the input unchanged and the Phase 40 retry is a
+        no-op.  The sum must remain unevaluated."""
+        denom = IRApply(ADD, (IRApply(POW, (K, _int(2))), _int(1)))
+        f = IRApply(DIV, (_int(1), denom))
+        result = _sum(f, _int(1), N)
+        assert _is_unevaluated_sum(result), (
+            f"Expected unevaluated for irreducible denominator; got {result!r}"
+        )
+
+    def test_non_div_summand_skips_apart_retry(self):
+        """``∑_{k=1}^{n} sin(k)`` is not a Div shape — Phase 40 must not
+        attempt the Apart retry (which would be expensive) and must
+        leave the result as the original unevaluated Sum."""
+        f = IRApply(SIN, (K,))
+        result = _sum(f, _int(1), N)
+        assert _is_unevaluated_sum(result)
+
+
+# ===========================================================================
 # 8. Product — constant factor
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Compose the existing `Apart` partial-fraction decomposition with the Phase 39 telescoping detector so classic sums like `∑ 1/(k(k+1))` close in one step.

## Pipeline

```
∑ 1/(k(k+1))  →  Apart → 1/k − 1/(k+1)
                 → telescope (Phase 39) → 1 − 1/(N+1)
                 → eval → N/(N+1)
```

## Implementation

- `sum_handler` adds a Phase 40 retry block between the initial `evaluate_sum` call and the unevaluated fallback. Guarded by `f.head == DIV` so non-rational summands (Sin, Log, …) skip the extra dispatch cost.
- New `_normalise_add_neg_to_sub`: rewrites Apart's `Add(Neg(b), a)` output into the `Sub(a, b)` form that the Phase 39 telescope detector matches.
- New `_canonicalise_add_operand_order`: deep walker that reorders each `Add` so numeric literals appear last; needed because the VM doesn't impose canonical ADD order and the telescope detector's `==` comparison would otherwise miss `Add(k,1)` vs `Add(1,k)`.

## Tests

6 new cases in `TestPhase40_ApartTelescope`:

- `∑_{k=1}^{4} 1/(k(k+1)) = 4/5`
- `∑_{k=1}^{10} 1/(k(k+1)) = 10/11`
- Symbolic upper bound `n` — closes to a non-`Sum` form.
- Shifted denominator `∑_{k=1}^{4} 1/((k+1)(k+2)) = 1/3`.
- Fallthrough: `1/(k²+1)` (irreducible denominator) stays unevaluated.
- Fallthrough: `sin(k)` (non-Div summand) skips the Apart retry.

Full sum suite: 45 passed (39 prior Phase 25 + 6 net new Phase 40). Broader Python symbolic-vm slice (Phase 25 + Phase 34 Weierstrass + integrate + cas-handlers): **295 passed, 8 skipped, no regressions**.

## Test plan

- [x] All existing Phase 25 sum tests still pass.
- [x] New Phase 40 tests verify both success and fallthrough paths.
- [x] No infinite-loop risk (Apart never re-fires on its own decomposed output — see security review).
- [x] Security review passed (no eval/exec/pickle; bounded recursion).

## Still deferred

- Multi-pass Apart for nested denominators.
- Limit-aware infinite telescopes (`∑_{k=1}^{∞} 1/(k(k+1)) = 1`).
- TypeScript / Rust ports (separate sprint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)