### PR TITLE
feat(ml-framework-core): MX10 Phase 3c — Rust fast path for reduce-all Sum/Mean backward

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,98 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 3c: optional Rust fast path for reduce-all `SumFunction.backward` / `MeanFunction.backward`
+
+The previous MX10 phases accelerated forward paths for the entire
+op family (matmul, all elementwise, all reductions, all 5 classic
+activations) plus the matmul backward path.  This PR is the first
+non-matmul **backward**-path dispatch: the reduce-all case of
+`SumFunction.backward` and `MeanFunction.backward`.
+
+#### What the backward does
+
+For both ops, the `dim is None` backward broadcasts the scalar
+gradient back to the input shape:
+
+- `SumFunction.backward(grad)`: every input grad cell = `grad[0]`.
+- `MeanFunction.backward(grad)`: every input grad cell = `grad[0] / numel`.
+
+Pure-Python uses a list multiplication (`[scalar] * a.numel`).
+The Rust path uses matrix-cpu's `Broadcast` op with input shape
+`(1,)` and `target_shape=a.shape` — pure data movement, no
+elementwise math involved.
+
+#### Mean folds its divisor into the scalar
+
+Rather than appending a `Mul` op + ones-tensor constant after
+`Broadcast`, the Mean helper pre-divides the scalar in Python
+(one float division done once) and ships the pre-scaled scalar
+through the same single-op `Broadcast` graph as Sum.  This keeps
+both ops at exactly one Rust op and zero constants.
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds:
+    - `should_use_rust_for_backward_broadcast(target_numel)` predicate.
+      Reuses the same `_ELEMENTWISE_RUST_THRESHOLD = 100_000` for
+      consistency; broadcast-from-scalar is pure data movement so
+      the per-cell cost is even lower than forward reduction, but
+      the FFI round-trip is still the dominant cost.
+    - `_broadcast_scalar_via_rust(scalar, target_shape, device)`
+      single-op graph helper.  Builds a 2-tensor 1-op envelope:
+      input shape `(1,)` carrying the scalar, output shape
+      `target_shape`, op = `Broadcast` with `target_shape`.
+    - Two thin public wrappers: `sum_backward_reduce_all_via_rust`
+      and `mean_backward_reduce_all_via_rust`.  Mean wraps with one
+      Python division.
+
+- **`functions.py`** — imports the two new helpers + predicate;
+  adds a 4-line dispatch block at the top of both `SumFunction.backward`
+  and `MeanFunction.backward`'s `dim is None` branch.  Pure-Python
+  list-multiplication kernels stay byte-identical in the fallback path.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `numel ≥ 100_000` | **Rust** (1-op Broadcast) |
+| Extension installed, `numel < 100_000` | Pure-Python `[scalar] * numel` |
+| Extension NOT installed | Pure-Python `[scalar] * numel` |
+| `dim != None` (axis-specific backward) | Pure-Python (always — Phase 3d) |
+
+#### Tests (72 total MX10 tests, was 65)
+
+- **`ReductionParityTests.test_sum_reduce_all_backward_parity`** and
+  **`test_mean_reduce_all_backward_parity`** (2 cases, skip if
+  extension missing): builds a 100_000-cell `requires_grad=True`
+  tensor, runs `.sum().backward(grad)` / `.mean().backward(grad)`
+  via Rust, then re-runs via pure-Python and compares gradients.
+  Sum uses exact equality (no float ops); Mean uses
+  `assertAlmostEqual(places=6)` (one Python division per dispatch).
+- **`ReductionBackwardFallbackTests`** (5 cases, always run):
+  predicate short-circuit, defence-in-depth `RuntimeError` for
+  both helpers, correctness for Sum (3-element tensor, grad=7 →
+  `[7,7,7]`), correctness for Mean (4-element tensor, grad=8,
+  numel=4 → `[2,2,2,2]`).
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**367 passed + 27 skipped (parity tests that need the extension)**;
+the pre-existing `test_device.py` failure on main is unrelated.
+
+### What's NOT in Phase 3c
+
+- Axis-specific backward (`dim != None`).  Deferred to Phase 3d —
+  needs a `Reshape + Broadcast` composition because grad_output
+  rank is smaller than input rank (the reduced axis is collapsed),
+  so the rank-bump-then-broadcast is non-trivial to wire generically.
+- Backward-path Rust dispatch for the activation family (ReLU,
+  Sigmoid, Tanh, GELU, Softmax).  Sigmoid/Tanh are scalar ops on
+  saved output; ReLU is a mask; GELU/Softmax have multi-op
+  backwards.  Each gets its own sub-phase if profiling shows demand.
+- Backward-path Rust dispatch for elementwise ops.  Most are
+  trivial (`+1` / `-1` / pass-through of grad); not worth a Rust
+  round-trip.
+
 ### Added — MX10 Phase 4c: optional Rust fast path for `GELUFunction` via a 9-op composed graph (tanh approximation)
 
 Closes the Phase 4 activation family: with this PR, **every member

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -1176,3 +1176,150 @@ def gelu_via_rust(a: Tensor) -> Tensor:
     out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
 
     return _Tensor(out_floats, a.shape, device=a.device)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Backward-path helpers (MX10 Phase 3c)
