### PR TITLE
feat(ml-framework-core): MX10 Phase 3d — Rust fast path for axis-specific Sum/Mean backward

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 3d: optional Rust fast path for axis-specific `SumFunction.backward` / `MeanFunction.backward` (`dim != None`)
+
+Closes the gap Phase 3c explicitly deferred: the `dim != None`
+branch of `SumFunction.backward` and `MeanFunction.backward` now
+dispatches through Rust at the same `100_000`-cell threshold.
+With this PR, **all reduce-all and axis-specific Sum/Mean
+forward/backward paths** in `ml-framework-core` get the optional
+Rust fast path.
+
+#### Key insight: declare the input shape with size 1 at dim
+
+matrix-cpu's `Broadcast` op requires the source rank to match the
+target rank.  The flat data of `grad_output` is the same whether
+its declared shape is `(K,)` (keepdim=False) or `(1, K)`
+(keepdim=True for a 2-D input with dim=0) — same K floats in the
+same order.
+
+So the helper **always declares the input shape as "target shape
+with size 1 at dim"** regardless of the user's keepdim flag — no
+Reshape op is needed, just a single Broadcast.  This avoids the
+2-op `Reshape → Broadcast` composition the prerequisite design
+sketch assumed.
+
+#### Mean folds /count into the grad in Python
+
+For axis Mean, divide is by `count = target_shape[dim]`.  Rather
+than appending a `Mul` op + materialising an inverse-count
+constant tensor at full target shape, the helper pre-divides each
+grad cell by `count` in Python before packing.  This is cheap —
+the divisor loop is `len(grad_data)` divisions, where `grad_data`
+has the reduced shape (typically much smaller than `target_numel`).
+The alternative of shipping the constant would add
+`target_numel * 4` bytes per call.
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds:
+    - `_broadcast_reduced_grad_via_rust(grad_data, input_shape_with_size1_at_dim, target_shape, device)`:
+      single-op graph helper.  Validates that the declared input
+      shape's product equals `len(grad_data)` (catches caller
+      bugs where the size-1 insertion was forgotten).
+    - `sum_backward_axis_via_rust(grad_data, target_shape, dim, device)`
+      thin wrapper.  Computes the size-1-at-dim shape, ships
+      grad as-is.
+    - `mean_backward_axis_via_rust(grad_data, target_shape, dim, device)`
+      wrapper.  Pre-divides grad by `target_shape[dim]` in Python,
+      then ships through the same single-op graph as Sum.
+
+- **`functions.py`** — imports + 5-line dispatch in
+  `SumFunction.backward` and `MeanFunction.backward` after the
+  negative-dim normalisation; pure-Python axis-loop kernels stay
+  byte-identical in the fallback path.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `numel ≥ 100_000`, `dim != None` | **Rust** (1-op Broadcast) |
+| Extension installed, `numel < 100_000`, `dim != None` | Pure-Python axis loop |
+| `dim is None` | Phase 3c (reduce-all backward) |
+| Extension NOT installed | Pure-Python axis loop |
+
+#### Tests (78 total MX10 tests, was 72)
+
+- **`ReductionAxisParityTests.test_sum_axis_dim0_backward_parity`**
+  and **`test_mean_axis_dim1_backward_parity`** (2 cases, skip if
+  extension missing): builds a 100_000-cell `requires_grad=True`
+  tensor, runs `.sum(dim=0).backward(grad)` / `.mean(dim=1).backward(grad)`
+  via Rust, compares vs pure-Python.  Sum uses exact equality
+  (no float ops); Mean uses `assertAlmostEqual(places=5)` (per-row
+  division round-trips through f32).
+- **`ReductionBackwardFallbackTests`** gains 4 new cases (in
+  addition to Phase 3c's 5): defence-in-depth `RuntimeError` for
+  both axis helpers, plus hand-computed correctness for
+  `sum(dim=0)` on a 2x3 tensor (column broadcast) and
+  `mean(dim=1)` on a 2x3 tensor (row broadcast with /3 scaling).
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**371 passed + 29 skipped (parity tests that need the extension)**;
+the pre-existing `test_device.py` failure on main is unrelated.
+
+### What's NOT in Phase 3d
+
+- Backward-path Rust dispatch for the activation family.  ReLU
+  backward is a mask `g * (x > 0)`; Sigmoid/Tanh backward are
+  small scalar ops on the saved output; GELU/Softmax backwards
+  are multi-op composed graphs.  Each gets its own sub-phase
+  if profiling identifies it as a bottleneck.
+- Multi-axis reductions (e.g. `dim=(0, 2)`).  The Sum/Mean API
+  takes `int | None`, not a tuple, so this is API-shaped not
+  dispatch-shaped — would need surface changes.
+- Other reductions (Min, Max, Std, Var, ArgMin, ArgMax) and
+  their backward paths.  Same story as the forward: Sum/Mean
+  are the most common; others can be added with the same
+  factory.
+
 ### Added — MX10 Phase 3c: optional Rust fast path for reduce-all `SumFunction.backward` / `MeanFunction.backward`
 
 The previous MX10 phases accelerated forward paths for the entire

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -1323,3 +1323,170 @@ def mean_backward_reduce_all_via_rust(
     """
     scaled = float(grad_scalar) / float(target_numel)
     return _broadcast_scalar_via_rust(scaled, target_shape, device=device)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Axis-specific reduction backward (MX10 Phase 3d)
+#
+# Phase 3c shipped the dim=None backward.  This adds the dim != None
+# case: grad_output has shape ``a.shape with axis collapsed`` (or
+# with axis size 1 if keepdim was True), and we need to broadcast
+# it back to ``a.shape``.
+#
+# Key observation: matrix-cpu's Broadcast op requires the source
+# rank to match the target rank.  The flat data of grad_output is
+# the same whether its declared shape is ``(K,)`` (keepdim=False) or
+# ``(1, K)`` (keepdim=True for a 2-D input with dim=0) — it's the
+# same K floats in the same order.  So we can **always declare the
+# input shape as "input shape with size 1 at dim"** regardless of
+# the user's keepdim flag — no Reshape op is needed, just Broadcast.
+#
+# For Mean, divide by ``count = a.shape[dim]`` is folded into the
+# input bytes in Python (one division per grad_output cell) so the
+# Rust graph is still a single Broadcast op.  ``count`` is typically
+# tiny (the reduced dimension), so the Python divide loop is cheap
+# vs the alternative of materialising an inverse-count constant
+# tensor at full input shape and appending a Mul op.
+# ──────────────────────────────────────────────────────────────────
+
+
+def _broadcast_reduced_grad_via_rust(
+    grad_data: list[float],
+    input_shape_with_size1_at_dim: tuple[int, ...] | list[int],
+    target_shape: tuple[int, ...],
+    *,
+    device: str | None = None,
+) -> Tensor:
+    """Broadcast a reduced-shape gradient back to ``target_shape``.
+
+    ``grad_data`` is the flat data of grad_output, which has
+    ``len(grad_data)`` elements.  The Rust input tensor is declared
+    with shape ``input_shape_with_size1_at_dim`` (same rank as
+    ``target_shape``, with size 1 at the reduced axis), so
+    matrix-cpu's Broadcast can expand it directly to ``target_shape``.
+
+    Single-op graph: 2 tensors, 1 Broadcast op.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "_broadcast_reduced_grad_via_rust called but Rust backend is "
+            "not available; callers must check "
+            "should_use_rust_for_backward_broadcast() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    grad_numel = len(grad_data)
+    target_shape_list = list(target_shape)
+    input_shape_list = list(input_shape_with_size1_at_dim)
+
+    # Sanity: product of input_shape must equal grad_numel.
+    declared_input_numel = 1
+    for s in input_shape_list:
+        declared_input_numel *= s
+    if declared_input_numel != grad_numel:
+        raise RuntimeError(
+            f"_broadcast_reduced_grad_via_rust: declared input shape "
+            f"{input_shape_list} has product {declared_input_numel} but "
+            f"grad_data has {grad_numel} elements"
+        )
+
+    target_numel = 1
+    for s in target_shape_list:
+        target_numel *= s
+
+    grad_bytes = struct.pack(f"<{grad_numel}f", *grad_data)
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    # input: reduced grad with size 1 at the collapsed axis
+                    {"id": 0, "dtype": "f32", "shape": input_shape_list},
+                    # output: broadcast back to target_shape
+                    {"id": 1, "dtype": "f32", "shape": target_shape_list},
+                ],
+                "inputs": [0],
+                "outputs": [1],
+                "ops": [
+                    {
+                        "kind": "Broadcast",
+                        "input": 0,
+                        "target_shape": target_shape_list,
+                        "output": 1,
+                    }
+                ],
+                "constants": [],
+            },
+            "inputs": [grad_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_hex = result["outputs"][0]
+    out_bytes = bytes.fromhex(out_hex)
+
+    expected_bytes = target_numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"_broadcast_reduced_grad_via_rust: expected {expected_bytes} "
+            f"output bytes ({target_numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{target_numel}f", out_bytes))
+
+    return _Tensor(out_floats, target_shape, device=device)
+
+
+def sum_backward_axis_via_rust(
+    grad_data: list[float],
+    target_shape: tuple[int, ...],
+    dim: int,
+    *,
+    device: str | None = None,
+) -> Tensor:
+    """``SumFunction.backward(grad)`` for ``dim != None``.
+
+    The grad_output is treated as if it had shape
+    ``target_shape with size 1 at dim`` (which works regardless of
+    the user's original keepdim flag — the flat data ordering is the
+    same).  Single Broadcast op expands to ``target_shape``.
+    """
+    input_shape_with_size1_at_dim = list(target_shape)
+    input_shape_with_size1_at_dim[dim] = 1
+    return _broadcast_reduced_grad_via_rust(
+        grad_data,
+        input_shape_with_size1_at_dim,
+        target_shape,
+        device=device,
+    )
+
+
+def mean_backward_axis_via_rust(
+    grad_data: list[float],
+    target_shape: tuple[int, ...],
+    dim: int,
+    *,
+    device: str | None = None,
+) -> Tensor:
+    """``MeanFunction.backward(grad)`` for ``dim != None``.
+
+    Pre-divides each grad cell by ``count = target_shape[dim]`` in
+    Python (``len(grad_data)`` cheap float divisions) before
+    packing, then broadcasts the pre-scaled values.  This keeps the
+    Rust graph at one Broadcast op — the alternative of appending
+    a Mul + materialising an inverse-count constant tensor at
+    target_shape would cost an extra ``product(target_shape) * 4``
+    bytes per call to ship the constant.
+    """
+    count = float(target_shape[dim])
+    scaled_grad = [g / count for g in grad_data]
+    input_shape_with_size1_at_dim = list(target_shape)
+    input_shape_with_size1_at_dim[dim] = 1
+    return _broadcast_reduced_grad_via_rust(
+        scaled_grad,
+        input_shape_with_size1_at_dim,
+        target_shape,
+        device=device,
+    )

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -50,6 +50,7 @@ from ._rust_backend import (
     gelu_via_rust,
     matmul_via_rust,
     mean_axis_via_rust,
+    mean_backward_axis_via_rust,
     mean_backward_reduce_all_via_rust,
     mean_via_rust,
     mul_via_rust,
@@ -64,6 +65,7 @@ from ._rust_backend import (
     softmax_via_rust,
     sub_via_rust,
     sum_axis_via_rust,
+    sum_backward_axis_via_rust,
     sum_backward_reduce_all_via_rust,
     sum_via_rust,
     tanh_via_rust,
@@ -512,6 +514,18 @@ class SumFunction(Function):
         if dim < 0:
             dim = a.ndim + dim
 
+        # MX10 Phase 3d — optional Rust fast path (axis-specific
+        # backward).  Same threshold as Phase 3c.  The Rust helper
+        # declares grad_output with shape "input shape with size 1
+        # at dim" — which works regardless of the user's keepdim
+        # flag because the flat data ordering matches either way.
+        if should_use_rust_for_backward_broadcast(a.numel):
+            return (
+                sum_backward_axis_via_rust(
+                    grad_output.data, a.shape, dim, device=a.device
+                ),
+            )
+
         # Expand gradient along the reduced dimension
         grad_data = [0.0] * a.numel
         strides = _compute_strides(a.shape)
@@ -605,6 +619,17 @@ class MeanFunction(Function):
         if dim < 0:
             dim = a.ndim + dim
         count = a.shape[dim]
+
+        # MX10 Phase 3d — optional Rust fast path.  Pre-divides each
+        # grad cell by ``count`` in Python (cheap — len(grad_data)
+        # divisions, where grad_data is the reduced shape) then
+        # broadcasts.  Same single-op Broadcast graph as Sum.
+        if should_use_rust_for_backward_broadcast(a.numel):
+            return (
+                mean_backward_axis_via_rust(
+                    grad_output.data, a.shape, dim, device=a.device
+                ),
+            )
 
         # Expand gradient (same as SumFunction) then divide by count
         sum_grad_fn = SumFunction()

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -393,6 +393,55 @@ class ReductionBackwardFallbackTests(unittest.TestCase):
         self.assertEqual(a.grad.shape, (4,))
         self.assertEqual(a.grad.data, [2.0, 2.0, 2.0, 2.0])
 
+    def test_sum_axis_backward_via_rust_raises_when_unavailable(self) -> None:
+        """``sum_backward_axis_via_rust`` must raise (defence-in-depth)."""
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.sum_backward_axis_via_rust(
+                [1.0, 2.0, 3.0], (2, 3), dim=0
+            )
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_mean_axis_backward_via_rust_raises_when_unavailable(self) -> None:
+        """``mean_backward_axis_via_rust`` must raise."""
+        with self.assertRaises(RuntimeError):
+            _rust_backend.mean_backward_axis_via_rust(
+                [1.0, 2.0, 3.0], (2, 3), dim=0
+            )
+
+    def test_sum_axis_backward_correct_via_fallback(self) -> None:
+        """``a.sum(dim=0).backward(grad)`` broadcasts column-wise.
+
+        Hand-computed: for ``a.shape = (2, 3)`` and
+        ``grad = [10, 20, 30]``, the input gradient is
+        ``[[10,20,30],[10,20,30]]`` (every row of the input
+        gets the same column-grad).
+        """
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3), requires_grad=True)
+        s = a.sum(dim=0)
+        s.backward(Tensor([10.0, 20.0, 30.0], (3,)))
+        self.assertIsNotNone(a.grad)
+        self.assertEqual(a.grad.shape, (2, 3))
+        self.assertEqual(
+            a.grad.data, [10.0, 20.0, 30.0, 10.0, 20.0, 30.0]
+        )
+
+    def test_mean_axis_backward_correct_via_fallback(self) -> None:
+        """``a.mean(dim=1).backward(grad)`` broadcasts row-wise / count.
+
+        For ``a.shape = (2, 3)`` and ``grad = [6, 12]``,
+        count along dim=1 is 3, so input gradient is
+        ``[[2,2,2],[4,4,4]]`` (each row k's grad spreads as
+        ``grad[k] / 3`` across all 3 columns).
+        """
+        a = Tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], (2, 3), requires_grad=True)
+        m = a.mean(dim=1)
+        m.backward(Tensor([6.0, 12.0], (2,)))
+        self.assertIsNotNone(a.grad)
+        self.assertEqual(a.grad.shape, (2, 3))
+        self.assertEqual(
+            a.grad.data, [2.0, 2.0, 2.0, 4.0, 4.0, 4.0]
+        )
+
 
 # ──────────────────────────────────────────────────────────────────
 # MX10 Phase 3b — axis-specific reduction fallback tests

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -665,6 +665,81 @@ class ReductionAxisParityTests(unittest.TestCase):
 
         self._assert_close_vec(rust_result.data, python_result.data)
 
