### PR TITLE
feat(ruby-parser): Phase 6a — `def name(params) … end` method definitions

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,9 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = assignment | method_call | expression_stmt ;
+statement    = def_statement | assignment | method_call | expression_stmt ;
+def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
+params       = NAME { COMMA NAME } ;
 assignment   = NAME EQUALS expression ;
 method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPAREN ;
 expression_stmt = expression ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.2.0] - 2026-05-20
+
+### Added (Phase 6a — `def name(params) … end` method definitions)
+- New `def_statement` grammar rule in `code/grammars/ruby.grammar`:
+  - `def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end"`
+  - `params = NAME { COMMA NAME }`
+- Added as the first alternative in `statement`, so `def`-led statements dispatch ahead of the `assignment` / `method_call` / `expression_stmt` branches.
+- The body's `Repetition { statement }` uses a **negative lookahead** `!"end"` so it stops greedy-matching once the trailing `end` keyword comes into view.  Without the lookahead, `expression_stmt → factor → KEYWORD` would happily consume `end` itself as part of the body and leave nothing for the closing literal.
+- Regenerated `src/_grammar.rs` via `grammar-tools compile-grammar`.
+
+### Tests (+4 new, total 10)
+- `test_parse_def_no_params_no_body` — `def foo()\nend`.
+- `test_parse_def_with_params` — `def add(x, y)\nend` produces a `params` subnode with names `["x", "y"]`.
+- `test_parse_def_with_body` — `def add(x, y)\n  x + y\nend` carries at least one body `statement`.
+- `test_parse_def_without_parens` — `def foo\nend` works (parens optional per Ruby).
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -18,11 +18,41 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"statement"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"def_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression_stmt"#.to_string() },
             ] },
             line_number: 28,
