### PR TITLE
feat(cas-summation,symbolic-vm): Phase 42 — degree-aware vanishing-at-infinity

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.4.0 — 2026-05-22
+
+**Phase 42 — Degree-aware vanishing-at-infinity recogniser.**
+
+Widens Phase 41's narrow constant-numerator check to handle *any*
+proper rational ``P(k)/Q(k)`` shape with ``deg(P) < deg(Q)``.  This
+covers Apart outputs from any partial-fraction decomposition with
+non-constant numerators — e.g. infinite telescopes built from
+``k/(k²+1) − (k+1)/((k+1)²+1)`` close in one dispatch.
+
+### Added
+
+- **`_polynomial_degree_in_k(node, k) -> int | None`** in
+  `summation.py` — returns the polynomial degree of an IR node in
+  ``k`` (or ``None`` for non-polynomial shapes like ``Div``, ``Sin``,
+  ``Pow(k, fractional)``).
+- **Phase 42 widening branch** in `_g_vanishes_at_infinity`: when the
+  numerator is *not* constant in ``k``, fall through to a
+  degree-comparison check.  The function still returns ``True`` for
+  Phase 41 fast-path shapes (constant numerator + positive-degree
+  polynomial denominator) so Phase 41 remains a strict special case.
+
+### Added — tests
+
+`tests/test_summation.py` — new
+`TestEvaluateSumPhase42DegreeAware` class with 5 cases:
+
+- `test_proper_rational_k_over_k_squared_plus_1_minus_shift` —
+  `∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)] = g(1) = 1/2`.
+- `test_polynomial_degree_constant_numerator_still_works` — Phase 41
+  fast-path regression: `∑_{k=1}^∞ [1/k − 1/(k+1)] = 1` still closes.
+- `test_improper_rational_falls_through` — `g(k) = k/(k+1)` has equal
+  degrees; limit is 1, not 0.  Phase 42 refuses; sum stays unevaluated.
+- `test_super_improper_rational_falls_through` — `g(k) = k²/(k+1)` has
+  deg(num) > deg(den); limit is +∞.  Sum stays unevaluated.
+- `test_transcendental_numerator_falls_through` — `g(k) = sin(k)/k²`
+  has a non-polynomial numerator; the degree comparison can't run, so
+  Phase 42 conservatively refuses (transcendental limits deferred).
+
+Full suite: **77 passed** (72 prior + 5 net new).
+
+### Still deferred
+
+- Transcendental limit-finder (`sin(k)/k²`, `log(k)/k`, `1/exp(k)`,
+  …).  These require a real symbolic limit machine; out of scope for
+  Phase 42's pure polynomial path.
+- Cross-language port to TypeScript / Rust (blocked on porting
+  `Apart` to those backends — see Phase 40 deferral).
+
 ## 0.3.0 — 2026-05-22
 
 **Phase 41 — Limit-aware infinite telescope.**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "0.3.0"
+version = "0.4.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -301,53 +301,123 @@ def _is_positive_degree_polynomial_in_k(node: IRNode, k: IRSymbol) -> bool:
     return False
 
 
