### PR TITLE
feat(cas-summation,symbolic-vm): Phase 43 — transcendental vanishing-at-infinity (Python)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## 0.5.0 — 2026-05-22
+
+**Phase 43 — Transcendental vanishing-at-infinity (`Exp(h)` and
+`Pow(b, h)` shapes).**
+
+Extends Phase 41/42's vanishing-at-infinity recogniser to accept
+exponentially diverging denominators, so infinite telescopes like
+
+    ∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1
+    ∑_{k=1}^∞ [1/(k·2^k) − 1/((k+1)·2^(k+1))] = 1/2
+
+close in one dispatch.
+
+### Added
+
+- **`_h_diverges_at_infinity(node, k)`** in `summation.py` — the
+  union of the Phase 41/42 positive-degree polynomial recogniser and
+  three new transcendental cases:
+  1. ``Exp(h(k))`` with ``h`` a positive-degree polynomial in ``k``
+     AND positive leading coefficient (so ``h → +∞``, not ``−∞``).
+  2. ``Pow(b, h(k))`` with ``b`` a rational of magnitude > 1 and
+     ``h`` positive-degree with positive leading coefficient.
+  3. ``Mul(...)`` where at least one factor diverges and the others
+     are constant in ``k`` or also diverging.  Recursive.
+- **`_polynomial_leading_coeff_sign_in_k(node, k) -> int | None`** —
+  returns the sign (``+1`` or ``−1``) of the polynomial's leading
+  coefficient in ``k``, or ``None`` for non-polynomial / degree-0 /
+  unknown-sign shapes.  Conservatively refuses on tied-degree ``Add``
+  terms (where leading coefficients could cancel) and symbolic
+  constants of unknown sign.  Required for the Exp / Pow branches
+  above so we don't claim ``exp(-k)`` or ``2^(-k)`` diverges (they
+  actually vanish).
+
+### Changed
+
+- `_g_vanishes_at_infinity` Phase 41 fast path now calls
+  `_h_diverges_at_infinity` instead of
+  `_is_positive_degree_polynomial_in_k` directly, picking up the
+  transcendental cases automatically.  Phase 42 widening (proper
+  rational `deg(P) < deg(Q)`) is unchanged.
+
+### Added — tests
+
+`tests/test_summation.py` — new
+`TestEvaluateSumPhase43Transcendental` class with 7 cases:
+
+- ``∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1``.
+- ``∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = 1/3``.
+- Negative base magnitude > 1: ``∑ [1/(-2)^k − …] = 1``.
+- Base = 1 falls through (Step 1 constant rule fires first; pins the
+  Phase 43 ``|b| > 1`` guard against accidental closure at b=1).
+- Rational base 3/2 diverges → closed form.
+- Base 1/2 falls through (denominator ``(1/2)^k → 0``, not ∞).
+- ``Mul`` of polynomial × exponential (``k · 2^k``) diverges → closed
+  form ``g(1) = 1/2``.
+
+Plus 4 sign-aware regression tests (from the in-flight security review):
+
+- ``exp(-k)`` and its symmetric pair MUST refuse (``-k`` has negative
+  leading coefficient → ``exp(-k) → 0``, not ∞; closing the sum would
+  silently emit a wrong answer).
+- ``2^(-k)`` MUST refuse for the same reason.
+- ``k · 2^(-k)`` MUST refuse — the Mul recursion propagates the
+  child-level refusal.
+- ``Exp(Neg(k))`` MUST refuse — same semantics as ``Exp(Mul(-1, k))``
+  but written with the explicit ``NEG`` wrapper.
+
+Full suite: **88 passed** (77 prior + 7 Phase 43 + 4 regression).
+
+### Still deferred
+
+- ``Log(h(k))`` divergence (``log(k) → ∞`` but only at logarithmic
+  rate; needs explicit limit handling).
+- Cross-language port to TypeScript / Rust.
+
 ## 0.4.0 — 2026-05-22
 
 **Phase 42 — Degree-aware vanishing-at-infinity recogniser.**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "0.4.0"
