### PR TITLE
feat(ruby-parser): Phase 6b — `if … else … end` and `unless`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,9 +25,13 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | assignment | method_call | expression_stmt ;
+statement    = def_statement | if_statement | unless_statement | assignment | method_call | expression_stmt ;
 def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
 params       = NAME { COMMA NAME } ;
+if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
+elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;
+else_clause  = "else" { !"end" statement } ;
+unless_statement = "unless" expression { !"else" !"end" statement } [ else_clause ] "end" ;
 assignment   = NAME EQUALS expression ;
 method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPAREN ;
 expression_stmt = expression ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.3.0] - 2026-05-20
+
+### Added (Phase 6b — `if … else … end` and `unless`)
+- New grammar rules in `code/grammars/ruby.grammar`:
+
+      if_statement     = "if" expression { !"else" !"elsif" !"end" statement }
+                           { elsif_clause } [ else_clause ] "end"
+      elsif_clause     = "elsif" expression { !"else" !"elsif" !"end" statement }
+      else_clause      = "else" { !"end" statement }
+      unless_statement = "unless" expression { !"else" !"end" statement }
+                           [ else_clause ] "end"
+
+- `if_statement` and `unless_statement` are added as alternatives in `statement` right after `def_statement`, so the dispatch order is: def → if → unless → assignment → method_call → expression_stmt.
+- The body repetitions all use negative lookaheads (`!"end"`, `!"else"`, `!"elsif"`) so they stop short of the closing keyword — same trick as `def_statement` in Phase 6a.
+- Regenerated `src/_grammar.rs`.
+
+### Tests (+4 new, total 14)
+- `if` with body, `if`/`else`, `if`/`elsif`/`else`, `unless`.
+
 ## [0.2.0] - 2026-05-20
 
 ### Added (Phase 6a — `def name(params) … end` method definitions)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -19,6 +19,8 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"statement"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
                 GrammarElement::RuleReference { name: r#"def_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"if_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"unless_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression_stmt"#.to_string() },
@@ -55,13 +57,70 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 30,
         },
         GrammarRule {
+            name: r#"if_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"if"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"else"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"elsif"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"elsif_clause"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 31,
+        },
+        GrammarRule {
+            name: r#"elsif_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"elsif"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"else"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"elsif"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 32,
+        },
+        GrammarRule {
+            name: r#"else_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"else"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 33,
+        },
+        GrammarRule {
+            name: r#"unless_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"unless"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"else"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 34,
+        },
+        GrammarRule {
             name: r#"assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 31,
+            line_number: 35,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -80,12 +139,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 32,
+            line_number: 36,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 33,
+            line_number: 37,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
@@ -99,7 +158,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 34,
+            line_number: 38,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -113,7 +172,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 35,
+            line_number: 39,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -128,7 +187,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 36,
+            line_number: 40,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -215,5 +215,80 @@ mod tests {
         assert_program_root(&ast);
         assert!(find_def_statement(&ast).is_some());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6b — `if … else … end` and `unless`
+    // -----------------------------------------------------------------------
+
+    fn find_statement_inner<'a>(
+        ast: &'a GrammarASTNode,
+        rule: &str,
+    ) -> Option<&'a GrammarASTNode> {
+        for child in &ast.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                if n.rule_name == "statement" {
+                    for inner in &n.children {
+                        if let ASTNodeOrToken::Node(d) = inner {
+                            if d.rule_name == rule {
+                                return Some(d);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_parse_if_with_body() {
+        let ast = parse_ruby("if x\n  y = 1\nend");
+        assert_program_root(&ast);
+        let node = find_statement_inner(&ast, "if_statement")
+            .expect("expected if_statement");
+        // The body has at least one `statement` subnode.
+        let body_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert!(body_count >= 1);
+    }
+
+    #[test]
+    fn test_parse_if_else() {
+        let ast = parse_ruby("if x\n  y = 1\nelse\n  y = 2\nend");
+        let node = find_statement_inner(&ast, "if_statement")
+            .expect("expected if_statement");
+        let has_else = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "else_clause"));
+        assert!(has_else, "expected else_clause subnode");
+    }
+
+    #[test]
+    fn test_parse_if_elsif_else() {
+        let ast = parse_ruby("if x\n  a = 1\nelsif y\n  a = 2\nelse\n  a = 3\nend");
+        let node = find_statement_inner(&ast, "if_statement")
+            .expect("expected if_statement");
+        let elsif_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "elsif_clause"))
+            .count();
+        assert_eq!(elsif_count, 1);
+        let has_else = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "else_clause"));
+        assert!(has_else);
+    }
+
+    #[test]
+    fn test_parse_unless() {
+        let ast = parse_ruby("unless x\n  y = 1\nend");
+        assert!(find_statement_inner(&ast, "unless_statement").is_some());
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.3.0] - 2026-05-20
+
+### Added (Phase 6b — `if … else … end` / `unless` lowering)
+- New `lower_if_or_unless` handler — both rules produce a single `Expr::If` because SIR treats conditionals as expressions (every branch yields a value).
+- `unless cond` lowers to `if !cond` by wrapping the condition in `BuiltinCall("not", [cond])`.
+- `elsif` chains lower with right-associative nesting: the outermost `If`'s `else_branch` is itself a `Block` whose `value` is another `If` for the first `elsif`, and so on.  The validator sees one well-formed expression tree.
+- New `lower_clause_statements` helper saves/restores `declared_locals` around each branch so locals introduced in one `if`/`elsif`/`else` arm don't leak into siblings (which would have caused spurious `Stmt::Assign` emissions and validator errors).
+- `Lowerer.features_used: HashSet<Feature>` — tracks which SIR features the lowering actually exercises.  `compile` now emits a manifest that lists *only* the features in use:
+  - `DynamicTyping` whenever a function has at least one untyped param.
+  - `MutableBindings` whenever a `Stmt::Assign` re-binds an existing local.
+  This swaps the previous "always declare DynamicTyping" approach for an exact-match manifest, which is what the validator requires.
+
+### Tests (+5 new, total 19)
+- `if_lowers_to_expr_if` — basic if/end produces `Expr::If`.
+- `if_else_lowers_with_else_branch` — explicit else branch is captured.
+- `unless_negates_condition` — `unless cond` wraps the cond in `BuiltinCall("not", ...)`.
+- `if_elsif_else_chain_nests_right` — elsif chain produces nested `Expr::If` in `else_branch.value`.
+- `if_module_passes_sir_validator` — an `if … else … end` containing module passes `semantic_ir::validate`.
+
 ## [0.2.0] - 2026-05-20
 
 ### Added (Phase 6a — `def name(params) … end` method definitions)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -317,6 +317,108 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------