+def _polynomial_degree_in_k(node: IRNode, k: IRSymbol) -> int | None:
+    """Return the polynomial degree of ``node`` in ``k`` (Phase 42).
+
+    Returns ``0`` for expressions constant in ``k``, ``1`` for bare
+    ``k``, ``n`` for ``k^n``, the maximum of children for ``Add``, and
+    the sum of children for ``Mul``.  Returns ``None`` for shapes that
+    are not pure polynomials in ``k`` (e.g. ``Div``, ``Sin``, ``Cos``,
+    ``Log``, ``Pow(k, fractional)``, ``Pow(non-constant, k)``).
+
+    The polynomial degree is used by :func:`_g_vanishes_at_infinity` to
+    decide whether a rational ``P(k)/Q(k)`` summand tends to 0 as
+    ``k → ∞`` — true iff ``deg(P) < deg(Q)``.
+
+    Recognised shapes
+    -----------------
+
+    +-------------------------+-------------------------+
+    | Input                   | Degree                  |
+    +=========================+=========================+
+    | constant in ``k``       | ``0``                   |
+    | ``k``                   | ``1``                   |
+    | ``k^n`` integer n ≥ 0   | ``n``                   |
+    | ``Neg(p)``              | ``deg(p)``              |
+    | ``Add(p1, p2, …)``      | ``max(deg(pi))``        |
+    | ``Sub(p1, p2)``         | ``max(deg(p1), deg(p2))`` |
+    | ``Mul(p1, p2, …)``      | ``sum(deg(pi))``        |
+    | otherwise (Div, Pow,…)  | ``None``                |
+    +-------------------------+-------------------------+
+    """
+    # Constant in k — degree 0.
+    if _is_constant_in(node, k):
+        return 0
+    # Bare k — degree 1.
+    if node == k:
+        return 1
+    if not isinstance(node, IRApply):
+        return None
+    # k^n where n is a non-negative integer.
+    if node.head == POW and len(node.args) == 2:
+        base, exp = node.args
+        if base == k and isinstance(exp, IRInteger) and exp.value >= 0:
+            return int(exp.value)
+        # Pow(non-k base depending on k, …) or fractional exponent: not a
+        # pure polynomial in k.
+        return None
+    # Unary Neg preserves degree.
+    if node.head == NEG and len(node.args) == 1:
+        return _polynomial_degree_in_k(node.args[0], k)
+    # ADD / SUB: max of child degrees (None propagates).
+    if node.head in (ADD, SUB):
+        degrees = [_polynomial_degree_in_k(a, k) for a in node.args]
+        if any(d is None for d in degrees):
+            return None
+        return max(degrees)  # type: ignore[arg-type]
+    # MUL: sum of child degrees (None propagates).
+    if node.head == MUL:
+        degrees = [_polynomial_degree_in_k(a, k) for a in node.args]
+        if any(d is None for d in degrees):
+            return None
+        return sum(degrees)  # type: ignore[misc]
+    # Div, Sin, Cos, Log, Exp, Sqrt, … — not pure polynomials.
+    return None
+
+
 def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     """Return True when ``g(k)`` provably tends to 0 as ``k → ∞``.
 
-    Narrow recognition for Phase 41 — we only fire on shapes where the
-    vanishing limit is obvious without needing a full symbolic
-    limit-finder:
+    Two-tier recognition:
+
+    1.  **Phase 41 fast path** — ``Div(c, h(k))`` with ``c`` constant
+        in ``k`` and ``h(k)`` recognised as a positive-degree polynomial
+        in ``k`` (via :func:`_is_positive_degree_polynomial_in_k`).
+        This handles every shape Apart can emit from a rational summand
+        whose denominator factors over ℚ into simple linear factors.
+
+    2.  **Phase 42 widening** — ``Div(P(k), Q(k))`` where both ``P`` and
+        ``Q`` are polynomials in ``k`` (via
+        :func:`_polynomial_degree_in_k`) and ``deg(P) < deg(Q)``.  This
+        closes telescopes like ``k/((k+1)(k+2)(k+3))`` and any other
+        proper rational shape Apart might emit.
 
     +-------------------------------+--------------------------+
     | ``g`` shape                   | Provably ``→ 0``?        |
     +===============================+==========================+
-    | ``Div(c, h(k))``              | yes, iff ``h(k) → ∞``    |
-    |   with ``c`` constant in k    |                          |
-    |   and ``h`` recognised as a   |                          |
-    |   positive-degree polynomial  |                          |
-    |   in ``k`` by                 |                          |
-    |   :func:`_is_positive_degree_…` |                        |
+    | ``Div(constant, k+a)``        | yes (Phase 41)           |
+    | ``Div(constant, k²·(k+1))``   | yes (Phase 41)           |
+    | ``Div(k, k²+1)``              | yes (Phase 42)           |
+    | ``Div(k+1, k³−5)``            | yes (Phase 42)           |
+    | constant                      | no (limit is the const)  |
+    | ``k`` or ``k²+1``             | no (limit is ∞)          |
+    | ``1/sin(k)`` / ``log(k)/k``   | no (numerator is not a   |
+    |                               |    polynomial; transcend- |
+    |                               |    ental limits deferred) |
     +-------------------------------+--------------------------+
-    | anything else                 | no (conservatively)      |
-    +-------------------------------+--------------------------+
-
-    This covers every shape Apart can emit from a rational summand
-    ``P(k)/Q(k)`` whose denominator factors over ℚ into simple linear
-    factors — the common case is ``c / (k + a)^m`` for integer ``m ≥ 1``
-    and rational ``a``.
 
     Examples
     --------
-    - ``1/k`` → True (denominator is bare ``k``, positive degree).
-    - ``1/(k+1)`` → True (denominator is ``Add(k, 1)``, positive degree).
-    - ``3/(k*(k+2))`` → True (denominator is a product of two positive-
-      degree factors).
-    - ``1/(k**2)`` → True (positive-degree ``POW(k, 2)``).
-    - ``1`` → False (constant in k; the limit is 1, not 0).
-    - ``k`` → False (the limit is ∞, not 0).
-    - ``1/sin(k)`` → False (denominator's behaviour at ∞ is undecidable
-      without a deeper limit-finder; conservatively refuse).
+    - ``1/k`` → True (Phase 41: constant/k).
+    - ``k/(k²+1)`` → True (Phase 42: deg 1 < deg 2).
+    - ``(k²+1)/k³`` → True (Phase 42: deg 2 < deg 3).
+    - ``k/(k+1)`` → False (deg 1 = deg 1; limit is 1, not 0).
+    - ``k²/(k+1)`` → False (improper; limit is ∞).
     """
     if not isinstance(g, IRApply) or g.head != DIV or len(g.args) != 2:
         return False
     num, den = g.args