+version = "0.5.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -52,6 +52,7 @@ from fractions import Fraction
 from symbolic_ir import (
     ADD,
     DIV,
+    EXP,
     MUL,
     NEG,
     POW,
@@ -365,6 +366,185 @@ def _polynomial_degree_in_k(node: IRNode, k: IRSymbol) -> int | None:
     return None
 
 
+def _polynomial_leading_coeff_sign_in_k(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 43 helper: return the *sign* of the leading coefficient of
+    ``node`` as a polynomial in ``k``, or ``None`` if ``node`` is not a
+    polynomial in ``k`` (or has degree 0).
+
+    Returns ``+1`` or ``−1``.  Used by :func:`_h_diverges_at_infinity` to
+    decide whether the polynomial exponent inside ``Exp`` / ``Pow``
+    actually drives the value toward ``+∞`` (sign ``+1``, divergent) or
+    toward ``−∞`` (sign ``−1``, makes ``exp(h)`` / ``b^h`` → 0).
+
+    A naïve "positive-degree polynomial" check (Phase 41/42) is *not*
+    sign-aware: ``Mul(-1, k)`` (the canonical IR for ``-k``) passes the
+    positive-degree test but its leading coefficient is ``-1``.  Without
+    this helper, ``Exp(-k)`` and ``Pow(2, -k)`` would be wrongly claimed
+    to diverge — they actually vanish.
+
+    Recognised shapes
+    -----------------
+
+    +-----------------------------+-------------------------------+
+    | Input                       | Sign of leading coefficient   |
+    +=============================+===============================+
+    | constant in k               | ``None`` (degree 0)           |
+    | ``k``                       | +1                            |
+    | ``k^n`` with n ≥ 1 integer  | +1                            |
+    | ``Neg(p)``                  | flips sign of ``p``           |
+    | ``Mul(c, p)`` with ``c``    | ``sign(c) * sign(p)``         |
+    |   constant in k (rational)  |                               |
+    | ``Mul(p1, p2, …)`` pure     | product of signs              |
+    |   polynomials in k          |                               |
+    | ``Add(p1, p2, …)`` — sign   | sign of the maximum-degree    |
+    |   of the highest-degree     | term (assuming non-cancelling |
+    |   term                      | leading coefficients)         |
+    | anything else (Div, Sin,    | ``None``                      |
+    |   fractional Pow, …)        |                               |
+    +-----------------------------+-------------------------------+
+    """
+    # Constant in k — no leading coefficient (degree 0).
+    if _is_constant_in(node, k):
+        return None
+    if node == k:
+        return 1
+    if not isinstance(node, IRApply):
+        return None
+    # k^n with n ≥ 1.
+    if node.head == POW and len(node.args) == 2:
+        base, exp_arg = node.args
+        if (
+            base == k
+            and isinstance(exp_arg, IRInteger)
+            and exp_arg.value >= 1
+        ):
+            return 1
+        return None
+    # Neg(p): flip sign.
+    if node.head == NEG and len(node.args) == 1:
+        inner = _polynomial_leading_coeff_sign_in_k(node.args[0], k)
+        return None if inner is None else -inner
+    # Mul(...): pick the k-bearing factor(s) and multiply their signs;
+    # constants-in-k contribute their own sign.
+    if node.head == MUL:
+        sign = 1
+        any_k_bearing = False
+        for arg in node.args:
+            if _is_constant_in(arg, k):
+                # Constant factor — multiply by its sign.
+                val = _ir_rational_val(arg)
+                if val is None:
+                    # Symbolic constant whose sign we can't decide.
+                    return None
+                if val == 0:
+                    return None  # Vanishing factor; not a leading coeff.
+                if val < 0:
+                    sign = -sign
+                continue
+            inner = _polynomial_leading_coeff_sign_in_k(arg, k)
+            if inner is None:
+                return None
+            sign = sign if inner == 1 else -sign
+            any_k_bearing = True
+        return sign if any_k_bearing else None
+    # Add(...): the highest-degree term dominates.  Walk children,
+    # picking the one with the largest polynomial degree and use its
+    # leading-coefficient sign.  If multiple children share the maximum
+    # degree we conservatively return ``None`` (could cancel).
+    if node.head == ADD:
+        max_deg: int = -1
+        leader_sign: int | None = None
+        tied_at_max = False
+        for arg in node.args:
+            deg = _polynomial_degree_in_k(arg, k)
+            if deg is None:
+                return None  # non-polynomial child — refuse
+            if deg == 0:
+                continue  # constant terms don't determine leading sign
+            if deg > max_deg:
+                max_deg = deg
+                leader_sign = _polynomial_leading_coeff_sign_in_k(arg, k)
+                tied_at_max = False
+            elif deg == max_deg:
+                tied_at_max = True
+        if tied_at_max:
+            # Two or more terms share the highest degree; the leading
+            # coefficient could cancel, so we conservatively refuse.
+            return None
+        return leader_sign
+    return None
+
+
+def _h_diverges_at_infinity(node: IRNode, k: IRSymbol) -> bool:
+    """Phase 43: Return True when ``node`` provably diverges (to ±∞) as
+    ``k → ∞``.
+
+    A union of the Phase 41/42 positive-degree polynomial recogniser and
+    new transcendental cases:
+
+    +-----------------------------------+------------------------------+
+    | Input                             | Diverges?                    |
+    +===================================+==============================+
+    | positive-degree polynomial in k   | yes (Phase 41/42)            |
+    | ``Exp(h(k))`` with ``h``          | yes (Phase 43)               |
+    |   diverging                       |                              |
+    | ``Pow(b, h(k))`` with             | yes (Phase 43)               |
+    |   ``b ∈ ℤ``, ``|b| > 1`` rational |                              |
+    |   and ``h`` diverging             |                              |
+    | ``Mul(...)`` where at least       | yes (Phase 43)               |
+    |   one factor diverges and others  |                              |
+    |   are constant-in-k or diverging  |                              |
+    | anything else                     | no (conservatively)          |
+    +-----------------------------------+------------------------------+
+
+    Notes
+    -----
+    The ``b`` check uses ``|b| > 1`` so both ``2`` and ``−2`` (and
+    rationals like ``3/2``) count.  For negative bases the sign
+    oscillates but the magnitude diverges; ``c / b^k`` still tends to
+    0 because the absolute value of the denominator grows.
+    """
+    # Phase 41/42 fast path — pure polynomial in k of positive degree.
+    if _is_positive_degree_polynomial_in_k(node, k):
+        return True
+    if not isinstance(node, IRApply):
+        return False
+    # Phase 43: Exp(h(k)) with h → +∞.  `exp(+∞) = +∞` but `exp(−∞) = 0`,
+    # so we MUST verify the leading coefficient of h is positive — a
+    # naïve "positive-degree polynomial" check accepts ``Mul(-1, k)``
+    # (i.e. ``-k``) whose leading coefficient is ``-1``, in which case
+    # ``exp(h) → 0`` and the closed form would be silently wrong.
+    if node.head == EXP and len(node.args) == 1:
+        inner = node.args[0]
+        if _is_positive_degree_polynomial_in_k(inner, k):
+            return _polynomial_leading_coeff_sign_in_k(inner, k) == 1
+        return False
+    # Phase 43: Pow(b, h(k)) with |b| > 1 rational and h → +∞.  Same
+    # sign-of-leading-coefficient requirement as the Exp branch —
+    # ``Pow(2, Mul(-1, k))`` is ``2^(-k) → 0``, not ∞.
+    if node.head == POW and len(node.args) == 2:
+        base, exp = node.args
+        if _is_constant_in(base, k):
+            base_val = _ir_rational_val(base)
+            if base_val is not None and abs(base_val) > 1:
+                if _is_positive_degree_polynomial_in_k(exp, k):
+                    if _polynomial_leading_coeff_sign_in_k(exp, k) == 1:
+                        return True
+    # Phase 43: Mul(...) — at least one factor diverges, others are
+    # constant in k or also diverging.  Recursive.
+    if node.head == MUL and len(node.args) >= 2:
+        has_divergent = False
+        for arg in node.args:
+            if _is_constant_in(arg, k):
+                continue
+            if _h_diverges_at_infinity(arg, k):
+                has_divergent = True
+                continue
+            return False  # unrecognised k-dependence
+        return has_divergent
+    return False
+
+
 def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     """Return True when ``g(k)`` provably tends to 0 as ``k → ∞``.
 
@@ -407,9 +587,10 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     if not isinstance(g, IRApply) or g.head != DIV or len(g.args) != 2:
         return False
     num, den = g.args
-    # Phase 41 fast path: constant numerator + positive-degree denominator.
+    # Phase 41/43 fast path: constant numerator + diverging denominator
+    # (positive-degree polynomial OR exp / b^k transcendental).
     if _is_constant_in(num, k):
-        return _is_positive_degree_polynomial_in_k(den, k)
+        return _h_diverges_at_infinity(den, k)
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -600,3 +600,250 @@ class TestEvaluateSumPhase42DegreeAware:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         # Conservative: refuse since num is not a polynomial.
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+# ---------------------------------------------------------------------------
+# Phase 43: transcendental vanishing-at-infinity.
+#
+# Extends Phase 41's denominator recogniser to also accept exponentially
+# diverging shapes:
+#   - Exp(h(k)) with h(k) a positive-degree polynomial in k
+#   - Pow(b, h(k)) with |b| > 1 rational and h(k) positive-degree
+#   - Mul(...) with at least one diverging factor and others constant
+#     in k or also diverging
+#
+# Closes telescopes like ∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = g(0) = 1.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase43Transcendental:
+    def test_antisymmetric_one_over_2_pow_k(self):
+        """``∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = g(0) = 1/2^0 = 1``.
+
+        Phase 43 recognises ``Pow(2, k)`` as a diverging denominator;
+        the antisymmetric telescope emits ``g(0) = 1``.
+        """
+        from symbolic_ir import SUB
+
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(POW, (IRInteger(2), IRApply(ADD, (_k, IRInteger(1)))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRInteger) and result.value == 1
+
+    def test_pow_3_with_higher_starting_index(self):
+        """``∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = g(1) = 1/3``.
+
+        Phase 43: base = 3 (>1), exponent = k (positive degree).
+        Antisymmetric closed form is ``g(1) = 1/3``.
+        """
+        from fractions import Fraction
+        from symbolic_ir import SUB
+
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (IRInteger(3), _k))))
+        g_kp1 = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(POW, (IRInteger(3), IRApply(ADD, (_k, IRInteger(1)))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        from symbolic_ir import IRRational
+
+        assert isinstance(result, IRRational)
+        assert Fraction(result.numer, result.denom) == Fraction(1, 3)
+
+    def test_pow_negative_base_with_magnitude_above_one(self):
+        """``∑_{k=0}^∞ [1/(-2)^k − 1/(-2)^(k+1)] = 1/(-2)^0 = 1``.
+
+        Phase 43 accepts ``|b| > 1`` for the base, so negative bases
+        with magnitude > 1 still count (the magnitude diverges; the
+        sign oscillates but doesn't affect the limit being 0).
+        """
+        from symbolic_ir import SUB
+
+        neg2 = IRInteger(-2)
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (neg2, _k))))
+        g_kp1 = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(POW, (neg2, IRApply(ADD, (_k, IRInteger(1)))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRInteger) and result.value == 1
+
+    def test_base_one_falls_through(self):
+        """``Pow(1, k) = 1`` doesn't diverge; Phase 43 refuses.
+
+        ``∑_{k=0}^∞ [1/1^k − 1/1^(k+1)] = ∑ [1 − 1] = ∑ 0`` — but the
+        constant-summand rule fires first (Step 1) so it never reaches
+        Phase 43.  This test pins the Phase 43 ``|b| > 1`` guard against
+        accidentally claiming ``b = 1`` diverges.
+        """
+        from symbolic_ir import SUB
+
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (IRInteger(1), _k))))
+        g_kp1 = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(POW, (IRInteger(1), IRApply(ADD, (_k, IRInteger(1)))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        # Constant-summand path folds [1 − 1] = 0 first; check it's
+        # either the integer 0 OR fell through to unevaluated (the
+        # stub VM may not fold the SUB).  Definitely must not emit
+        # ``−g(lo) = −1`` via a wrongly-fired Phase 43.
+        if isinstance(result, IRInteger):
+            assert result.value == 0
+        else:
+            assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_pow_fractional_base_above_one_diverges(self):
+        """``Pow(3/2, k)`` has rational base 3/2 with magnitude > 1 →
+        diverges.  ``∑_{k=0}^∞ [1/(3/2)^k − 1/(3/2)^(k+1)] = 1``.
+        """
+        from symbolic_ir import SUB
+
+        three_halves = IRRational(3, 2)
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (three_halves, _k))))
+        g_kp1 = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(POW, (three_halves, IRApply(ADD, (_k, IRInteger(1)))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRInteger) and result.value == 1
+
+    def test_pow_half_falls_through(self):
+        """``Pow(1/2, k) = (1/2)^k → 0``, not diverging.  Phase 43
+        refuses (we need denominator to diverge).
+        """
+        from symbolic_ir import SUB
+
+        half = IRRational(1, 2)
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (half, _k))))
+        g_kp1 = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(POW, (half, IRApply(ADD, (_k, IRInteger(1)))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        # Phase 43 must refuse — the denominator (1/2)^k → 0, so g(k)
+        # actually diverges; emitting ``−g(lo)`` would be wrong.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_mul_of_polynomial_and_exponential_diverges(self):
+        """``∑_{k=1}^∞ [1/(k·2^k) − 1/((k+1)·2^(k+1))] = 1/2``.
+
+        Denominator is ``k · 2^k`` — Phase 43 ``Mul`` case combines a
+        positive-degree polynomial factor (``k``) with an exponential
+        factor (``2^k``), both diverging.  Closed form: ``g(1) = 1/2``.
+        """
+        from fractions import Fraction
+        from symbolic_ir import SUB
+
+        g_k = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(MUL, (_k, IRApply(POW, (IRInteger(2), _k))))),
+        )
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_kp1 = IRApply(
+            DIV, (IRInteger(1), IRApply(MUL, (kp1, IRApply(POW, (IRInteger(2), kp1))))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        from symbolic_ir import IRRational
+
+        assert isinstance(result, IRRational)
+        assert Fraction(result.numer, result.denom) == Fraction(1, 2)
+
+    # ----- Phase 43 sign-aware regressions (from security review) -----
+
+    def test_exp_negative_polynomial_exponent_does_not_diverge(self):
+        """``Exp(Mul(-1, k))`` represents ``exp(-k) → 0``, NOT ∞.
+
+        The Phase 43 sign-aware guard must refuse to claim divergence
+        when the polynomial exponent has a negative leading coefficient.
+        Otherwise ``Div(c, exp(-k)) = c·exp(k) → ∞`` would be wrongly
+        claimed to vanish.
+        """
+        from symbolic_ir import EXP, SUB
+
+        neg_k = IRApply(MUL, (IRInteger(-1), _k))
+        neg_kp1 = IRApply(MUL, (IRInteger(-1), IRApply(ADD, (_k, IRInteger(1)))))
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(EXP, (neg_k,))))
+        g_kp1 = IRApply(DIV, (IRInteger(1), IRApply(EXP, (neg_kp1,))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        # MUST stay unevaluated — g(k) = 1/exp(-k) = exp(k) actually
+        # diverges, so the sum doesn't have a finite closed form via
+        # this rule.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_pow_negative_polynomial_exponent_does_not_diverge(self):
+        """``Pow(2, Mul(-1, k)) = 2^(-k) → 0``, NOT ∞.
+
+        Same regression as the Exp case: Phase 43 must refuse the
+        ``Div(c, 2^(-k))`` shape because the denominator vanishes
+        rather than diverging.
+        """
+        from symbolic_ir import SUB
+
+        neg_k = IRApply(MUL, (IRInteger(-1), _k))
+        neg_kp1 = IRApply(MUL, (IRInteger(-1), IRApply(ADD, (_k, IRInteger(1)))))
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(POW, (IRInteger(2), neg_k))))
+        g_kp1 = IRApply(DIV, (IRInteger(1), IRApply(POW, (IRInteger(2), neg_kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_mul_with_negative_polynomial_exponent_does_not_diverge(self):
+        """``k · 2^(-k) → 0``, NOT ∞ (the exponential decay wins).
+
+        Phase 43's ``Mul`` recursion must propagate the sign-aware
+        refusal from its child: ``k`` is positive-degree, but ``2^(-k)``
+        is correctly rejected by the Pow branch, so the overall ``Mul``
+        recogniser refuses too.
+        """
+        from symbolic_ir import SUB
+
+        neg_k = IRApply(MUL, (IRInteger(-1), _k))
+        neg_kp1 = IRApply(MUL, (IRInteger(-1), IRApply(ADD, (_k, IRInteger(1)))))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_k = IRApply(
+            DIV,
+            (IRInteger(1), IRApply(MUL, (_k, IRApply(POW, (IRInteger(2), neg_k))))),
+        )
+        g_kp1 = IRApply(
+            DIV,
+            (
+                IRInteger(1),
+                IRApply(MUL, (kp1, IRApply(POW, (IRInteger(2), neg_kp1)))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_exp_with_neg_wrapper_does_not_diverge(self):
+        """``Exp(Neg(k))`` — the canonical ``-k`` written as an
+        explicit ``NEG`` wrapper rather than ``Mul(-1, k)``.  Same
+        ``exp(-k) → 0`` behaviour; Phase 43 must refuse.
+        """
+        from symbolic_ir import EXP, NEG, SUB
+
+        g_k = IRApply(DIV, (IRInteger(1), IRApply(EXP, (IRApply(NEG, (_k,)),))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                IRInteger(1),
+                IRApply(
+                    EXP, (IRApply(NEG, (IRApply(ADD, (_k, IRInteger(1))),)),),
+                ),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(0), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.67.0 — 2026-05-22
+
+**Phase 43 dep bump — transcendental vanishing-at-infinity.**
+
+Bumps the `coding-adventures-cas-summation` dependency to `>=0.5.0`,
+which introduces Phase 43's transcendental denominator recogniser
+(``Exp(h(k))``, ``Pow(b, h(k))`` with ``|b| > 1``, and ``Mul`` of
+such factors).  Combined with the existing Phase 40 Apart-retry path,
+``∑_{k=0}^∞ [c_1/2^k + c_2/3^k + …]`` style series now close in one
+dispatch through the `sum_handler`.
+
+### Changed
+
+- Bumped dep `coding-adventures-cas-summation>=0.5.0` (was `>=0.4.0`).
+
 ## 0.66.0 — 2026-05-22
 
 **Phase 42 dep bump — degree-aware vanishing-at-infinity.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.66.0"
+version = "0.67.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -33,7 +33,7 @@ dependencies = [
     "coding-adventures-cas-ode>=0.2.0",
     "coding-adventures-cas-algebraic>=0.1.0",
     "coding-adventures-cas-multivariate>=0.1.0",
-    "coding-adventures-cas-summation>=0.4.0",
+    "coding-adventures-cas-summation>=0.5.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary

Phase 43 extends the cas-summation vanishing-at-infinity recogniser to accept exponentially diverging denominators. Closes infinite telescopes built from `1/2^k`, `1/3^k`, `1/(k·2^k)`, etc. — e.g. `∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1`.

## Recogniser additions

`_h_diverges_at_infinity(node, k)` is now the union of the existing positive-degree polynomial check and three new transcendental cases:

1. `Exp(h(k))` where `h` is a positive-degree polynomial **with positive leading coefficient**.
2. `Pow(b, h(k))` where `b` is a rational with `|b| > 1` **and** `h` has positive leading coefficient.
3. `Mul(...)` where at least one factor diverges and the others are constant-in-k or also diverging. Recursive.

The sign-aware leading-coefficient check (new helper `_polynomial_leading_coeff_sign_in_k`) is critical: `Exp(Mul(-1, k)) = exp(-k) → 0` (not ∞), so naïvely accepting any positive-degree polynomial would silently emit wrong closed forms.

## Versions

| Package | Was | Now |
|---|---|---|
| `python/cas-summation` | 0.4.0 | 0.5.0 |
| `python/symbolic-vm` | 0.66.0 | 0.67.0 (dep range bump only) |

## Tests

`tests/test_summation.py` — new `TestEvaluateSumPhase43Transcendental` class with **11 cases** (7 happy-path + 4 sign-aware regressions):

- `∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1`
- `∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = 1/3`
- Negative base magnitude > 1 (`(-2)^k`)
- Base = 1 falls through (pins `|b| > 1` guard)
- Rational base 3/2 diverges
- Base 1/2 falls through (`(1/2)^k → 0`)
- `Mul` of polynomial × exponential (`k · 2^k`) closes
- **Regression** `exp(-k)` (via `Mul(-1, k)`) does NOT diverge → refuse
- **Regression** `2^(-k)` does NOT diverge → refuse
- **Regression** `k · 2^(-k)` does NOT diverge → refuse (Mul recursion propagates)
- **Regression** `exp(-k)` via `Neg(k)` wrapper → refuse

Full suite: **88 passed** (77 prior + 11 net new).

## Test plan

- [x] All existing Phase 39/40/41/42 tests still pass.
- [x] New Phase 43 happy-path tests verify divergence is recognised.
- [x] Sign-aware regression tests pin the leading-coefficient guard.
- [x] Security/correctness review passed (MEDIUM bugs flagged in the first round are fully addressed in this amendment).

## Still deferred

- `Log(h(k))` divergence (logarithmic rate; needs explicit handling).
- TS / Rust ports — blocked on porting `Apart` to those backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)