### PR TITLE
feat(ruby-parser): Phase 6c — `while … end` / `until … end` loops

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,13 +25,15 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | if_statement | unless_statement | assignment | method_call | expression_stmt ;
+statement    = def_statement | if_statement | unless_statement | while_statement | until_statement | assignment | method_call | expression_stmt ;
 def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
 params       = NAME { COMMA NAME } ;
 if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
 elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;
 else_clause  = "else" { !"end" statement } ;
 unless_statement = "unless" expression { !"else" !"end" statement } [ else_clause ] "end" ;
+while_statement = "while" expression { !"end" statement } "end" ;
+until_statement = "until" expression { !"end" statement } "end" ;
 assignment   = NAME EQUALS expression ;
 method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPAREN ;
 expression_stmt = expression ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.4.0] - 2026-05-20
+
+### Added (Phase 6c — `while … end` / `until … end` loops)
+- `while_statement = "while" expression { !"end" statement } "end"`
+- `until_statement = "until" expression { !"end" statement } "end"`
+- Added as alternatives in `statement` after the conditionals.
+- Body uses the same `!"end"` negative-lookahead trick from Phase 6a/6b.
+
+### Tests (+3 new, total 17)
+- `while` with body, `until`, `while` with empty body.
+
 ## [0.3.0] - 2026-05-20
 
 ### Added (Phase 6b — `if … else … end` and `unless`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -21,6 +21,8 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"def_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"if_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"unless_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"while_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"until_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression_stmt"#.to_string() },