-    # Numerator must not introduce k-dependence — restrict to "constant
-    # in k" so the limit of g is fully determined by the denominator's
-    # behaviour.  A future phase could widen this to "deg(num) < deg(den)".
-    if not _is_constant_in(num, k):
+    # Phase 41 fast path: constant numerator + positive-degree denominator.
+    if _is_constant_in(num, k):
+        return _is_positive_degree_polynomial_in_k(den, k)
+    # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
+    num_degree = _polynomial_degree_in_k(num, k)
+    if num_degree is None:
         return False
-    # Denominator must grow without bound as k → ∞.
-    return _is_positive_degree_polynomial_in_k(den, k)
+    den_degree = _polynomial_degree_in_k(den, k)
+    if den_degree is None:
+        return False
+    return num_degree < den_degree
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -471,3 +471,132 @@ class TestEvaluateSumPhase41InfiniteTelescope:
         f = IRApply(SUB, (IRApply(ADD, (_k, IRInteger(1))), _k))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+# ---------------------------------------------------------------------------
+# Phase 42: degree-aware vanishing-at-infinity.
+#
+# Extends Phase 41's narrow constant-numerator recogniser to handle any
+# proper rational ``P(k)/Q(k)`` where ``deg(P) < deg(Q)``.  This widens
+# the set of telescopes that close at infinity to cover Apart outputs
+# from any partial-fraction decomposition with non-constant numerators.
+#
+# The Phase 41 fast path (constant numerator) is preserved as a special
+# case — these tests pin the new degree-aware behaviour.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase42DegreeAware:
+    def test_proper_rational_k_over_k_squared_plus_1_minus_shift(self):
+        """``∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)]``.
+
+        g(k) = k/(k²+1) has deg(num)=1 < deg(den)=2, so vanishes at ∞.
+        Closed form (antisymmetric): g(1) = 1/2.
+        """
+        from fractions import Fraction
+        from symbolic_ir import POW, SUB
+
+        # g(k) = k / (k² + 1)
+        g_k = IRApply(
+            DIV,
+            (
+                _k,
+                IRApply(ADD, (IRApply(POW, (_k, IRInteger(2))), IRInteger(1))),
+            ),
+        )
+        # g(k+1) = (k+1) / ((k+1)² + 1)
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                kp1,
+                IRApply(ADD, (IRApply(POW, (kp1, IRInteger(2))), IRInteger(1))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # g(1) = 1 / (1 + 1) = 1/2
+        from symbolic_ir import IRRational
+
+        assert isinstance(result, IRRational)
+        assert Fraction(result.numer, result.denom) == Fraction(1, 2)
+
+    def test_polynomial_degree_constant_numerator_still_works(self):
+        """Regression: Phase 41 fast path (constant/Q) still closes.
+
+        ``∑_{k=1}^∞ [1/k − 1/(k+1)] = 1`` must continue to work after the
+        Phase 42 degree-aware widening replaces some of the recogniser.
+        """
+        from symbolic_ir import SUB
+
+        f = IRApply(
+            SUB,
+            (
+                IRApply(DIV, (IRInteger(1), _k)),
+                IRApply(DIV, (IRInteger(1), IRApply(ADD, (_k, IRInteger(1))))),
+            ),
+        )
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRInteger) and result.value == 1
+
+    def test_improper_rational_falls_through(self):
+        """``∑_{k=1}^∞ [k/(k+1) − (k+1)/(k+2)]``.
+
+        g(k) = k/(k+1) has deg(num)=1 = deg(den)=1; the limit is 1
+        (not 0), so Phase 42 must refuse and the sum stays unevaluated.
+        """
+        from symbolic_ir import SUB
+
+        g_k = IRApply(DIV, (_k, IRApply(ADD, (_k, IRInteger(1)))))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_kp1 = IRApply(
+            DIV, (kp1, IRApply(ADD, (_k, IRInteger(2))))
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Limit isn't 0; must stay unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_super_improper_rational_falls_through(self):
+        """``g(k) = k²/(k+1)``: limit is ∞, not 0.  Phase 42 refuses.
+
+        We construct the SUB shape ``[k²/(k+1) − (k+1)²/(k+2)]`` and
+        confirm Phase 41/42 both refuse to close it (the limit is +∞,
+        not 0).
+        """
+        from symbolic_ir import POW, SUB
+
+        g_k = IRApply(
+            DIV, (IRApply(POW, (_k, IRInteger(2))), IRApply(ADD, (_k, IRInteger(1))))
+        )
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_kp1 = IRApply(
+            DIV,
+            (IRApply(POW, (kp1, IRInteger(2))), IRApply(ADD, (_k, IRInteger(2)))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_transcendental_numerator_falls_through(self):
+        """``g(k) = sin(k)/k²``: numerator is not a polynomial, so the
+        degree-aware path refuses.  (The limit IS 0 by squeeze, but
+        decidably proving so needs a transcendental limit-finder we
+        don't have yet.)
+        """
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sin_kp1 = IRApply(SIN, (IRApply(ADD, (_k, IRInteger(1))),))
+        g_k = IRApply(DIV, (sin_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                sin_kp1,
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(2))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Conservative: refuse since num is not a polynomial.
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.66.0 — 2026-05-22
+
+**Phase 42 dep bump — degree-aware vanishing-at-infinity.**
+
+Bumps the `coding-adventures-cas-summation` dependency to `>=0.4.0`,
+which introduces Phase 42's degree-aware `_g_vanishes_at_infinity`
+recogniser.  No symbolic-vm code changes — the existing Phase 40
+Apart-retry path automatically benefits when the partial-fraction
+output has a non-constant numerator, e.g. infinite series like
+``∑_{k=1}^∞ k/(k²+1) − (k+1)/((k+1)²+1) = 1/2`` now close in one
+dispatch through the `sum_handler`.
+
+### Changed
+
+- Bumped dep `coding-adventures-cas-summation>=0.4.0` (was `>=0.3.0`).
+
 ## 0.65.0 — 2026-05-22
 
 **Phase 40 + Phase 41 chain end-to-end.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.65.0"
+version = "0.66.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -33,7 +33,7 @@ dependencies = [
     "coding-adventures-cas-ode>=0.2.0",
     "coding-adventures-cas-algebraic>=0.1.0",
     "coding-adventures-cas-multivariate>=0.1.0",
-    "coding-adventures-cas-summation>=0.3.0",
+    "coding-adventures-cas-summation>=0.4.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary

Phase 42 widens Phase 41's narrow constant-numerator vanishing-at-infinity recogniser to handle *any* proper rational `P(k)/Q(k)` shape with `deg(P) < deg(Q)`.  This covers Apart outputs from any partial-fraction decomposition with non-constant numerators.

## Math

For polynomials `P(k)`, `Q(k)` over ℚ:

$$\lim_{k \to \infty} \frac{P(k)}{Q(k)} = 0 \iff \deg(P) < \deg(Q).$$

The new path runs only when both numerator and denominator are pure polynomials in `k` (returns `None` for `Div`, `Sin`, `Pow(k, fractional)`, …).  Anything transcendental or improper falls through to the unevaluated `Sum(...)`.

## cas-summation 0.4.0

- **New `_polynomial_degree_in_k(node, k) -> int | None`** — returns the polynomial degree of an IR node in `k` or `None` for non-polynomial shapes.
- **`_g_vanishes_at_infinity` two-tier** — Phase 41 fast path (constant numerator + positive-degree polynomial denominator) preserved as a strict special case; Phase 42 widening fires only when the numerator is *not* constant in k.

## symbolic-vm 0.66.0

- Dep bump `coding-adventures-cas-summation>=0.4.0` (was `>=0.3.0`).
- No code changes — the existing Phase 40 Apart-retry path automatically benefits.

## Tests

5 new `TestEvaluateSumPhase42DegreeAware` cases in `tests/test_summation.py`:

- `∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)] = 1/2` (proper rational).
- Phase 41 fast-path regression (`∑ 1/k − 1/(k+1) = 1`).
- Improper rational `k/(k+1)` (limit is 1, falls through).
- Super-improper `k²/(k+1)` (limit is +∞, falls through).
- Transcendental numerator `sin(k)/k²` (non-polynomial, falls through — deferred to a future transcendental limit-finder).

Full `cas-summation` suite: **77 passed** (72 prior + 5 net new). `symbolic-vm` Phase 25 sum slice: 64 passed, 8 skipped, no regressions.

## Test plan

- [x] All Phase 41 fast-path tests still pass (Phase 42 is a strict widening).
- [x] New Phase 42 tests pin both success and fallthrough paths.
- [x] Security review passed (no eval/network; bounded recursion identical in shape to pre-existing helpers; mathematically sound degree predicate).

## Still deferred

- Transcendental limit-finder (`sin(k)/k²`, `log(k)/k`, `1/exp(k)`, …) — needs a real symbolic limit machine.
- TS / Rust ports — blocked on porting `Apart` to those backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)