+    // Phase 6b — `if … else … end` / `unless … else … end`
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn if_lowers_to_expr_if() {
+        let m = lower("x = 1\nif x\n  y = 2\nend\n");
+        let main = main_body(&m);
+        // main.stmts: LetBinding(x=1), ExprStmt(If { ... })
+        let if_stmt = main.stmts.iter().find_map(|s| match s {
+            Stmt::ExprStmt { expr: Expr::If { cond, .. }, .. } => Some(cond),
+            _ => None,
+        });
+        assert!(if_stmt.is_some(), "expected If expr-stmt in main body");
+    }
+
+    #[test]
+    fn if_else_lowers_with_else_branch() {
+        let m = lower("if x\n  y = 1\nelse\n  y = 2\nend\n");
+        let main = main_body(&m);
+        let if_expr = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::ExprStmt { expr: e @ Expr::If { .. }, .. } => Some(e),
+                _ => None,
+            })
+            .expect("expected If expr");
+        // The else_branch has one statement.
+        if let Expr::If { else_branch, .. } = if_expr {
+            assert!(
+                !else_branch.stmts.is_empty()
+                    || !matches!(else_branch.value, Expr::NilLit { .. }),
+                "expected non-empty else branch"
+            );
+        }
+    }
+
+    #[test]
+    fn unless_negates_condition() {
+        let m = lower("unless x\n  y = 1\nend\n");
+        let main = main_body(&m);
+        let if_expr = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::ExprStmt { expr: e @ Expr::If { .. }, .. } => Some(e),
+                _ => None,
+            })
+            .expect("expected If expr");
+        // `unless cond` lowers to `if !cond` — the cond should be a
+        // `BuiltinCall("not", ...)`.
+        if let Expr::If { cond, .. } = if_expr {
+            assert!(
+                matches!(&**cond, Expr::BuiltinCall { name, .. } if name == "not"),
+                "expected `unless` to wrap cond in `not` builtin, got {:?}",
+                cond
+            );
+        }
+    }
+
+    #[test]
+    fn if_elsif_else_chain_nests_right() {
+        let m = lower("if x\n  a = 1\nelsif y\n  a = 2\nelse\n  a = 3\nend\n");
+        let main = main_body(&m);
+        let if_expr = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::ExprStmt { expr: e @ Expr::If { .. }, .. } => Some(e),
+                _ => None,
+            })
+            .expect("expected If expr");
+        // The outer if's else_branch.value should itself be another If
+        // (the elsif).  The inner If's else_branch contains the final
+        // else clause.
+        if let Expr::If { else_branch, .. } = if_expr {
+            match &else_branch.value {
+                Expr::If { .. } => {} // ✓
+                other => panic!("expected nested If in else_branch.value, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn if_module_passes_sir_validator() {
+        let m = lower(concat!(
+            "x = 1\n",
+            "if x\n",
+            "  y = 2\n",
+            "else\n",
+            "  y = 3\n",
+            "end\n",
+        ));
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn module_with_def_passes_sir_validator() {
         // v0 grammar can't yet parse nested method calls in args

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -68,6 +68,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         declared_locals: HashSet::new(),
         current_params: HashSet::new(),
         user_functions: Vec::new(),
+        features_used: HashSet::new(),
     };
     // Phase 6a: hoist `def name(params) … end` declarations to
     // top-level Functions BEFORE walking the rest of the program so
@@ -93,12 +94,21 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
     let mut functions = std::mem::take(&mut lw.user_functions);
     functions.push(main);
 
-    // SIR's validator requires modules that use untyped params or
-    // globals (which everything Ruby produces in v0) to declare the
-    // `DynamicTyping` feature.  Ruby is dynamically typed, so we
-    // always declare it.
+    // SIR's validator requires the manifest to *exactly* match
+    // usage (declared-but-unused is a warning, used-but-undeclared
+    // is an error).  We've been tallying features as we lowered;
+    // here we materialise them into the manifest in a stable
+    // chronological order.
     let mut manifest = FeatureManifest::new();
-    manifest.add(Feature::DynamicTyping);
+    for f in [
+        Feature::DynamicTyping,
+        Feature::MutableBindings,
+        Feature::Closures,
+    ] {
+        if lw.features_used.contains(&f) {
+            manifest.add(f);
+        }
+    }
 
     Ok(Module {
         name: module_name.to_string(),
@@ -138,6 +148,12 @@ struct Lowerer {
     /// `collect_def_statements` (a top-level hoisting pass) before
     /// the main-body lowerer runs.
     user_functions: Vec<Function>,
+    /// Phase 6b: SIR features actually exercised by this lowering.
+    /// The SIR validator requires manifests to *exactly* match
+    /// usage (declared-but-unused is a warning, used-but-undeclared
+    /// is an error), so we track on-demand instead of unconditionally
+    /// declaring every feature.
+    features_used: HashSet<semantic_ir::Feature>,
 }
 
 impl Lowerer {
@@ -273,12 +289,194 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "if_statement" | "unless_statement" => {
+                // Phase 6b: SIR's `Expr::If` is an *expression* — it
+                // always yields a value.  We wrap it in `Stmt::ExprStmt`
+                // here so the body's value (or NilLit) propagates
+                // through the SIR statement stream.
+                let expr = self.lower_if_or_unless(node)?;
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
             other => Err(RubyLowerError {
                 message: format!("unsupported statement form `{other}`"),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
             }),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6b — `if … else … end` / `unless … else … end`
+    // -------------------------------------------------------------------
+
+    /// Lower an `if_statement` or `unless_statement` node into an
+    /// `Expr::If`.  Both rules have the same shape from the AST's
+    /// perspective; the only difference is that `unless`'s
+    /// condition is negated.  `elsif` chains nest right — the
+    /// `else_branch` of the outermost `If` is itself an `If` for
+    /// the first elsif, etc.
+    fn lower_if_or_unless(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let is_unless = node.rule_name == "unless_statement";
+        // The first `expression` child is the condition.
+        let cond_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
+                message: format!("{} missing condition expression", node.rule_name),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let mut cond = self.lower_expression(cond_node)?;
+        if is_unless {
+            // `unless cond` is `if !cond` — wrap in `not` builtin.
+            cond = Expr::BuiltinCall {
+                name: "not".to_string(),
+                args: vec![cond],
+                effects: EffectSet::PURE,
+                span: self.span_of(cond_node),
+            };
+        }
+
+        // Then-branch body: every `statement` child *until* the
+        // first elsif/else/end terminator.  Since the grammar
+        // already segregates elsif/else into their own subnodes,
+        // direct `statement` children of `node` are the then-body.
+        let then_body = self.lower_clause_statements(node)?;
+
+        // elsif chain — right-associative nesting.  Build the
+        // tail starting from `else_clause` and unwind back through
+        // any `elsif_clause` nodes in reverse order.
+        let elsifs: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "elsif_clause" => Some(n),
+                _ => None,
+            })
+            .collect();
+        let else_clause: Option<&GrammarASTNode> = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "else_clause" => Some(n),
+            _ => None,
+        });
+
+        // Start with the `else` body (or `NilLit` if absent).
+        let mut tail = if let Some(ec) = else_clause {
+            self.lower_clause_statements(ec)?
+        } else {
+            Block {
+                stmts: Vec::new(),
+                value: Expr::NilLit { span: self.span_of(node) },
+                span: self.span_of(node),
+            }
+        };
+
+        // Unwind elsif clauses in reverse order, each wrapping the
+        // accumulated tail as its own else-branch.
+        for ec in elsifs.iter().rev() {
+            let ec_cond = self.find_node_child(ec, "expression").ok_or_else(|| {
+                RubyLowerError {
+                    message: "elsif_clause missing condition expression".to_string(),
+                    line: ec.start_line.unwrap_or(0),
+                    column: ec.start_column.unwrap_or(0),
+                }
+            })?;
+            let ec_cond_expr = self.lower_expression(ec_cond)?;
+            let ec_body = self.lower_clause_statements(ec)?;
+            tail = Block {
+                stmts: Vec::new(),
+                value: Expr::If {
+                    cond: Box::new(ec_cond_expr),
+                    then_branch: Box::new(ec_body),
+                    else_branch: Box::new(tail),
+                    span: self.span_of(ec),
+                },
+                span: self.span_of(ec),
+            };
+        }
+
+        Ok(Expr::If {
+            cond: Box::new(cond),
+            then_branch: Box::new(then_body),
+            else_branch: Box::new(tail),
+            span: self.span_of(node),
+        })
+    }
+
+    /// Lower the `statement` children of a clause node (`if_statement`,
+    /// `elsif_clause`, `else_clause`, `unless_statement`) into a
+    /// `Block`.  Tail-expression promotion follows the same rule as
+    /// `lower_program` — last bare `expression_stmt` / `method_call`
+    /// becomes `value`, otherwise `value = NilLit`.
+    fn lower_clause_statements(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Block, RubyLowerError> {
+        // Phase 6b: each branch is an independent SIR `Block`.
+        // Lock the declared-locals set to the outer-scope's snapshot
+        // before lowering the body, then restore on exit.  Without
+        // this, locals introduced in one `if`-branch would leak
+        // into the other branch's scope and cause spurious
+        // `Stmt::Assign` emissions (or vice versa).
+        let saved_locals = self.declared_locals.clone();
+        let stmts_in: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+        if stmts_in.is_empty() {
+            return Ok(Block {
+                stmts: Vec::new(),
+                value: Expr::NilLit { span: self.span_of(node) },
+                span: self.span_of(node),
+            });
+        }
+        let last_idx = stmts_in.len() - 1;
+        let mut stmts_out: Vec<Stmt> = Vec::new();
+        let mut value: Option<Expr> = None;
+        for (i, s) in stmts_in.iter().enumerate() {
+            let inner = self.first_node_child(s).ok_or_else(|| RubyLowerError {
+                message: "statement node had no child rule".to_string(),
+                line: s.start_line.unwrap_or(0),
+                column: s.start_column.unwrap_or(0),
+            })?;
+            let is_tail = i == last_idx;
+            let kind = inner.rule_name.as_str();
+            if is_tail && matches!(kind, "expression_stmt" | "method_call") {
+                let v = match kind {
+                    "expression_stmt" => {
+                        let expr_node = self.first_node_child(inner).ok_or_else(|| {
+                            RubyLowerError {
+                                message: "expression_stmt had no expression child".to_string(),
+                                line: inner.start_line.unwrap_or(0),
+                                column: inner.start_column.unwrap_or(0),
+                            }
+                        })?;
+                        self.lower_expression(expr_node)?
+                    }
+                    "method_call" => self.lower_method_call(inner)?,
+                    _ => unreachable!(),
+                };
+                value = Some(v);
+            } else {
+                stmts_out.push(self.lower_statement_inner(inner)?);
+            }
+        }
+        let value = value.unwrap_or(Expr::NilLit { span: self.span_of(node) });
+        // Restore the outer scope's declared locals.
+        self.declared_locals = saved_locals;
+        Ok(Block {
+            stmts: stmts_out,
+            value,
+            span: self.span_of(node),
+        })
     }
 
     // -------------------------------------------------------------------
@@ -360,6 +558,13 @@ impl Lowerer {
         } else {
             Vec::new()
         };
+
+        // Phase 6b: any non-empty parameter list means we'll emit
+        // untyped Params (sir_type=None), which the SIR validator
+        // requires `dynamic-typing` to be declared for.
+        if !params.is_empty() {
+            self.features_used.insert(Feature::DynamicTyping);
+        }
 
         // Lower the body using a fresh locals + params scope so the
         // outer program's bindings don't leak into the method.
@@ -471,6 +676,10 @@ impl Lowerer {
 
         let span = self.span_of(node);
         if self.declared_locals.contains(&name) {
+            // Phase 6b: `Stmt::Assign` re-binds an existing local —
+            // the SIR validator requires the manifest to declare
+            // `mutable-bindings` whenever this node appears.
+            self.features_used.insert(Feature::MutableBindings);
             Ok(Stmt::Assign {
                 name,
                 scope: Scope::Local,


### PR DESCRIPTION
## Summary

Second parser-grammar extension after [Phase 6a](https://github.com/adhithyan15/coding-adventures/pull/3879) shipped `def`-led method definitions.  Adds `if`/`elsif`/`else`/`end` and `unless` conditionals to the grammar, then plumbs them through to `semantic_ir::Expr::If`.

## Parser changes

New grammar rules in [`code/grammars/ruby.grammar`](code/grammars/ruby.grammar):

\`\`\`
if_statement     = "if" expression { !"else" !"elsif" !"end" statement }
                     { elsif_clause } [ else_clause ] "end"
elsif_clause     = "elsif" expression { !"else" !"elsif" !"end" statement }
else_clause      = "else" { !"end" statement }
unless_statement = "unless" expression { !"else" !"end" statement }
                     [ else_clause ] "end"
\`\`\`

All body repetitions use the same negative-lookahead trick that 6a introduced.

## SIR lowering changes

- `lower_if_or_unless` produces a single `Expr::If` — SIR treats conditionals as expressions, so every branch yields a value.
- `unless cond` lowers to `if !cond` by wrapping the condition in `BuiltinCall("not", [cond])`.
- `elsif` chains lower right-associative — the outermost If's `else_branch.value` is itself an `If` for the first `elsif`, etc.
- New `lower_clause_statements` saves/restores `declared_locals` around each branch so locals introduced in one arm don't leak into siblings.
- New **`Lowerer.features_used`** set — the module's manifest now lists *exactly* the SIR features the lowering exercises (`DynamicTyping` for untyped params, `MutableBindings` for `Stmt::Assign`).  This swaps the previous "always declare DynamicTyping" approach for an exact-match manifest, which is what the validator requires (declared-but-unused = warning, used-but-undeclared = error).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — 92 passed (unchanged).
- [x] `cargo test -p coding-adventures-ruby-parser` — 14 passed (was 10; +4 new conditional tests).
- [x] `cargo test -p ruby-to-semantic-ir` — 19 passed (was 14; +5 new conditional tests, including end-to-end validator pass).

## What's next

Last merged was [Phase 4c lexer](https://github.com/adhithyan15/coding-adventures/pull/3885); this is parser.  Next chunk: Phase 4d — 2.7 numbered block params `_1`..`_9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)