+    def test_sum_axis_dim0_backward_parity(self) -> None:
+        """``a.sum(dim=0).backward(grad)`` — axis-specific backward.
+
+        Phase 3d — broadcasts the reduced grad back to a.shape via
+        a single Broadcast op.  Expected: each input gradient cell
+        equals the corresponding grad_output cell (no scaling for
+        Sum), broadcast along the reduced axis.
+
+        Hand-computed: ``a.shape = (500, 200)``, sum along dim=0
+        produces ``(200,)``.  Backward with ``grad = [k for k in
+        range(200)]`` gives gradient where every row of the input
+        is the gradient vector itself.
+        """
+        from ml_framework_core import Tensor, _rust_backend
+
+        # Use small, non-random values so any indexing bug is
+        # obvious.  Backward only depends on shape and the grad
+        # passed in.
+        a_data = [0.0] * (500 * 200)
+        a = Tensor(a_data, self.SHAPE, requires_grad=True)
+        s = a.sum(dim=0)
+        # grad = [0, 1, 2, ..., 199]
+        grad = Tensor([float(k) for k in range(200)], (200,))
+        s.backward(grad)
+        rust_grad = a.grad
+        self.assertIsNotNone(rust_grad)
+        self.assertEqual(rust_grad.shape, self.SHAPE)
+
+        a2 = Tensor(list(a_data), self.SHAPE, requires_grad=True)
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            s_py = a2.sum(dim=0)
+            s_py.backward(Tensor([float(k) for k in range(200)], (200,)))
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        # Exact equality — pure data movement, no float ops.
+        self.assertEqual(rust_grad.data, a2.grad.data)
+
+    def test_mean_axis_dim1_backward_parity(self) -> None:
+        """``a.mean(dim=1).backward(grad)`` — Mean axis backward.
+
+        Mean folds ``/count`` into the grad in Python before
+        broadcasting.  For ``a.shape = (500, 200)`` reduced along
+        dim=1, count = 200.  Each input cell of row k gets
+        ``grad[k] / 200``.
+
+        Uses ``assertAlmostEqual(places=5)`` because the per-row
+        division round-trips through f32 (matrix-cpu's f32-only
+        dtype is the binding constraint, not the Python pre-divide).
+        """
+        from ml_framework_core import Tensor, _rust_backend
+
+        a_data = [0.0] * (500 * 200)
+        a = Tensor(a_data, self.SHAPE, requires_grad=True)
+        m = a.mean(dim=1)
+        # grad = [1, 1, ..., 1] of shape (500,)
+        m.backward(Tensor([1.0] * 500, (500,)))
+        rust_grad = a.grad
+        self.assertIsNotNone(rust_grad)
+        self.assertEqual(rust_grad.shape, self.SHAPE)
+
+        a2 = Tensor(list(a_data), self.SHAPE, requires_grad=True)
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            m_py = a2.mean(dim=1)
+            m_py.backward(Tensor([1.0] * 500, (500,)))
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        for got, want in zip(rust_grad.data, a2.grad.data, strict=False):
+            self.assertAlmostEqual(got, want, places=5)
+
 
 # ──────────────────────────────────────────────────────────────────
 # MX10 Phase 4 — activation parity tests (Tanh + ReLU)


