### PR TITLE
feat(forme-doc-sidebar-builder): DOC00 v0 hierarchical sidebar builder

### DIFF
--- a/code/packages/typescript/forme-doc-sidebar-builder/BUILD
+++ b/code/packages/typescript/forme-doc-sidebar-builder/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-doc-sidebar-builder/CHANGELOG.md
+++ b/code/packages/typescript/forme-doc-sidebar-builder/CHANGELOG.md
@@ -1,0 +1,161 @@
+# Changelog — @coding-adventures/forme-doc-sidebar-builder
+
+## 0.1.0 — 2026-05-22
+
+Initial release.  Sixth concrete DOC00 v0 package — take a
+directory layout (file paths) + each file's frontmatter and
+produce a hierarchical, JSON-able sidebar navigation tree the
+page-shell can render to HTML.
+
+Pure transform: `{ pages: PageInput[] }` → `SidebarEntry[]`.
+Capabilities `[]`.  **Zero runtime dependencies.**
+
+### Added
+
+- `buildSidebar(pages, options?): readonly SidebarEntry[]` —
+  main entry.  Filters drafts, normalises paths, builds a
+  directory trie, recursively emits a sorted sidebar tree.
+- `humanise(slug): string` — standalone helper exported for
+  callers building related UI text (breadcrumbs, page titles).
+  Acronym-aware: `api → "API"`, `http → "HTTP"`, etc.
+- `normalisePath(rawPath): { parts, isIndex }` — standalone
+  helper exported for advanced callers building custom sidebar
+  layouts.
+- `stripRoot(parts, root): readonly string[] | null` — companion
+  to `normalisePath` for root-prefix matching.
+- `PageInput`, `BuildSidebarOptions`, `SidebarEntry`,
+  `SidebarPageEntry`, `SidebarGroupEntry` types.
+
+### Spec adherence
+
+Implements DOC00 v0's `forme-doc-sidebar-builder` per
+`code/specs/DOC00-docs-vision.md`:
+
+> Take a directory layout (file paths) + each file's frontmatter
+> (sidebar position, title overrides, group metadata) → sidebar
+> nav structure.  Output is a plain JSON-able tree the page
+> shell renders to HTML.
+
+Spec adherence is direct.  Spec also mentions "group metadata"
+— v0 honours `title` / `sidebar_label` / `sidebar_position` /
+`draft` on each page (and on `index.md` pages for groups).
+Explicit per-directory `category.json` files (a Docusaurus
+convention) are deferred to v1.
+
+### Algorithm
+
+Three-phase pipeline, O(N log N) overall (dominated by sort):
+
+1. **Filter + Normalise** — drop `draft: true` pages; strip
+   extensions, leading/trailing slashes, optional `root`
+   prefix; detect index pages.
+2. **Trie build** — insert each page into a directory trie
+   keyed by normalised parts.  Index pages attach to their
+   directory's node; non-index pages go at leaves.  Duplicate
+   slugs / duplicate indexes throw `TypeError`.
+3. **Emit** — recursive depth-first walk; at each level, sort
+   by `(position ?? +Infinity, label)`.  Locale-independent
+   string compare; positioned entries first, unpositioned
+   alphabetical last.
+
+### Behavioural notes
+
+- **Pure transform.**  Input `pages` array and input
+  `frontmatter` objects are never mutated.  Verified by JSON
+  snapshot.
+- **Deterministic.**  Same input bytes → identical output bytes.
+  Locale-independent ordering (`toLowerCase` not
+  `toLocaleLowerCase`), V8's stable `Array.prototype.sort`.
+- **Output is JSON-safe.**  No AST references, no `Date`s, no
+  symbols.  `JSON.parse(JSON.stringify(result))` round-trips.
+- **Frontmatter is read defensively via `Object.hasOwn`** so
+  hand-crafted `{ __proto__: { title: "Polluted" } }` literals
+  don't leak inherited values into the sidebar.  In practice
+  `forme-doc-frontmatter` returns null-prototype objects
+  anyway; this is defence-in-depth for callers using arbitrary
+  frontmatter sources.
+- **Group destinations from index pages.**  A `<dir>/index.md`
+  (case-insensitive) becomes the group's `path` /
+  `label` / `position` rather than a separate child entry.
+  Sidebar widgets make the group label clickable in that case.
+- **All-draft groups disappear.**  A group whose children all
+  end up filtered out is also omitted from the output.
+- **Acronym-aware humanisation.**  ~40-entry alias table covers
+  `api`, `sdk`, `url`, `http`, `https`, `json`, `yaml`, `html`,
+  `css`, `cli`, `cpu`, `gpu`, `io` (renders as `I/O`), etc.
+  Built via `Object.create(null)` for defence-in-depth.
+
+### Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver** —
+  pure data construction.
+- **No mutation** of inputs (verified).
+- **`Object.hasOwn` on every frontmatter read** — defends
+  against prototype-pollution-style attacks where the caller
+  hands us `{ __proto__: { … } }`.
+- **`Object.create(null)` for the acronym table** — directory
+  named `__proto__` falls through to default capitalisation.
+- **64-level directory-depth cap** in `normalisePath` —
+  prevents stack-overflow DoS from adversarial deeply-nested
+  inputs (e.g. `a/b/c/…/z.md` with 10k segments would otherwise
+  trigger `RangeError` during `emit`'s recursive walk).  Real
+  docs sites essentially never exceed ~8 levels; 64 leaves a
+  wide safety margin.
+- **No I/O** — capabilities `[]`.  Zero runtime dependencies.
+- **Total-ordering comparator** — `Array.prototype.sort` is
+  stable in V8 (and the contract since ES2019), so equal
+  entries preserve input order.
+
+### Tests
+
+97 tests across 3 files:
+
+- `labels.test.ts` (23) — humanise() coverage: kebab-case /
+  snake_case / mixed, acronyms (12+), case-insensitive acronym
+  lookup, Unicode preservation, edge cases (empty,
+  only-separators, only-whitespace, run collapsing,
+  `__proto__` defence).
+- `path-utils.test.ts` (31) — extension stripping (`.md` /
+  `.mdx` / `.html` / `.htm`, case-insensitive, non-doc
+  preserved), slash handling (leading / trailing / multiple /
+  empty segments), index detection (root / nested /
+  case-insensitive / index-like-but-not), root-prefix stripping
+  (matching / non-matching / multi-part / leading slash /
+  whitespace), empty-path errors, `"/"` → empty parts case.
+- `builder.test.ts` (43) — degenerate inputs, ordering (position
+  ascending, alphabetical fallback, positioned-before-
+  unpositioned, tie-breaks), labels (title / sidebar_label /
+  fallthrough / non-string ignored / acronyms), drafts (skipped
+  / `draft: false` not skipped / string `"true"` not draft /
+  group collapses when empty), grouping (single-level / mixed
+  root pages and groups / deeply nested), index pages (group
+  destination / null path / not listed in children / root index
+  / duplicate throws), duplicate detection (`.md` vs `.mdx` /
+  `.md` vs `.html` / slugless `"/"`), root-prefix option,
+  frontmatter robustness (non-numeric / NaN / Infinity /
+  negative / unknown keys / `__proto__` defence), determinism,
+  immutability, JSON-safety, realistic-doc scenario.
+
+Coverage: **100% line / 100% branch / 100% function** across
+all source files with logic (`types.ts` is type-only).
+
+### v0 simplifications (documented)
+
+- **No multi-sidebar support.**  v0 produces ONE tree.  Sites
+  that want separate sidebars per section wrap the function and
+  pass filtered page subsets.
+- **No `category.json`-style explicit group metadata.**  Group
+  labels come from `index.md` frontmatter or from the humanised
+  directory name.  v1 can add explicit metadata injection.
+- **Root index page's metadata is unsurfaced.**  A root
+  `index.md` contributes to the implicit root group's metadata,
+  but since we return `root.children`, the root group itself
+  isn't visible.  Use a top-level `intro.md` for a navigable
+  root entry.
+- **No collapsed/expanded state.**  Output is structural only.
+  Collapse state is the page-shell's concern.
+- **Strict-boolean `draft` check.**  `draft: "true"` (string),
+  `draft: 1` (number), etc. are NOT treated as drafts.  Only
+  the literal boolean `true` suppresses a page.  Authors who
+  accidentally quote their `draft` value will see their page
+  in the sidebar — surfaces the mistake.

--- a/code/packages/typescript/forme-doc-sidebar-builder/README.md
+++ b/code/packages/typescript/forme-doc-sidebar-builder/README.md
@@ -1,0 +1,231 @@
+# @coding-adventures/forme-doc-sidebar-builder
+
+> Sixth DOC00 v0 package — take a directory layout (file paths) +
+> each file's frontmatter and produce a hierarchical, JSON-able
+> sidebar navigation tree the page-shell can render to HTML.
+
+Pure transform. Capabilities: `[]`. **Zero runtime dependencies.**
+
+## What it does
+
+```ts
+import { buildSidebar } from "@coding-adventures/forme-doc-sidebar-builder";
+
+const sidebar = buildSidebar([
+  { path: "intro.md",          frontmatter: { sidebar_position: 1 } },
+  { path: "guide/index.md",    frontmatter: { title: "Guide", sidebar_position: 2 } },
+  { path: "guide/setup.md",    frontmatter: { sidebar_position: 1 } },
+  { path: "guide/api.md",      frontmatter: { sidebar_position: 2 } },
+  { path: "advanced.md",       frontmatter: { draft: true } },  // skipped
+]);
+// sidebar = [
+//   { kind: "page",  label: "Intro", path: "intro.md", position: 1 },
+//   { kind: "group", label: "Guide", path: "guide/index.md", position: 2, children: [
+//     { kind: "page", label: "Setup", path: "guide/setup.md", position: 1 },
+//     { kind: "page", label: "API",   path: "guide/api.md",   position: 2 },
+//   ]},
+// ]
+```
+
+## Frontmatter keys consulted
+
+The builder reads four well-known keys from each page's
+frontmatter. **All other keys are ignored** — pages can carry
+arbitrary user metadata without affecting the sidebar.
+
+| Key                 | Type      | Effect                                                                                  |
+|---------------------|-----------|-----------------------------------------------------------------------------------------|
+| `title`             | `string`  | Display label for the entry. Falls back to humanised filename if absent.                |
+| `sidebar_label`     | `string`  | Sidebar-specific label. Takes precedence over `title` when both are present.            |
+| `sidebar_position`  | `number`  | Sort key within the directory (ascending). Missing / non-finite → sorts last.           |
+| `draft`             | `boolean` | When strictly `true`, the page is omitted. A group with all-draft children disappears.  |
+
+All reads use `Object.hasOwn(frontmatter, key)` so a frontmatter
+literal like `{ __proto__: { title: "Polluted" } }` doesn't leak
+inherited values into the output — defence-in-depth for callers
+using arbitrary frontmatter sources. In practice
+`@coding-adventures/forme-doc-frontmatter` returns null-prototype
+objects anyway.
+
+## Output shape
+
+JSON-safe — only strings, numbers, booleans, nulls, and
+arrays/objects of the same. `JSON.stringify`-cacheable.
+
+```ts
+type SidebarEntry = SidebarPageEntry | SidebarGroupEntry;
+
+interface SidebarPageEntry {
+  readonly kind: "page";
+  readonly label: string;           // sidebar_label ?? title ?? humanised slug
+  readonly path: string;            // original (non-normalised) path
+  readonly position: number | null; // sidebar_position or null
+}
+
+interface SidebarGroupEntry {
+  readonly kind: "group";
+  readonly label: string;           // index page's label, or humanised dir name
+  readonly path: string | null;     // index page's path, or null if no index
+  readonly position: number | null; // index page's position, or null
+  readonly children: readonly SidebarEntry[];
+}
+```
+
+## Algorithm (three phases, O(N log N))
+
+**Phase 1 — Filter + Normalise.** Drop drafts. Normalise each
+remaining path:
+- Strip leading slashes, trailing slashes, recognised extensions
+  (`.md`, `.mdx`, `.html`, `.htm` — case-insensitive).
+- Detect `index` (case-insensitive) as the last segment → mark
+  as the directory's index page; otherwise the last segment is
+  the file slug.
+- Apply optional `root` prefix stripping (pages outside `root`
+  are skipped).
+
+**Phase 2 — Trie build.** Insert each normalised page into a
+directory trie. Non-index pages go at leaves; index pages attach
+to their directory node. Duplicate slugs at the same directory
+or duplicate indexes throw `TypeError`.
+
+**Phase 3 — Emit.** Recursively walk the trie depth-first. At
+each level, sort by `(position ?? +Infinity, label)` — positioned
+entries first by position ascending; unpositioned entries last,
+alphabetical among themselves. Locale-independent string compare
+for cross-machine stability.
+
+## Index page handling
+
+A `<dir>/index.md` (or `index.mdx` / `Index.md`, case-insensitive)
+becomes the **destination** of the group, not a separate page
+entry:
+
+| Input                                    | Effect                                                                      |
+|------------------------------------------|-----------------------------------------------------------------------------|
+| `guide/index.md` only                    | Group "Guide" with `path: "guide/index.md"`, no children.                   |
+| `guide/index.md` + `guide/setup.md`      | Group "Guide" with `path: "guide/index.md"`, one child "Setup".             |
+| `guide/setup.md` only (no index)         | Group "Guide" with `path: null`, one child "Setup".                          |
+| Two index pages for same directory       | Throws `TypeError`.                                                          |
+
+The group's `label`, `path`, and `position` are inherited from
+the index page's frontmatter. Sidebar widgets typically make
+the group label clickable in that case.
+
+## Acronym-aware humanisation
+
+Directory and filename slugs are humanised via a small alias
+table so `api` becomes `"API"`, not `"Api"`. The table covers
+HTTP / web / cloud / language acronyms:
+
+| Slug           | Label         |
+|----------------|---------------|
+| `api`          | `API`         |
+| `sdk`          | `SDK`         |
+| `url`          | `URL`         |
+| `http`         | `HTTP`        |
+| `https`        | `HTTPS`       |
+| `json`         | `JSON`        |
+| `yaml`         | `YAML`        |
+| `html`         | `HTML`        |
+| `css`          | `CSS`         |
+| `cli`          | `CLI`         |
+| `gpu` / `cpu`  | `GPU` / `CPU` |
+| `io`           | `I/O`         |
+| ... (~40 more) |               |
+
+Unknown words fall back to first-letter-uppercase, rest-lower
+(`getting-started` → `"Getting Started"`).
+
+## Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver.**
+  Pure data construction.
+- **No mutation of input.** Verified by JSON snapshot test —
+  input array, input frontmatter objects, all unchanged.
+- **Output is JSON-safe.** No AST refs, no `Date`s, no
+  symbols. Tested via `JSON.parse(JSON.stringify(result))`.
+- **`Object.hasOwn` on every frontmatter read.** Defends against
+  hand-crafted `{ __proto__: { … } }` inputs that would otherwise
+  leak prototype-chain values into the sidebar.
+- **Acronym table built via `Object.create(null)`.** Directory
+  named `__proto__` falls through to default capitalisation
+  rather than reading `Object.prototype.__proto__`.
+- **64-level directory-depth cap.** Adversarial deeply-nested
+  inputs (e.g. `a/b/c/…/z.md` with 10k segments) would
+  otherwise trigger `RangeError` during the recursive `emit`
+  walk. The cap throws a clear `TypeError` instead. Real docs
+  sites never exceed ~8 levels.
+- **No I/O.** Capabilities `[]`. **Zero runtime dependencies.**
+- **Deterministic.** Same input → identical output bytes.
+- **Total ordering.** Sort comparator is a total order (numeric
+  then alphabetical); `Array.prototype.sort` is stable in V8.
+
+## Tests
+
+97 tests across three files:
+
+- `labels.test.ts` (23) — humanise() coverage: basic kebab/snake,
+  acronyms (API/SDK/HTTP/etc.), case-insensitive acronym lookup,
+  edge cases (empty, only-separators, only-whitespace,
+  `__proto__` falls through).
+- `path-utils.test.ts` (31) — extension stripping (`.md` / `.mdx`
+  / `.html` / `.htm`, case-insensitive, non-doc extensions left
+  alone), slash handling (leading / trailing / multiple / empty
+  segments), index detection (root / nested / case-insensitive /
+  not-index variants), root-prefix stripping (matching /
+  non-matching / multi-part / leading slash / whitespace),
+  empty-path errors, `"/"`-style stripped-to-empty cases.
+- `builder.test.ts` (43) — degenerate inputs, ordering (position
+  ascending, alphabetical fallback, positioned-before-unpositioned,
+  tie-breaks), labels (title / sidebar_label / fallthrough /
+  non-string ignored / acronyms), drafts (skipped / draft-false
+  not skipped / string "true" not draft / group collapses when
+  empty), grouping (single-level / mixed root pages and groups /
+  deeply nested), index pages (group destination / null path /
+  not listed in children / root index / duplicate throws),
+  duplicate detection, root-prefix option, frontmatter robustness
+  (non-numeric position / NaN / Infinity / negative / unknown
+  keys / `__proto__` defence), determinism, immutability,
+  JSON-safety, realistic-doc scenario.
+
+Coverage: **100% line / 100% branch / 100% function** on every
+source file with logic (`types.ts` is type-only).
+
+## How it fits in the stack
+
+Sixth concrete DOC00 v0 package. Sits at the site-structure
+layer, consuming the per-page frontmatter from
+`forme-doc-frontmatter` and emitting the structural tree for the
+page-shell:
+
+```
+.md files ─┬─► frontmatter (per file) ──────────┐
+           └─► commonmark-parser → headings ──┐ │
+                                              │ │
+                                              ▼ ▼
+                                       sidebar-builder ────► sidebar tree
+                                                                  ↓
+                                                            page-shell renders HTML
+```
+
+Next DOC00 v0 packages: `forme-doc-page-shell`,
+`forme-doc-search-tokenizer`, `forme-doc-search-index-builder`,
+`forme-doc-search-client-js`, `forme-doc-site-emitter`.
+
+## v0 simplifications (documented)
+
+- **No multi-sidebar support.** v0 produces ONE tree. Sites that
+  want separate sidebars per section (e.g. Docusaurus's
+  `docs.sidebars.js`) wrap the function and pass filtered page
+  subsets.
+- **No `category.json`-style explicit group metadata.** Group
+  labels come from `index.md`'s frontmatter or from the
+  humanised directory name. v1 can add explicit metadata
+  injection.
+- **Root index page's metadata is unsurfaced.** A root `index.md`
+  contributes to the implicit root group's metadata, but since
+  we return `root.children`, the root group itself isn't visible
+  in the output. Use a top-level `intro.md` if you want a
+  navigable root entry.
+- **No collapsed/expanded state.** The output is structural only;
+  collapse state is the page-shell's concern.

--- a/code/packages/typescript/forme-doc-sidebar-builder/package-lock.json
+++ b/code/packages/typescript/forme-doc-sidebar-builder/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-doc-sidebar-builder",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-doc-sidebar-builder",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/package.json
+++ b/code/packages/typescript/forme-doc-sidebar-builder/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@coding-adventures/forme-doc-sidebar-builder",
+  "version": "0.1.0",
+  "description": "Take a directory layout (file paths) + each file's frontmatter (sidebar position, title overrides, draft flag) and produce a hierarchical, JSON-able sidebar navigation tree the page-shell can render to HTML.  Groups by directory, orders by `sidebar_position` (alphabetical fallback), honours `title` overrides, skips drafts, and surfaces `index.md` pages as the group's own destination.  Pure transform, capability [].  DOC00 v0 site-structure package.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/required_capabilities.json
+++ b/code/packages/typescript/forme-doc-sidebar-builder/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-doc-sidebar-builder",
+  "capabilities": [],
+  "justification": "Pure transform: { pages: { path, frontmatter }[] } → hierarchical SidebarEntry tree.  Builds a directory trie from path strings, groups pages, applies frontmatter title/position/draft overrides, sorts by sidebar_position (alphabetical fallback), humanises directory names, and emits a JSON-able nested structure.  No eval, no Function, no JSON.parse-with-reviver, no fs/network/env/shell.  Zero runtime dependencies — operates purely on plain JS objects supplied by the caller."
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/src/builder.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/src/builder.ts
@@ -1,0 +1,335 @@
+/**
+ * builder.ts — main `buildSidebar` entry.
+ *
+ * =============================================================================
+ * THE ALGORITHM
+ * =============================================================================
+ *
+ * The transformation is conceptually:
+ *
+ *   pages: PageInput[]  ──►  SidebarEntry[]
+ *
+ * but the interesting bit is the three-phase pipeline:
+ *
+ *   Phase 1 — Filter + Normalise
+ *     Drop drafts (`frontmatter.draft === true`).  Normalise each
+ *     remaining page's path to `{ parts: string[], isIndex: bool }`
+ *     and (if a `root` option was given) strip the root prefix.
+ *     Pages outside the root are dropped.
+ *
+ *   Phase 2 — Trie build
+ *     Build a directory trie keyed by normalised parts.  Each trie
+ *     node holds:
+ *       - `pages`: leaf pages whose parts terminate AT this node
+ *       - `subdirs`: child trie nodes keyed by the next path part
+ *       - `indexPage`: a page whose `isIndex` was true and whose
+ *                       parts ended exactly here.  At most one.
+ *     Duplicate non-index pages at the same path throw; duplicate
+ *     indexes throw too (catches misconfigurations early).
+ *
+ *   Phase 3 — Emit
+ *     Recursively walk the trie depth-first, emitting:
+ *       - `SidebarPageEntry` for each `pages` entry
+ *       - `SidebarGroupEntry` for each `subdirs` entry (recursing)
+ *     At each level, sort by `(position ?? +Infinity, label)`.
+ *     A group with an index page inherits the index's title,
+ *     position, and path.
+ *
+ * =============================================================================
+ * INVARIANTS
+ * =============================================================================
+ *
+ *   - Output is JSON-safe: only strings, numbers, booleans, nulls,
+ *     and arrays/objects of the same.  No AST references, no
+ *     `Date`s, no symbols.
+ *   - Same input → identical output (sort is stable + total).
+ *   - No mutation of input — the caller's `pages` array and
+ *     `frontmatter` objects are never written to.
+ *
+ * @module builder
+ */
+
+import { humanise } from "./labels.js";
+import { normalisePath, stripRoot } from "./path-utils.js";
+import type {
+  PageInput,
+  BuildSidebarOptions,
+  SidebarEntry,
+  SidebarPageEntry,
+  SidebarGroupEntry,
+} from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Internal trie types
+// ─────────────────────────────────────────────────────────────────────
+
+interface TrieNode {
+  /** Sub-directory name → child trie node. */
+  readonly subdirs: Map<string, TrieNode>;
+  /** File-slug → leaf page descriptor (non-index pages). */
+  readonly pages: Map<string, NormalisedPage>;
+  /** Index page for this directory, or `null` if none. */
+  indexPage: NormalisedPage | null;
+}
+
+/** A page after normalisation, with the four well-known frontmatter
+ *  fields extracted defensively. */
+interface NormalisedPage {
+  /** Original path verbatim (for output). */
+  readonly path: string;
+  /** Whether this is an `index.md`-style page. */
+  readonly isIndex: boolean;
+  /** Normalised directory parts (incl. file slug for non-index). */
+  readonly parts: readonly string[];
+  /** Effective label: `sidebar_label ?? title ?? humanised slug`. */
+  readonly label: string;
+  /** Numeric `sidebar_position` or `null`. */
+  readonly position: number | null;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Public entry
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a hierarchical sidebar tree from a flat list of pages.
+ *
+ * @param pages - One entry per `.md` page in the site.  Order
+ *                doesn't matter; the builder sorts deterministically.
+ * @param options - `{ root?: string }`.  Default: no root stripping.
+ * @returns A `SidebarEntry[]` ready to render or `JSON.stringify`.
+ * @throws `TypeError` on duplicate non-index pages at the same
+ *         path, duplicate index pages for the same directory, or
+ *         empty `path` strings.
+ */
+export function buildSidebar(
+  pages: readonly PageInput[],
+  options: BuildSidebarOptions = {},
+): readonly SidebarEntry[] {
+  const root = options.root ?? "";
+
+  // ─── Phase 1: filter + normalise ─────────────────────────────────
+  const normalised: NormalisedPage[] = [];
+  for (const page of pages) {
+    if (isDraft(page.frontmatter)) continue;
+    const np = normalisePath(page.path);
+    const remaining = stripRoot(np.parts, root);
+    if (remaining === null) continue;
+    normalised.push({
+      path: page.path,
+      isIndex: np.isIndex,
+      parts: remaining,
+      label: deriveLabel(page.frontmatter, remaining, np.isIndex),
+      position: readPosition(page.frontmatter),
+    });
+  }
+
+  // ─── Phase 2: trie build ─────────────────────────────────────────
+  const rootNode = makeNode();
+  for (const np of normalised) {
+    insertIntoTrie(rootNode, np);
+  }
+
+  // ─── Phase 3: emit ───────────────────────────────────────────────
+  return emit(rootNode);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase-1 helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Read an own (non-inherited) property from frontmatter.  Returns
+ * `undefined` if the key isn't directly present on the object,
+ * EVEN IF a prototype-chain ancestor would have provided a value.
+ *
+ * This matters when the caller hand-crafts a frontmatter literal
+ * like `{ __proto__: { title: "Polluted" } }` — the JS object
+ * literal syntax treats `__proto__` specially and sets the
+ * prototype rather than creating an own property.  A naive
+ * `frontmatter.title` lookup would then traverse the prototype
+ * and return `"Polluted"`, which is a prototype-pollution-style
+ * surprise.  `Object.hasOwn` bypasses the chain.
+ *
+ * In practice `forme-doc-frontmatter` returns null-prototype
+ * objects (via `Object.create(null)`), so the chain is always
+ * empty.  This is defence-in-depth for callers using arbitrary
+ * frontmatter sources.
+ */
+function readOwn(
+  frontmatter: Readonly<Record<string, unknown>>,
+  key: string,
+): unknown {
+  return Object.hasOwn(frontmatter, key) ? frontmatter[key] : undefined;
+}
+
+/**
+ * True iff frontmatter has `draft: true` as an OWN property.
+ * Defensive against unknown shapes — any non-boolean-`true` value
+ * (incl. truthy strings like `"true"`) is treated as non-draft.
+ * v0 keeps the contract strict; relaxation can come later if needed.
+ */
+function isDraft(frontmatter: Readonly<Record<string, unknown>>): boolean {
+  return readOwn(frontmatter, "draft") === true;
+}
+
+/**
+ * Compute the effective display label for a page:
+ *   `sidebar_label` (string) ?? `title` (string) ?? humanised slug.
+ *
+ * For index pages, the "slug" is the parent directory's name (the
+ * group label).  For empty `parts` (root index), it's `"Home"`.
+ */
+function deriveLabel(
+  frontmatter: Readonly<Record<string, unknown>>,
+  parts: readonly string[],
+  isIndex: boolean,
+): string {
+  const sb = readOwn(frontmatter, "sidebar_label");
+  if (typeof sb === "string" && sb.length > 0) return sb;
+  const t = readOwn(frontmatter, "title");
+  if (typeof t === "string" && t.length > 0) return t;
+  if (parts.length === 0) {
+    // Root index page — sensible default.  (Only reachable for
+    // `index.md` at the site root; the non-index branch is
+    // guarded against in `insertIntoTrie`, which rejects
+    // slug-less non-index pages.)
+    void isIndex;
+    return "Home";
+  }
+  return humanise(parts[parts.length - 1]!);
+}
+
+/**
+ * Read `sidebar_position` defensively.  Accepts only finite
+ * numbers; everything else (string, NaN, ±Infinity, undefined,
+ * non-numeric) becomes `null`.
+ */
+function readPosition(frontmatter: Readonly<Record<string, unknown>>): number | null {
+  const p = readOwn(frontmatter, "sidebar_position");
+  if (typeof p !== "number") return null;
+  if (!Number.isFinite(p)) return null;
+  return p;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase-2 helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function makeNode(): TrieNode {
+  return {
+    subdirs: new Map(),
+    pages: new Map(),
+    indexPage: null,
+  };
+}
+
+function insertIntoTrie(root: TrieNode, page: NormalisedPage): void {
+  if (page.isIndex) {
+    // Walk to the directory the index belongs to.
+    const dir = walkTo(root, page.parts);
+    if (dir.indexPage !== null) {
+      throw new TypeError(
+        `forme-doc-sidebar-builder: duplicate index page for directory ` +
+          `${JSON.stringify(page.parts.join("/"))} ` +
+          `(saw ${JSON.stringify(dir.indexPage.path)} and ${JSON.stringify(page.path)})`,
+      );
+    }
+    dir.indexPage = page;
+    return;
+  }
+  // Non-index: last part is the file slug, prior parts are dir.
+  if (page.parts.length === 0) {
+    // path normalised to "" with isIndex=false — shouldn't happen
+    // (the normaliser only produces empty parts for index), but
+    // guard defensively.
+    throw new TypeError(
+      `forme-doc-sidebar-builder: page ${JSON.stringify(page.path)} has no slug`,
+    );
+  }
+  const dir = walkTo(root, page.parts.slice(0, -1));
+  const slug = page.parts[page.parts.length - 1]!;
+  if (dir.pages.has(slug)) {
+    throw new TypeError(
+      `forme-doc-sidebar-builder: duplicate page at path ${JSON.stringify(page.path)} ` +
+        `(slug ${JSON.stringify(slug)} already present at ${JSON.stringify(dir.pages.get(slug)!.path)})`,
+    );
+  }
+  dir.pages.set(slug, page);
+}
+
+/**
+ * Walk the trie, creating intermediate subdir nodes as needed.
+ * Returns the node at `parts`.  Empty `parts` returns `root`.
+ */
+function walkTo(root: TrieNode, parts: readonly string[]): TrieNode {
+  let cur = root;
+  for (const seg of parts) {
+    let next = cur.subdirs.get(seg);
+    if (next === undefined) {
+      next = makeNode();
+      cur.subdirs.set(seg, next);
+    }
+    cur = next;
+  }
+  return cur;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase-3 helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Emit a sorted `SidebarEntry[]` for the given trie node.
+ *
+ * Sort key: `(position ?? +Infinity, label)` ascending.  Numeric
+ * positions tie-break by label alphabetical; absent positions all
+ * sink to the end and tie-break by label too.  This gives a
+ * predictable order even for fully-unannotated sites.
+ */
+function emit(node: TrieNode): readonly SidebarEntry[] {
+  const entries: SidebarEntry[] = [];
+
+  // Pages (non-index leaves) — one entry each.
+  for (const p of node.pages.values()) {
+    entries.push({
+      kind: "page",
+      label: p.label,
+      path: p.path,
+      position: p.position,
+    });
+  }
+
+  // Subdirs — recurse, attach index metadata if present.
+  for (const [seg, child] of node.subdirs) {
+    entries.push(emitGroup(seg, child));
+  }
+
+  // Sort.
+  entries.sort(compareEntries);
+  return entries;
+}
+
+function emitGroup(seg: string, child: TrieNode): SidebarGroupEntry {
+  const idx = child.indexPage;
+  const childEntries = emit(child);
+  return {
+    kind: "group",
+    label: idx !== null ? idx.label : humanise(seg),
+    path: idx !== null ? idx.path : null,
+    position: idx !== null ? idx.position : null,
+    children: childEntries,
+  };
+}
+
+function compareEntries(a: SidebarEntry, b: SidebarEntry): number {
+  // Primary: numeric position ascending.  `null` sorts last (treat
+  // as +Infinity).
+  const ap = a.position ?? Number.POSITIVE_INFINITY;
+  const bp = b.position ?? Number.POSITIVE_INFINITY;
+  if (ap !== bp) return ap - bp;
+  // Secondary: label alphabetical (locale-independent).
+  if (a.label < b.label) return -1;
+  if (a.label > b.label) return 1;
+  return 0;
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/src/index.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @coding-adventures/forme-doc-sidebar-builder
+ *
+ * Take a directory layout (file paths) + each file's frontmatter
+ * (sidebar position, title overrides, draft flag) and produce a
+ * hierarchical, JSON-able sidebar navigation tree the page-shell
+ * can render to HTML.
+ *
+ *   - Groups by directory.
+ *   - Orders by frontmatter `sidebar_position` (alphabetical fallback).
+ *   - Honours `title` / `sidebar_label` overrides.
+ *   - Skips drafts (`draft: true`) — groups that empty out are
+ *     also skipped.
+ *   - Surfaces `index.md` pages as the group's own destination
+ *     (the group's `path` field points to the index page).
+ *   - Humanises directory names (`getting-started` →
+ *     `"Getting Started"`, `api` → `"API"` via an acronym table).
+ *
+ * Pure transform.  Capabilities: `[]`.  No `eval`, no `new Function`,
+ * no `JSON.parse` reviver, no fs / network / env / shell.  Zero
+ * runtime dependencies.
+ *
+ * ```ts
+ * import { buildSidebar } from "@coding-adventures/forme-doc-sidebar-builder";
+ *
+ * const sidebar = buildSidebar([
+ *   { path: "intro.md",          frontmatter: { sidebar_position: 1 } },
+ *   { path: "guide/index.md",    frontmatter: { title: "Guide", sidebar_position: 2 } },
+ *   { path: "guide/setup.md",    frontmatter: { sidebar_position: 1 } },
+ *   { path: "guide/api.md",      frontmatter: { sidebar_position: 2 } },
+ *   { path: "advanced.md",       frontmatter: { draft: true } },  // skipped
+ * ]);
+ * // sidebar = [
+ * //   { kind: "page",  label: "Intro", path: "intro.md", position: 1 },
+ * //   { kind: "group", label: "Guide", path: "guide/index.md", position: 2, children: [
+ * //     { kind: "page", label: "Setup", path: "guide/setup.md", position: 1 },
+ * //     { kind: "page", label: "API",   path: "guide/api.md",   position: 2 },
+ * //   ]},
+ * // ]
+ * ```
+ *
+ * Sixth concrete DOC00 v0 package (after `forme-doc-frontmatter`,
+ * `forme-doc-heading-anchors`, `forme-doc-toc-extractor`,
+ * `forme-doc-code-block-decorator`, `forme-doc-syntax-highlighter`).
+ *
+ * @module index
+ */
+
+export { buildSidebar } from "./builder.js";
+export { humanise } from "./labels.js";
+export { normalisePath, stripRoot } from "./path-utils.js";
+export type {
+  PageInput,
+  BuildSidebarOptions,
+  SidebarEntry,
+  SidebarPageEntry,
+  SidebarGroupEntry,
+} from "./types.js";

--- a/code/packages/typescript/forme-doc-sidebar-builder/src/labels.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/src/labels.ts
@@ -1,0 +1,102 @@
+/**
+ * labels.ts — humanise directory / file names into display labels.
+ *
+ * Authors write directory names in `kebab-case` or `snake_case`
+ * because file systems and URLs hate spaces.  Sidebars want
+ * `Title Case` because humans hate hyphens.  This module bridges
+ * the two with a deterministic, locale-independent transform.
+ *
+ * Rules:
+ *   1. Replace `-` and `_` with single spaces.
+ *   2. Collapse runs of whitespace.
+ *   3. Title-case each word (first letter uppercased; rest lowered
+ *      where possible — but acronyms like `API` / `SDK` / `URL`
+ *      stay all-caps).
+ *   4. Strip leading / trailing whitespace.
+ *
+ * @module labels
+ */
+
+/**
+ * Acronyms / initialisms that should stay all-caps in display
+ * labels.  Lowercased keys so the lookup matches the
+ * normalisation step.
+ *
+ * Built as `Object.create(null)` so a directory literally named
+ * `__proto__` doesn't read the inherited prototype accessor
+ * during lookup — falls through to the default capitalisation
+ * instead, same as any other unknown word.
+ */
+const ACRONYMS: Record<string, string> = Object.assign(Object.create(null), {
+  "api": "API",
+  "sdk": "SDK",
+  "url": "URL",
+  "uri": "URI",
+  "ui": "UI",
+  "ux": "UX",
+  "id": "ID",
+  "ip": "IP",
+  "dns": "DNS",
+  "http": "HTTP",
+  "https": "HTTPS",
+  "tcp": "TCP",
+  "udp": "UDP",
+  "tls": "TLS",
+  "ssl": "SSL",
+  "ssh": "SSH",
+  "json": "JSON",
+  "yaml": "YAML",
+  "xml": "XML",
+  "html": "HTML",
+  "css": "CSS",
+  "sql": "SQL",
+  "ai": "AI",
+  "ml": "ML",
+  "vm": "VM",
+  "os": "OS",
+  "cpu": "CPU",
+  "gpu": "GPU",
+  "ssd": "SSD",
+  "hdd": "HDD",
+  "ram": "RAM",
+  "cdn": "CDN",
+  "cli": "CLI",
+  "gui": "GUI",
+  "ide": "IDE",
+  "tdd": "TDD",
+  "bdd": "BDD",
+  "ci": "CI",
+  "cd": "CD",
+  "qa": "QA",
+  "io": "I/O",
+  "faq": "FAQ",
+});
+
+/**
+ * Humanise a slug-style name (`getting-started`, `api_reference`)
+ * into a display label (`Getting Started`, `API Reference`).
+ *
+ * @param slug - Directory or file name (without extension).
+ * @returns The humanised label.  Empty input returns the empty
+ *          string.
+ */
+export function humanise(slug: string): string {
+  // Step 1: replace separators with spaces, then trim + collapse
+  // runs of whitespace.
+  const spaced = slug.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim();
+  if (spaced === "") return "";
+  // Step 2: title-case each word, honouring the acronym table.
+  return spaced
+    .split(" ")
+    .map((word) => {
+      const lower = word.toLowerCase();
+      const acro = ACRONYMS[lower];
+      if (acro !== undefined) return acro;
+      // Default: first letter upper, rest lower.  Locale-independent
+      // toUpperCase / toLowerCase per the same reasoning as the slug
+      // module in heading-anchors — sidebar labels must be stable
+      // across machines.
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(" ");
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/src/path-utils.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/src/path-utils.ts
@@ -1,0 +1,126 @@
+/**
+ * path-utils.ts — path normalisation and index-page detection.
+ *
+ * Pages arrive with paths in any of several common forms:
+ *
+ *   "guide/setup.md"          (file path, .md)
+ *   "guide/setup.mdx"         (file path, .mdx)
+ *   "guide/setup.html"        (already built)
+ *   "/guide/setup"            (URL path, leading slash, no ext)
+ *   "guide/setup/"            (trailing slash)
+ *   "guide/setup/index.md"    (explicit index)
+ *
+ * We normalise all of them to a single canonical form
+ * (`["guide", "setup"]` — directory parts as a list) before
+ * building the tree.  Index pages get a flag so the group knows
+ * to attach the page's path / metadata to itself rather than as
+ * a child entry.
+ *
+ * @module path-utils
+ */
+
+/**
+ * Result of normalising a path.
+ */
+export interface NormalisedPath {
+  /**
+   * The directory parts up to the filename, after stripping
+   * extensions and `index` suffixes.  For an index page, the
+   * last part of the original path is consumed into the group
+   * and `parts` is the parent directory.  For a non-index page,
+   * `parts` ends with the file slug.
+   *
+   * Examples:
+   *   "guide/setup.md"        → ["guide", "setup"]
+   *   "guide/index.md"        → ["guide"]                  (index)
+   *   "index.md"              → []                          (root index)
+   *   "intro.md"              → ["intro"]
+   *   "/docs/api/v1.md"       → ["docs", "api", "v1"]
+   */
+  readonly parts: readonly string[];
+
+  /** True iff the path refers to an index page for its directory. */
+  readonly isIndex: boolean;
+}
+
+/**
+ * Strip leading slashes, trailing slashes, and a recognised
+ * extension from a raw path, then split on `/`.
+ *
+ * @internal
+ */
+function splitAndClean(rawPath: string): string[] {
+  // Strip leading slash.
+  let p = rawPath.replace(/^\/+/, "");
+  // Strip trailing slash.
+  p = p.replace(/\/+$/, "");
+  // Strip recognised extension (case-insensitive on the dot+ext).
+  p = p.replace(/\.(md|mdx|html|htm)$/i, "");
+  if (p === "") return [];
+  return p.split("/").filter((s) => s.length > 0);
+}
+
+/**
+ * Maximum directory nesting depth.  Caps stack usage in
+ * `builder.emit` (which recurses one JS frame per level) at well
+ * below V8's default stack limit.  Real-world docs sites
+ * essentially never exceed 8 levels; 64 leaves a wide safety
+ * margin while preventing an adversarial path like
+ * `a/b/c/.../z.md` (10k segments) from triggering a `RangeError`
+ * on emit.
+ */
+const MAX_DEPTH = 64;
+
+/**
+ * Normalise a raw page path into directory parts + index flag.
+ *
+ * @param rawPath - The input path string.
+ * @returns `{ parts, isIndex }`.
+ * @throws `TypeError` if `rawPath` is empty after trimming
+ *         leading/trailing whitespace (every page needs a place
+ *         in the tree), or if the resulting depth would exceed
+ *         `MAX_DEPTH` (64) — prevents stack-overflow DoS from
+ *         adversarial deeply-nested inputs.
+ */
+export function normalisePath(rawPath: string): NormalisedPath {
+  const trimmed = rawPath.trim();
+  if (trimmed === "") {
+    throw new TypeError(
+      "forme-doc-sidebar-builder: empty path — every page needs a place in the tree",
+    );
+  }
+  const parts = splitAndClean(trimmed);
+  if (parts.length > MAX_DEPTH) {
+    throw new TypeError(
+      `forme-doc-sidebar-builder: path ${JSON.stringify(rawPath)} exceeds ` +
+        `${MAX_DEPTH}-level directory-depth cap`,
+    );
+  }
+  // Detect index: last segment is "index" (case-insensitive).
+  if (parts.length > 0 && parts[parts.length - 1]!.toLowerCase() === "index") {
+    return { parts: parts.slice(0, -1), isIndex: true };
+  }
+  return { parts, isIndex: false };
+}
+
+/**
+ * Apply an optional root prefix: strip it from `parts` if
+ * present, return `null` if `parts` doesn't start with it.
+ *
+ * @param parts - The normalised directory parts.
+ * @param root - The root prefix string (`""` = no stripping).
+ * @returns The remaining parts, or `null` if the prefix doesn't match.
+ */
+export function stripRoot(
+  parts: readonly string[],
+  root: string,
+): readonly string[] | null {
+  const rootTrim = root.trim();
+  if (rootTrim === "") return parts;
+  const rootParts = splitAndClean(rootTrim);
+  if (rootParts.length > parts.length) return null;
+  for (let i = 0; i < rootParts.length; i++) {
+    if (parts[i] !== rootParts[i]) return null;
+  }
+  return parts.slice(rootParts.length);
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/src/path-utils.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/src/path-utils.ts
@@ -44,18 +44,47 @@ export interface NormalisedPath {
 }
 
 /**
+ * Strip leading and trailing slashes using explicit index walks.
+ *
+ * We do this with index loops rather than `.replace(/^\/+/, "")`
+ * /  `.replace(/\/+$/, "")` because CodeQL's `js/polynomial-redos`
+ * query flags those anchored-`+` patterns as potentially
+ * super-linear on adversarial input (even though both ARE
+ * linear in V8's regex engine).  Linear index walks make the
+ * O(N) cost obvious to both the static analyser and the
+ * reader.
+ *
+ * @internal
+ */
+function stripSlashes(s: string): string {
+  let start = 0;
+  while (start < s.length && s.charCodeAt(start) === 0x2f /* "/" */) start++;
+  let end = s.length;
+  while (end > start && s.charCodeAt(end - 1) === 0x2f) end--;
+  if (start === 0 && end === s.length) return s;
+  return s.slice(start, end);
+}
+
+/**
  * Strip leading slashes, trailing slashes, and a recognised
  * extension from a raw path, then split on `/`.
  *
  * @internal
  */
 function splitAndClean(rawPath: string): string[] {
-  // Strip leading slash.
-  let p = rawPath.replace(/^\/+/, "");
-  // Strip trailing slash.
-  p = p.replace(/\/+$/, "");
-  // Strip recognised extension (case-insensitive on the dot+ext).
-  p = p.replace(/\.(md|mdx|html|htm)$/i, "");
+  // Strip leading / trailing slashes (linear, regex-free).
+  let p = stripSlashes(rawPath);
+  // Strip recognised extension.  Anchored `$`, finite literal
+  // alternation, single non-quantified `\.` — not polynomial.
+  // We use endsWith() instead of a regex anyway to keep the
+  // intent obvious and the analyser happy.
+  const lower = p.toLowerCase();
+  for (const ext of [".md", ".mdx", ".html", ".htm"]) {
+    if (lower.endsWith(ext)) {
+      p = p.slice(0, p.length - ext.length);
+      break;
+    }
+  }
   if (p === "") return [];
   return p.split("/").filter((s) => s.length > 0);
 }
@@ -72,6 +101,15 @@ function splitAndClean(rawPath: string): string[] {
 const MAX_DEPTH = 64;
 
 /**
+ * Maximum raw-path length (in characters).  Caps the input size
+ * BEFORE any per-character processing runs, defending against
+ * adversarial inputs that might otherwise consume disproportionate
+ * CPU even with linear-time helpers.  Real filesystem paths max
+ * out around 4 KiB on most platforms; we leave a generous margin.
+ */
+const MAX_PATH_LENGTH = 8192;
+
+/**
  * Normalise a raw page path into directory parts + index flag.
  *
  * @param rawPath - The input path string.
@@ -83,6 +121,16 @@ const MAX_DEPTH = 64;
  *         adversarial deeply-nested inputs.
  */
 export function normalisePath(rawPath: string): NormalisedPath {
+  // Cheap upfront cap — fail fast before any per-character work.
+  // This bounds the CPU cost of normalisation against adversarial
+  // inputs (e.g. a 100MB path of slashes) regardless of how
+  // efficient the inner helpers are.
+  if (rawPath.length > MAX_PATH_LENGTH) {
+    throw new TypeError(
+      `forme-doc-sidebar-builder: raw path exceeds ${MAX_PATH_LENGTH}-character ` +
+        `length cap (got ${rawPath.length})`,
+    );
+  }
   const trimmed = rawPath.trim();
   if (trimmed === "") {
     throw new TypeError(

--- a/code/packages/typescript/forme-doc-sidebar-builder/src/types.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/src/types.ts
@@ -1,0 +1,118 @@
+/**
+ * types.ts — public signatures for the sidebar builder.
+ *
+ * @module types
+ */
+
+/**
+ * One input page — what the caller already has after running the
+ * `commonmark-parser` (for the body) and `forme-doc-frontmatter` (for
+ * the metadata) on every `.md` file under the site root.
+ *
+ * The sidebar builder only needs the PATH and the FRONTMATTER — it
+ * never sees the body content.  That keeps it cheap to re-run when
+ * adding/removing pages (no need to re-parse every file).
+ */
+export interface PageInput {
+  /**
+   * The page's path, relative to the site root.  May be a file
+   * path (`"guide/setup.md"`), a URL path (`"/guide/setup"`), or
+   * an extensionless slug (`"guide/setup"`).  The builder
+   * normalises by stripping leading `/`, trailing `.md` / `.mdx` /
+   * `.html`, and trailing `/index` / `/index.md` etc. before
+   * building the directory tree.
+   *
+   * Empty string is rejected (throws `TypeError`) — every page
+   * needs a place in the tree.
+   */
+  readonly path: string;
+
+  /**
+   * The parsed frontmatter object — any string-keyed `unknown`
+   * map.  The builder reads four well-known keys (others are
+   * ignored):
+   *
+   *   - `title: string` — overrides the auto-derived label.
+   *   - `sidebar_label: string` — alternative to `title`, used
+   *     only for the sidebar entry (not for `<title>` etc.).
+   *     Takes precedence over `title` when both are present.
+   *   - `sidebar_position: number` — sort key within the
+   *     directory (ascending).  Missing or non-numeric →
+   *     `+Infinity` (alphabetical fallback).
+   *   - `draft: boolean` — when `true`, the page is omitted
+   *     from the sidebar entirely (and any group that becomes
+   *     empty as a result is also omitted).
+   *
+   * Frontmatter is supplied as `Record<string, unknown>` because
+   * `forme-doc-frontmatter` returns null-prototype objects with
+   * arbitrary user-defined keys.  We read only the four above
+   * defensively — unknown keys never affect output.
+   */
+  readonly frontmatter: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Options for `buildSidebar`.
+ */
+export interface BuildSidebarOptions {
+  /**
+   * Optional prefix to strip from every page's normalised path
+   * before building the tree.  Useful when the docs live under a
+   * subdirectory of a larger site (e.g. `root: "docs"` for paths
+   * like `"docs/guide/setup.md"`).
+   *
+   * The prefix is matched after path normalisation (leading `/`,
+   * trailing extensions, etc. already removed).  Pages whose
+   * normalised path doesn't start with the prefix are silently
+   * skipped — the assumption being the caller passed a wider
+   * input set and only wants this subset in the sidebar.
+   *
+   * Default: `""` (no prefix stripping).
+   */
+  readonly root?: string;
+}
+
+/**
+ * A single navigable page entry in the sidebar tree.
+ */
+export interface SidebarPageEntry {
+  readonly kind: "page";
+  /** Display label — `sidebar_label` ?? `title` ?? humanised filename. */
+  readonly label: string;
+  /** The original (non-normalised) path from the input. */
+  readonly path: string;
+  /**
+   * The numeric `sidebar_position` from frontmatter, or `null` if
+   * absent / non-numeric.  Exposed so renderers can show a
+   * position badge or assert on ordering.
+   */
+  readonly position: number | null;
+}
+
+/**
+ * A directory grouping containing pages and/or nested groups.
+ *
+ * `path` is set iff the directory has an `index.md` (or
+ * `index.mdx` / `index.html`) page.  Sidebar widgets typically
+ * make the group label clickable in that case — clicking
+ * navigates to the index page.
+ */
+export interface SidebarGroupEntry {
+  readonly kind: "group";
+  /** Humanised directory name, or `title` override if the group has an index page with a `title`. */
+  readonly label: string;
+  /** Original path of the index page, or `null` if the directory has no index. */
+  readonly path: string | null;
+  /**
+   * The numeric `sidebar_position` from the GROUP itself — taken
+   * from the index page's frontmatter, or `null` if no index page
+   * or the index has no `sidebar_position`.  Used by the parent
+   * directory to order this group among its siblings.
+   */
+  readonly position: number | null;
+  /** Pages and sub-groups within this directory. */
+  readonly children: readonly SidebarEntry[];
+}
+
+/** Union of the two entry kinds. */
+export type SidebarEntry = SidebarPageEntry | SidebarGroupEntry;

--- a/code/packages/typescript/forme-doc-sidebar-builder/tests/builder.test.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/tests/builder.test.ts
@@ -1,0 +1,471 @@
+/**
+ * builder.test.ts — `buildSidebar` integration tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildSidebar } from "../src/index.js";
+import type { PageInput, SidebarEntry } from "../src/index.js";
+
+/** Convenience helper: page with empty frontmatter. */
+function p(path: string, fm: Record<string, unknown> = {}): PageInput {
+  return { path, frontmatter: fm };
+}
+
+/** Drop position/path/kind details for compact structural assertions. */
+function shape(entries: readonly SidebarEntry[]): unknown {
+  return entries.map((e) => {
+    if (e.kind === "page") return { kind: "page", label: e.label };
+    return { kind: "group", label: e.label, children: shape(e.children) };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Degenerate inputs
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — degenerate inputs", () => {
+  it("empty array → []", () => {
+    expect(buildSidebar([])).toEqual([]);
+  });
+  it("single root page", () => {
+    const result = buildSidebar([p("intro.md")]);
+    expect(result).toEqual([
+      { kind: "page", label: "Intro", path: "intro.md", position: null },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Ordering
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — ordering", () => {
+  it("by sidebar_position ascending", () => {
+    const result = buildSidebar([
+      p("c.md", { sidebar_position: 3 }),
+      p("a.md", { sidebar_position: 1 }),
+      p("b.md", { sidebar_position: 2 }),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["A", "B", "C"]);
+  });
+  it("alphabetical fallback when no positions", () => {
+    const result = buildSidebar([
+      p("zebra.md"),
+      p("apple.md"),
+      p("banana.md"),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["Apple", "Banana", "Zebra"]);
+  });
+  it("positioned entries before unpositioned", () => {
+    const result = buildSidebar([
+      p("apple.md"),                            // null position
+      p("banana.md", { sidebar_position: 1 }),
+      p("zebra.md"),                            // null
+      p("cherry.md", { sidebar_position: 2 }),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["Banana", "Cherry", "Apple", "Zebra"]);
+  });
+  it("tiebreak among same-position entries is alphabetical", () => {
+    const result = buildSidebar([
+      p("zulu.md", { sidebar_position: 1 }),
+      p("alpha.md", { sidebar_position: 1 }),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["Alpha", "Zulu"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Labels
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — labels", () => {
+  it("title overrides slug", () => {
+    const result = buildSidebar([p("setup.md", { title: "Initial Setup" })]);
+    expect(result[0].label).toBe("Initial Setup");
+  });
+  it("sidebar_label overrides title", () => {
+    const result = buildSidebar([
+      p("setup.md", { title: "Initial Setup", sidebar_label: "Setup" }),
+    ]);
+    expect(result[0].label).toBe("Setup");
+  });
+  it("empty sidebar_label falls back to title", () => {
+    const result = buildSidebar([
+      p("setup.md", { title: "Initial Setup", sidebar_label: "" }),
+    ]);
+    expect(result[0].label).toBe("Initial Setup");
+  });
+  it("empty title falls back to humanised slug", () => {
+    const result = buildSidebar([p("getting-started.md", { title: "" })]);
+    expect(result[0].label).toBe("Getting Started");
+  });
+  it("non-string title is ignored", () => {
+    const result = buildSidebar([p("intro.md", { title: 42 })]);
+    expect(result[0].label).toBe("Intro");
+  });
+  it("acronym slug → humanised", () => {
+    const result = buildSidebar([p("api.md")]);
+    expect(result[0].label).toBe("API");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Drafts
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — drafts", () => {
+  it("draft: true pages are skipped", () => {
+    const result = buildSidebar([
+      p("public.md"),
+      p("draft.md", { draft: true }),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["Public"]);
+  });
+  it("draft: false pages are NOT skipped", () => {
+    const result = buildSidebar([p("public.md", { draft: false })]);
+    expect(result).toHaveLength(1);
+  });
+  it("draft: 'true' (string) is NOT a draft (strict boolean check)", () => {
+    const result = buildSidebar([p("public.md", { draft: "true" })]);
+    expect(result).toHaveLength(1);
+  });
+  it("a group whose pages are all drafts collapses (no children → no group)", () => {
+    const result = buildSidebar([
+      p("guide/a.md", { draft: true }),
+      p("guide/b.md", { draft: true }),
+      p("intro.md"),
+    ]);
+    // No "Guide" group should appear.
+    expect(shape(result)).toEqual([{ kind: "page", label: "Intro" }]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Grouping
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — grouping", () => {
+  it("single-level directory", () => {
+    const result = buildSidebar([
+      p("guide/setup.md", { sidebar_position: 1 }),
+      p("guide/api.md", { sidebar_position: 2 }),
+    ]);
+    expect(shape(result)).toEqual([
+      {
+        kind: "group",
+        label: "Guide",
+        children: [
+          { kind: "page", label: "Setup" },
+          { kind: "page", label: "API" },
+        ],
+      },
+    ]);
+  });
+  it("mixed root pages and groups (unpositioned group sinks below positioned pages)", () => {
+    // The Guide group has no position (no index.md with sidebar_position),
+    // so it sorts at +Infinity — AFTER Conclusion (99).  This is the
+    // documented behaviour: positioned entries first (by position
+    // ascending), unpositioned entries last (alphabetical among
+    // themselves).
+    const result = buildSidebar([
+      p("intro.md", { sidebar_position: 1 }),
+      p("guide/setup.md"),
+      p("conclusion.md", { sidebar_position: 99 }),
+    ]);
+    expect(shape(result)).toEqual([
+      { kind: "page", label: "Intro" },
+      { kind: "page", label: "Conclusion" },
+      { kind: "group", label: "Guide", children: [{ kind: "page", label: "Setup" }] },
+    ]);
+  });
+  it("deeply nested groups", () => {
+    const result = buildSidebar([
+      p("a/b/c/leaf.md"),
+    ]);
+    expect(shape(result)).toEqual([
+      {
+        kind: "group",
+        label: "A",
+        children: [
+          {
+            kind: "group",
+            label: "B",
+            children: [
+              {
+                kind: "group",
+                label: "C",
+                children: [{ kind: "page", label: "Leaf" }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Index pages
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — index pages", () => {
+  it("group's index.md becomes the group's destination", () => {
+    const result = buildSidebar([
+      p("guide/index.md", { title: "User Guide", sidebar_position: 5 }),
+      p("guide/setup.md", { sidebar_position: 1 }),
+    ]);
+    const grp = result[0];
+    expect(grp.kind).toBe("group");
+    if (grp.kind === "group") {
+      expect(grp.label).toBe("User Guide");
+      expect(grp.path).toBe("guide/index.md");
+      expect(grp.position).toBe(5);
+      expect(grp.children).toHaveLength(1);
+      expect(grp.children[0].label).toBe("Setup");
+    }
+  });
+  it("group without index has null path", () => {
+    const result = buildSidebar([p("guide/a.md")]);
+    const grp = result[0];
+    if (grp.kind === "group") {
+      expect(grp.path).toBeNull();
+      expect(grp.position).toBeNull();
+    }
+  });
+  it("index page is NOT listed among children", () => {
+    const result = buildSidebar([
+      p("guide/index.md"),
+      p("guide/a.md"),
+      p("guide/b.md"),
+    ]);
+    const grp = result[0];
+    if (grp.kind === "group") {
+      expect(grp.children.map((c) => c.label)).toEqual(["A", "B"]);
+    }
+  });
+  it("root index.md becomes a top-level page (or group's own metadata)", () => {
+    const result = buildSidebar([
+      p("index.md", { title: "Home" }),
+      p("intro.md"),
+    ]);
+    // Root index is on the synthetic root group, which has no
+    // representation in the output — only its `children` are
+    // returned.  But the index DOES live somewhere; for now it
+    // becomes the root-level "Home" entry by having parts=[].
+    // Our implementation treats a root index as living on the
+    // root TrieNode, so it doesn't appear as a page entry — it
+    // only contributes metadata to the implicit root group which
+    // we don't surface.  Document this clearly via the test.
+    //
+    // For the user-facing result, only `intro.md` appears at top
+    // level (the root index page is reachable via "/" in the URL
+    // structure but isn't a sidebar entry).
+    expect(shape(result)).toEqual([{ kind: "page", label: "Intro" }]);
+  });
+  it("duplicate index for same directory throws", () => {
+    expect(() => {
+      buildSidebar([
+        p("guide/index.md"),
+        p("guide/index.mdx"),
+      ]);
+    }).toThrow(/duplicate index page/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Duplicate detection
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — duplicate detection", () => {
+  it("two pages at same path throw", () => {
+    expect(() => {
+      buildSidebar([p("intro.md"), p("intro.mdx")]);
+    }).toThrow(/duplicate page/);
+  });
+  it("two pages with different extensions at same slug throw", () => {
+    expect(() => {
+      buildSidebar([p("guide/setup.md"), p("guide/setup.html")]);
+    }).toThrow(/duplicate page/);
+  });
+  it("root path '/' is a slugless non-index page and throws", () => {
+    // splitAndClean("/") → [], isIndex stays false (no "index"
+    // segment).  insertIntoTrie defensively rejects this — a page
+    // with no slug has no place in the tree.
+    expect(() => {
+      buildSidebar([p("/")]);
+    }).toThrow(/no slug/);
+  });
+});
+
+describe("buildSidebar — root index page", () => {
+  it("a root index.md becomes the root group's metadata (not a visible entry)", () => {
+    // Index pages contribute their label/path/position to the
+    // group they belong to.  The root group itself isn't surfaced
+    // in the output (we return root.children), so the root index
+    // page's metadata is currently unsurfaced — documented as a
+    // v0 simplification.  This test pins the behaviour so any
+    // future change is intentional.
+    const result = buildSidebar([
+      p("index.md", { title: "Welcome" }),
+      p("intro.md"),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["Intro"]);
+  });
+});
+
+describe("buildSidebar — compareEntries tie-break on identical labels", () => {
+  it("two pages with identical title overrides at same dir sort stably", () => {
+    // Two different slugs both get the same title via override.
+    // Same null position, same label → compareEntries returns 0,
+    // exercises the equal-label branch of the comparator.
+    const result = buildSidebar([
+      p("a.md", { title: "Shared", sidebar_position: 1 }),
+      p("b.md", { title: "Shared", sidebar_position: 1 }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.label === "Shared")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Root prefix
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — root prefix", () => {
+  it("strips matching root (no positions → alphabetical by label)", () => {
+    // Both entries are unpositioned, so they sort alphabetical:
+    // "Guide" (group) < "Intro" (page).
+    const result = buildSidebar(
+      [
+        p("docs/intro.md"),
+        p("docs/guide/setup.md"),
+      ],
+      { root: "docs" },
+    );
+    expect(shape(result)).toEqual([
+      { kind: "group", label: "Guide", children: [{ kind: "page", label: "Setup" }] },
+      { kind: "page", label: "Intro" },
+    ]);
+  });
+  it("skips pages outside root", () => {
+    const result = buildSidebar(
+      [
+        p("docs/intro.md"),
+        p("blog/post-1.md"),  // outside docs
+      ],
+      { root: "docs" },
+    );
+    expect(result.map((e) => e.label)).toEqual(["Intro"]);
+  });
+  it("empty root option behaves as no-op", () => {
+    const result = buildSidebar([p("intro.md")], { root: "" });
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Frontmatter robustness
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — frontmatter robustness", () => {
+  it("non-numeric sidebar_position → null", () => {
+    const result = buildSidebar([p("a.md", { sidebar_position: "1" as unknown as number })]);
+    expect(result[0].position).toBeNull();
+  });
+  it("NaN sidebar_position → null", () => {
+    const result = buildSidebar([p("a.md", { sidebar_position: NaN })]);
+    expect(result[0].position).toBeNull();
+  });
+  it("Infinity sidebar_position → null", () => {
+    const result = buildSidebar([p("a.md", { sidebar_position: Infinity })]);
+    expect(result[0].position).toBeNull();
+  });
+  it("negative sidebar_position respected (sorts before positive)", () => {
+    const result = buildSidebar([
+      p("a.md", { sidebar_position: 1 }),
+      p("b.md", { sidebar_position: -5 }),
+    ]);
+    expect(result.map((e) => e.label)).toEqual(["B", "A"]);
+  });
+  it("frontmatter with arbitrary unknown keys is harmless", () => {
+    const result = buildSidebar([p("a.md", { custom_field: { nested: true }, tags: ["x"] })]);
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("A");
+  });
+  it("__proto__ as a frontmatter key is harmless (own-property lookup)", () => {
+    const result = buildSidebar([p("a.md", { __proto__: { title: "Polluted" } } as Record<string, unknown>)]);
+    expect(result[0].label).toBe("A");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Determinism + immutability
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — determinism + immutability", () => {
+  it("same input → identical output", () => {
+    const input: PageInput[] = [
+      p("guide/index.md", { title: "Guide", sidebar_position: 1 }),
+      p("guide/setup.md", { sidebar_position: 1 }),
+      p("intro.md", { sidebar_position: 0 }),
+    ];
+    const a = JSON.stringify(buildSidebar(input));
+    const b = JSON.stringify(buildSidebar(input));
+    expect(a).toBe(b);
+  });
+  it("does not mutate input array", () => {
+    const input = [p("a.md"), p("b.md")];
+    const snapshot = JSON.stringify(input);
+    buildSidebar(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+  it("does not mutate input frontmatter objects", () => {
+    const fm = { title: "T", sidebar_position: 1 };
+    buildSidebar([{ path: "a.md", frontmatter: fm }]);
+    expect(fm).toEqual({ title: "T", sidebar_position: 1 });
+  });
+  it("output is JSON-safe (no AST, no Date, no symbol)", () => {
+    const result = buildSidebar([p("a.md", { title: "Hi", sidebar_position: 1 })]);
+    expect(() => JSON.parse(JSON.stringify(result))).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Realistic scenario
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSidebar — realistic scenario", () => {
+  it("handles a typical docs site", () => {
+    const result = buildSidebar([
+      p("intro.md", { sidebar_position: 1 }),
+      p("guide/index.md", { title: "Guide", sidebar_position: 2 }),
+      p("guide/setup.md", { sidebar_position: 1 }),
+      p("guide/configuration.md", { sidebar_position: 2 }),
+      p("guide/draft-feature.md", { draft: true }),
+      p("api/index.md", { title: "API Reference", sidebar_position: 3 }),
+      p("api/endpoints.md", { sidebar_position: 1 }),
+      p("api/authentication.md", { sidebar_position: 2 }),
+      p("changelog.md", { sidebar_position: 99 }),
+    ]);
+    expect(shape(result)).toEqual([
+      { kind: "page", label: "Intro" },
+      {
+        kind: "group",
+        label: "Guide",
+        children: [
+          { kind: "page", label: "Setup" },
+          { kind: "page", label: "Configuration" },
+        ],
+      },
+      {
+        kind: "group",
+        label: "API Reference",
+        children: [
+          { kind: "page", label: "Endpoints" },
+          { kind: "page", label: "Authentication" },
+        ],
+      },
+      { kind: "page", label: "Changelog" },
+    ]);
+  });
+});

--- a/code/packages/typescript/forme-doc-sidebar-builder/tests/labels.test.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/tests/labels.test.ts
@@ -1,0 +1,63 @@
+/**
+ * labels.test.ts — humanise() tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { humanise } from "../src/index.js";
+
+describe("humanise — basic", () => {
+  it("kebab-case → Title Case", () => {
+    expect(humanise("getting-started")).toBe("Getting Started");
+  });
+  it("snake_case → Title Case", () => {
+    expect(humanise("api_reference")).toBe("API Reference");
+  });
+  it("mixed separators", () => {
+    expect(humanise("my_doc-page")).toBe("My Doc Page");
+  });
+  it("already spaced input", () => {
+    expect(humanise("Hello World")).toBe("Hello World");
+  });
+  it("single word", () => {
+    expect(humanise("intro")).toBe("Intro");
+  });
+  it("preserves Unicode (locale-independent toLowerCase)", () => {
+    expect(humanise("café-résumé")).toBe("Café Résumé");
+  });
+});
+
+describe("humanise — acronyms", () => {
+  it("api → API", () => expect(humanise("api")).toBe("API"));
+  it("sdk → SDK", () => expect(humanise("sdk")).toBe("SDK"));
+  it("url → URL", () => expect(humanise("url")).toBe("URL"));
+  it("http → HTTP", () => expect(humanise("http")).toBe("HTTP"));
+  it("html → HTML", () => expect(humanise("html")).toBe("HTML"));
+  it("json → JSON", () => expect(humanise("json")).toBe("JSON"));
+  it("css → CSS", () => expect(humanise("css")).toBe("CSS"));
+  it("cli → CLI", () => expect(humanise("cli")).toBe("CLI"));
+  it("api in mixed phrase", () => {
+    expect(humanise("api-reference")).toBe("API Reference");
+  });
+  it("multiple acronyms", () => {
+    expect(humanise("http-api-cli")).toBe("HTTP API CLI");
+  });
+  it("io renders as I/O (special case)", () => {
+    expect(humanise("io")).toBe("I/O");
+  });
+  it("case-insensitive acronym match", () => {
+    expect(humanise("API")).toBe("API");
+    expect(humanise("Api")).toBe("API");
+  });
+});
+
+describe("humanise — edge cases", () => {
+  it("empty string", () => expect(humanise("")).toBe(""));
+  it("only separators", () => expect(humanise("---")).toBe(""));
+  it("only whitespace", () => expect(humanise("   ")).toBe(""));
+  it("collapses runs of separators", () => {
+    expect(humanise("foo---bar___baz")).toBe("Foo Bar Baz");
+  });
+  it("__proto__ falls through to default capitalisation (not Object.prototype's __proto__)", () => {
+    expect(humanise("__proto__")).toBe("Proto");
+  });
+});

--- a/code/packages/typescript/forme-doc-sidebar-builder/tests/path-utils.test.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/tests/path-utils.test.ts
@@ -1,0 +1,126 @@
+/**
+ * path-utils.test.ts — normalisePath + stripRoot tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { normalisePath, stripRoot } from "../src/index.js";
+
+describe("normalisePath — extension stripping", () => {
+  it(".md", () => {
+    expect(normalisePath("guide/setup.md")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it(".mdx", () => {
+    expect(normalisePath("guide/setup.mdx")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it(".html", () => {
+    expect(normalisePath("guide/setup.html")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it(".htm", () => {
+    expect(normalisePath("guide/setup.htm")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it(".MD (case-insensitive)", () => {
+    expect(normalisePath("guide/setup.MD")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it("no extension", () => {
+    expect(normalisePath("guide/setup")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it(".png NOT stripped (only doc extensions)", () => {
+    expect(normalisePath("img.png")).toEqual({ parts: ["img.png"], isIndex: false });
+  });
+});
+
+describe("normalisePath — slash handling", () => {
+  it("leading slash stripped", () => {
+    expect(normalisePath("/guide/setup")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it("multiple leading slashes", () => {
+    expect(normalisePath("///guide/setup")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it("trailing slash stripped", () => {
+    expect(normalisePath("guide/setup/")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it("both leading and trailing slashes", () => {
+    expect(normalisePath("/guide/setup/")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+  it("empty segments filtered", () => {
+    expect(normalisePath("guide//setup")).toEqual({ parts: ["guide", "setup"], isIndex: false });
+  });
+});
+
+describe("normalisePath — index detection", () => {
+  it("index.md at root", () => {
+    expect(normalisePath("index.md")).toEqual({ parts: [], isIndex: true });
+  });
+  it("guide/index.md", () => {
+    expect(normalisePath("guide/index.md")).toEqual({ parts: ["guide"], isIndex: true });
+  });
+  it("deeply nested index.md", () => {
+    expect(normalisePath("a/b/c/index.md")).toEqual({ parts: ["a", "b", "c"], isIndex: true });
+  });
+  it("INDEX (case-insensitive)", () => {
+    expect(normalisePath("guide/INDEX.md")).toEqual({ parts: ["guide"], isIndex: true });
+  });
+  it("Index.mdx", () => {
+    expect(normalisePath("guide/Index.mdx")).toEqual({ parts: ["guide"], isIndex: true });
+  });
+  it("filename starting with 'index' but not exactly 'index' is NOT index", () => {
+    expect(normalisePath("guide/indexes.md")).toEqual({ parts: ["guide", "indexes"], isIndex: false });
+  });
+  it("filename 'index-old.md' is NOT index", () => {
+    expect(normalisePath("guide/index-old.md")).toEqual({ parts: ["guide", "index-old"], isIndex: false });
+  });
+});
+
+describe("normalisePath — path that strips to empty parts", () => {
+  it("'/' → [] (parts empty, not index)", () => {
+    expect(normalisePath("/")).toEqual({ parts: [], isIndex: false });
+  });
+  it("'///' → [] (multiple slashes only)", () => {
+    expect(normalisePath("///")).toEqual({ parts: [], isIndex: false });
+  });
+});
+
+describe("normalisePath — errors", () => {
+  it("empty string throws", () => {
+    expect(() => normalisePath("")).toThrow(/empty path/);
+  });
+  it("whitespace-only throws", () => {
+    expect(() => normalisePath("   ")).toThrow(/empty path/);
+  });
+  it("path deeper than 64 levels throws (stack-overflow defence)", () => {
+    const deep = Array.from({ length: 65 }, (_, i) => `d${i}`).join("/") + ".md";
+    expect(() => normalisePath(deep)).toThrow(/directory-depth cap/);
+  });
+  it("path at exactly 64 levels is accepted", () => {
+    // 63 dirs + 1 file slug = 64 parts.
+    const ok = Array.from({ length: 63 }, (_, i) => `d${i}`).join("/") + "/file.md";
+    expect(() => normalisePath(ok)).not.toThrow();
+  });
+});
+
+describe("stripRoot", () => {
+  it("empty root → unchanged", () => {
+    expect(stripRoot(["guide", "setup"], "")).toEqual(["guide", "setup"]);
+  });
+  it("matching root → stripped", () => {
+    expect(stripRoot(["docs", "guide", "setup"], "docs")).toEqual(["guide", "setup"]);
+  });
+  it("multi-part root → stripped", () => {
+    expect(stripRoot(["site", "docs", "guide"], "site/docs")).toEqual(["guide"]);
+  });
+  it("non-matching root → null", () => {
+    expect(stripRoot(["other", "guide"], "docs")).toBeNull();
+  });
+  it("root longer than parts → null", () => {
+    expect(stripRoot(["docs"], "docs/api")).toBeNull();
+  });
+  it("root with leading slash", () => {
+    expect(stripRoot(["docs", "guide"], "/docs")).toEqual(["guide"]);
+  });
+  it("root with trailing slash", () => {
+    expect(stripRoot(["docs", "guide"], "docs/")).toEqual(["guide"]);
+  });
+  it("whitespace root → no stripping", () => {
+    expect(stripRoot(["guide"], "   ")).toEqual(["guide"]);
+  });
+});

--- a/code/packages/typescript/forme-doc-sidebar-builder/tests/path-utils.test.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/tests/path-utils.test.ts
@@ -96,6 +96,18 @@ describe("normalisePath — errors", () => {
     const ok = Array.from({ length: 63 }, (_, i) => `d${i}`).join("/") + "/file.md";
     expect(() => normalisePath(ok)).not.toThrow();
   });
+  it("raw path exceeding 8192-char length cap throws (regex-DoS defence)", () => {
+    // E.g. 10,000 leading slashes — the old regex-based stripper
+    // would have done linear-but-large work; the new explicit
+    // loop is also bounded, but the upfront length cap fails fast
+    // before any per-character processing runs.
+    const huge = "/".repeat(10_000) + "x.md";
+    expect(() => normalisePath(huge)).toThrow(/length cap/);
+  });
+  it("raw path at exactly 8192 chars is accepted", () => {
+    const ok = "a".repeat(8189) + ".md"; // 8189 + 3 = 8192
+    expect(() => normalisePath(ok)).not.toThrow();
+  });
 });
 
 describe("stripRoot", () => {

--- a/code/packages/typescript/forme-doc-sidebar-builder/tsconfig.json
+++ b/code/packages/typescript/forme-doc-sidebar-builder/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-doc-sidebar-builder/vitest.config.ts
+++ b/code/packages/typescript/forme-doc-sidebar-builder/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- **New package** `@coding-adventures/forme-doc-sidebar-builder` — takes `{ pages: { path, frontmatter }[] }` and produces a hierarchical, JSON-able sidebar navigation tree. Honours `title` / `sidebar_label` / `sidebar_position` / `draft` frontmatter keys; surfaces `index.md` pages as their parent group's destination.
- **Sixth concrete DOC00 v0 package** (after `forme-doc-frontmatter` PR #3781, `forme-doc-heading-anchors` PR #3829, `forme-doc-toc-extractor` PR #3837, `forme-doc-code-block-decorator` PR #3865, `forme-doc-syntax-highlighter` PR #3867).
- **Three-phase O(N log N) algorithm** — filter+normalise → trie build → sorted emit. Stable, deterministic, locale-independent.
- **Capabilities `[]` and ZERO runtime dependencies** — no transitive cascade risk for this site-structure layer.
- **Acronym-aware humanisation** — `api` → `"API"`, `http` → `"HTTP"`, `io` → `"I/O"`, etc. ~40-entry alias table.
- **`Object.hasOwn` on every frontmatter read** — defends against hand-crafted `{ __proto__: { title: "Polluted" } }` literals.
- **64-level directory-depth cap** in `normalisePath` — prevents stack-overflow DoS from adversarial deeply-nested inputs (the recursive `emit` walk would otherwise `RangeError` on ~10k-deep paths). Real docs sites never exceed ~8 levels.
- **Coverage: 100% line / 100% branch / 100% function** across all executable source files. **99 tests** across 3 files (labels, path-utils, builder).
- **Security review: no findings.** One informational item (stack-overflow on deep paths) addressed by adding the `MAX_DEPTH = 64` cap.

## Test plan

- [x] `npm install && npx vitest run --coverage` — 99/99 pass, 100% coverage
- [x] `humanise()`: kebab/snake/mixed separators, 12+ acronyms, case-insensitive lookup, Unicode preservation, edge cases (empty / separators-only / `__proto__`)
- [x] `normalisePath()`: extension stripping (`.md`/`.mdx`/`.html`/`.htm`, case-insensitive), slash handling (leading/trailing/multiple), index detection (root/nested/case-insensitive/false-positive guards), empty-path errors, `"/"`→empty case, **64-level depth cap** (65 throws, 64 OK)
- [x] `stripRoot()`: matching / non-matching / multi-part / leading slash / whitespace
- [x] `buildSidebar()`: degenerate inputs, ordering matrix (position / alphabetical / positioned-first / tie-breaks), label derivation (title / sidebar_label / fallthrough / non-string ignored / acronyms), drafts (skipped / `draft: false` not skipped / string `"true"` not draft / empty-group collapses), grouping (single-level / mixed / deeply nested), index pages (group destination / null path / not in children / root index / duplicate throws), duplicate detection, root prefix, frontmatter robustness (NaN/Infinity/negative/non-numeric/unknown keys/`__proto__` defence), determinism, immutability (JSON snapshot), JSON-safety, realistic docs scenario
- [x] `/security-review` passes (no findings, one informational item addressed)
- [ ] CI (per babysit cron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)