+        },
+        GrammarRule {
+            name: r#"def_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"def"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"params"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 29,
+        },
+        GrammarRule {
+            name: r#"params"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 30,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -31,7 +61,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 29,
+            line_number: 31,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -50,12 +80,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 30,
+            line_number: 32,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 31,
+            line_number: 33,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
@@ -69,7 +99,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 32,
+            line_number: 34,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -83,7 +113,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 33,
+            line_number: 35,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -98,7 +128,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 34,
+            line_number: 36,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -129,5 +129,91 @@ mod tests {
         assert_program_root(&ast);
         assert!(!ast.children.is_empty());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6a — method definitions
+    // -----------------------------------------------------------------------
+
+    /// Look up the first `def_statement` node in a parsed program.
+    fn find_def_statement(ast: &GrammarASTNode) -> Option<&GrammarASTNode> {
+        for child in &ast.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                if n.rule_name == "statement" {
+                    for inner in &n.children {
+                        if let ASTNodeOrToken::Node(d) = inner {
+                            if d.rule_name == "def_statement" {
+                                return Some(d);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_parse_def_no_params_no_body() {
+        let ast = parse_ruby("def foo()\nend");
+        assert_program_root(&ast);
+        let def = find_def_statement(&ast).expect("expected def_statement");
+        let name_token = def.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Name) => {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        });
+        assert_eq!(name_token, Some("foo"));
+    }
+
+    #[test]
+    fn test_parse_def_with_params() {
+        let ast = parse_ruby("def add(x, y)\nend");
+        assert_program_root(&ast);
+        let def = find_def_statement(&ast).expect("expected def_statement");
+        let params_node = def
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
+                _ => None,
+            })
+            .expect("expected params subnode");
+        let names: Vec<&str> = params_node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Name) =>
+                {
+                    Some(t.value.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn test_parse_def_with_body() {
+        let ast = parse_ruby("def add(x, y)\n  x + y\nend");
+        assert_program_root(&ast);
+        let def = find_def_statement(&ast).expect("expected def_statement");
+        let body_stmts: usize = def
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert!(body_stmts >= 1, "expected body statements, got {body_stmts}");
+    }
+
+    #[test]
+    fn test_parse_def_without_parens() {
+        // `def foo` without `()` is valid Ruby — the parens are
+        // optional in the grammar.
+        let ast = parse_ruby("def foo\nend");
+        assert_program_root(&ast);
+        assert!(find_def_statement(&ast).is_some());
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.2.0] - 2026-05-20
+
+### Added (Phase 6a — `def name(params) … end` method definitions)
+- New `collect_def_statements` pre-pass hoists every `def_statement` from the program to a top-level `semantic_ir::Function` *before* the main-body lowerer runs.
+- `lower_def_statement` translates the AST node into a `Function`:
+  - The first `Name` token after the leading `def` keyword becomes the function name (the `def` keyword itself is skipped so the function isn't named `"def"`).
+  - The optional `params` sub-rule's `Name` tokens become `Param`s.
+  - The body is lowered using a *fresh* `declared_locals` set so the outer program's bindings don't leak in.  Params are pre-declared as locals (so `x = 2` inside `def f(x)` routes through `Stmt::Assign`) *and* tracked in a new `current_params` set so `VarRef` to them gets `Scope::Param` (the validator's expectation for parameters).
+  - The tail expression (if any) is promoted to the body block's `value`; otherwise `value = NilLit`.
+- `Module::manifest` now declares `Feature::DynamicTyping` — Ruby is dynamically typed, and the SIR validator requires this whenever a module produces untyped params or globals.
+- `def_statement` nodes left behind in the program body lower to a no-op `Stmt::ExprStmt(NilLit)` so the SIR-level statement stream stays in sync with the source line count.
+
+### Tests (+5 new, total 14)
+- `def_lowers_to_top_level_function` — `def add(x, y); x + y; end` produces an `add` function with two params and a `+` builtin call body.
+- `def_with_no_params_lowers_cleanly` — `def hello; end` produces a paramless function whose body value is `NilLit`.
+- `def_does_not_leak_locals_to_outer_scope` — locals in a method body don't leak into the program-level scope (each gets its own first-occurrence `LetBinding`).
+- `def_with_param_reassignment_routes_through_assign` — `def f(x); x = 2; end` re-binds via `Stmt::Assign` (the param is pre-declared as local).
+- `module_with_def_passes_sir_validator` — a `def`-containing module passes `semantic_ir::validate`.
+
 ## [0.1.0] - 2026-05-20
 
 ### Added (Phase 5 — initial Ruby → SIR frontend)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -231,4 +231,111 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6a — `def name(params) … end` method definitions.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn def_lowers_to_top_level_function() {
+        let m = lower("def add(x, y)\n  x + y\nend\n");
+        // The user-defined function comes first; `main` is last.
+        let add = m
+            .functions
+            .iter()
+            .find(|f| f.name == "add")
+            .expect("expected `add` function");
+        assert_eq!(add.params.len(), 2);
+        assert_eq!(add.params[0].name, "x");
+        assert_eq!(add.params[1].name, "y");
+        match &add.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected BuiltinCall(+, …), got {:?}", other),
+        }
+        // `main` is still present and exported.
+        assert!(m.functions.iter().any(|f| f.name == "main"));
+        assert!(m.exports.iter().any(|e| e.name == "main"));
+    }
+
+    #[test]
+    fn def_with_no_params_lowers_cleanly() {
+        let m = lower("def hello\nend\n");
+        let hello = m
+            .functions
+            .iter()
+            .find(|f| f.name == "hello")
+            .expect("expected `hello` function");
+        assert!(hello.params.is_empty());
+        // Empty body → block.value is NilLit.
+        assert!(matches!(hello.body.value, Expr::NilLit { .. }));
+    }
+
+    #[test]
+    fn def_does_not_leak_locals_to_outer_scope() {
+        // The method body declares `x` as a local (via `x = 1`); the
+        // outer program also has `x = 2`.  Both should be first
+        // occurrences (LetBinding), because the method's locals are
+        // confined to its body.
+        let m = lower("def inner\n  x = 1\nend\nx = 2\n");
+        let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+        // First main statement is the no-op for the hoisted def.
+        // Second is the outer `x = 2` LetBinding.
+        let outer_x = main.body.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { name, .. } if name == "x" => Some(name.as_str()),
+            _ => None,
+        });
+        assert_eq!(outer_x, Some("x"));
+        let inner = m.functions.iter().find(|f| f.name == "inner").unwrap();
+        let inner_x_kind = match &inner.body.stmts[0] {
+            Stmt::LetBinding { name, .. } => format!("LetBinding({})", name),
+            Stmt::Assign { name, .. } => format!("Assign({})", name),
+            other => format!("{:?}", other),
+        };
+        // The method's `x = 1` is a LetBinding (first occurrence in
+        // the *method scope*), not an Assign.
+        assert!(
+            inner_x_kind.starts_with("LetBinding"),
+            "expected LetBinding in method body, got {inner_x_kind}"
+        );
+    }
+
+    #[test]
+    fn def_with_param_reassignment_routes_through_assign() {
+        // Parameters are pre-declared as locals inside the method,
+        // so `x = 2` re-binds and emits `Stmt::Assign`.
+        let m = lower("def f(x)\n  x = 2\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").unwrap();
+        match &f.body.stmts[0] {
+            Stmt::Assign { name, scope, .. } => {
+                assert_eq!(name, "x");
+                assert_eq!(*scope, Scope::Local);
+            }
+            other => panic!("expected Assign(x), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn module_with_def_passes_sir_validator() {
+        // v0 grammar can't yet parse nested method calls in args
+        // (`puts(add(1, 2))` — `add(1, 2)` isn't a `factor`).  The
+        // grammar extension lands in Phase 6+.  Until then, exercise
+        // the `def` lowering with sibling statements that the
+        // grammar already accepts.
+        let m = lower(concat!(
+            "def add(x, y)\n",
+            "  x + y\n",
+            "end\n",
+            "z = 3 + 4\n",
+            "puts(z)\n",
+        ));
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -13,8 +13,8 @@ use std::collections::HashSet;
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, Effect, EffectSet, ExportName, Expr, FeatureManifest, Function, Metadata, Module,
-    Scope, Span, Stmt,
+    Block, Effect, EffectSet, ExportName, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Param, Scope, Span, Stmt,
 };
 
 /// A failure encountered during Ruby → SIR lowering.
@@ -66,7 +66,14 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
     let mut lw = Lowerer {
         file_name: module_name.to_string(),
         declared_locals: HashSet::new(),
+        current_params: HashSet::new(),
+        user_functions: Vec::new(),
     };
+    // Phase 6a: hoist `def name(params) … end` declarations to
+    // top-level Functions BEFORE walking the rest of the program so
+    // the main-body lowerer knows which names resolve as
+    // `DirectCall` targets vs. unknown builtins.
+    lw.collect_def_statements(program)?;
     let block = lw.lower_program(program)?;
 
     let main = Function {
@@ -80,9 +87,22 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         span: lw.span_of(program),
     };
 
+    // User-defined functions come first, then `main`.  The SIR
+    // validator doesn't care about ordering — backends that emit
+    // forward declarations will still see `main` exported.
+    let mut functions = std::mem::take(&mut lw.user_functions);
+    functions.push(main);
+
+    // SIR's validator requires modules that use untyped params or
+    // globals (which everything Ruby produces in v0) to declare the
+    // `DynamicTyping` feature.  Ruby is dynamically typed, so we
+    // always declare it.
+    let mut manifest = FeatureManifest::new();
+    manifest.add(Feature::DynamicTyping);
+
     Ok(Module {
         name: module_name.to_string(),
-        manifest: FeatureManifest::new(),
+        manifest,
         imports: Vec::new(),
         // `main` is the conventional entry point — exporting it lets
         // SIR backends recognise it as such.
@@ -90,7 +110,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
             name: "main".to_string(),
             span: Span::synthetic(),
         }],
-        functions: vec![main],
+        functions,
         globals: Vec::new(),
         metadata: Metadata::new(),
         span: lw.span_of(program),
@@ -107,6 +127,17 @@ struct Lowerer {
     /// current scope.  Drives the `LetBinding` vs `Assign` choice:
     /// first occurrence binds, subsequent occurrences re-assign.
     declared_locals: HashSet<String>,
+    /// Phase 6a: parameter names visible in the *current* function
+    /// scope.  Empty at the top level (main).  When a Name token is
+    /// emitted as a `VarRef`, this set decides whether the `scope`
+    /// is `Scope::Param` (the validator's expectation for function
+    /// parameters) or `Scope::Local`.
+    current_params: HashSet<String>,
+    /// Phase 6a: user-defined functions collected from
+    /// `def name(params) … end` declarations.  Filled by
+    /// `collect_def_statements` (a top-level hoisting pass) before
+    /// the main-body lowerer runs.
+    user_functions: Vec<Function>,
 }
 
 impl Lowerer {
@@ -229,12 +260,197 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "def_statement" => {
+                // `def` declarations were hoisted to top-level
+                // Functions in the pre-pass; here we drop them from
+                // the main-body statement stream.  Returning a no-op
+                // ExprStmt keeps the `Block.stmts` slot occupied but
+                // valid SIR-wise.
+                Ok(Stmt::ExprStmt {
+                    expr: Expr::NilLit {
+                        span: self.span_of(node),
+                    },
+                    span: self.span_of(node),
+                })
+            }
             other => Err(RubyLowerError {
                 message: format!("unsupported statement form `{other}`"),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
             }),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6a — def_statement hoisting
+    // -------------------------------------------------------------------
+
+    /// Pre-pass: walk `program` children and lift every
+    /// `def_statement` into a top-level `Function` on
+    /// `self.user_functions`.  Method bodies are recursively
+    /// lowered using a *fresh* declared-locals set so the outer
+    /// program's let-bindings don't leak in.
+    fn collect_def_statements(
+        &mut self,
+        program: &GrammarASTNode,
+    ) -> Result<(), RubyLowerError> {
+        for child in &program.children {
+            let stmt = match child {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => n,
+                _ => continue,
+            };
+            let inner = match self.first_node_child(stmt) {
+                Some(n) => n,
+                None => continue,
+            };
+            if inner.rule_name != "def_statement" {
+                continue;
+            }
+            let func = self.lower_def_statement(inner)?;
+            self.user_functions.push(func);
+        }
+        Ok(())
+    }
+
+    fn lower_def_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Function, RubyLowerError> {
+        // Shape:
+        //   KEYWORD("def") NAME [ LPAREN [ params ] RPAREN ]
+        //                  { !"end" statement } KEYWORD("end")
+        // The first child token is the `def` keyword itself; the
+        // method name is the *Name* token that follows.  We can't
+        // use `expect_first_name_token` because it accepts both
+        // Name and Keyword — it would return "def".
+        let name_token = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+            _ => None,
+        });
+        let name_token = name_token.ok_or_else(|| RubyLowerError {
+            message: "def_statement missing method-name token".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })?;
+        let name = name_token.value.clone();
+
+        // Collect parameters.  The optional `params` rule node lists
+        // each parameter name as a sequence of Name tokens separated
+        // by COMMA tokens — we only care about the names.
+        let params_node = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
+            _ => None,
+        });
+        let params: Vec<Param> = if let Some(pn) = params_node {
+            pn.children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Token(t)
+                        if matches!(t.type_, TokenType::Name) =>
+                    {
+                        Some(Param {
+                            name: t.value.clone(),
+                            sir_type: None,
+                            span: self.span_of_token(t),
+                        })
+                    }
+                    _ => None,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Lower the body using a fresh locals + params scope so the
+        // outer program's bindings don't leak into the method.
+        // Parameters are pre-declared as "locals" so a re-assignment
+        // to a param routes through `Stmt::Assign` (SIR-correct),
+        // *and* are tracked in `current_params` so any `VarRef` to
+        // them inside the body gets `Scope::Param` (validator-correct).
+        let saved_locals = std::mem::take(&mut self.declared_locals);
+        let saved_params = std::mem::take(&mut self.current_params);
+        for p in &params {
+            self.declared_locals.insert(p.name.clone());
+            self.current_params.insert(p.name.clone());
+        }
+
+        // The body is every `statement` child of the def_statement
+        // that *isn't* the method's own def_statement (we already
+        // matched that), in source order.
+        let body_stmts: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        let mut stmts_out: Vec<Stmt> = Vec::new();
+        let mut value: Option<Expr> = None;
+        if body_stmts.is_empty() {
+            value = Some(Expr::NilLit {
+                span: self.span_of(node),
+            });
+        } else {
+            let last_idx = body_stmts.len() - 1;
+            for (i, s) in body_stmts.iter().enumerate() {
+                let inner = self.first_node_child(s).ok_or_else(|| {
+                    RubyLowerError {
+                        message: "statement node had no child rule".to_string(),
+                        line: s.start_line.unwrap_or(0),
+                        column: s.start_column.unwrap_or(0),
+                    }
+                })?;
+                let is_tail = i == last_idx;
+                let kind = inner.rule_name.as_str();
+                if is_tail && matches!(kind, "expression_stmt" | "method_call") {
+                    let v = match kind {
+                        "expression_stmt" => {
+                            let expr_node =
+                                self.first_node_child(inner).ok_or_else(|| {
+                                    RubyLowerError {
+                                        message:
+                                            "expression_stmt had no expression child"
+                                                .to_string(),
+                                        line: inner.start_line.unwrap_or(0),
+                                        column: inner.start_column.unwrap_or(0),
+                                    }
+                                })?;
+                            self.lower_expression(expr_node)?
+                        }
+                        "method_call" => self.lower_method_call(inner)?,
+                        _ => unreachable!(),
+                    };
+                    value = Some(v);
+                } else {
+                    stmts_out.push(self.lower_statement_inner(inner)?);
+                }
+            }
+        }
+        let value = value.unwrap_or(Expr::NilLit {
+            span: self.span_of(node),
+        });
+
+        // Restore the outer scope's locals + params so the rest of
+        // the program lowers correctly.
+        self.declared_locals = saved_locals;
+        self.current_params = saved_params;
+
+        Ok(Function {
+            name,
+            params,
+            return_type: None,
+            captures: Vec::new(),
+            body: Block {
+                stmts: stmts_out,
+                value,
+                span: self.span_of(node),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: self.span_of(node),
+        })
     }
 
     // -------------------------------------------------------------------
@@ -432,13 +648,22 @@ impl Lowerer {
                             });
                         }
                         TokenType::Name => {
-                            // `nil` / `true` / `false` would be Keyword
-                            // tokens, not Name.  All Name tokens here
-                            // are locals (or unresolved — backend will
-                            // tell us).
+                            // Inside a function body, parameter
+                            // names lex as `VarRef` with
+                            // `Scope::Param` so the SIR validator
+                            // can verify they bind to a `Param`
+                            // declaration.  At the top level
+                            // (main) the params set is empty and
+                            // every name falls through to
+                            // `Scope::Local`.
+                            let scope = if self.current_params.contains(&tok.value) {
+                                Scope::Param
+                            } else {
+                                Scope::Local
+                            };
                             return Ok(Expr::VarRef {
                                 name: tok.value.clone(),
-                                scope: Scope::Local,
+                                scope,
                                 span,
                             });
                         }


### PR DESCRIPTION
## Summary

First parser-grammar extension after the [Phase 5](https://github.com/adhithyan15/coding-adventures/pull/3711) SIR frontend landed.  Extends `ruby-parser` to accept `def`-led method definitions, then plumbs them through to `semantic_ir::Function`.  This is the first PR where the SIR validator exercises function-shaped output.

## Parser changes

New `def_statement` rule in [`code/grammars/ruby.grammar`](code/grammars/ruby.grammar):

\`\`\`
def_statement = "def" NAME [ LPAREN [ params ] RPAREN ]
                  { !"end" statement } "end"
params        = NAME { COMMA NAME }
\`\`\`

Added as the first alternative in `statement` so `def`-led statements dispatch ahead of `assignment` / `method_call` / `expression_stmt`.

The body's `Repetition { statement }` uses a **negative lookahead** `!"end"` so it stops greedy-matching once the trailing `end` keyword comes into view.  Without it, the `expression_stmt → factor → KEYWORD` chain happily consumes `end` itself as part of the body and leaves nothing for the closing literal — that took one debug round to spot.

`src/_grammar.rs` regenerated via `grammar-tools compile-grammar`.

## SIR lowering changes

- New `collect_def_statements` pre-pass hoists every `def_statement` from the program to a top-level `semantic_ir::Function` *before* the main-body lowerer runs.
- `lower_def_statement` skips the leading `def` keyword token so the function isn't named `"def"`.
- Body lowers under a fresh `declared_locals` set + new `current_params` set:
  - Params are pre-declared as locals so `x = 2` inside `def f(x)` routes through `Stmt::Assign` (re-binding, not re-declaring).
  - Every `VarRef` to a param lexes with `Scope::Param` so the SIR validator can verify the binding.
- `Module::manifest` now declares `Feature::DynamicTyping` (required by the validator for untyped params / globals).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — 87 passed (unchanged).
- [x] `cargo test -p coding-adventures-ruby-parser` — 10 passed (was 6; +4 new `def` tests).
- [x] `cargo test -p ruby-to-semantic-ir` — 14 passed (was 9; +5 new `def` lowering tests).
- [x] The SIR validator accepts the lowered output for every `def`-containing test source.

## What's next in the alternating series

Last merged was [Phase 4b lexer](https://github.com/adhithyan15/coding-adventures/pull/3870); this is a parser PR.  Next chunk per the alternation rule is another lexer era-delta — Phase 4c: 2.3 safe-nav `&.`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)