@@ -114,13 +116,39 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 34,
         },
         GrammarRule {
+            name: r#"while_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"while"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 35,
+        },
+        GrammarRule {
+            name: r#"until_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"until"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 36,
+        },
+        GrammarRule {
             name: r#"assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 35,
+            line_number: 37,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -139,12 +167,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 36,
+            line_number: 38,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 37,
+            line_number: 39,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
@@ -158,7 +186,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 38,
+            line_number: 40,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -172,7 +200,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 39,
+            line_number: 41,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -187,7 +215,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 40,
+            line_number: 42,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -290,5 +290,36 @@ mod tests {
         let ast = parse_ruby("unless x\n  y = 1\nend");
         assert!(find_statement_inner(&ast, "unless_statement").is_some());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6c — `while` / `until` loops
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_while() {
+        let ast = parse_ruby("while x\n  y = 1\nend");
+        let node = find_statement_inner(&ast, "while_statement")
+            .expect("expected while_statement");
+        let body_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert!(body_count >= 1);
+    }
+
+    #[test]
+    fn test_parse_until() {
+        let ast = parse_ruby("until x\n  y = 1\nend");
+        assert!(find_statement_inner(&ast, "until_statement").is_some());
+    }
+
+    #[test]
+    fn test_parse_while_empty_body() {
+        // `while cond ; end` — zero-iteration body.  The grammar's
+        // Repetition matches zero statements, then `end` closes.
+        let ast = parse_ruby("while x\nend");
+        assert!(find_statement_inner(&ast, "while_statement").is_some());
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.4.0] - 2026-05-20
+
+### Added (Phase 6c — `while … end` / `until … end` lowering)
+- New `lower_while_or_until` handler emits a `Stmt::While`.  `until cond` lowers to `while !cond` (condition wrapped in `BuiltinCall("not", ...)`).
+- `Feature::Loops` is now added to the module manifest whenever a `Stmt::While` is emitted (the SIR validator requires it).
+- Loop body uses the existing `lower_clause_statements` helper, so locals introduced inside the loop don't leak to the outer scope.
+
+### Tests (+3 new, total 22)
+- `while_lowers_to_stmt_while` — basic while produces `Stmt::While`.
+- `until_negates_condition` — `until cond` wraps cond in `BuiltinCall("not", ...)`.
+- `while_module_passes_sir_validator` — a while-loop module passes `semantic_ir::validate` (Feature::Loops gating works).
+
 ## [0.3.0] - 2026-05-20
 
 ### Added (Phase 6b — `if … else … end` / `unless` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -419,6 +419,47 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Phase 6c — `while … end` / `until … end`
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn while_lowers_to_stmt_while() {
+        let m = lower("x = 0\nwhile x\n  y = 1\nend\n");
+        let main = main_body(&m);
+        let while_stmt = main.stmts.iter().find_map(|s| match s {
+            Stmt::While { cond, .. } => Some(cond),
+            _ => None,
+        });
+        assert!(while_stmt.is_some(), "expected While stmt");
+    }
+
+    #[test]
+    fn until_negates_condition() {
+        let m = lower("x = 0\nuntil x\n  y = 1\nend\n");
+        let main = main_body(&m);
+        let while_stmt = main.stmts.iter().find_map(|s| match s {
+            Stmt::While { cond, .. } => Some(cond),
+            _ => None,
+        }).expect("expected While stmt");
+        assert!(
+            matches!(while_stmt, Expr::BuiltinCall { name, .. } if name == "not"),
+            "expected `until` to wrap cond in `not`, got {:?}",
+            while_stmt
+        );
+    }
+
+    #[test]
+    fn while_module_passes_sir_validator() {
+        let m = lower("x = 0\nwhile x\n  y = 1\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn module_with_def_passes_sir_validator() {
         // v0 grammar can't yet parse nested method calls in args

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -103,6 +103,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
     for f in [
         Feature::DynamicTyping,
         Feature::MutableBindings,
+        Feature::Loops,
         Feature::Closures,
     ] {
         if lw.features_used.contains(&f) {
@@ -300,6 +301,12 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "while_statement" | "until_statement" => {
+                // Phase 6c: SIR's `Stmt::While` is the canonical
+                // top-level loop — `until cond` lowers to
+                // `while !cond` (wrap the condition in `not`).
+                self.lower_while_or_until(node)
+            }
             other => Err(RubyLowerError {
                 message: format!("unsupported statement form `{other}`"),
                 line: node.start_line.unwrap_or(0),
@@ -475,6 +482,46 @@ impl Lowerer {
         Ok(Block {
             stmts: stmts_out,
             value,
+            span: self.span_of(node),
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6c — `while cond … end` / `until cond … end`
+    // -------------------------------------------------------------------
+
+    /// Lower a `while_statement` or `until_statement` into a
+    /// `Stmt::While`.  `until cond` lowers to `while !cond`
+    /// (condition wrapped in `BuiltinCall("not", ...)`).
+    fn lower_while_or_until(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Stmt, RubyLowerError> {
+        let is_until = node.rule_name == "until_statement";
+        let cond_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
+                message: format!("{} missing condition expression", node.rule_name),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let mut cond = self.lower_expression(cond_node)?;
+        if is_until {
+            cond = Expr::BuiltinCall {
+                name: "not".to_string(),
+                args: vec![cond],
+                effects: EffectSet::PURE,
+                span: self.span_of(cond_node),
+            };
+        }
+        let body = self.lower_clause_statements(node)?;
+        // Phase 6c: the SIR validator requires `loops` to be
+        // declared whenever the module emits a `Stmt::While` /
+        // `Stmt::ForRange` / `Stmt::ForEach`.
+        self.features_used.insert(Feature::Loops);
+        Ok(Stmt::While {
+            cond,
+            body,
             span: self.span_of(node),
         })
     }


### PR DESCRIPTION
## Summary

Third parser-grammar extension after [Phase 6a (`def`)](https://github.com/adhithyan15/coding-adventures/pull/3879) and [Phase 6b (`if`/`unless`)](https://github.com/adhithyan15/coding-adventures/pull/3892).  Adds Ruby's two top-level loop forms (`while` / `until`) to the grammar and lowers them to `semantic_ir::Stmt::While`.

## Parser

New rules:

\`\`\`
while_statement = "while" expression { !"end" statement } "end"
until_statement = "until" expression { !"end" statement } "end"
\`\`\`

## SIR

- `lower_while_or_until` emits `Stmt::While`.  `until cond` lowers to `while !cond` (cond wrapped in `BuiltinCall("not", ...)`).
- `Feature::Loops` is added to the module manifest whenever a `Stmt::While` is emitted — the validator requires it.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — 97 passed (unchanged).
- [x] `cargo test -p coding-adventures-ruby-parser` — 17 passed (was 14; +3 new).
- [x] `cargo test -p ruby-to-semantic-ir` — 22 passed (was 19; +3 new, including validator pass).

## What's next

Last merged was [Phase 4d lexer](https://github.com/adhithyan15/coding-adventures/pull/3895); this is parser.  Next chunk: Phase 4e — 2.6 endless ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)