### PR TITLE
feat(forme-doc-search-tokenizer): DOC00 v0 text-to-tokens search pipeline

### DIFF
--- a/code/packages/typescript/forme-doc-search-tokenizer/BUILD
+++ b/code/packages/typescript/forme-doc-search-tokenizer/BUILD
@@ -1,0 +1,1 @@
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-doc-search-tokenizer/CHANGELOG.md
+++ b/code/packages/typescript/forme-doc-search-tokenizer/CHANGELOG.md
@@ -1,0 +1,129 @@
+# Changelog — @coding-adventures/forme-doc-search-tokenizer
+
+## 0.1.0 — 2026-05-22
+
+Initial release.  Eighth concrete DOC00 v0 package — text →
+tokens pipeline for the documentation-site search index.
+Lowercase, strip non-alphanumeric, split on whitespace,
+optional stop-word filter, optional Porter stemmer.
+
+Pure transform: `string → string[]`.  Capabilities `[]`.  **Zero
+runtime dependencies.**
+
+### Added
+
+- `tokenize(text, options?): string[]` — main entry.  Runs the
+  full pipeline (steps 1-5).
+- `normaliseToTokens(text): string[]` — pipeline steps 1-3 only
+  (lowercase, strip, split).  Standalone export for callers
+  that want raw normalised tokens without filtering/stemming.
+- `porterStem(word): string` — standalone Porter stemmer.
+- `STOP_WORDS: ReadonlySet<string>` — built-in ~35-word
+  English stop-word set.
+- `TokenizeOptions` type:
+  `{ filterStopWords?, stem?, customStopWords? }`.
+
+### Spec adherence
+
+Implements DOC00 v0's `forme-doc-search-tokenizer` per
+`code/specs/DOC00-docs-vision.md` exactly:
+
+> Text → tokens.  Pipeline:
+> 1. Lowercase.
+> 2. Strip punctuation (keep alphanumerics, drop everything else).
+> 3. Split on whitespace.
+> 4. Filter stop-words (optional — small built-in list).
+> 5. (Optional) Porter stemmer — small, well-known algorithm.
+
+All five steps implemented; steps 4 and 5 are opt-in via
+options.
+
+### Behavioural notes
+
+- **Pure transform.**  Inputs (incl.
+  `options.customStopWords` Set) are never mutated.  Verified
+  by snapshot test.
+- **Locale-independent.**  Uses `toLowerCase` (NOT
+  `toLocaleLowerCase`) — search indexes must be stable across
+  machines, and Turkish `'I' → 'ı'` would break cross-locale
+  recall.
+- **Underscore preserved.**  `setup_guide` / `__proto__` /
+  `MY_CONSTANT` all stay as single tokens.  Splitting on
+  underscores hurts code-block search recall.
+- **Unicode-aware.**  `\p{L}` (any Unicode letter) and `\p{N}`
+  (any Unicode number) are preserved.  `café`, `中文`,
+  `Привет`, `Καλημέρα` all tokenise correctly.  Emoji and
+  punctuation are stripped.
+- **Deterministic.**  Same input bytes → identical output
+  bytes.  Stable across machines.
+
+### Porter stemmer
+
+Faithful port of the canonical Martin Porter (1980) algorithm:
+five sequential suffix-stripping steps (1a/1b/1b'/1c, 2, 3, 4,
+5a/5b), each gated by Porter's "measure" m(W) — the number of
+consonant-vowel transitions in W.
+
+Coverage matches the published reference test vectors (lifted
+from Porter's 1980 paper examples + the Snowball project's
+English reference outputs).
+
+Porter is well-documented English-only.  Non-ASCII tokens pass
+through unchanged.
+
+### Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver** —
+  pure data construction.
+- **No `+`-quantified regex on user input.**  Every scan in
+  `normalise.ts` uses an explicit character-by-character index
+  loop.  The only regex in the package is the single-char-class
+  `/^[\p{L}\p{N}_]$/u` in `isTokenChar` (matches exactly one
+  code point, no quantifier — not subject to polynomial-time
+  concerns).  Background: previous DOC00 packages
+  (`forme-doc-sidebar-builder`, `forme-doc-page-shell`) hit
+  CodeQL's `js/polynomial-redos` query on simple
+  `+`-quantified anchored regexes.  Explicit loops are now the
+  project-wide standard for any user-facing trim/strip/scan.
+- **No I/O** — capabilities `[]`.  Zero runtime dependencies.
+- **No mutation** of inputs (verified).
+- **Deterministic** — locale-independent case-folding,
+  insertion-ordered Set iteration per ES spec, stable sort
+  not needed (output is in source order).
+
+### Tests
+
+127 tests across 3 files:
+
+- `normalise.test.ts` (23) — basic tokenisation, lowercasing
+  (incl. tr-TR stability), punctuation stripping, hyphen/URL
+  splitting, run collapsing, Unicode preservation
+  (Latin/Chinese/Cyrillic/Greek), emoji stripping, edge cases
+  (empty/punctuation-only/whitespace-only/single-char/trailing
+  token/leading separator).
+- `porter.test.ts` (85) — short-word passthrough, every step
+  (1a, 1b/1b'/1c, 2, 3, 4, 5a/5b), common docs words
+  (running/indexing/indexed/indexes), determinism.
+- `tokenize.test.ts` (19) — defaults, stop-word filter
+  (built-in/custom/empty), Porter stemming (alone, combined
+  with filter, ordering), realistic queries and doc bodies,
+  determinism, immutability, STOP_WORDS contents.
+
+Coverage: **100% line / 95.6% branch / 100% function** on all
+source files with logic (`types.ts` is type-only).  The
+remaining branches are defensive length-guards that the public
+entry `porterStem` already rejects upstream.
+
+### v0 simplifications (documented)
+
+- **English-only stemmer.**  Porter is English-only by
+  definition.  Non-ASCII tokens pass through `porterStem`
+  unchanged.  Multi-language sites disable stemming globally
+  OR shard indexes by language.
+- **No phrase tokens / n-grams.**  Each token is independent.
+- **No synonyms.**  v1 may add a synonym-expansion option.
+- **No language detection.**  v1 may add per-language pipeline
+  routing.
+- **No fuzzy matching.**  Strict exact-token match; typo
+  tolerance is a query-time concern for
+  `forme-doc-search-client-js`.

--- a/code/packages/typescript/forme-doc-search-tokenizer/README.md
+++ b/code/packages/typescript/forme-doc-search-tokenizer/README.md
@@ -1,0 +1,184 @@
+# @coding-adventures/forme-doc-search-tokenizer
+
+> Eighth DOC00 v0 package — text → tokens pipeline for the
+> documentation-site search index. Lowercase, strip
+> non-alphanumeric, split on whitespace, optional stop-word
+> filter, optional Porter stemmer.
+
+Pure transform. Capabilities: `[]`. **Zero runtime dependencies.**
+
+## What it does
+
+```ts
+import { tokenize } from "@coding-adventures/forme-doc-search-tokenizer";
+
+tokenize("Hello, World!");
+// → ["hello", "world"]
+
+tokenize("the quick brown fox", { filterStopWords: true });
+// → ["quick", "brown", "fox"]      (drops "the")
+
+tokenize("running and walking", { stem: true });
+// → ["run", "and", "walk"]
+
+tokenize("running and walking", { filterStopWords: true, stem: true });
+// → ["run", "walk"]
+```
+
+## Pipeline
+
+| Step                       | Default                       |
+|----------------------------|-------------------------------|
+| 1. Lowercase               | always (locale-independent)   |
+| 2. Strip non-alphanumeric  | always (keep `\p{L}` `\p{N}` `_`) |
+| 3. Split on whitespace     | always                        |
+| 4. Stop-word filter        | opt-in (`filterStopWords: true`) |
+| 5. Porter stemmer          | opt-in (`stem: true`)         |
+
+**Locale-independent lowercasing** uses `toLowerCase` (NOT
+`toLocaleLowerCase`) — same reasoning as
+`forme-doc-heading-anchors`. Under tr-TR, `'I' → 'ı'`, which
+would break cross-locale search recall. Default Unicode
+case-folding is the right call for stable indexes.
+
+**Underscore preserved inside tokens** so identifier-shaped
+strings like `setup_guide` and `__proto__` survive intact. Code
+blocks in docs often contain identifiers, and splitting them
+hurts search recall.
+
+## Public API
+
+| Export                   | Purpose                                                                  |
+|--------------------------|--------------------------------------------------------------------------|
+| `tokenize(text, opts?)`  | Main entry — runs the full pipeline.                                     |
+| `normaliseToTokens(text)`| Pipeline steps 1-3 only (lowercase, strip, split). No filtering/stemming.|
+| `porterStem(word)`       | Standalone Porter stemmer for a single word.                             |
+| `STOP_WORDS`             | Built-in ~35-word English stop-word set.                                 |
+| `TokenizeOptions`        | `{ filterStopWords?, stem?, customStopWords? }`.                         |
+
+## Stop-word list
+
+Curated ~35-word set, deliberately small for technical
+documentation context. Includes high-frequency function words
+(articles, pronouns, common prepositions, copulas) but
+**keeps** negation/question words (`not`, `no`, `how`, `what`,
+`when`, `why`, `where`) since they carry meaningful search
+signal in API descriptions and FAQ queries.
+
+Override the built-in list with `options.customStopWords` if
+your domain calls for it (e.g. drop common framework-specific
+boilerplate like `function`, `class`, `import` for
+JavaScript-only docs).
+
+## Porter stemmer
+
+The textbook Martin Porter (1980) English stemmer — five
+sequential suffix-stripping steps, each gated by Porter's
+"measure" m(W) (number of consonant-vowel transitions).
+Implementation faithfully follows the published reference;
+deviation produces non-portable stems.
+
+Examples:
+- `running` / `runs` → `run`
+- `happy` / `happiness` / `happily` → `happi`
+- `relational` → `relat` (`-ational` → `-ate`, then `-ate` step 4)
+- `airliner` → `airlin` (`-er` step 4)
+- `replacement` → `replac` (`-ment` step 4)
+
+Stemming is **optional** because:
+1. It hurts recall for exact-keyword queries (`"running" != "run"` for case-sensitive code searches).
+2. It increases index complexity (the index-builder must agree with the query-tokeniser).
+3. For short docs sites with English vocabulary, the stem-collapse benefit is modest.
+
+When you DO enable it, both the index-builder
+(`forme-doc-search-index-builder`) and the query tokeniser
+(`forme-doc-search-client-js`) must use `stem: true` — or
+queries won't match the index.
+
+## Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver.**
+  Pure data construction.
+- **No `+` quantifiers on user-controllable regex.** Every
+  scan in `normalise.ts` uses an explicit character-by-character
+  index loop. The only regex in the package is the
+  single-char-class `/^[\p{L}\p{N}_]$/u` in `isTokenChar`,
+  which matches exactly one code point (no quantifier) and is
+  therefore not subject to polynomial-time concerns.
+  - Background: previous DOC00 packages (`forme-doc-sidebar-builder`,
+    `forme-doc-page-shell`) hit CodeQL's `js/polynomial-redos`
+    query on simple `+`-quantified anchored regexes. The
+    explicit-loop approach is now the project-wide standard
+    for any user-facing trim/strip/scan.
+- **No I/O.** Capabilities `[]`. Zero runtime dependencies.
+- **Deterministic.** Same input bytes → identical output bytes.
+  Stable across machines (locale-independent case-folding,
+  insertion-ordered Set iteration per ES spec).
+- **No input mutation.** Verified by test (custom stop-word
+  set snapshot).
+
+## Tests
+
+127 tests across three files:
+
+- `normalise.test.ts` (23) — basic tokenisation, lowercasing
+  (including tr-TR stability), punctuation stripping, hyphen
+  splitting, URL splitting, run collapsing, Unicode preservation
+  (Latin/Chinese/Cyrillic/Greek), emoji stripping, edge cases
+  (empty/punctuation-only/whitespace-only/single-char/trailing
+  token/leading separator).
+- `porter.test.ts` (85) — short-word passthrough, every step
+  (1a plurals, 1b past participles + -ing, 1b' post-strip
+  adjustments, 1c -y → -i, 2 -ational/-tional/etc., 3
+  -icate/-ative/-alize, 4 -al/-ance/-ence/-er/etc. + -ion
+  after s/t, 5a -e cleanup, 5b -ll → -l), common docs words
+  (running, indexing, indexed, indexes), determinism.
+- `tokenize.test.ts` (19) — defaults, stop-word filter
+  (built-in / custom / empty), Porter stemming (alone,
+  combined with filter, ordering), realistic queries and
+  doc bodies, determinism, immutability, STOP_WORDS contents.
+
+Coverage: **100% line / 95.6% branch / 100% function** on all
+source files with logic (`types.ts` is type-only). The
+remaining branches are defensive guards for word lengths the
+public entry (`porterStem`) already rejects.
+
+## How it fits in the stack
+
+Eighth concrete DOC00 v0 package. Sits in the search-engine
+layer, used by both the build-time index builder and the
+runtime query tokeniser:
+
+```
+.md bodies + frontmatter  ──►  search-tokenizer (build time)
+                                       ↓
+                              search-index-builder  ──►  index shards
+                                                              ↓
+.md body in browser  ──►  search-tokenizer (runtime)        / disk
+        ↓                          ↓                          ↓
+   user query  ──►   search-client-js  ◄──  loaded shards    ↓
+        ↓                          ↓                          ↓
+        └──────── matched documents ranked + displayed
+```
+
+Next DOC00 v0 packages: `forme-doc-search-index-builder`,
+`forme-doc-search-client-js`, `forme-doc-site-emitter`.
+
+## v0 simplifications (documented)
+
+- **English-only.** Porter stemmer is documented English-only.
+  Non-ASCII tokens (`café`, `中文`) pass through `porterStem`
+  unchanged. Multi-language sites should disable stemming
+  globally OR shard their indexes by language.
+- **No phrase tokens.** Each token is independent. "machine
+  learning" tokenises to `["machine", "learning"]` with no
+  bigram tracking. v1 may add n-gram support for phrase
+  queries.
+- **No synonyms.** "color" and "colour" are different tokens.
+  Sites with regional vocabulary should pre-normalise.
+- **No language detection.** `tokenize` runs the same pipeline
+  on all input. Multi-language sites must route through
+  per-language tokenisers themselves.
+- **No fuzzy matching.** Strict exact-token match. Typo
+  tolerance (Levenshtein distance, etc.) is a query-time
+  concern for `forme-doc-search-client-js`.

--- a/code/packages/typescript/forme-doc-search-tokenizer/package-lock.json
+++ b/code/packages/typescript/forme-doc-search-tokenizer/package-lock.json
@@ -1,0 +1,2301 @@
+{
+  "name": "@coding-adventures/forme-doc-search-tokenizer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-doc-search-tokenizer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/package.json
+++ b/code/packages/typescript/forme-doc-search-tokenizer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@coding-adventures/forme-doc-search-tokenizer",
+  "version": "0.1.0",
+  "description": "Text → tokens pipeline for the documentation-site search index.  Lowercase (locale-independent), strip non-alphanumeric Unicode, split on whitespace, optional stop-word filter (~30-word English list), optional Porter stemmer.  Used by `forme-doc-search-index-builder` at build time and shipped to the browser by `forme-doc-search-client-js` for query tokenisation.  Pure transform, capability [], zero runtime dependencies.  DOC00 v0 search-engine package.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/required_capabilities.json
+++ b/code/packages/typescript/forme-doc-search-tokenizer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/specs/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-doc-search-tokenizer",
+  "capabilities": [],
+  "justification": "Pure transform: string → string[].  Lowercase, strip non-alphanumeric Unicode, split on whitespace runs, optional stop-word filter, optional Porter stemmer.  No eval, no Function, no JSON.parse-with-reviver, no fs/network/env/shell.  Zero runtime dependencies.  Per-character index-loop scanning (no `+`-quantified regex on user input) to avoid CodeQL `js/polynomial-redos` false positives that bit previous DOC00 packages."
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/src/index.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @coding-adventures/forme-doc-search-tokenizer
+ *
+ * Text → tokens pipeline for the documentation-site search index.
+ *
+ *   1. Lowercase (locale-independent — `toLowerCase`, NOT
+ *      `toLocaleLowerCase`, so the index stays stable across
+ *      machines).
+ *   2. Strip non-alphanumeric Unicode (keep `\p{L}`, `\p{N}`,
+ *      and `_`).
+ *   3. Split on whitespace/punctuation runs.
+ *   4. (Optional) Filter stop-words from a ~35-word English
+ *      built-in list — or a caller-supplied custom list.
+ *   5. (Optional) Reduce each surviving token to its Porter stem.
+ *
+ * Pure transform.  Capabilities: `[]`.  **Zero runtime
+ * dependencies.**
+ *
+ * Used at BUILD time by `forme-doc-search-index-builder` to
+ * tokenise document text into postings, and at RUNTIME (in the
+ * browser) by `forme-doc-search-client-js` to tokenise user
+ * queries.  Both sides MUST agree on the `stem` /
+ * `filterStopWords` flags, or query tokens won't match the
+ * index.
+ *
+ * ```ts
+ * import { tokenize } from "@coding-adventures/forme-doc-search-tokenizer";
+ *
+ * tokenize("Hello, World!");
+ * // → ["hello", "world"]
+ *
+ * tokenize("the quick brown fox", { filterStopWords: true });
+ * // → ["quick", "brown", "fox"]      (drops "the")
+ *
+ * tokenize("running and walking", { stem: true });
+ * // → ["run", "and", "walk"]
+ *
+ * tokenize("running and walking", { filterStopWords: true, stem: true });
+ * // → ["run", "walk"]
+ * ```
+ *
+ * Eighth concrete DOC00 v0 package (after frontmatter,
+ * heading-anchors, toc-extractor, code-block-decorator,
+ * syntax-highlighter, sidebar-builder, page-shell).
+ *
+ * @module index
+ */
+
+export { tokenize } from "./tokenize.js";
+export { normaliseToTokens } from "./normalise.js";
+export { porterStem } from "./porter.js";
+export { STOP_WORDS } from "./stop-words.js";
+export type { TokenizeOptions } from "./types.js";

--- a/code/packages/typescript/forme-doc-search-tokenizer/src/normalise.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/src/normalise.ts
@@ -1,0 +1,136 @@
+/**
+ * normalise.ts — text → list of cleaned tokens (no stemming, no
+ * stop-word filtering yet).
+ *
+ * =============================================================================
+ * THE PIPELINE
+ * =============================================================================
+ *
+ * Per the DOC00 spec:
+ *
+ *   1. Lowercase.
+ *   2. Strip punctuation (keep alphanumerics, drop everything else).
+ *   3. Split on whitespace.
+ *
+ * "Alphanumeric" here means Unicode letter (`\p{L}`) OR Unicode
+ * number (`\p{N}`).  We keep underscores too (`_`) because they
+ * appear inside identifier-shaped tokens like `setup_guide` and
+ * splitting them would hurt code-block search recall.
+ *
+ * =============================================================================
+ * WHY NOT REGEX-DRIVEN?
+ * =============================================================================
+ *
+ * The straightforward implementation is:
+ *
+ *     return text
+ *       .toLowerCase()
+ *       .replace(/[^\p{L}\p{N}_]+/gu, " ")
+ *       .trim()
+ *       .split(/\s+/);
+ *
+ * Both `+` regexes on user-controlled input would trip CodeQL's
+ * `js/polynomial-redos` query (even though they're actually
+ * linear).  Previous DOC00 packages
+ * (`forme-doc-sidebar-builder`, `forme-doc-page-shell`) hit this
+ * problem and resolved it with explicit index loops.  We do the
+ * same here — single-pass scan, accumulating chars into a
+ * "current token" buffer and emitting whenever we hit a
+ * separator.
+ *
+ * Bonus: the explicit loop is ~2× faster than the regex
+ * three-pass on V8 for typical paragraph-sized inputs (no
+ * intermediate strings, no Array allocation for `\s+` splits).
+ *
+ * @module normalise
+ */
+
+/**
+ * Maximum length (in code points) of any individual emitted
+ * token.  Characters beyond this cap within a single run of
+ * token-chars are silently dropped until the next separator.
+ *
+ * Why a cap matters: a 10 MB input that's all letters with no
+ * separators would otherwise produce a single 10 MB token,
+ * which downstream consumers (`porterStem`, `Set.has`, the
+ * search index itself) all then operate on.  The `buf += ch`
+ * accumulation is amortised O(N) under V8's cons-string
+ * representation, but the first read flattens it to O(N), and
+ * the downstream amplification dominates.
+ *
+ * 256 matches Lucene's default `maxTokenLength` (the most
+ * widely-deployed open-source search index, used as the
+ * reference for "reasonable token cap").  Real-world documents
+ * essentially never contain non-pathological tokens longer than
+ * ~30 chars; 256 leaves a wide margin while bounding
+ * adversarial inputs.
+ */
+const MAX_TOKEN_LENGTH = 256;
+
+/**
+ * Tokenise `text` into a flat list of lowercased
+ * letter/digit/underscore tokens.  Pure function — no stop-word
+ * filtering, no stemming.
+ *
+ * @param text - The input string.
+ * @returns A list of tokens in source order.  Empty input or
+ *          input with no alphanumeric content returns `[]`.
+ *          Individual tokens are truncated at
+ *          `MAX_TOKEN_LENGTH` (256 chars) to bound adversarial
+ *          inputs.
+ */
+export function normaliseToTokens(text: string): string[] {
+  // Lowercase first — locale-independent (NOT toLocaleLowerCase;
+  // same reasoning as forme-doc-heading-anchors: search indexes
+  // must be stable across machines, and tr-TR's `'I' → 'ı'`
+  // would break cross-locale recall).
+  const lower = text.toLowerCase();
+  const tokens: string[] = [];
+  // We walk the string ONCE, accumulating into a buffer.  When
+  // we hit a non-token character, we flush the buffer (if
+  // non-empty) and reset.
+  let buf = "";
+  for (const ch of lower) {
+    // `for...of` iterates code points, not UTF-16 code units —
+    // so surrogate-pair characters (most emoji, some CJK) are
+    // delivered as single iterations.  That's the right
+    // granularity for Unicode-aware classification.
+    if (isTokenChar(ch)) {
+      // Cap individual token length to bound CPU + memory cost
+      // for downstream consumers (porterStem, Set lookups, the
+      // index itself).  Characters beyond the cap are dropped
+      // until the next separator — same emitted token shape as
+      // a real word would have produced.
+      if (buf.length < MAX_TOKEN_LENGTH) {
+        buf += ch;
+      }
+    } else if (buf.length > 0) {
+      tokens.push(buf);
+      buf = "";
+    }
+    // If the char is a separator AND buf is empty, we just
+    // skip — collapses runs of whitespace/punctuation.
+  }
+  // Don't forget the trailing token (the loop only flushes on
+  // separator-after-token transitions; a string ending in a
+  // token has nothing to trigger the flush).
+  if (buf.length > 0) {
+    tokens.push(buf);
+  }
+  return tokens;
+}
+
+/**
+ * True iff `ch` is a Unicode letter, Unicode number, or
+ * underscore — i.e. a character we keep INSIDE a token.
+ *
+ * We use a small character-class regex with the `u` flag for
+ * the Unicode property escapes.  This regex has NO quantifier
+ * (matches exactly one code point), so it's not subject to
+ * polynomial-time concerns even on adversarial input.
+ *
+ * @internal
+ */
+function isTokenChar(ch: string): boolean {
+  return /^[\p{L}\p{N}_]$/u.test(ch);
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/src/porter.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/src/porter.ts
@@ -1,0 +1,408 @@
+/**
+ * porter.ts — the Porter stemmer (Martin Porter, 1980).
+ *
+ * =============================================================================
+ * WHAT IS A STEMMER?
+ * =============================================================================
+ *
+ * A stemmer collapses morphological variants of a word to a
+ * shared root form so that searches for one variant match
+ * documents containing another:
+ *
+ *     run  / running / runs / ran    →  "run"  (or "ran" for irregulars)
+ *     happy / happiness / happily    →  "happi"
+ *     index / indexes / indexed      →  "index"
+ *
+ * The Porter stemmer is the textbook English stemmer — published
+ * in 1980, ~30 lines of rules, and still the default choice for
+ * most search engines that don't need linguistic precision.  It
+ * works by suffix-stripping in five sequential steps, with each
+ * suffix rule gated by a "measure" check that prevents
+ * over-stripping of short words.
+ *
+ * =============================================================================
+ * THE MEASURE m(W)
+ * =============================================================================
+ *
+ * Porter's "measure" of a word W is the number of consonant-vowel
+ * transitions in W, written m(W).  Formally W is split into a
+ * sequence of consonant-runs (C) and vowel-runs (V), then
+ * m = number of VC pairs:
+ *
+ *     [C](VC)^m[V]
+ *
+ * Examples (consonants = c, vowels = v, y treated specially):
+ *
+ *     "tr"           → C    →  m = 0
+ *     "ee"           → V    →  m = 0
+ *     "tree"         → C V   →  m = 0
+ *     "trouble"      → C V C   →  m = 1
+ *     "troubles"     → C V C V C   →  m = 2
+ *     "troublesome"  → C V C V C V C   →  m = 3
+ *
+ * Suffix-stripping rules have the form `(condition) S1 → S2`
+ * where the condition is `m > N` (and sometimes `*v*`, `*o`,
+ * etc.).  The condition is checked on the word AFTER stripping
+ * S1 — so "agreement" with rule `(m > 1) EMENT →` would strip
+ * to "agree" only if "agre" has m > 1 (which it doesn't, so no
+ * strip).
+ *
+ * =============================================================================
+ * WHY THIS IS WORTH 200+ LINES
+ * =============================================================================
+ *
+ * Stemmer quality directly affects search recall.  A bad stemmer
+ * either misses relevant documents (under-stripping) or returns
+ * noise (over-stripping).  Porter is the well-known sweet spot:
+ * decades of empirical tuning, MIT-licensed reference
+ * implementations in every language, and used by everything from
+ * Lucene to old-school Unix `nroff` tools.
+ *
+ * We port a clean, well-commented reference (no clever tricks)
+ * rather than rolling our own — both because the algorithm has
+ * a million corner cases and because deviation from the
+ * published reference produces non-portable stems.
+ *
+ * @module porter
+ */
+
+// ─────────────────────────────────────────────────────────────────────
+// Vowel classification (Porter convention: 'y' is sometimes a vowel)
+// ─────────────────────────────────────────────────────────────────────
+
+const VOWELS: ReadonlySet<string> = new Set(["a", "e", "i", "o", "u"]);
+
+/**
+ * True iff position `i` in `w` is a consonant under Porter's
+ * convention.  'y' is a consonant if the previous char is a
+ * vowel, vowel otherwise.  Position 0 'y' is treated as a
+ * consonant.
+ *
+ * Implementation note: written iteratively rather than
+ * recursively.  A naive recursive version (`isConsonantAt(w, i-1)`
+ * for the 'y' lookback) overflows V8's stack on inputs like
+ * `"y".repeat(10000)` — a single very-long y-run in untrusted
+ * input would crash the indexer (security review caught this
+ * as a MEDIUM finding before push).
+ *
+ * The iterative form walks backwards through any 'y'-run to
+ * find the first non-'y' character (or the word start) and
+ * computes the final classification from the parity of the
+ * run length plus the "base" character's class.
+ *
+ * Behaviour-preserving derivation:
+ *   - If the run starts at position 0 (j < 0): position 0 'y'
+ *     is a consonant by spec.  Each subsequent 'y' alternates.
+ *     So result = (runLen is odd).
+ *   - If `w[j]` is a vowel: first 'y' flips to consonant.  Each
+ *     subsequent 'y' alternates.  result = (runLen is odd).
+ *   - If `w[j]` is a non-'y' consonant: first 'y' flips to vowel.
+ *     Each subsequent 'y' alternates.  result = (runLen is even).
+ *
+ * In all three cases combined:
+ *     result = baseIsConsonant === (runLen % 2 === 0)
+ * where `baseIsConsonant = false` at word start (treat-as-vowel)
+ * or `!VOWELS.has(w[j])` otherwise.
+ */
+function isConsonantAt(w: string, i: number): boolean {
+  const ch = w[i]!;
+  if (VOWELS.has(ch)) return false;
+  if (ch !== "y") return true;
+  // Walk back through any 'y'-run.  `j` ends up pointing at
+  // the first non-'y' char before the run, or -1 if the run
+  // started at position 0.
+  let j = i - 1;
+  while (j >= 0 && w[j] === "y") j--;
+  // "Base" classification — what the run is anchored against.
+  // Word start (j < 0) is treated as if a vowel preceded the
+  // run (which makes the first 'y' a consonant, matching
+  // Porter's spec for position 0 'y').
+  const baseIsConsonant = j < 0 ? false : !VOWELS.has(w[j]!);
+  const runLen = i - j; // 1..N
+  // Behaviour-preserving identity (see comment above).
+  return baseIsConsonant === (runLen % 2 === 0);
+}
+
+/**
+ * Porter's measure m(W) — number of VC pairs after stripping
+ * the optional leading C and trailing V.
+ */
+function measure(w: string): number {
+  // Build a 0/1 mask: 0 = vowel, 1 = consonant.
+  // Then count VC transitions: positions where mask[i] = 0
+  // followed by mask[i+1] = 1.
+  if (w.length === 0) return 0;
+  // First, find the start of the first vowel-run (skip leading
+  // consonants).
+  let i = 0;
+  while (i < w.length && isConsonantAt(w, i)) i++;
+  if (i >= w.length) return 0; // all consonants, no VC pair
+  // From here on, count VC transitions.
+  let m = 0;
+  let inVowelRun = true;
+  for (; i < w.length; i++) {
+    if (isConsonantAt(w, i)) {
+      if (inVowelRun) {
+        m++;
+        inVowelRun = false;
+      }
+    } else {
+      inVowelRun = true;
+    }
+  }
+  return m;
+}
+
+/** True iff `w` contains a vowel anywhere. */
+function containsVowel(w: string): boolean {
+  for (let i = 0; i < w.length; i++) {
+    if (!isConsonantAt(w, i)) return true;
+  }
+  return false;
+}
+
+/**
+ * True iff `w` ends in a double consonant (e.g. "tt", "ll").
+ */
+function endsDoubleConsonant(w: string): boolean {
+  if (w.length < 2) return false;
+  if (w[w.length - 1] !== w[w.length - 2]) return false;
+  return isConsonantAt(w, w.length - 1);
+}
+
+/**
+ * True iff `w` ends in CVC (consonant-vowel-consonant) where
+ * the final C is not w, x, or y.  Used by step 1b's `(m=1 and *o)`
+ * condition.
+ */
+function endsCVC(w: string): boolean {
+  if (w.length < 3) return false;
+  const n = w.length;
+  if (!isConsonantAt(w, n - 1)) return false;
+  if (isConsonantAt(w, n - 2)) return false;
+  if (!isConsonantAt(w, n - 3)) return false;
+  const last = w[n - 1]!;
+  if (last === "w" || last === "x" || last === "y") return false;
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Suffix matching utilities
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Apply the first matching rule from a table.  Each rule is
+ * `[suf, repl, predicate]`.  Returns the new word after the
+ * first hit, or `w` unchanged if no rule fires.
+ */
+function applyFirstMatchingRule(
+  w: string,
+  rules: readonly [string, string, (stem: string) => boolean][],
+): string {
+  for (const [suf, repl, pred] of rules) {
+    if (w.endsWith(suf)) {
+      const stem = w.slice(0, w.length - suf.length);
+      if (pred(stem)) {
+        return stem + repl;
+      }
+      // Suffix matched but predicate failed — Porter's
+      // convention is to STOP looking (only one rule per step).
+      return w;
+    }
+  }
+  return w;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Steps 1a, 1b, 1b', 1c — plurals + past participles + -y → -i
+// ─────────────────────────────────────────────────────────────────────
+
+function step1a(w: string): string {
+  // Order matters — Porter spec: try in order, first match wins.
+  if (w.endsWith("sses")) return w.slice(0, -4) + "ss";
+  if (w.endsWith("ies")) return w.slice(0, -3) + "i";
+  if (w.endsWith("ss")) return w;
+  if (w.endsWith("s")) return w.slice(0, -1);
+  return w;
+}
+
+function step1b(w: string): string {
+  // (m > 0) EED → EE
+  if (w.endsWith("eed")) {
+    const stem = w.slice(0, -3);
+    if (measure(stem) > 0) return stem + "ee";
+    return w;
+  }
+  // (*v*) ED → ε
+  // (*v*) ING → ε
+  let stem: string | null = null;
+  let stripped = w;
+  if (w.endsWith("ed")) {
+    const s = w.slice(0, -2);
+    if (containsVowel(s)) {
+      stem = s;
+      stripped = s;
+    }
+  } else if (w.endsWith("ing")) {
+    const s = w.slice(0, -3);
+    if (containsVowel(s)) {
+      stem = s;
+      stripped = s;
+    }
+  }
+  if (stem === null) return w;
+  // After ED / ING stripped: apply step 1b' adjustments.
+  if (stripped.endsWith("at")) return stripped + "e";
+  if (stripped.endsWith("bl")) return stripped + "e";
+  if (stripped.endsWith("iz")) return stripped + "e";
+  // (*d and not (*L or *S or *Z)) → strip the doubled consonant
+  if (endsDoubleConsonant(stripped)) {
+    const last = stripped[stripped.length - 1]!;
+    if (last !== "l" && last !== "s" && last !== "z") {
+      return stripped.slice(0, -1);
+    }
+    return stripped;
+  }
+  // (m=1 and *o) → add E
+  if (measure(stripped) === 1 && endsCVC(stripped)) return stripped + "e";
+  return stripped;
+}
+
+function step1c(w: string): string {
+  // (*v*) Y → I
+  if (!w.endsWith("y")) return w;
+  const stem = w.slice(0, -1);
+  if (!containsVowel(stem)) return w;
+  return stem + "i";
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Step 2 — common -ational, -tional, etc. suffixes
+// ─────────────────────────────────────────────────────────────────────
+
+const STEP_2_RULES: readonly [string, string, (s: string) => boolean][] = [
+  ["ational", "ate", (s) => measure(s) > 0],
+  ["tional",  "tion", (s) => measure(s) > 0],
+  ["enci",    "ence", (s) => measure(s) > 0],
+  ["anci",    "ance", (s) => measure(s) > 0],
+  ["izer",    "ize",  (s) => measure(s) > 0],
+  ["abli",    "able", (s) => measure(s) > 0],
+  ["alli",    "al",   (s) => measure(s) > 0],
+  ["entli",   "ent",  (s) => measure(s) > 0],
+  ["eli",     "e",    (s) => measure(s) > 0],
+  ["ousli",   "ous",  (s) => measure(s) > 0],
+  ["ization", "ize",  (s) => measure(s) > 0],
+  ["ation",   "ate",  (s) => measure(s) > 0],
+  ["ator",    "ate",  (s) => measure(s) > 0],
+  ["alism",   "al",   (s) => measure(s) > 0],
+  ["iveness", "ive",  (s) => measure(s) > 0],
+  ["fulness", "ful",  (s) => measure(s) > 0],
+  ["ousness", "ous",  (s) => measure(s) > 0],
+  ["aliti",   "al",   (s) => measure(s) > 0],
+  ["iviti",   "ive",  (s) => measure(s) > 0],
+  ["biliti",  "ble",  (s) => measure(s) > 0],
+];
+
+function step2(w: string): string {
+  return applyFirstMatchingRule(w, STEP_2_RULES);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Step 3 — -icate, -ative, -alize, etc.
+// ─────────────────────────────────────────────────────────────────────
+
+const STEP_3_RULES: readonly [string, string, (s: string) => boolean][] = [
+  ["icate", "ic", (s) => measure(s) > 0],
+  ["ative", "",   (s) => measure(s) > 0],
+  ["alize", "al", (s) => measure(s) > 0],
+  ["iciti", "ic", (s) => measure(s) > 0],
+  ["ical",  "ic", (s) => measure(s) > 0],
+  ["ful",   "",   (s) => measure(s) > 0],
+  ["ness",  "",   (s) => measure(s) > 0],
+];
+
+function step3(w: string): string {
+  return applyFirstMatchingRule(w, STEP_3_RULES);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Step 4 — -al, -ance, -ence, -er, -ic, -able, -ible, ...
+// ─────────────────────────────────────────────────────────────────────
+
+const STEP_4_SUFFIXES: readonly string[] = [
+  "al", "ance", "ence", "er", "ic", "able", "ible", "ant", "ement", "ment",
+  "ent", "ou", "ism", "ate", "iti", "ous", "ive", "ize",
+];
+
+function step4(w: string): string {
+  // Step 4 strips with predicate m > 1.  Special case: -ion is
+  // stripped only if preceded by 's' or 't'.
+  for (const suf of STEP_4_SUFFIXES) {
+    if (w.endsWith(suf)) {
+      const stem = w.slice(0, w.length - suf.length);
+      if (measure(stem) > 1) return stem;
+      return w;
+    }
+  }
+  // -ion (after 's' or 't')
+  if (w.endsWith("ion")) {
+    const stem = w.slice(0, -3);
+    if (stem.length === 0) return w;
+    const last = stem[stem.length - 1]!;
+    if ((last === "s" || last === "t") && measure(stem) > 1) return stem;
+  }
+  return w;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Step 5a/5b — final 'e' and double-'l' cleanup
+// ─────────────────────────────────────────────────────────────────────
+
+function step5a(w: string): string {
+  // (m > 1) E →
+  // (m = 1 and not *o) E →
+  if (!w.endsWith("e")) return w;
+  const stem = w.slice(0, -1);
+  const m = measure(stem);
+  if (m > 1) return stem;
+  if (m === 1 && !endsCVC(stem)) return stem;
+  return w;
+}
+
+function step5b(w: string): string {
+  // (m > 1 and *d and *L) → strip one L
+  if (w.length < 2) return w;
+  if (w[w.length - 1] !== "l") return w;
+  if (!endsDoubleConsonant(w)) return w;
+  if (measure(w.slice(0, -1)) <= 1) return w;
+  return w.slice(0, -1);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Public entry
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Reduce a single word to its Porter stem.
+ *
+ * @param word - The input word.  Should already be lowercased
+ *               (the stemmer doesn't lowercase — it's the
+ *               caller's job since the normaliser handles it).
+ *               Non-ASCII letters pass through unchanged
+ *               (Porter is an English-only algorithm).
+ * @returns The stem.  Words ≤ 2 chars are returned unchanged
+ *          (too short for any rule to fire usefully).
+ */
+export function porterStem(word: string): string {
+  if (word.length <= 2) return word;
+  let w = word;
+  w = step1a(w);
+  w = step1b(w);
+  w = step1c(w);
+  w = step2(w);
+  w = step3(w);
+  w = step4(w);
+  w = step5a(w);
+  w = step5b(w);
+  return w;
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/src/stop-words.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/src/stop-words.ts
@@ -1,0 +1,49 @@
+/**
+ * stop-words.ts — built-in English stop-word list.
+ *
+ * Small (~35-word) list of high-frequency English function words
+ * that carry little search signal.  Filtering them shrinks the
+ * search index meaningfully without hurting recall for typical
+ * docs-site queries.
+ *
+ * The list is curated for technical-documentation context — it
+ * deliberately KEEPS words like `not`, `no`, `do`, `if`,
+ * `then` (often appearing in API descriptions where the
+ * polarity matters).  It also keeps `how`, `what`, `when`,
+ * `where`, `why` (question words common in FAQ/tutorial
+ * queries).  Add more via `options.customStopWords` if your
+ * domain calls for it.
+ *
+ * @module stop-words
+ */
+
+/**
+ * The built-in stop-word set.  Frozen at module load so callers
+ * can't accidentally pollute it (e.g. by treating the read-only
+ * type contract as advisory).
+ */
+const STOP_WORDS_INTERNAL = new Set<string>([
+  "a", "an", "and", "are", "as", "at",
+  "be", "but", "by",
+  "for", "from",
+  "has", "have", "had", "he", "her", "him", "his",
+  "in", "is", "it", "its",
+  "of", "on", "or",
+  "she",
+  "that", "the", "their", "them", "these", "they", "this", "those", "to",
+  "was", "were", "will", "with",
+  "you", "your",
+]);
+
+/**
+ * Read-only view of the built-in stop-word list.  Iteration
+ * order is insertion order per ES spec.
+ *
+ * Note: `ReadonlySet<string>` is a TypeScript-only contract;
+ * the underlying `Set` is technically mutable at runtime.  This
+ * is the same trade-off as `forme-doc-syntax-highlighter`'s
+ * `SUPPORTED_LANGUAGES` — callers casting away the type to
+ * mutate the set are on their own; no security boundary
+ * depends on its immutability.
+ */
+export const STOP_WORDS: ReadonlySet<string> = STOP_WORDS_INTERNAL;

--- a/code/packages/typescript/forme-doc-search-tokenizer/src/tokenize.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/src/tokenize.ts
@@ -1,0 +1,45 @@
+/**
+ * tokenize.ts — main `tokenize` entry composing the pipeline.
+ *
+ * @module tokenize
+ */
+
+import { normaliseToTokens } from "./normalise.js";
+import { porterStem } from "./porter.js";
+import { STOP_WORDS } from "./stop-words.js";
+import type { TokenizeOptions } from "./types.js";
+
+/**
+ * Tokenise `text` per the DOC00 spec pipeline:
+ *
+ *   1. Lowercase (locale-independent).
+ *   2. Strip non-alphanumeric (keep Unicode letters/digits +
+ *      underscore).
+ *   3. Split on whitespace / punctuation runs.
+ *   4. Filter stop-words (when `options.filterStopWords`).
+ *   5. Porter stem each surviving token (when `options.stem`).
+ *
+ * The four behaviour flags (`filterStopWords`, `stem`,
+ * `customStopWords`) are all optional; the default is
+ * `tokenize(text)` → just steps 1-3 (lowercased
+ * alphanumeric tokens, no filtering, no stemming).
+ *
+ * @param text - The input string.  Non-string inputs are
+ *               coerced via `String(...)`.
+ * @param options - `{ filterStopWords?, stem?, customStopWords? }`.
+ * @returns A flat list of tokens in source order.
+ */
+export function tokenize(text: string, options: TokenizeOptions = {}): string[] {
+  const tokens = normaliseToTokens(String(text));
+  // Phase 4: stop-word filter.
+  let filtered = tokens;
+  if (options.filterStopWords === true) {
+    const stopWords = options.customStopWords ?? STOP_WORDS;
+    filtered = tokens.filter((t) => !stopWords.has(t));
+  }
+  // Phase 5: Porter stem.
+  if (options.stem === true) {
+    filtered = filtered.map(porterStem);
+  }
+  return filtered;
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/src/types.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/src/types.ts
@@ -1,0 +1,38 @@
+/**
+ * types.ts — public signatures for the search tokeniser.
+ *
+ * @module types
+ */
+
+/**
+ * Optional tokenisation configuration.
+ */
+export interface TokenizeOptions {
+  /**
+   * When `true`, tokens matching the (built-in or custom)
+   * stop-word list are filtered out.  Default: `false` — the
+   * caller decides whether to drop high-frequency function
+   * words.  Indexing typically wants `true` to shrink the
+   * index; query-time tokenising might want `false` to preserve
+   * exact-match semantics for explicit-keyword queries.
+   */
+  readonly filterStopWords?: boolean;
+
+  /**
+   * When `true`, each surviving token is reduced to its Porter
+   * stem (e.g. `"running"` → `"run"`, `"happiness"` → `"happi"`).
+   * Default: `false`.  Indexing and query-tokenising sides MUST
+   * agree on this option, or queries won't match the index.
+   */
+  readonly stem?: boolean;
+
+  /**
+   * Override the built-in English stop-word list.  Only consulted
+   * when `filterStopWords` is `true`.  Pass `new Set()` to filter
+   * NO words (effectively disabling the filter).  Word
+   * comparison is exact-match on the already-lowercased token.
+   *
+   * Default: the built-in `STOP_WORDS` set.
+   */
+  readonly customStopWords?: ReadonlySet<string>;
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/tests/normalise.test.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/tests/normalise.test.ts
@@ -1,0 +1,116 @@
+/**
+ * normalise.test.ts — text → tokens pipeline tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { normaliseToTokens } from "../src/index.js";
+
+describe("normaliseToTokens — basic", () => {
+  it("simple ASCII words", () => {
+    expect(normaliseToTokens("hello world")).toEqual(["hello", "world"]);
+  });
+  it("preserves digit-only tokens", () => {
+    expect(normaliseToTokens("year 2026")).toEqual(["year", "2026"]);
+  });
+  it("preserves mixed alphanumeric tokens", () => {
+    expect(normaliseToTokens("v1.2.3 release")).toEqual(["v1", "2", "3", "release"]);
+  });
+  it("preserves underscores inside tokens", () => {
+    expect(normaliseToTokens("getting_started_guide")).toEqual(["getting_started_guide"]);
+  });
+});
+
+describe("normaliseToTokens — lowercasing", () => {
+  it("uppercase → lowercase", () => {
+    expect(normaliseToTokens("HELLO WORLD")).toEqual(["hello", "world"]);
+  });
+  it("mixed case → lowercase", () => {
+    expect(normaliseToTokens("Hello, World!")).toEqual(["hello", "world"]);
+  });
+  it("Turkish I uses locale-independent case-folding (NOT tr-TR)", () => {
+    // Under tr-TR, 'I' would fold to 'ı'; default Unicode folds
+    // to 'i'.  Search indexes must be stable across locales.
+    expect(normaliseToTokens("INTRODUCTION")).toEqual(["introduction"]);
+  });
+});
+
+describe("normaliseToTokens — punctuation stripping", () => {
+  it("commas and periods", () => {
+    expect(normaliseToTokens("Hello, world.")).toEqual(["hello", "world"]);
+  });
+  it("quotes and brackets", () => {
+    expect(normaliseToTokens('She said "hi" (loudly).')).toEqual([
+      "she", "said", "hi", "loudly",
+    ]);
+  });
+  it("hyphens split tokens", () => {
+    expect(normaliseToTokens("state-of-the-art")).toEqual(["state", "of", "the", "art"]);
+  });
+  it("URL gets split into letter runs", () => {
+    expect(normaliseToTokens("https://example.com/path")).toEqual([
+      "https", "example", "com", "path",
+    ]);
+  });
+  it("collapses runs of punctuation/whitespace", () => {
+    expect(normaliseToTokens("a !!! b???   c")).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("normaliseToTokens — Unicode", () => {
+  it("preserves accented Latin letters", () => {
+    expect(normaliseToTokens("café résumé")).toEqual(["café", "résumé"]);
+  });
+  it("preserves Chinese characters", () => {
+    expect(normaliseToTokens("中文 标题")).toEqual(["中文", "标题"]);
+  });
+  it("preserves Cyrillic", () => {
+    expect(normaliseToTokens("Привет мир")).toEqual(["привет", "мир"]);
+  });
+  it("preserves Greek", () => {
+    expect(normaliseToTokens("Καλημέρα κόσμε")).toEqual(["καλημέρα", "κόσμε"]);
+  });
+  it("emoji are non-alphanumeric → stripped", () => {
+    expect(normaliseToTokens("rocket 🚀 launch")).toEqual(["rocket", "launch"]);
+  });
+});
+
+describe("normaliseToTokens — token-length cap (DoS defence)", () => {
+  it("caps individual token at 256 characters", () => {
+    // 1000 letters, no separators → one 256-char token.
+    const huge = "a".repeat(1000);
+    const tokens = normaliseToTokens(huge);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].length).toBe(256);
+  });
+  it("multiple long tokens cap independently", () => {
+    const text = "a".repeat(500) + " " + "b".repeat(500);
+    const tokens = normaliseToTokens(text);
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0].length).toBe(256);
+    expect(tokens[1].length).toBe(256);
+  });
+  it("normal-length tokens unaffected", () => {
+    expect(normaliseToTokens("normal length words")).toEqual(["normal", "length", "words"]);
+  });
+});
+
+describe("normaliseToTokens — edge cases", () => {
+  it("empty string", () => {
+    expect(normaliseToTokens("")).toEqual([]);
+  });
+  it("only punctuation", () => {
+    expect(normaliseToTokens("!@#$%^&*()")).toEqual([]);
+  });
+  it("only whitespace", () => {
+    expect(normaliseToTokens("   \t\n")).toEqual([]);
+  });
+  it("single character word", () => {
+    expect(normaliseToTokens("a")).toEqual(["a"]);
+  });
+  it("trailing token (no separator after)", () => {
+    expect(normaliseToTokens("foo bar")).toEqual(["foo", "bar"]);
+  });
+  it("leading separator", () => {
+    expect(normaliseToTokens("  foo")).toEqual(["foo"]);
+  });
+});

--- a/code/packages/typescript/forme-doc-search-tokenizer/tests/porter.test.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/tests/porter.test.ts
@@ -1,0 +1,165 @@
+/**
+ * porter.test.ts — Porter stemmer tests.
+ *
+ * Test inputs lifted from Porter's original 1980 paper examples
+ * + the canonical test vectors published at
+ * https://tartarus.org/martin/PorterStemmer/voc.txt and the
+ * Snowball project's English reference outputs.
+ *
+ * Only ASCII lowercase input is well-defined for Porter; the
+ * stemmer is a documented English-only algorithm.
+ */
+
+import { describe, it, expect } from "vitest";
+import { porterStem } from "../src/index.js";
+
+describe("porterStem — short words pass unchanged", () => {
+  it("empty string", () => expect(porterStem("")).toBe(""));
+  it("1-char word", () => expect(porterStem("a")).toBe("a"));
+  it("2-char word", () => expect(porterStem("at")).toBe("at"));
+});
+
+describe("porterStem — step 1a (plurals)", () => {
+  it("caresses → caress", () => expect(porterStem("caresses")).toBe("caress"));
+  it("ponies → poni", () => expect(porterStem("ponies")).toBe("poni"));
+  it("ties → ti", () => expect(porterStem("ties")).toBe("ti"));
+  it("caress → caress (ss stays)", () => expect(porterStem("caress")).toBe("caress"));
+  it("cats → cat", () => expect(porterStem("cats")).toBe("cat"));
+});
+
+describe("porterStem — step 1b (past participles + -ing)", () => {
+  it("feed → feed (eed with m=0 → no strip)", () => expect(porterStem("feed")).toBe("feed"));
+  it("agreed → agre", () => expect(porterStem("agreed")).toBe("agre"));
+  it("plastered → plaster", () => expect(porterStem("plastered")).toBe("plaster"));
+  it("bled → bled (ed with no vowel in stem → no strip)", () => expect(porterStem("bled")).toBe("bled"));
+  it("motoring → motor", () => expect(porterStem("motoring")).toBe("motor"));
+  it("sing → sing (ing with no vowel in stem → no strip)", () => expect(porterStem("sing")).toBe("sing"));
+});
+
+describe("porterStem — step 1b' (post-strip adjustments)", () => {
+  it("conflated → conflate (at → ate)", () => expect(porterStem("conflated")).toBe("conflat"));
+  it("troubled → trouble (bl → ble)", () => expect(porterStem("troubled")).toBe("troubl"));
+  it("sized → size (iz → ize)", () => expect(porterStem("sized")).toBe("size"));
+  it("hopping → hop (double consonant stripped)", () => expect(porterStem("hopping")).toBe("hop"));
+  it("tanned → tan", () => expect(porterStem("tanned")).toBe("tan"));
+  it("falling → fall (LL preserved)", () => expect(porterStem("falling")).toBe("fall"));
+  it("hissing → hiss (SS preserved)", () => expect(porterStem("hissing")).toBe("hiss"));
+  it("fizzed → fizz (ZZ preserved)", () => expect(porterStem("fizzed")).toBe("fizz"));
+  it("failing → fail (m=1 + *o → add e)", () => expect(porterStem("failing")).toBe("fail"));
+  it("filing → file (m=1 + *o → add e)", () => expect(porterStem("filing")).toBe("file"));
+});
+
+describe("porterStem — step 1c (-y → -i)", () => {
+  it("happy → happi", () => expect(porterStem("happy")).toBe("happi"));
+  it("sky → sky (no vowel in stem → no strip)", () => expect(porterStem("sky")).toBe("sky"));
+});
+
+describe("porterStem — step 2 (-ational, -tional, etc.)", () => {
+  it("relational → relate", () => expect(porterStem("relational")).toBe("relat"));
+  it("conditional → condition", () => expect(porterStem("conditional")).toBe("condit"));
+  it("valenci → valence", () => expect(porterStem("valenci")).toBe("valenc"));
+  it("hesitanci → hesitance", () => expect(porterStem("hesitanci")).toBe("hesit"));
+  it("digitizer → digitize", () => expect(porterStem("digitizer")).toBe("digit"));
+  it("conformabli → conformable", () => expect(porterStem("conformabli")).toBe("conform"));
+  it("radicalli → radical", () => expect(porterStem("radicalli")).toBe("radic"));
+  it("differentli → different", () => expect(porterStem("differentli")).toBe("differ"));
+  it("vileli → vile", () => expect(porterStem("vileli")).toBe("vile"));
+  it("analogousli → analogous", () => expect(porterStem("analogousli")).toBe("analog"));
+  it("vietnamization → vietnamize", () => expect(porterStem("vietnamization")).toBe("vietnam"));
+  it("predication → predicate", () => expect(porterStem("predication")).toBe("predic"));
+  it("operator → operate", () => expect(porterStem("operator")).toBe("oper"));
+  it("feudalism → feudal", () => expect(porterStem("feudalism")).toBe("feudal"));
+  it("decisiveness → decisive", () => expect(porterStem("decisiveness")).toBe("decis"));
+  it("hopefulness → hopeful", () => expect(porterStem("hopefulness")).toBe("hope"));
+  it("callousness → callous", () => expect(porterStem("callousness")).toBe("callous"));
+  it("formaliti → formal", () => expect(porterStem("formaliti")).toBe("formal"));
+  it("sensitiviti → sensitive", () => expect(porterStem("sensitiviti")).toBe("sensit"));
+  it("sensibiliti → sensible", () => expect(porterStem("sensibiliti")).toBe("sensibl"));
+});
+
+describe("porterStem — step 3 (-icate, -ative, -alize)", () => {
+  it("triplicate → triplic", () => expect(porterStem("triplicate")).toBe("triplic"));
+  it("formative → form", () => expect(porterStem("formative")).toBe("form"));
+  it("formalize → formal", () => expect(porterStem("formalize")).toBe("formal"));
+  it("electriciti → electric", () => expect(porterStem("electriciti")).toBe("electr"));
+  it("electrical → electric", () => expect(porterStem("electrical")).toBe("electr"));
+  it("hopeful → hope", () => expect(porterStem("hopeful")).toBe("hope"));
+  it("goodness → good", () => expect(porterStem("goodness")).toBe("good"));
+});
+
+describe("porterStem — step 4 (-al, -ance, -ence, etc.)", () => {
+  it("revival → reviv", () => expect(porterStem("revival")).toBe("reviv"));
+  it("allowance → allow", () => expect(porterStem("allowance")).toBe("allow"));
+  it("inference → infer", () => expect(porterStem("inference")).toBe("infer"));
+  it("airliner → airlin", () => expect(porterStem("airliner")).toBe("airlin"));
+  it("gyroscopic → gyroscop", () => expect(porterStem("gyroscopic")).toBe("gyroscop"));
+  it("adjustable → adjust", () => expect(porterStem("adjustable")).toBe("adjust"));
+  it("defensible → defens", () => expect(porterStem("defensible")).toBe("defens"));
+  it("irritant → irrit", () => expect(porterStem("irritant")).toBe("irrit"));
+  it("replacement → replac", () => expect(porterStem("replacement")).toBe("replac"));
+  it("adjustment → adjust", () => expect(porterStem("adjustment")).toBe("adjust"));
+  it("dependent → depend", () => expect(porterStem("dependent")).toBe("depend"));
+  it("homologous → homolog", () => expect(porterStem("homologous")).toBe("homolog"));
+  it("communism → commun", () => expect(porterStem("communism")).toBe("commun"));
+  it("activate → activ", () => expect(porterStem("activate")).toBe("activ"));
+  it("angulariti → angular", () => expect(porterStem("angulariti")).toBe("angular"));
+  it("homologous (second variant) → homolog", () => expect(porterStem("homologous")).toBe("homolog"));
+  it("effective → effect", () => expect(porterStem("effective")).toBe("effect"));
+  it("bowdlerize → bowdler", () => expect(porterStem("bowdlerize")).toBe("bowdler"));
+  it("adoption → adopt (ion after -t)", () => expect(porterStem("adoption")).toBe("adopt"));
+  it("decision → decis (ion after -s)", () => expect(porterStem("decision")).toBe("decis"));
+});
+
+describe("porterStem — step 5a (-e cleanup)", () => {
+  it("probate → probat", () => expect(porterStem("probate")).toBe("probat"));
+  it("rate → rate", () => expect(porterStem("rate")).toBe("rate"));
+  it("cease → ceas", () => expect(porterStem("cease")).toBe("ceas"));
+});
+
+describe("porterStem — step 5b (-ll → -l)", () => {
+  it("controll → control", () => expect(porterStem("controll")).toBe("control"));
+  it("roll → roll (m=0 → no strip)", () => expect(porterStem("roll")).toBe("roll"));
+});
+
+describe("porterStem — common docs words (sanity checks)", () => {
+  it("running → run", () => expect(porterStem("running")).toBe("run"));
+  it("ran → ran (no rule strips this — Porter is morphology-only)", () => expect(porterStem("ran")).toBe("ran"));
+  it("happily → happili", () => expect(porterStem("happily")).toBe("happili"));
+  it("indexing → index", () => expect(porterStem("indexing")).toBe("index"));
+  it("indexed → index", () => expect(porterStem("indexed")).toBe("index"));
+  it("indexes → index", () => expect(porterStem("indexes")).toBe("index"));
+});
+
+describe("porterStem — stack-overflow defence (MEDIUM finding fixed)", () => {
+  // The original recursive isConsonantAt overflowed V8's stack
+  // on inputs like "y".repeat(10000) — a single very-long
+  // y-run in untrusted input would crash the indexer.  The
+  // iterative implementation handles arbitrary lengths.
+  it("10,000 'y' characters does not overflow stack", () => {
+    const huge = "y".repeat(10000);
+    expect(() => porterStem(huge)).not.toThrow();
+  });
+  it("50,000 'y' characters does not overflow stack", () => {
+    const huge = "y".repeat(50000);
+    expect(() => porterStem(huge)).not.toThrow();
+  });
+  it("alternating yyyy still classifies correctly (behaviour-preserved)", () => {
+    // For a 4-character "yyyy" word: position 0 'y' = consonant,
+    // position 1 'y' = vowel, position 2 'y' = consonant,
+    // position 3 'y' = vowel.  containsVowel("yyyy") is therefore
+    // true (positions 1 and 3).  The stemmer applies step1c
+    // (y → i) when the stem has a vowel.  For "yyyy":
+    // step1a / step1b are no-ops.  step1c sees ending "y", stem
+    // "yyy" — containsVowel("yyy") is true (position 1).  So
+    // "yyyy" → "yyyi".
+    expect(porterStem("yyyy")).toBe("yyyi");
+  });
+});
+
+describe("porterStem — determinism", () => {
+  it("same input → identical output", () => {
+    for (const w of ["running", "happiness", "national", "consign"]) {
+      expect(porterStem(w)).toBe(porterStem(w));
+    }
+  });
+});

--- a/code/packages/typescript/forme-doc-search-tokenizer/tests/tokenize.test.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/tests/tokenize.test.ts
@@ -1,0 +1,119 @@
+/**
+ * tokenize.test.ts — top-level pipeline tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { tokenize, STOP_WORDS } from "../src/index.js";
+
+describe("tokenize — defaults (no filter, no stem)", () => {
+  it("plain text", () => {
+    expect(tokenize("Hello, World!")).toEqual(["hello", "world"]);
+  });
+  it("empty", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+  it("non-string coerced", () => {
+    expect(tokenize(42 as unknown as string)).toEqual(["42"]);
+  });
+});
+
+describe("tokenize — stop-word filter", () => {
+  it("filters built-in stop words", () => {
+    expect(tokenize("the quick brown fox", { filterStopWords: true })).toEqual([
+      "quick", "brown", "fox",
+    ]);
+  });
+  it("does NOT filter when option omitted", () => {
+    expect(tokenize("the quick brown fox")).toEqual([
+      "the", "quick", "brown", "fox",
+    ]);
+  });
+  it("custom stop-word list overrides built-in", () => {
+    const custom = new Set(["fox"]);
+    expect(
+      tokenize("the quick brown fox", { filterStopWords: true, customStopWords: custom }),
+    ).toEqual(["the", "quick", "brown"]);
+  });
+  it("empty custom list filters nothing", () => {
+    expect(
+      tokenize("the quick brown fox", { filterStopWords: true, customStopWords: new Set() }),
+    ).toEqual(["the", "quick", "brown", "fox"]);
+  });
+});
+
+describe("tokenize — Porter stemming", () => {
+  it("stems each token", () => {
+    expect(tokenize("running and walking", { stem: true })).toEqual([
+      "run", "and", "walk",
+    ]);
+  });
+  it("does NOT stem when option omitted", () => {
+    expect(tokenize("running and walking")).toEqual([
+      "running", "and", "walking",
+    ]);
+  });
+  it("combines stop-word filter + stem", () => {
+    expect(
+      tokenize("running and walking", { filterStopWords: true, stem: true }),
+    ).toEqual(["run", "walk"]);
+  });
+  it("stemming is applied AFTER stop-word filter", () => {
+    // "the" gets filtered → never reaches the stemmer (which
+    // wouldn't change it anyway, but the test pins the ordering).
+    expect(
+      tokenize("the running", { filterStopWords: true, stem: true }),
+    ).toEqual(["run"]);
+  });
+});
+
+describe("tokenize — realistic docs queries", () => {
+  it("user query: 'How do I install?'", () => {
+    expect(tokenize("How do I install?")).toEqual(["how", "do", "i", "install"]);
+  });
+  it("user query with filter + stem", () => {
+    expect(
+      tokenize("How do I install?", { filterStopWords: true, stem: true }),
+    ).toEqual(["how", "do", "i", "instal"]);
+  });
+  it("doc body: paragraph", () => {
+    const body =
+      "The Porter stemmer reduces morphological variants of a word to a shared root form.";
+    expect(tokenize(body)).toEqual([
+      "the", "porter", "stemmer", "reduces", "morphological", "variants",
+      "of", "a", "word", "to", "a", "shared", "root", "form",
+    ]);
+  });
+});
+
+describe("tokenize — determinism + immutability", () => {
+  it("same input → identical output", () => {
+    const t = "The quick brown fox jumps over the lazy dog";
+    const a = JSON.stringify(tokenize(t, { filterStopWords: true, stem: true }));
+    const b = JSON.stringify(tokenize(t, { filterStopWords: true, stem: true }));
+    expect(a).toBe(b);
+  });
+  it("does not mutate options.customStopWords set", () => {
+    const custom = new Set(["foo"]);
+    const snapshot = [...custom];
+    tokenize("foo bar", { filterStopWords: true, customStopWords: custom });
+    expect([...custom]).toEqual(snapshot);
+  });
+});
+
+describe("STOP_WORDS — built-in list", () => {
+  it("includes common articles", () => {
+    expect(STOP_WORDS.has("the")).toBe(true);
+    expect(STOP_WORDS.has("a")).toBe(true);
+    expect(STOP_WORDS.has("an")).toBe(true);
+  });
+  it("includes common pronouns", () => {
+    expect(STOP_WORDS.has("he")).toBe(true);
+    expect(STOP_WORDS.has("she")).toBe(true);
+    expect(STOP_WORDS.has("you")).toBe(true);
+  });
+  it("does NOT include negation/question words (kept for docs queries)", () => {
+    expect(STOP_WORDS.has("not")).toBe(false);
+    expect(STOP_WORDS.has("how")).toBe(false);
+    expect(STOP_WORDS.has("what")).toBe(false);
+  });
+});

--- a/code/packages/typescript/forme-doc-search-tokenizer/tsconfig.json
+++ b/code/packages/typescript/forme-doc-search-tokenizer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-doc-search-tokenizer/vitest.config.ts
+++ b/code/packages/typescript/forme-doc-search-tokenizer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- **New package** `@coding-adventures/forme-doc-search-tokenizer` — `string → string[]` pipeline for the documentation-site search index. Lowercase, strip non-alphanumeric Unicode, split on whitespace, optional stop-word filter (~35-word English list), optional Porter stemmer.
- **Eighth concrete DOC00 v0 package** (after frontmatter PR #3781, heading-anchors #3829, toc-extractor #3837, code-block-decorator #3865, syntax-highlighter #3867, sidebar-builder #3873, page-shell #3883).
- **Capabilities `[]` + ZERO runtime dependencies.**
- **Full canonical Porter (1980) stemmer** — 5-step suffix stripping. Test inputs lifted from Porter's paper + Snowball English reference.
- **Project-wide convention enforced**: prefer explicit index loops over regex for any user-facing trim/strip/scan (CodeQL's `js/polynomial-redos` flags `+` quantifiers regardless of actual polynomial behaviour — bit `forme-doc-sidebar-builder` and `forme-doc-page-shell`; pre-empted here).
- **Security review found TWO findings, both fixed BEFORE push:**
  - **MEDIUM**: stack overflow in recursive `isConsonantAt` on `"y".repeat(10000)` inputs (would crash the indexer). Fixed via iterative rewrite + parity-calculation; tested with 50k-char y-runs.
  - **LOW**: unbounded individual token length amplifies all per-token downstream work. Fixed with `MAX_TOKEN_LENGTH = 256` cap (matches Lucene default).
- **Coverage: 100% line / 100% function / 96.4% branch** across all 5 executable source files. **133 tests** across 3 files.

## Test plan

- [x] `npm install && npx vitest run --coverage` — 133/133 pass
- [x] `normalise.test.ts` (26): tokenisation, lowercasing (incl. tr-TR stability), punctuation/hyphen/URL splitting, run collapsing, Unicode (Latin/Chinese/Cyrillic/Greek), emoji stripping, edge cases, **token-length cap (3 tests)**
- [x] `porter.test.ts` (88): every step (1a/1b/1b'/1c, 2, 3, 4, 5a/5b), common docs words, **stack-overflow defence (3 tests for 10k+ y-runs)**, determinism
- [x] `tokenize.test.ts` (19): defaults, stop-word filter (built-in/custom/empty), Porter stemming, realistic queries, determinism, immutability, STOP_WORDS contents
- [x] `/security-review` × 2 — first pass found 2 issues, both fixed; behaviour preserved
- [ ] CI (per babysit cron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)