+#
+# Phase 3 (forward) and Phase 3b (forward axis-specific) routed the
+# reduce-all and axis-specific Sum/Mean forwards through Rust.
+# Phase 3c starts wiring the **backward** path for the reduce-all
+# case (``dim is None``).
+#
+# Sum's reduce-all backward is ``[grad_output[0]] * a.numel`` —
+# the same scalar repeated ``numel`` times.  Mean's reduce-all
+# backward is the same shape, but with each cell divided by
+# ``a.numel`` first.
+#
+# Both reduce to **broadcast a scalar to a target shape** via
+# matrix-cpu's ``Broadcast`` op.  For Mean we pre-divide the scalar
+# in Python (one division done once) rather than appending a Mul to
+# the graph, so a single helper covers both ops with zero ops
+# difference between them.
+#
+# Axis-specific backward (``dim != None``) is deferred to Phase 3d
+# — it needs a Reshape + Broadcast composition because the
+# grad_output rank is smaller than the input rank, and the rank
+# bump is non-trivial to wire generically.
+# ──────────────────────────────────────────────────────────────────
+
+
+def should_use_rust_for_backward_broadcast(target_numel: int) -> bool:
+    """Predicate gating ``_broadcast_scalar_via_rust``.
+
+    Broadcast-from-scalar is pure data movement (every output cell
+    is the same f32 value), so the per-cell cost is lower than a
+    forward reduction.  We reuse the same ``100_000`` threshold for
+    now — if profiling shows backward break-even at a different
+    point we can split into its own constant.
+    """
+    if not _RUST_AVAILABLE:
+        return False
+    return target_numel >= _ELEMENTWISE_RUST_THRESHOLD
+
+
+def _broadcast_scalar_via_rust(
+    scalar: float, target_shape: tuple[int, ...], *, device: str | None = None
+) -> Tensor:
+    """Broadcast a single f32 ``scalar`` to a tensor of ``target_shape``.
+
+    Single-op graph: input is shape ``(1,)`` carrying ``[scalar]``,
+    output is shape ``target_shape``, the op is ``Broadcast`` with
+    ``target_shape``.
+
+    Output numel = product of ``target_shape``.  Caller passes
+    ``device`` so the returned ``Tensor`` lands on the same device
+    as the original autograd-tracked input (matches the pure-Python
+    contract for SumFunction/MeanFunction backward).
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "_broadcast_scalar_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_backward_broadcast() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    target_shape_list = list(target_shape)
+    target_numel = 1
+    for s in target_shape_list:
+        target_numel *= s
+
+    scalar_bytes = struct.pack("<f", float(scalar))
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    # input: shape (1,) carrying the scalar
+                    {"id": 0, "dtype": "f32", "shape": [1]},
+                    # output: shape target_shape, every cell = scalar
+                    {"id": 1, "dtype": "f32", "shape": target_shape_list},
+                ],
+                "inputs": [0],
+                "outputs": [1],
+                "ops": [
+                    {
+                        "kind": "Broadcast",
+                        "input": 0,
+                        "target_shape": target_shape_list,
+                        "output": 1,
+                    }
+                ],
+                "constants": [],
+            },
+            "inputs": [scalar_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    expected_bytes = target_numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"_broadcast_scalar_via_rust: expected {expected_bytes} output "
+            f"bytes ({target_numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{target_numel}f", out_bytes))
+
+    return _Tensor(out_floats, target_shape, device=device)
+
+
+def sum_backward_reduce_all_via_rust(
+    grad_scalar: float, target_shape: tuple[int, ...], *, device: str | None = None
+) -> Tensor:
+    """``SumFunction.backward(grad)`` for the ``dim=None`` case.
+
+    Pure-Python equivalent: ``[grad_scalar] * a.numel``.
+    Rust path: broadcast ``grad_scalar`` from shape ``(1,)`` to
+    ``target_shape`` in a single Broadcast op.
+    """
+    return _broadcast_scalar_via_rust(grad_scalar, target_shape, device=device)
+
+
+def mean_backward_reduce_all_via_rust(
+    grad_scalar: float,
+    target_shape: tuple[int, ...],
+    target_numel: int,
+    *,
+    device: str | None = None,
+) -> Tensor:
+    """``MeanFunction.backward(grad)`` for the ``dim=None`` case.
+
+    Pure-Python equivalent: ``[grad_scalar / a.numel] * a.numel``.
+    Rust path: pre-divide ``grad_scalar`` by ``target_numel`` in
+    Python (one division), then broadcast the result.  Same Rust
+    op as ``sum_backward_reduce_all_via_rust`` — we just hand it a
+    pre-scaled scalar.
+
+    Composing as ``Broadcast → Mul(c_inv_count)`` would also work,
+    but appending the Mul + materialising the inverse-count
+    constant tensor at full input shape would be net-loss for
+    backward.  One Python division up front is strictly cheaper.
+    """
+    scaled = float(grad_scalar) / float(target_numel)
+    return _broadcast_scalar_via_rust(scaled, target_shape, device=device)

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -50,11 +50,13 @@ from ._rust_backend import (
     gelu_via_rust,
     matmul_via_rust,
     mean_axis_via_rust,
+    mean_backward_reduce_all_via_rust,
     mean_via_rust,
     mul_via_rust,
     neg_via_rust,
     relu_via_rust,
     should_use_rust_for_activation,
+    should_use_rust_for_backward_broadcast,
     should_use_rust_for_elementwise,
     should_use_rust_for_matmul,
     should_use_rust_for_reduction,
@@ -62,6 +64,7 @@ from ._rust_backend import (
     softmax_via_rust,
     sub_via_rust,
     sum_axis_via_rust,
+    sum_backward_reduce_all_via_rust,
     sum_via_rust,
     tanh_via_rust,
 )
@@ -488,7 +491,16 @@ class SumFunction(Function):
         dim = self.saved_metadata["dim"]
 
         if dim is None:
-            # Scalar sum: broadcast gradient to all elements
+            # Scalar sum: broadcast gradient to all elements.
+            # MX10 Phase 3c — optional Rust fast path.  Same scalar
+            # broadcast via matrix-cpu's Broadcast op (input shape
+            # (1,) → target_shape).
+            if should_use_rust_for_backward_broadcast(a.numel):
+                return (
+                    sum_backward_reduce_all_via_rust(
+                        grad_output.data[0], a.shape, device=a.device
+                    ),
+                )
             return (
                 Tensor(
                     [grad_output.data[0]] * a.numel,
@@ -572,6 +584,16 @@ class MeanFunction(Function):
 
         if dim is None:
             n = a.numel
+            # MX10 Phase 3c — optional Rust fast path.  Pre-divide
+            # the scalar once in Python, then broadcast via matrix-cpu
+            # (same single Broadcast op as Sum.backward; the Mean
+            # /n is folded into the scalar before dispatch).
+            if should_use_rust_for_backward_broadcast(n):
+                return (
+                    mean_backward_reduce_all_via_rust(
+                        grad_output.data[0], a.shape, n, device=a.device
+                    ),
+                )
             return (
                 Tensor(
                     [grad_output.data[0] / n] * n,

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -325,6 +325,76 @@ class ReductionFallbackTests(unittest.TestCase):
 
 
 # ──────────────────────────────────────────────────────────────────
+# MX10 Phase 3c — Sum/Mean reduce-all backward fallback tests
+#
+# Phase 3c adds backward-path dispatch for SumFunction and
+# MeanFunction when ``dim is None``.  Both go through a single
+# Broadcast op (scalar → input shape) in Rust; Mean folds its
+# ``/numel`` into the scalar before dispatch.
+#
+# Fallback: when ``_RUST_AVAILABLE = False``, dispatch must
+# short-circuit and the pure-Python ``[grad[0]] * a.numel`` list
+# multiplication must still produce the correct gradient.
+# ──────────────────────────────────────────────────────────────────
+
+
+class ReductionBackwardFallbackTests(unittest.TestCase):
+    """Confirm Sum/Mean reduce-all backward still works without Rust."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_predicate_returns_false_when_unavailable(self) -> None:
+        """Even a giant target must fall back when the extension is missing."""
+        self.assertFalse(
+            _rust_backend.should_use_rust_for_backward_broadcast(10_000_000)
+        )
+
+    def test_sum_backward_via_rust_raises_when_unavailable(self) -> None:
+        """``sum_backward_reduce_all_via_rust`` must raise."""
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.sum_backward_reduce_all_via_rust(1.0, (3,))
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_mean_backward_via_rust_raises_when_unavailable(self) -> None:
+        """``mean_backward_reduce_all_via_rust`` must raise."""
+        with self.assertRaises(RuntimeError):
+            _rust_backend.mean_backward_reduce_all_via_rust(1.0, (3,), 3)
+
+    def test_sum_reduce_all_backward_correct_via_fallback(self) -> None:
+        """``a.sum().backward(grad)`` fills the input grad with ``grad[0]``.
+
+        Hand-computed: for ``a = [1, 2, 3]`` (any values), ``a.sum()``
+        backward with ``grad = [7.0]`` puts ``7.0`` in every input
+        gradient cell.
+        """
+        a = Tensor([1.0, 2.0, 3.0], (3,), requires_grad=True)
+        scalar_sum = a.sum()
+        scalar_sum.backward(Tensor([7.0], (1,)))
+        self.assertIsNotNone(a.grad)
+        self.assertEqual(a.grad.shape, (3,))
+        self.assertEqual(a.grad.data, [7.0, 7.0, 7.0])
+
+    def test_mean_reduce_all_backward_correct_via_fallback(self) -> None:
+        """``a.mean().backward(grad)`` fills the input grad with
+        ``grad[0] / numel``.
+
+        Hand-computed: for ``a = [1, 2, 3, 4]`` and ``grad = [8.0]``,
+        each gradient cell = ``8.0 / 4 = 2.0``.
+        """
+        a = Tensor([1.0, 2.0, 3.0, 4.0], (4,), requires_grad=True)
+        scalar_mean = a.mean()
+        scalar_mean.backward(Tensor([8.0], (1,)))
+        self.assertIsNotNone(a.grad)
+        self.assertEqual(a.grad.shape, (4,))
+        self.assertEqual(a.grad.data, [2.0, 2.0, 2.0, 2.0])
+
+
+# ──────────────────────────────────────────────────────────────────
 # MX10 Phase 3b — axis-specific reduction fallback tests
 #
 # Phase 3 covered the dim=None case; Phase 3b adds dim != None.

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -469,6 +469,78 @@ class ReductionParityTests(unittest.TestCase):
 
         self._assert_close_scalar(rust_result.data[0], python_result.data[0])
 
