### PR TITLE
feat(cas-summation): Phase 41+42 port to TypeScript and Rust (one PR)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.3.0 — 2026-05-22
+
+**Phase 41 + Phase 42 — Limit-aware infinite telescope (Rust port).**
+
+Ports Python `cas-summation` 0.3.0 (PR #3880 ✅) and 0.4.0
+(PR #3887 ✅) in one go.  Extends `evaluate_sum`'s telescope detection
+to handle `hi = %inf` when `g(k)` provably vanishes at infinity:
+
+    ∑_{k=lo}^∞ [g(k+1) − g(k)]  =  −g(lo)   (standard orientation)
+    ∑_{k=lo}^∞ [g(k) − g(k+1)]  =   g(lo)   (antisymmetric)
+
+The vanishing-at-infinity check uses two tiers:
+
+1.  **Phase 41 fast path** — `Div(constant-in-k, h(k))` with `h` a
+    positive-degree polynomial in `k`.
+2.  **Phase 42 widening** — `Div(P(k), Q(k))` where both are pure
+    polynomials and `deg(P) < deg(Q)`.
+
+Anything transcendental, improper, or non-Div falls through to the
+unevaluated `Sum(...)`.
+
+### Added
+
+- **`is_positive_degree_polynomial_in_k(node, k)`** — recogniser for
+  `k`, `k^n` (n ≥ 1), `Add`, and `Mul` of these.
+- **`polynomial_degree_in_k(node, k) -> Option<i64>`** — returns the
+  polynomial degree of an IR node in `k`, or `None` for non-polynomial
+  shapes (Div, Sin, fractional Pow, …).
+- **`g_vanishes_at_infinity(g, k)`** — two-tier predicate combining
+  the above.
+
+### Changed
+
+- The `!inf_upper` gate around the Phase 39 telescope branch is
+  lifted; the dispatcher now runs telescope detection for both finite
+  and infinite ranges and routes through the new vanishing-at-infinity
+  check when `hi = %inf`.
+- Existing `phase39_infinite_upper_falls_through` test docstring
+  updated to reflect that it now pins the Phase 41 guard against
+  divergent telescopes (`g(k) = k`).
+
+### Added — tests
+
+`tests/tests.rs` — 7 new `#[test]` functions:
+
+- `phase41_antisymmetric_one_over_k_minus_one_over_kp1` (= 1).
+- `phase41_standard_orientation_kp1_minus_k` (= −1).
+- `phase41_higher_starting_index` (= 1/2).
+- `phase41_quadratic_denominator` (= 1).
+- `phase42_proper_rational_k_over_k_squared_plus_1` (= 1/2).
+- `phase42_improper_rational_falls_through` (`k/(k+1)`).
+- `phase42_transcendental_numerator_falls_through` (`sin(k)/k²`).
+
+Full suite: **21 passed** (14 prior + 7 net new).
+
+### Still deferred
+
+- Apart-induced telescopes (`1/(k(k+1))`) — blocked on porting the
+  `Apart` partial-fraction-decomposition handler to Rust.
+- Transcendental limit-finder (`sin(k)/k²`, `log(k)/k`, `1/exp(k)`).
+
 ## 0.2.0 — 2026-05-20
 
 **Phase 39 — Telescoping sum recognition (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -268,13 +268,32 @@ where
         }
     }
 
-    // Phase 39: telescoping sums.  Detect `f = g(k+1) − g(k)` (or the
-    // antisymmetric `g(k) − g(k+1)`) and emit `g(hi+1) − g(lo)` (resp.
-    // `g(lo) − g(hi+1)`).  Pure structural detection — no partial
-    // fraction expansion; infinite case deferred to a future limit-aware
-    // phase.
-    if !inf_upper {
-        if let Some((g_expr, sign)) = try_telescoping(&f, &k, &mut eval_fn) {
+    // Phase 39 (finite) + Phase 41/42 (infinite) telescoping sums.
+    //
+    // Detect `f = g(k+1) − g(k)` (or its antisymmetric `g(k) − g(k+1)`)
+    // and emit a closed form:
+    // - Phase 39 (finite hi): g(hi+1) − g(lo) / g(lo) − g(hi+1).
+    // - Phase 41+42 (hi = %inf): emit −g(lo) (standard) or g(lo)
+    //   (antisymmetric) when g(k) provably vanishes at infinity per
+    //   `g_vanishes_at_infinity` (constant numerator + positive-degree
+    //   polynomial denominator, or any proper rational with
+    //   deg(num) < deg(den)).  Otherwise fall through to the
+    //   unevaluated SUM at the bottom.
+    if let Some((g_expr, sign)) = try_telescoping(&f, &k, &mut eval_fn) {
+        if inf_upper {
+            if g_vanishes_at_infinity(&g_expr, &k) {
+                let g_at_lo = substitute(&g_expr, &k, &lo);
+                let closed = if sign > 0 {
+                    // ∑[g(k+1) − g(k)] from lo to ∞ = −g(lo)
+                    apply(sym(NEG), vec![g_at_lo])
+                } else {
+                    // ∑[g(k) − g(k+1)] from lo to ∞ = g(lo)
+                    g_at_lo
+                };
+                return eval_fn(closed);
+            }
+            // Limit not provably zero — fall through.
+        } else {
             let hi_plus_one = binary(ADD, hi.clone(), int(1));
             let g_at_hi_plus_one = substitute(&g_expr, &k, &hi_plus_one);
             let g_at_lo = substitute(&g_expr, &k, &lo);
@@ -476,6 +495,158 @@ where
         return Some((left.clone(), -1));
     }
     None
+}
+
+/// Phase 41+42: True when `node` is a polynomial in `k` of strictly
+/// positive degree.  Used by `g_vanishes_at_infinity` to decide whether
+/// a denominator grows without bound as `k → ∞`.
+fn is_positive_degree_polynomial_in_k(node: &IRNode, k: &IRNode) -> bool {
+    if node == k {
+        return true;
+    }
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    let head_str = match &apply_node.head {
+        IRNode::Symbol(s) => s.as_str(),
+        _ => return false,
+    };
+    // k^n with n ≥ 1.
+    if head_str == POW && apply_node.args.len() == 2 {
+        let base = &apply_node.args[0];
+        let exp = &apply_node.args[1];
+        if base == k {
+            if let IRNode::Integer(n) = exp {
+                if *n >= 1 {
+                    return true;
+                }
+            }
+        }
+    }
+    if head_str == ADD && apply_node.args.len() >= 2 {
+        if !apply_node
+            .args
+            .iter()
+            .any(|a| is_positive_degree_polynomial_in_k(a, k))
+        {
+            return false;
+        }
+        return apply_node
+            .args
+            .iter()
+            .all(|a| is_constant_in(a, k) || is_positive_degree_polynomial_in_k(a, k));
+    }
+    if head_str == MUL && apply_node.args.len() >= 2 {
+        let mut has_positive = false;
+        for arg in &apply_node.args {
+            if is_constant_in(arg, k) {
+                continue;
+            }
+            if is_positive_degree_polynomial_in_k(arg, k) {
+                has_positive = true;
+                continue;
+            }
+            return false;
+        }
+        return has_positive;
+    }
+    false
+}
+
+/// Phase 42: Return the polynomial degree of `node` in `k`, or `None`
+/// for non-polynomial shapes.
+fn polynomial_degree_in_k(node: &IRNode, k: &IRNode) -> Option<i64> {
+    if is_constant_in(node, k) {
+        return Some(0);
+    }
+    if node == k {
+        return Some(1);
+    }
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    let head_str = match &apply_node.head {
+        IRNode::Symbol(s) => s.as_str(),
+        _ => return None,
+    };
+    if head_str == POW && apply_node.args.len() == 2 {
+        let base = &apply_node.args[0];
+        let exp = &apply_node.args[1];
+        if base == k {
+            if let IRNode::Integer(n) = exp {
+                if *n >= 0 {
+                    return Some(*n);
+                }
+            }
+        }
+        return None;
+    }
+    if head_str == NEG && apply_node.args.len() == 1 {
+        return polynomial_degree_in_k(&apply_node.args[0], k);
+    }
+    if head_str == ADD || head_str == SUB {
+        let mut max_deg: i64 = 0;
+        for arg in &apply_node.args {
+            match polynomial_degree_in_k(arg, k) {
+                Some(d) => {
+                    if d > max_deg {
+                        max_deg = d;
+                    }
+                }
+                None => return None,
+            }
+        }
+        return Some(max_deg);
+    }
+    if head_str == MUL {
+        let mut sum_deg: i64 = 0;
+        for arg in &apply_node.args {
+            match polynomial_degree_in_k(arg, k) {
+                Some(d) => sum_deg += d,
+                None => return None,
+            }
+        }
+        return Some(sum_deg);
+    }
+    None
+}
+
+/// Phase 41+42: True when `g(k)` provably tends to 0 as `k → ∞`.
+///
+/// Two-tier recognition:
+///   1. Phase 41 fast path: `Div(c, h(k))` with `c` constant in `k` and
+///      `h(k)` recognised as a positive-degree polynomial.
+///   2. Phase 42 widening: `Div(P(k), Q(k))` with both pure polynomials
+///      and `deg(P) < deg(Q)`.
+///
+/// Anything else (transcendental, improper rational, non-Div) returns
+/// `false`.
+fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
+    let apply_node = match g {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    if !matches!(&apply_node.head, IRNode::Symbol(s) if s == DIV) || apply_node.args.len() != 2 {
+        return false;
+    }
+    let num = &apply_node.args[0];
+    let den = &apply_node.args[1];
+    // Phase 41 fast path: constant numerator + positive-degree denominator.
+    if is_constant_in(num, k) {
+        return is_positive_degree_polynomial_in_k(den, k);
+    }
+    // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
+    let num_deg = match polynomial_degree_in_k(num, k) {
+        Some(d) => d,
+        None => return false,
+    };
+    let den_deg = match polynomial_degree_in_k(den, k) {
+        Some(d) => d,
+        None => return false,
+    };
+    num_deg < den_deg
 }
 
 fn split_linear_coeff(f: &IRNode, k: &IRNode) -> Option<Rational> {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -298,11 +298,169 @@ fn phase39_symbolic_upper_bound_non_unevaluated() {
 
 #[test]
 fn phase39_infinite_upper_falls_through() {
+    // g(k) = k grows at infinity; Phase 41 guard refuses.
     let k = sym("k");
     let f = apply(
         sym(SUB),
         vec![apply(sym(ADD), vec![k.clone(), int(1)]), k.clone()],
     );
     let out = evaluate_sum(f, k, int(0), sym("%inf"), eval);
+    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 41+42: limit-aware infinite telescope.
+//
+// When `hi = %inf` AND `g(k)` provably vanishes at infinity, the dispatcher
+// emits −g(lo) (standard orientation) or g(lo) (antisymmetric).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase41_antisymmetric_one_over_k_minus_one_over_kp1() {
+    // ∑_{k=1}^∞ [1/k − 1/(k+1)] = 1 (Phase 41 antisymmetric).
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(sym(DIV), vec![int(1), k.clone()]),
+            apply(
+                sym(DIV),
+                vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])],
+            ),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), int(1));
+}
+
+#[test]
+fn phase41_standard_orientation_kp1_minus_k() {
+    // ∑_{k=1}^∞ [1/(k+1) − 1/k] = −1.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(DIV),
+                vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])],
+            ),
+            apply(sym(DIV), vec![int(1), k.clone()]),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), int(-1));
+}
+
+#[test]
+fn phase41_higher_starting_index() {
+    // ∑_{k=2}^∞ [1/k − 1/(k+1)] = 1/2.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(sym(DIV), vec![int(1), k.clone()]),
+            apply(
+                sym(DIV),
+                vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])],
+            ),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(2), sym("%inf"), eval), rat(1, 2));
+}
+
+#[test]
+fn phase41_quadratic_denominator() {
+    // ∑_{k=1}^∞ [1/k² − 1/(k+1)²] = 1.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(DIV),
+                vec![int(1), apply(sym(POW), vec![k.clone(), int(2)])],
+            ),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(
+                        sym(POW),
+                        vec![apply(sym(ADD), vec![k.clone(), int(1)]), int(2)],
+                    ),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), int(1));
+}
+
+#[test]
+fn phase42_proper_rational_k_over_k_squared_plus_1() {
+    // ∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)] = g(1) = 1/2.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let g_k = apply(
+        sym(DIV),
+        vec![
+            k.clone(),
+            apply(
+                sym(ADD),
+                vec![apply(sym(POW), vec![k.clone(), int(2)]), int(1)],
+            ),
+        ],
+    );
+    let g_kp1 = apply(
+        sym(DIV),
+        vec![
+            kp1.clone(),
+            apply(
+                sym(ADD),
+                vec![apply(sym(POW), vec![kp1.clone(), int(2)]), int(1)],
+            ),
+        ],
+    );
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), rat(1, 2));
+}
+
+#[test]
+fn phase42_improper_rational_falls_through() {
+    // g(k) = k/(k+1) has equal degrees; limit is 1, not 0.  Refuse.
+    let k = sym("k");
+    let g_k = apply(
+        sym(DIV),
+        vec![k.clone(), apply(sym(ADD), vec![k.clone(), int(1)])],
+    );
+    let g_kp1 = apply(
+        sym(DIV),
+        vec![
+            apply(sym(ADD), vec![k.clone(), int(1)]),
+            apply(sym(ADD), vec![k.clone(), int(2)]),
+        ],
+    );
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase42_transcendental_numerator_falls_through() {
+    // sin(k)/k² is non-polynomial; conservative refuse.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(DIV),
+                vec![sin_k, apply(sym(POW), vec![k.clone(), int(2)])],
+            ),
+            apply(
+                sym(DIV),
+                vec![sin_kp1, apply(sym(POW), vec![kp1, int(2)])],
+            ),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 0.3.0 — 2026-05-22
+
+**Phase 41 + Phase 42 — Limit-aware infinite telescope (TypeScript port).**
+
+Ports Python `cas-summation` 0.3.0 (PR #3880 ✅) and 0.4.0
+(PR #3887 ✅) in one go.  Extends `evaluateSum`'s telescope detection
+to handle `hi = %inf` when `g(k)` provably vanishes at infinity:
+
+    ∑_{k=lo}^∞ [g(k+1) − g(k)]  =  −g(lo)   (standard orientation)
+    ∑_{k=lo}^∞ [g(k) − g(k+1)]  =   g(lo)   (antisymmetric)
+
+The vanishing-at-infinity check uses two tiers:
+
+1.  **Phase 41 fast path** — `Div(constant-in-k, h(k))` with `h` a
+    positive-degree polynomial in `k`.
+2.  **Phase 42 widening** — `Div(P(k), Q(k))` where both are pure
+    polynomials and `deg(P) < deg(Q)`.
+
+Anything transcendental, improper, or non-Div falls through to the
+unevaluated `Sum(...)`.
+
+### Added
+
+- **`isPositiveDegreePolynomialInK(node, k)`** — recogniser for ``k``,
+  ``k^n`` (n ≥ 1), ``Add``, and ``Mul`` of these.
+- **`polynomialDegreeInK(node, k) -> number | undefined`** — returns
+  the polynomial degree of an IR node in ``k``, or undefined for
+  non-polynomial shapes (Div, Sin, fractional Pow, …).
+- **`gVanishesAtInfinity(g, k)`** — two-tier predicate combining the
+  above.
+
+### Changed
+
+- The `infUpper` gate around the Phase 39 telescope branch is lifted;
+  the dispatcher now runs telescope detection for both finite and
+  infinite ranges and routes through the new vanishing-at-infinity
+  check when `hi = %inf`.
+- Existing "infinite upper bound falls through" test renamed to
+  pin the Phase 41 guard against divergent telescopes
+  (`g(k) = k` doesn't vanish).
+
+### Added — tests
+
+`tests/cas-summation.test.ts` — new
+`summation: Phase 41+42 limit-aware infinite telescope` describe
+block with 7 cases:
+
+- `∑_{k=1}^∞ [1/k − 1/(k+1)] = 1` (Phase 41 antisymmetric).
+- `∑_{k=1}^∞ [1/(k+1) − 1/k] = −1` (standard orientation).
+- Higher starting index `∑_{k=2}^∞ … = 1/2`.
+- Quadratic denominator `∑ 1/k² − 1/(k+1)² = 1`.
+- Phase 42 proper rational
+  `∑ k/(k²+1) − (k+1)/((k+1)²+1) = 1/2`.
+- Improper rational `k/(k+1)` falls through (limit is 1).
+- Transcendental `sin(k)/k²` falls through (non-polynomial).
+
+Full suite: **21 passed** (14 prior + 7 net new).
+
+### Still deferred
+
+- Apart-induced telescopes (`1/(k(k+1))`) — blocked on porting the
+  `Apart` partial-fraction-decomposition handler to TypeScript.
+- Transcendental limit-finder (`sin(k)/k²`, `log(k)/k`, `1/exp(k)`).
+
 ## 0.2.0 — 2026-05-20
 
 **Phase 39 — Telescoping sum recognition (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -124,22 +124,41 @@ export function evaluateSum(f: IRNode, k: IRNode, lo: IRNode, hi: IRNode, evalFn
     if (raw !== undefined) return evalFn(raw);
   }
 
-  // Phase 39: telescoping sums. Detect ``f = g(k+1) − g(k)`` (or the
-  // antisymmetric ``g(k) − g(k+1)``) and emit ``g(hi+1) − g(lo)``
-  // (resp. ``g(lo) − g(hi+1)``).  Only the finite case is handled —
-  // infinite telescopes need a limit argument we leave to a future
-  // phase.  When ``α = 1, β = 0`` this is purely structural, no
-  // partial-fraction work is attempted.
-  if (!infUpper) {
+  // Phase 39 (finite) + Phase 41/42 (infinite) telescoping sums.
+  //
+  // Detect ``f = g(k+1) − g(k)`` (or its antisymmetric ``g(k) − g(k+1)``)
+  // and emit a closed form:
+  // - Phase 39 (finite ``hi``): ``g(hi+1) − g(lo)`` / ``g(lo) − g(hi+1)``.
+  // - Phase 41+42 (``hi = %inf``): emit ``−g(lo)`` (standard) or ``g(lo)``
+  //   (antisymmetric) when ``g(k)`` provably vanishes at infinity per
+  //   :func:`gVanishesAtInfinity` (constant numerator + positive-degree
+  //   polynomial denominator, or any proper rational with
+  //   ``deg(num) < deg(den)``).  When the limit isn't decidable by the
+  //   narrow recogniser, fall through to later rules — the original
+  //   unevaluated ``Sum`` node is then returned at the bottom.
+  {
     const tele = tryTelescoping(f, k, evalFn);
     if (tele !== undefined) {
-      const hiPlusOne = app(ADD, [hi, int(1)]);
-      const gAtHiPlusOne = substitute(tele.gExpr, k, hiPlusOne);
-      const gAtLo = substitute(tele.gExpr, k, lo);
-      if (tele.sign === 1) {
-        return evalFn(app(SUB, [gAtHiPlusOne, gAtLo]));
+      if (infUpper) {
+        if (gVanishesAtInfinity(tele.gExpr, k)) {
+          const gAtLo = substitute(tele.gExpr, k, lo);
+          if (tele.sign === 1) {
+            // ∑[g(k+1) − g(k)] from lo to ∞ = 0 − g(lo) = −g(lo)
+            return evalFn(app(NEG, [gAtLo]));
+          }
+          // ∑[g(k) − g(k+1)] from lo to ∞ = g(lo) − 0 = g(lo)
+          return evalFn(gAtLo);
+        }
+        // Limit not provably zero — fall through.
+      } else {
+        const hiPlusOne = app(ADD, [hi, int(1)]);
+        const gAtHiPlusOne = substitute(tele.gExpr, k, hiPlusOne);
+        const gAtLo = substitute(tele.gExpr, k, lo);
+        if (tele.sign === 1) {
+          return evalFn(app(SUB, [gAtHiPlusOne, gAtLo]));
+        }
+        return evalFn(app(SUB, [gAtLo, gAtHiPlusOne]));
       }
-      return evalFn(app(SUB, [gAtLo, gAtHiPlusOne]));
     }
   }
 
@@ -255,6 +274,123 @@ function tryTelescoping(
     return { gExpr: left, sign: -1 };
   }
   return undefined;
+}
+
+/**
+ * Phase 41+42: True when ``node`` is recognised as a polynomial in ``k``
+ * of strictly positive degree.
+ *
+ * Used by :func:`gVanishesAtInfinity` to decide whether a denominator
+ * grows without bound as ``k → ∞``.  Recognised shapes: ``k``, ``k^n``
+ * (integer n ≥ 1), ``Add`` with at least one positive-degree term and
+ * all other args either constant-in-k or positive-degree, and ``Mul``
+ * with at least one positive-degree factor and all others either
+ * constant-in-k or positive-degree.  Anything else returns ``false``.
+ */
+function isPositiveDegreePolynomialInK(node: IRNode, k: IRNode): boolean {
+  if (equals(node, k)) return true;
+  if (node.kind !== "apply") return false;
+  if (equals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    if (equals(base, k) && exp.kind === "integer" && exp.value >= 1n) {
+      return true;
+    }
+  }
+  if (equals(node.head, ADD) && node.args.length >= 2) {
+    if (!node.args.some((a) => isPositiveDegreePolynomialInK(a, k))) return false;
+    return node.args.every(
+      (a) => isConstantIn(a, k) || isPositiveDegreePolynomialInK(a, k),
+    );
+  }
+  if (equals(node.head, MUL) && node.args.length >= 2) {
+    let hasPositive = false;
+    for (const arg of node.args) {
+      if (isConstantIn(arg, k)) continue;
+      if (isPositiveDegreePolynomialInK(arg, k)) {
+        hasPositive = true;
+        continue;
+      }
+      return false;
+    }
+    return hasPositive;
+  }
+  return false;
+}
+
+/**
+ * Phase 42: Return the polynomial degree of ``node`` in ``k``, or
+ * ``undefined`` for non-polynomial shapes.
+ *
+ * +-----------------------+---------------------------+
+ * | Input                 | Returns                   |
+ * +=======================+===========================+
+ * | constant in k         | 0                         |
+ * | k                     | 1                         |
+ * | k^n (integer n ≥ 0)   | n                         |
+ * | Neg(p)                | deg(p)                    |
+ * | Add(p1, p2, …)        | max(deg(pi))              |
+ * | Sub(p1, p2)           | max(deg(p1), deg(p2))     |
+ * | Mul(p1, p2, …)        | sum(deg(pi))              |
+ * | otherwise             | undefined                 |
+ * +-----------------------+---------------------------+
+ */
+function polynomialDegreeInK(node: IRNode, k: IRNode): number | undefined {
+  if (isConstantIn(node, k)) return 0;
+  if (equals(node, k)) return 1;
+  if (node.kind !== "apply") return undefined;
+  if (equals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    if (equals(base, k) && exp.kind === "integer" && exp.value >= 0n) {
+      return Number(exp.value);
+    }
+    return undefined;
+  }
+  if (equals(node.head, NEG) && node.args.length === 1) {
+    return polynomialDegreeInK(node.args[0], k);
+  }
+  if (equals(node.head, ADD) || equals(node.head, SUB)) {
+    const degrees = node.args.map((a) => polynomialDegreeInK(a, k));
+    if (degrees.some((d) => d === undefined)) return undefined;
+    return Math.max(...(degrees as number[]));
+  }
+  if (equals(node.head, MUL)) {
+    const degrees = node.args.map((a) => polynomialDegreeInK(a, k));
+    if (degrees.some((d) => d === undefined)) return undefined;
+    return (degrees as number[]).reduce((a, b) => a + b, 0);
+  }
+  return undefined;
+}
+
+/**
+ * Phase 41+42: True when ``g(k)`` provably tends to 0 as ``k → ∞``.
+ *
+ * Two-tier recognition:
+ *
+ * 1. **Phase 41 fast path** — ``Div(c, h(k))`` with ``c`` constant in
+ *    ``k`` and ``h(k)`` recognised as a positive-degree polynomial.
+ * 2. **Phase 42 widening** — ``Div(P(k), Q(k))`` with both
+ *    ``P`` and ``Q`` pure polynomials in ``k`` and
+ *    ``deg(P) < deg(Q)``.
+ *
+ * Anything else (transcendental numerator, improper rational with
+ * ``deg(P) ≥ deg(Q)``, non-Div shapes) returns ``false`` —
+ * conservatively refusing keeps the closed-form emission safe.
+ */
+function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
+  if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
+    return false;
+  }
+  const [num, den] = g.args;
+  // Phase 41 fast path: constant numerator + positive-degree denominator.
+  if (isConstantIn(num, k)) {
+    return isPositiveDegreePolynomialInK(den, k);
+  }
+  // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
+  const numDeg = polynomialDegreeInK(num, k);
+  if (numDeg === undefined) return false;
+  const denDeg = polynomialDegreeInK(den, k);
+  if (denDeg === undefined) return false;
+  return numDeg < denDeg;
 }
 
 function tryPowerOfK(f: IRNode, k: IRNode): { coeff: RationalValue; m: number } | undefined {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -246,11 +246,96 @@ describe("summation: Phase 39 telescoping", () => {
     expect(out.kind === "apply" && out.head === SUM).toBe(false);
   });
 
-  it("infinite upper bound falls through (no limit-aware telescope yet)", () => {
+  it("infinite upper bound with non-vanishing g falls through (Phase 41 guard)", () => {
+    // g(k) = k grows at infinity, so the Phase 41 limit check refuses.
     const k = sym("k");
     const f = app(SUB, [app(ADD, [k, int(1)]), k]);
     const out = evaluateSum(f, k, int(0), sym("%inf"), evalNode);
     expect(out.kind).toBe("apply");
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 41+42: limit-aware infinite telescope.
+//
+// When `hi = %inf` AND `g(k)` provably vanishes at infinity, the
+// dispatcher emits −g(lo) (standard orientation) or g(lo) (antisymmetric).
+//
+// The narrow vanishing-at-infinity recogniser handles:
+//   - Phase 41 fast path: Div(constant, positive-degree-polynomial-in-k)
+//   - Phase 42 widening: Div(P, Q) with both polynomials and deg(P)<deg(Q)
+//
+// Anything else (transcendental, improper rational, non-Div) falls
+// through to the unevaluated Sum(...).
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 41+42 limit-aware infinite telescope", () => {
+  it("∑_{k=1}^∞ [1/k − 1/(k+1)] = 1 (Phase 41 antisymmetric)", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), k]),
+      app(DIV, [int(1), app(ADD, [k, int(1)])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(1));
+  });
+
+  it("∑_{k=1}^∞ [1/(k+1) − 1/k] = −1 (Phase 41 standard orientation)", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), app(ADD, [k, int(1)])]),
+      app(DIV, [int(1), k]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(-1));
+  });
+
+  it("higher starting index ∑_{k=2}^∞ [1/k − 1/(k+1)] = 1/2", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), k]),
+      app(DIV, [int(1), app(ADD, [k, int(1)])]),
+    ]);
+    expect(evaluateSum(f, k, int(2), sym("%inf"), evalNode)).toEqual(rational(1, 2));
+  });
+
+  it("quadratic denominator ∑_{k=1}^∞ [1/k² − 1/(k+1)²] = 1", () => {
+    const k = sym("k");
+    const kSq = app(POW, [k, int(2)]);
+    const kPlus1Sq = app(POW, [app(ADD, [k, int(1)]), int(2)]);
+    const f = app(SUB, [app(DIV, [int(1), kSq]), app(DIV, [int(1), kPlus1Sq])]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(1));
+  });
+
+  it("Phase 42 proper rational ∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)] = 1/2", () => {
+    const k = sym("k");
+    const gK = app(DIV, [k, app(ADD, [app(POW, [k, int(2)]), int(1)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const gKp1 = app(DIV, [kp1, app(ADD, [app(POW, [kp1, int(2)]), int(1)])]);
+    const f = app(SUB, [gK, gKp1]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(rational(1, 2));
+  });
+
+  it("Phase 42 improper rational ∑_{k=1}^∞ [k/(k+1) − (k+1)/(k+2)] falls through", () => {
+    // g(k) = k/(k+1) has equal degrees, limit is 1 (not 0).
+    const k = sym("k");
+    const gK = app(DIV, [k, app(ADD, [k, int(1)])]);
+    const gKp1 = app(DIV, [app(ADD, [k, int(1)]), app(ADD, [k, int(2)])]);
+    const f = app(SUB, [gK, gKp1]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+
+  it("transcendental numerator ∑_{k=1}^∞ [sin(k)/k² − sin(k+1)/(k+1)²] falls through", () => {
+    // sin(k)/k² is non-polynomial; conservative refuse.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kPlus1]);
+    const f = app(SUB, [
+      app(DIV, [sinK, app(POW, [k, int(2)])]),
+      app(DIV, [sinKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });


### PR DESCRIPTION
## Summary

Ports the Python Phase 41 (limit-aware infinite telescope — PR #3880) + Phase 42 (degree-aware vanishing-at-infinity — PR #3887) to TypeScript and Rust in a single PR.

Extends `evaluateSum` / `evaluate_sum` to close infinite telescopes when `g(k)` provably vanishes at infinity:

$$\sum_{k=lo}^{\infty} [g(k+1) - g(k)] = -g(lo), \qquad \sum_{k=lo}^{\infty} [g(k) - g(k+1)] = g(lo).$$

## Vanishing-at-infinity recogniser (two tiers)

1. **Phase 41 fast path** — `Div(constant-in-k, h(k))` with `h` a positive-degree polynomial in `k`.
2. **Phase 42 widening** — `Div(P(k), Q(k))` with both pure polynomials and `deg(P) < deg(Q)`.

Anything transcendental, improper, or non-Div falls through.

## Versions

| Package | Was | Now |
|---|---|---|
| `typescript/cas-summation` | 0.2.0 | 0.3.0 |
| `rust/cas-summation` | 0.2.0 | 0.3.0 |

## Tests

7 new cases each in TypeScript and Rust mirroring the Python suite:
- `∑ 1/k − 1/(k+1) = 1`, `∑ 1/(k+1) − 1/k = −1`, higher starting index `= 1/2`.
- Quadratic denominator `∑ 1/k² − 1/(k+1)² = 1`.
- Phase 42 proper rational `∑ k/(k²+1) − (k+1)/((k+1)²+1) = 1/2`.
- Improper rational `k/(k+1)` falls through.
- Transcendental `sin(k)/k²` falls through.

Existing finite-telescope and infinite-fallthrough tests still pass (the existing `infinite_upper_falls_through` test uses `g(k)=k` which doesn't vanish, so it now pins the Phase 41 guard).

| Suite | Was | Now |
|---|---|---|
| TS | 14 passed | **21 passed** |
| Rust | 14 passed | **21 passed** |

## Test plan

- [x] Existing Phase 39 finite-telescope tests still pass in both languages.
- [x] New Phase 41+42 tests verify both success and fallthrough paths.
- [x] No new external dependencies.
- [x] Security review passed (no eval/unsafe; bounded recursion; conservative refuse for unrecognized shapes).

## Still deferred (in TS / Rust)

- Apart-induced telescopes like `1/(k(k+1))` — blocked on porting the `Apart` partial-fraction-decomposition handler to TypeScript / Rust.
- Transcendental limit-finder (`sin(k)/k²`, `log(k)/k`, `1/exp(k)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)