### PR DESCRIPTION
## Summary

- Closes the gap Phase 3c deferred — `SumFunction.backward` and `MeanFunction.backward` for `dim != None` now dispatch through Rust at the same 100_000-cell threshold.
- **All reduce-all and axis-specific Sum/Mean forward/backward paths** in `ml-framework-core` now get the optional Rust fast path.
- **Key design**: matrix-cpu's `Broadcast` requires source/target rank to match. Since `grad_output`'s flat data ordering is the same whether its shape is `(K,)` or `(1, K)`, the helper always **declares the input shape with size 1 at the reduced axis** — single Broadcast op, no Reshape needed.
- Mean folds `/count` into the grad in Python (cheap — `len(grad_data)` divisions, bounded by reduced shape) before broadcasting; same single-op Rust graph as Sum.
- +6 tests (2 parity, 4 fallback). Full suite: **371 passed + 29 skipped + 1 pre-existing unrelated failure**.
- Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes (371/372 with the 1 pre-existing failure)
- [x] New `test_{sum,mean}_axis_*_backward_parity` (2 cases) skip gracefully without the C extension
- [x] New axis-backward fallback tests (4 cases) always run; column- and row-broadcast hand-computations verified
- [x] Sum exact equality, Mean `assertAlmostEqual(places=5)` (per-row division through f32)
- [ ] CI green on full repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)