+    def test_sum_reduce_all_backward_parity(self) -> None:
+        """``SumFunction.backward(grad)`` for ``dim=None`` produces
+        the same broadcast gradient via Rust and pure-Python.
+
+        Phase 3c — backward broadcasts the scalar gradient back to
+        the input shape.  Rust uses a single Broadcast op (input
+        shape (1,) → input shape); pure-Python uses the
+        ``[grad[0]] * a.numel`` list multiplication.  Both should
+        produce element-wise identical results (no floating-point
+        ops involved — pure data movement).
+        """
+        from ml_framework_core import Tensor, _rust_backend
+
+        # Build a requires_grad tensor at the threshold (100_000 cells).
+        a_data = [0.0] * (500 * 200)
+        a = Tensor(a_data, self.SHAPE, requires_grad=True)
+        scalar_sum = a.sum()
+        # Backward with grad = 42.0 (any non-trivial value; the
+        # broadcast itself doesn't depend on the value).
+        scalar_sum.backward(Tensor([42.0], (1,)))
+        rust_grad = a.grad
+        self.assertIsNotNone(rust_grad)
+        self.assertEqual(rust_grad.shape, self.SHAPE)
+
+        # Pure-Python reference: each cell = 42.0.
+        a2 = Tensor(list(a_data), self.SHAPE, requires_grad=True)
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            scalar_sum_py = a2.sum()
+            scalar_sum_py.backward(Tensor([42.0], (1,)))
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        # Element-wise equality (no f32 quantisation issue —
+        # 42.0 round-trips through f32 exactly).
+        self.assertEqual(rust_grad.data, a2.grad.data)
+
+    def test_mean_reduce_all_backward_parity(self) -> None:
+        """``MeanFunction.backward(grad)`` for ``dim=None`` —
+        Rust pre-divides the scalar then broadcasts; pure-Python
+        divides per-cell.  Both produce ``grad / numel`` in every
+        cell.
+
+        Using ``grad = 100.0`` and numel = 100_000: per-cell value
+        is exactly ``0.001`` which round-trips through f32 cleanly
+        enough that ``assertAlmostEqual(places=6)`` catches any
+        real numerical bug.
+        """
+        from ml_framework_core import Tensor, _rust_backend
+
+        a_data = [0.0] * (500 * 200)
+        a = Tensor(a_data, self.SHAPE, requires_grad=True)
+        scalar_mean = a.mean()
+        scalar_mean.backward(Tensor([100.0], (1,)))
+        rust_grad = a.grad
+        self.assertIsNotNone(rust_grad)
+        self.assertEqual(rust_grad.shape, self.SHAPE)
+
+        a2 = Tensor(list(a_data), self.SHAPE, requires_grad=True)
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            scalar_mean_py = a2.mean()
+            scalar_mean_py.backward(Tensor([100.0], (1,)))
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        # Element-wise approx equality (100.0 / 100_000 = 0.001)
+        for got, want in zip(rust_grad.data, a2.grad.data, strict=False):
+            self.assertAlmostEqual(got, want, places=6)
+
 
 # ──────────────────────────────────────────────────────────────────
 # MX10 Phase 3b — axis-specific reduction parity tests


### PR DESCRIPTION
## Summary

- **First non-matmul backward-path Rust dispatch.** `SumFunction.backward` and `MeanFunction.backward` for `dim is None` now route through matrix-cpu's `Broadcast` op (input shape `(1,)` → input shape) when input numel ≥ 100_000.
- Both helpers use the **same single-op Broadcast graph**. Mean folds its `/numel` into the scalar in Python (one float division done once) before dispatch rather than appending a Mul op + ones-tensor constant.
- New predicate `should_use_rust_for_backward_broadcast` reuses the same 100_000 threshold for consistency; broadcast-from-scalar is pure data movement so per-cell cost is even lower than forward reduction.
- Axis-specific backward (`dim != None`) deferred to Phase 3d (needs Reshape + Broadcast composition).
- +7 tests (2 parity, 5 fallback including hand-computed Sum/Mean gradients).
- Full suite: **367 passed + 27 skipped + 1 pre-existing unrelated failure**.
- Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes (367/368 with the 1 pre-existing failure)
- [x] New `test_{sum,mean}_reduce_all_backward_parity` (2 cases) skip gracefully without the C extension
- [x] New `ReductionBackwardFallbackTests` (5 cases) always run; hand-computed Sum/Mean gradient values verified
- [x] Sum exact equality, Mean `assertAlmostEqual(places=6)` (one Python division per dispatch)
- [ ] CI green on full repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)