### PR TITLE
feat(forme-doc-search-index-builder): DOC00 v0 sharded inverted-index builder

### DIFF
--- a/code/packages/typescript/forme-doc-search-index-builder/BUILD
+++ b/code/packages/typescript/forme-doc-search-index-builder/BUILD
@@ -1,0 +1,2 @@
+cd ../forme-doc-search-tokenizer && npm ci --quiet
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-doc-search-index-builder/CHANGELOG.md
+++ b/code/packages/typescript/forme-doc-search-index-builder/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog — @coding-adventures/forme-doc-search-index-builder
+
+## 0.1.0 — 2026-05-22
+
+Initial release.  Ninth concrete DOC00 v0 package — build-time
+inverted-index builder for the documentation-site search.
+Takes per-page text + metadata, builds a `token → postings`
+inverted index, shards by token-prefix for incremental browser
+loading, and emits the shards plus a small bootstrap manifest.
+
+Pure transform: `{ pages: IndexPageInput[] }` →
+`{ shards: Map<string, IndexShard>, manifest: IndexManifest }`.
+Capabilities `[]`.  One transitive dependency
+(`@coding-adventures/forme-doc-search-tokenizer`, itself
+`[]`-capability and zero-dep).
+
+### Added
+
+- `buildSearchIndex(pages, options?): BuildIndexOutput` — main
+  entry.  Validates input, tokenises each page, builds the
+  inverted index, shards by token-prefix, emits sorted
+  manifest.
+- Types: `IndexPageInput`, `BuildIndexOptions`,
+  `BuildIndexOutput`, `IndexShard`, `IndexManifest`,
+  `IndexStats`, `Posting`.
+
+### Spec adherence
+
+Implements DOC00 v0's `forme-doc-search-index-builder` per
+`code/specs/DOC00-docs-vision.md` — build-time inverted index,
+sharded for incremental browser loading, with a small
+bootstrap manifest.
+
+v0 decision: postings record `freq` only (no positions).  v1
+may add position lists if phrase-query support proves needed.
+
+### Pipeline
+
+1. **Validate** — reject if `pages.length > maxPages`; throw
+   on duplicate page ids.
+2. **Tokenise** each page's body + title via
+   `forme-doc-search-tokenizer`.  Title hits set
+   `titleHit: true` so query-time ranking can boost them.
+   Per-page unique tokens capped at `maxTokensPerPage`.
+3. **Inverted-index build** — `Map<token, Map<pageId, Posting>>`.
+   Repeated token occurrences in the same page increment that
+   posting's `freq`.  Per-token postings list capped at
+   `maxPostingsPerToken`.
+4. **Shard** by token prefix (`token.slice(0, shardPrefix)`).
+   Within each shard, postings sorted by descending freq
+   (ascending pageId tiebreak) for cheap top-k retrieval.
+5. **Manifest** — sorted lists of all pages and all shard keys,
+   plus the option flags used (so the query-side tokeniser
+   can mirror them) and aggregate stats.
+
+### Memory bounds
+
+Three explicit caps protect against adversarial / overly-large
+inputs:
+
+- `maxPages` (default `100_000`): rejects `pages` longer than
+  this with `TypeError`.
+- `maxTokensPerPage` (default `10_000`): silently drops unique
+  tokens beyond this per page.
+- `maxPostingsPerToken` (default `10_000`): silently drops
+  additional postings beyond this per token — the "the"
+  mitigation.
+
+### Behavioural notes
+
+- **Pure transform.**  Input `pages` array and input page
+  objects never mutated.  Verified by JSON snapshot test.
+- **Deterministic.**  Same input bytes → identical output
+  structure.  Stable sort (V8's `Array.prototype.sort` is
+  stable since ES2019); stable shard-key derivation; sorted
+  manifest lists.
+- **Title hits surface in postings** (`titleHit: true`).  The
+  builder doesn't implement weighting itself — it surfaces the
+  signal for query-time ranking (TF-IDF / BM25 / custom).
+
+### Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver** —
+  pure data construction.
+- **No mutation** of input (verified).
+- **Bounded memory** via three explicit caps.
+- **No regex DoS** — the tokeniser dependency uses explicit
+  index loops (per the project-wide convention established by
+  `forme-doc-sidebar-builder` and `forme-doc-page-shell`);
+  this package adds no regex of its own.
+- **No I/O** — capabilities `[]`.  Single transitive dep
+  (`forme-doc-search-tokenizer`) is also `[]` and zero-dep.
+  Caller is responsible for serialising the output to disk.
+- **Total-ordering comparator** — within one shard, no two
+  postings share both `freq` and `pageId` (duplicates throw
+  at insert time), so the comparator is a strict total order.
+
+### Tests
+
+31 tests in `builder.test.ts`:
+
+- Degenerate inputs (empty, empty-body page).
+- Basic indexing (single page single token, freq counts,
+  title hits, combined title + body).
+- Multi-page (postings across pages, sorted by freq desc,
+  alphabetical tiebreak).
+- Sharding (default `shardPrefix=2`, `=1`, `=3`, short tokens
+  use whole token as key).
+- Options forwarding (filterStopWords on/off, stem on/off,
+  customStopWords).
+- Memory caps (maxPages throws, maxTokensPerPage caps,
+  maxPostingsPerToken caps).
+- Validation (duplicate id throws, shardPrefix < 1 throws).
+- Manifest (sorted pages, sorted shardKeys, accurate stats,
+  records option flags).
+- Determinism + immutability.
+- Realistic 5-page docs site.
+
+Coverage: **99.3% line / 93.6% branch / 100% function** across
+all source files with logic (`types.ts` is type-only).  The
+remaining branch is a defensive `return 0` in the comparator
+marked `/* v8 ignore */` — unreachable because duplicate
+pageIds throw upstream.
+
+### v0 simplifications (documented)
+
+- **No positions** in postings (just freq).  v1 may add
+  position lists for phrase queries.
+- **No TF-IDF / BM25** — surfaces `titleHit` for query-time
+  ranking but doesn't implement weighting itself.
+- **No incremental rebuild** — every build rebuilds from
+  scratch.  v1 may add a "rebuild only changed pages" mode
+  with delta-merging of postings.
+- **No multi-language index sharding** — all pages go into
+  one index.  Multi-language sites build per-language indexes
+  and route queries by detected language.
+- **No fuzzy match indexing** — strict exact-token postings;
+  typo tolerance is a query-time concern for
+  `forme-doc-search-client-js`.

--- a/code/packages/typescript/forme-doc-search-index-builder/README.md
+++ b/code/packages/typescript/forme-doc-search-index-builder/README.md
@@ -1,0 +1,208 @@
+# @coding-adventures/forme-doc-search-index-builder
+
+> Ninth DOC00 v0 package — build-time inverted-index builder
+> for the documentation-site search. Takes per-page text +
+> metadata, builds a `token → postings` inverted index, shards
+> by token-prefix for incremental browser loading, and emits
+> the shards plus a small bootstrap manifest.
+
+Pure transform. Capabilities: `[]`. Depends only on
+`@coding-adventures/forme-doc-search-tokenizer` (itself
+`[]`-capability and zero-dep).
+
+## What it does
+
+```ts
+import { buildSearchIndex } from "@coding-adventures/forme-doc-search-index-builder";
+
+const { shards, manifest } = buildSearchIndex([
+  { id: "/intro",       body: "Welcome to the docs", title: "Introduction" },
+  { id: "/guide/setup", body: "Install via npm install foo", title: "Setup Guide" },
+]);
+
+// manifest.pages       = ["/guide/setup", "/intro"]                  (sorted)
+// manifest.shardKeys   = ["do", "fo", "gu", "in", "no", "se", "we"]  (sorted)
+// shards.get("fo").postings.get("foo") = [{pageId:"/guide/setup", freq:1, titleHit:false}]
+```
+
+The caller is responsible for **serialising the output to disk**.
+This package has no fs access (capabilities `[]`); it returns
+in-memory data structures that the `forme-doc-site-emitter`
+package writes out as JSON.
+
+## What is an inverted index?
+
+The straightforward "page → terms" layout is the inverse of
+what queries need:
+
+```
+forward:   "intro.md" → ["welcome", "guide", "setup"]
+inverted:  "welcome" → [{pageId: "intro.md", freq: 1}, ...]
+           "guide"   → [{pageId: "intro.md", freq: 1}, ...]
+           "setup"   → [{pageId: "intro.md", freq: 1}, ...]
+```
+
+Looking up pages matching "setup" is O(1) in the inverted
+index; scanning all pages would be O(N) per query.
+
+## Sharding
+
+For browser-side search, we DON'T want to ship the whole index
+upfront. The output is sharded by token prefix: shard `"ge"`
+holds all tokens starting with `"ge"`. When the user types
+`"getting"`, the client tokenises it, looks up `"ge"` in the
+manifest's `shardKeys`, fetches just that shard, and searches
+within it.
+
+| `shardPrefix` | Typical shard count (English) | Per-shard size | Trade-off                        |
+|---------------|-------------------------------|----------------|----------------------------------|
+| `1`           | ~26                           | Larger          | Few shards, simpler routing      |
+| `2` (default) | ~600                          | Medium          | Good balance for most sites      |
+| `3`           | ~5k                           | Smaller         | Many shards, finer-grained load  |
+
+## Postings
+
+Each posting records that a token appears in a page:
+
+```ts
+interface Posting {
+  readonly pageId: string;
+  readonly freq: number;       // term frequency in body + title
+  readonly titleHit: boolean;  // true if token also appeared in title
+}
+```
+
+Postings within each token's list are sorted by **descending
+frequency** (then ascending pageId for stable tiebreak), so
+top-k retrieval at query time is cheap (just take the first
+k entries).
+
+## Memory bounds
+
+Adversarial or just very large inputs can produce indexes far
+larger than the browser will tolerate. Three caps protect this:
+
+| Cap                    | Default   | What happens beyond                                    |
+|------------------------|-----------|--------------------------------------------------------|
+| `maxPages`             | `100_000` | Throws `TypeError` (fail fast at build time)            |
+| `maxTokensPerPage`     | `10_000`  | Silently drops tokens beyond cap for that page          |
+| `maxPostingsPerToken`  | `10_000`  | Silently drops additional postings for that token       |
+
+The `maxPostingsPerToken` cap is the "the" mitigation:
+extremely common tokens that match essentially every page
+would otherwise produce huge postings lists with low search
+value.
+
+## Public API
+
+| Export                  | Purpose                                                                  |
+|-------------------------|--------------------------------------------------------------------------|
+| `buildSearchIndex(pages, options?)` | Main entry. Returns `{ shards, manifest }`.                  |
+| Types                   | `IndexPageInput`, `BuildIndexOptions`, `BuildIndexOutput`, `IndexShard`, `IndexManifest`, `IndexStats`, `Posting`. |
+
+## Pipeline summary
+
+1. **Validate** input — reject if `pages.length > maxPages`,
+   throw on duplicate page ids.
+2. **Tokenise** each page's body (and title, if present) via
+   `@coding-adventures/forme-doc-search-tokenizer`. Tokens
+   beyond `maxTokensPerPage` are dropped.
+3. **Build inverted index** — `Map<token, Map<pageId, Posting>>`.
+   For each token-occurrence, increment the matching posting's
+   `freq`; for title hits, also set `titleHit: true`. Per-token
+   posting list capped at `maxPostingsPerToken`.
+4. **Shard by token prefix** — `Map<shardKey, IndexShard>`.
+   Within each shard, postings lists are sorted by descending
+   freq (ascending pageId tiebreak) for cheap top-k retrieval.
+5. **Emit manifest** — sorted lists of `pages` and `shardKeys`,
+   plus option flags and aggregate stats.
+
+## Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver.**
+  Pure data construction.
+- **No mutation of input.** Verified by JSON snapshot test.
+- **Bounded memory.** Three explicit caps (pages, tokens-per-page,
+  postings-per-token) prevent adversarial inputs from
+  producing pathologically large indexes.
+- **No regex DoS.** The tokeniser dependency follows the
+  project-wide convention of explicit index loops; this
+  package adds no regex of its own.
+- **No I/O.** Capabilities `[]`. Single transitive dep
+  (`forme-doc-search-tokenizer`) is also `[]` with zero deps.
+- **Deterministic.** Same input bytes → identical output
+  bytes. Stable sort, stable shard-key derivation, stable
+  manifest ordering.
+- **Total-ordering comparator** — within one shard, no two
+  postings share both `freq` and `pageId` (duplicates throw
+  upstream), so the comparator gives a strict total order.
+
+## Tests
+
+31 tests in `builder.test.ts`:
+
+- **Degenerate** — empty input, empty-body page.
+- **Basic indexing** — single page with single token, freq
+  counts, title hits, title-and-body combined.
+- **Multi-page** — token in multiple pages, postings sorted
+  by freq desc, alphabetical tiebreak.
+- **Sharding** — default `shardPrefix=2`, `shardPrefix=1`,
+  `shardPrefix=3`, short tokens use whole token as key.
+- **Options forwarding** — `filterStopWords` on/off, `stem`
+  on/off, `customStopWords`.
+- **Memory caps** — `maxPages` throws, default allows 100k,
+  `maxTokensPerPage` silently caps, `maxPostingsPerToken`
+  silently caps.
+- **Validation** — duplicate page id throws,
+  `shardPrefix < 1` throws.
+- **Manifest** — sorted pages, sorted shardKeys, accurate stats,
+  records option flags.
+- **Determinism + immutability** — same input identical
+  output; no mutation of input.
+- **Realistic** — typical 5-page docs site.
+
+Coverage: **99.3% line / 93.6% branch / 100% function** on all
+source files with logic (`types.ts` is type-only). The
+remaining branch is a defensive `return 0` in the comparator
+marked `/* v8 ignore */` — unreachable because duplicate
+pageIds throw upstream.
+
+## How it fits in the stack
+
+Ninth concrete DOC00 v0 package. Sits at build time, between
+the tokeniser and the site emitter:
+
+```
+page bodies + titles
+        ↓
+  search-tokenizer (per page)
+        ↓
+  index-builder (this package)
+        ↓
+  { shards, manifest } ─► written to disk by forme-doc-site-emitter
+                              ↓
+                      browser fetches manifest at boot
+                      browser fetches shards on demand
+                              ↓
+                      forme-doc-search-client-js (runtime)
+```
+
+Remaining DOC00 v0 packages: `forme-doc-search-client-js`,
+`forme-doc-site-emitter`.
+
+## v0 simplifications (documented)
+
+- **No positions** in postings (just freq). v1 may add
+  position lists for phrase queries.
+- **No field weighting beyond `titleHit`** — body and title
+  hits both count toward freq equally; the `titleHit` flag is
+  surfaced for query-time ranking but the builder doesn't
+  implement TF-IDF or BM25.
+- **No incremental rebuild** — every build rebuilds from
+  scratch. v1 may add a "rebuild only changed pages" mode.
+- **No multi-language index sharding** — all pages go into one
+  index. Multi-language sites should build per-language
+  indexes and route queries by detected language.
+- **No fuzzy match indexing** — strict exact-token postings.
+  Typo tolerance is a query-time concern for
+  `forme-doc-search-client-js`.

--- a/code/packages/typescript/forme-doc-search-index-builder/package-lock.json
+++ b/code/packages/typescript/forme-doc-search-index-builder/package-lock.json
@@ -1,0 +1,2317 @@
+{
+  "name": "@coding-adventures/forme-doc-search-index-builder",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-doc-search-index-builder",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-doc-search-tokenizer": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-doc-search-tokenizer": {
+      "resolved": "../forme-doc-search-tokenizer",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-doc-search-index-builder/package.json
+++ b/code/packages/typescript/forme-doc-search-index-builder/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@coding-adventures/forme-doc-search-index-builder",
+  "version": "0.1.0",
+  "description": "Build-time inverted-index builder for the documentation-site search.  Takes per-page text + metadata, tokenises each body via @coding-adventures/forme-doc-search-tokenizer, builds a token → postings inverted index, shards by token-prefix for incremental browser loading, and emits the shards plus a small bootstrap manifest.  Bounded memory via configurable caps (pages, tokens-per-page, postings-per-token).  Pure transform, capability [].  DOC00 v0 search-engine package.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-doc-search-index-builder/required_capabilities.json
+++ b/code/packages/typescript/forme-doc-search-index-builder/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-doc-search-index-builder",
+  "capabilities": [],
+  "justification": "Pure transform: { pages: { id, body, title? }[] } → { shards: Map<string, IndexShard>, manifest: IndexManifest }.  Tokenises each page body via @coding-adventures/forme-doc-search-tokenizer (which itself is []-capability), builds a token → postings inverted index, shards by token-prefix.  Bounded memory via explicit caps (max pages, max tokens per page, max postings per token).  No eval, no Function, no JSON.parse-reviver.  No fs/network/env/shell — the caller is responsible for serialising the shards to disk."
+}

--- a/code/packages/typescript/forme-doc-search-index-builder/src/builder.ts
+++ b/code/packages/typescript/forme-doc-search-index-builder/src/builder.ts
@@ -1,0 +1,317 @@
+/**
+ * builder.ts — main `buildSearchIndex` entry.
+ *
+ * =============================================================================
+ * THE INVERTED INDEX
+ * =============================================================================
+ *
+ * Search engines store an "inverted" index — the inverse of the
+ * obvious "document → list of terms" layout:
+ *
+ *     forward:   "intro.md" → ["welcome", "guide", "setup"]
+ *     inverted:  "welcome" → [{pageId: "intro.md", freq: 1}, ...]
+ *                "guide"   → [{pageId: "intro.md", freq: 1}, ...]
+ *                "setup"   → [{pageId: "intro.md", freq: 1}, ...]
+ *
+ * The inverted form is what queries actually need.  Looking up
+ * pages matching "setup" is O(1) in the index; looking it up by
+ * scanning all pages would be O(N) per query.
+ *
+ * =============================================================================
+ * SHARDING
+ * =============================================================================
+ *
+ * For browser-side search, we DON'T want to ship the whole index
+ * upfront.  Instead, we shard by token prefix: shard "ge" holds
+ * all tokens starting with "ge".  When the user types "getting",
+ * the client tokenises it, looks up "ge" in the manifest's
+ * `shardKeys`, fetches just that shard, and searches within it.
+ *
+ * Shard size scales with vocabulary distribution.  For
+ * `shardPrefix=2`, English produces ~600 non-empty shards
+ * (most 2-letter prefixes occur somewhere); each shard is
+ * proportional to the number of tokens starting with that
+ * prefix.  Typical docs sites: a few KB to a few tens of KB
+ * per shard.
+ *
+ * =============================================================================
+ * MEMORY BOUNDS
+ * =============================================================================
+ *
+ * Adversarial or just very large inputs can produce indexes
+ * far larger than the browser will tolerate.  We cap THREE
+ * dimensions:
+ *
+ *   - `maxPages` (default 100k): refuse inputs with too many pages.
+ *   - `maxTokensPerPage` (default 10k): drop tokens beyond this
+ *     per page — silently, since downstream consumers don't
+ *     care.
+ *   - `maxPostingsPerToken` (default 10k): drop additional
+ *     postings beyond this per token — silently.  This is the
+ *     "the" mitigation: extremely common tokens that match
+ *     essentially every page would otherwise produce huge
+ *     postings lists with low search value.
+ *
+ * All caps configurable per call.
+ *
+ * @module builder
+ */
+
+import { tokenize } from "@coding-adventures/forme-doc-search-tokenizer";
+
+import type {
+  IndexPageInput,
+  BuildIndexOptions,
+  BuildIndexOutput,
+  IndexShard,
+  IndexManifest,
+  IndexStats,
+  Posting,
+} from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Defaults
+// ─────────────────────────────────────────────────────────────────────
+
+const DEFAULT_SHARD_PREFIX = 2;
+const DEFAULT_FILTER_STOP_WORDS = true;
+const DEFAULT_STEM = true;
+const DEFAULT_MAX_PAGES = 100_000;
+const DEFAULT_MAX_TOKENS_PER_PAGE = 10_000;
+const DEFAULT_MAX_POSTINGS_PER_TOKEN = 10_000;
+
+// ─────────────────────────────────────────────────────────────────────
+// Internal mutable types
+// ─────────────────────────────────────────────────────────────────────
+
+interface MutablePosting {
+  pageId: string;
+  freq: number;
+  titleHit: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Public entry
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a sharded inverted search index from a list of pages.
+ *
+ * @param pages - One entry per page.  Page ids must be unique
+ *                (duplicates throw `TypeError`).
+ * @param options - `BuildIndexOptions` — all fields optional.
+ * @returns `{ shards, manifest }`.  Shards are keyed by the
+ *          token-prefix `shardKey`; the manifest lists all
+ *          pages and shard keys (sorted for stable output).
+ * @throws `TypeError` if `pages.length > maxPages` or if two
+ *         pages share the same `id`.
+ */
+export function buildSearchIndex(
+  pages: readonly IndexPageInput[],
+  options: BuildIndexOptions = {},
+): BuildIndexOutput {
+  const shardPrefix = options.shardPrefix ?? DEFAULT_SHARD_PREFIX;
+  const filterStopWords = options.filterStopWords ?? DEFAULT_FILTER_STOP_WORDS;
+  const stem = options.stem ?? DEFAULT_STEM;
+  const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+  const maxTokensPerPage = options.maxTokensPerPage ?? DEFAULT_MAX_TOKENS_PER_PAGE;
+  const maxPostingsPerToken = options.maxPostingsPerToken ?? DEFAULT_MAX_POSTINGS_PER_TOKEN;
+
+  // Input-validation guardrails.  We validate each numeric
+  // option independently rather than just relying on the cap
+  // comparison, because `pages.length > NaN`, `Set.size >= NaN`,
+  // and similar comparisons are ALL `false` — so passing
+  // `maxPages: NaN` (or any other cap as NaN) would silently
+  // disable the cap and let an adversarial input through.
+  // Same for negative / non-finite values.
+  if (!Number.isFinite(maxPages) || maxPages < 0) {
+    throw new TypeError(
+      `forme-doc-search-index-builder: maxPages must be a non-negative finite number (got ${maxPages})`,
+    );
+  }
+  if (!Number.isFinite(maxTokensPerPage) || maxTokensPerPage < 0) {
+    throw new TypeError(
+      `forme-doc-search-index-builder: maxTokensPerPage must be a non-negative finite number (got ${maxTokensPerPage})`,
+    );
+  }
+  if (!Number.isFinite(maxPostingsPerToken) || maxPostingsPerToken < 0) {
+    throw new TypeError(
+      `forme-doc-search-index-builder: maxPostingsPerToken must be a non-negative finite number (got ${maxPostingsPerToken})`,
+    );
+  }
+  if (!Number.isInteger(shardPrefix) || shardPrefix < 1) {
+    throw new TypeError(
+      `forme-doc-search-index-builder: shardPrefix must be an integer >= 1 (got ${shardPrefix})`,
+    );
+  }
+  if (pages.length > maxPages) {
+    throw new TypeError(
+      `forme-doc-search-index-builder: ${pages.length} pages exceeds maxPages cap (${maxPages})`,
+    );
+  }
+
+  // Phase 1: tokenise + build a global inverted index.
+  const seenPageIds = new Set<string>();
+  // token → (pageId → mutable posting)
+  const invIndex = new Map<string, Map<string, MutablePosting>>();
+  let totalTokens = 0;
+
+  for (const page of pages) {
+    if (seenPageIds.has(page.id)) {
+      throw new TypeError(
+        `forme-doc-search-index-builder: duplicate page id ${JSON.stringify(page.id)}`,
+      );
+    }
+    seenPageIds.add(page.id);
+
+    // Tokenise body + title separately so we can record `titleHit`.
+    const bodyTokens = tokenize(page.body, {
+      filterStopWords,
+      stem,
+      customStopWords: options.customStopWords,
+    });
+    const titleTokens = page.title !== undefined
+      ? tokenize(page.title, {
+          filterStopWords,
+          stem,
+          customStopWords: options.customStopWords,
+        })
+      : [];
+
+    // Cap per-page unique tokens to bound memory.
+    const pageUnique = new Set<string>();
+    const titleSet = new Set<string>(titleTokens);
+
+    for (const tok of bodyTokens) {
+      if (pageUnique.size >= maxTokensPerPage && !pageUnique.has(tok)) continue;
+      pageUnique.add(tok);
+      // Only count toward `totalTokens` if the posting was
+      // actually accepted (i.e. NOT dropped by the per-token
+      // cap).  Otherwise `stats.totalTokens` would over-count.
+      if (addPosting(invIndex, tok, page.id, titleSet.has(tok), maxPostingsPerToken)) {
+        totalTokens++;
+      }
+    }
+    for (const tok of titleTokens) {
+      if (pageUnique.size >= maxTokensPerPage && !pageUnique.has(tok)) continue;
+      pageUnique.add(tok);
+      if (addPosting(invIndex, tok, page.id, true, maxPostingsPerToken)) {
+        totalTokens++;
+      }
+    }
+  }
+
+  // Phase 2: shard the inverted index by token prefix.
+  const shards = new Map<string, Map<string, Posting[]>>();
+  for (const [token, pageMap] of invIndex) {
+    const key = shardKeyFor(token, shardPrefix);
+    let shard = shards.get(key);
+    if (shard === undefined) {
+      shard = new Map<string, Posting[]>();
+      shards.set(key, shard);
+    }
+    // Materialise postings as a sorted array (descending freq,
+    // then ascending pageId for stable ordering).
+    const postings = Array.from(pageMap.values()).map(toReadonlyPosting);
+    postings.sort(compareByFreqDesc);
+    shard.set(token, postings);
+  }
+
+  // Phase 3: emit shards + manifest.
+  const sortedShardKeys = Array.from(shards.keys()).sort();
+  const outputShards = new Map<string, IndexShard>();
+  for (const key of sortedShardKeys) {
+    outputShards.set(key, {
+      shardKey: key,
+      postings: shards.get(key)!,
+    });
+  }
+
+  const stats: IndexStats = {
+    totalTokens,
+    uniqueTokens: invIndex.size,
+    pageCount: pages.length,
+    shardCount: outputShards.size,
+  };
+
+  const manifest: IndexManifest = {
+    pages: Array.from(seenPageIds).sort(),
+    shardKeys: sortedShardKeys,
+    shardPrefix,
+    filterStopWords,
+    stem,
+    stats,
+  };
+
+  return { shards: outputShards, manifest };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Add/increment a posting for `token` in `pageId`.  Increments
+ * `freq` if a posting for this page already exists.  Respects
+ * the per-token postings cap.
+ *
+ * @returns `true` if the posting was accepted (created or
+ *          incremented); `false` if it was silently dropped
+ *          because the per-token cap was reached for a new
+ *          pageId.  Callers use this to keep their token
+ *          counts accurate.
+ */
+function addPosting(
+  invIndex: Map<string, Map<string, MutablePosting>>,
+  token: string,
+  pageId: string,
+  titleHit: boolean,
+  maxPostingsPerToken: number,
+): boolean {
+  let pageMap = invIndex.get(token);
+  if (pageMap === undefined) {
+    pageMap = new Map();
+    invIndex.set(token, pageMap);
+  }
+  const existing = pageMap.get(pageId);
+  if (existing !== undefined) {
+    existing.freq++;
+    if (titleHit) existing.titleHit = true;
+    return true;
+  }
+  // New posting — check cap.
+  if (pageMap.size >= maxPostingsPerToken) {
+    // Silently drop (the "the" mitigation).
+    return false;
+  }
+  pageMap.set(pageId, { pageId, freq: 1, titleHit });
+  return true;
+}
+
+/**
+ * Compute the shard key for a token: the first `shardPrefix`
+ * characters of the token, or the whole token if it's shorter
+ * than `shardPrefix`.
+ */
+function shardKeyFor(token: string, shardPrefix: number): string {
+  // String.prototype.slice safely truncates if the token is
+  // shorter than `shardPrefix`, returning the whole token.
+  return token.slice(0, shardPrefix);
+}
+
+function toReadonlyPosting(p: MutablePosting): Posting {
+  return { pageId: p.pageId, freq: p.freq, titleHit: p.titleHit };
+}
+
+function compareByFreqDesc(a: Posting, b: Posting): number {
+  if (a.freq !== b.freq) return b.freq - a.freq;
+  // Stable tiebreak: ascending pageId.
+  if (a.pageId < b.pageId) return -1;
+  if (a.pageId > b.pageId) return 1;
+  /* v8 ignore start */
+  // Unreachable: postings within one shard are keyed by pageId
+  // (one posting per page per token), and duplicate pageIds
+  // throw at insert time.  Kept as defensive total-ordering.
+  return 0;
+  /* v8 ignore stop */
+}

--- a/code/packages/typescript/forme-doc-search-index-builder/src/index.ts
+++ b/code/packages/typescript/forme-doc-search-index-builder/src/index.ts
@@ -1,0 +1,45 @@
+/**
+ * @coding-adventures/forme-doc-search-index-builder
+ *
+ * Build-time inverted-index builder for the documentation-site
+ * search.  Takes per-page text + metadata, tokenises each body
+ * via `@coding-adventures/forme-doc-search-tokenizer`, builds a
+ * `token → postings` inverted index, shards by token-prefix for
+ * incremental browser loading, and emits the shards plus a
+ * small bootstrap manifest.
+ *
+ * Pure transform.  Capabilities: `[]`.  Depends only on
+ * `@coding-adventures/forme-doc-search-tokenizer` (itself
+ * `[]`-capability and zero-dep).
+ *
+ * ```ts
+ * import { buildSearchIndex } from "@coding-adventures/forme-doc-search-index-builder";
+ *
+ * const { shards, manifest } = buildSearchIndex([
+ *   { id: "/intro",       body: "Welcome to the docs", title: "Introduction" },
+ *   { id: "/guide/setup", body: "Install via npm install foo", title: "Setup Guide" },
+ * ]);
+ *
+ * // manifest.pages      = ["/guide/setup", "/intro"]            (sorted)
+ * // manifest.shardKeys  = ["do", "fo", "gu", "in", "no", "se", "we"]  (etc., sorted)
+ * // shards.get("se").postings.get("setup") = [{pageId:"/guide/setup", freq:1, titleHit:true}]
+ * ```
+ *
+ * Ninth concrete DOC00 v0 package (after frontmatter,
+ * heading-anchors, toc-extractor, code-block-decorator,
+ * syntax-highlighter, sidebar-builder, page-shell,
+ * search-tokenizer).
+ *
+ * @module index
+ */
+
+export { buildSearchIndex } from "./builder.js";
+export type {
+  IndexPageInput,
+  BuildIndexOptions,
+  BuildIndexOutput,
+  IndexShard,
+  IndexManifest,
+  IndexStats,
+  Posting,
+} from "./types.js";

--- a/code/packages/typescript/forme-doc-search-index-builder/src/types.ts
+++ b/code/packages/typescript/forme-doc-search-index-builder/src/types.ts
@@ -1,0 +1,172 @@
+/**
+ * types.ts — public signatures for the search-index builder.
+ *
+ * @module types
+ */
+
+/**
+ * One input page — what the caller hands in for each `.md`
+ * page in the site.
+ */
+export interface IndexPageInput {
+  /**
+   * Unique page identifier — typically the URL path or
+   * relative file path.  Used as the key in postings and the
+   * manifest's `pages` list.  Caller's responsibility to keep
+   * unique; duplicates throw `TypeError`.
+   */
+  readonly id: string;
+
+  /**
+   * The page's body content as PLAIN TEXT (markdown stripped,
+   * HTML stripped).  Will be tokenised via
+   * `@coding-adventures/forme-doc-search-tokenizer`.  Empty
+   * string is fine — produces no postings for this page (but
+   * the page still appears in the manifest).
+   */
+  readonly body: string;
+
+  /**
+   * Optional page title.  When present, the title text is
+   * tokenised separately and its tokens are recorded with a
+   * `titleHit: true` flag in postings — query-time ranking
+   * can boost hits in titles.
+   */
+  readonly title?: string;
+}
+
+/**
+ * Options for `buildSearchIndex`.
+ */
+export interface BuildIndexOptions {
+  /**
+   * Number of leading characters of each token used as the
+   * shard key.  Smaller values produce fewer / larger shards
+   * (better cold-start cache hits, worse incremental loading);
+   * larger values produce many smaller shards.  Default: `2`.
+   *
+   * For sites < 1k pages, `1` (26 shards if alphabet-dominant)
+   * is plenty.  For 10k+ pages, `2` or `3` distributes load
+   * better.  Practical range: `1..4`.
+   */
+  readonly shardPrefix?: number;
+
+  /**
+   * Forwarded to the tokeniser.  Default: `true` (drops common
+   * stop-words to shrink the index).  Query tokenisation MUST
+   * use the same flag.
+   */
+  readonly filterStopWords?: boolean;
+
+  /**
+   * Forwarded to the tokeniser.  Default: `true` (Porter
+   * stemming collapses morphological variants).  Query
+   * tokenisation MUST use the same flag.
+   */
+  readonly stem?: boolean;
+
+  /**
+   * Override the tokeniser's stop-word set.  Only consulted
+   * when `filterStopWords` is `true`.
+   */
+  readonly customStopWords?: ReadonlySet<string>;
+
+  /**
+   * Maximum number of pages the index will accept.  Inputs
+   * beyond this throw `TypeError`.  Default: `100_000`.
+   *
+   * Why a cap: the index data structure scales as
+   * O(uniqueTokens × averagePostingsPerToken), and adversarial
+   * (or just very large) inputs can produce indexes far larger
+   * than the browser will tolerate.  Failing fast at build
+   * time is preferable to shipping a too-big index.
+   */
+  readonly maxPages?: number;
+
+  /**
+   * Maximum unique tokens accepted from any single page.
+   * Tokens beyond this are silently dropped.  Default:
+   * `10_000`.  Real-world doc pages essentially never exceed
+   * ~1000 unique tokens; 10k leaves a wide margin.
+   */
+  readonly maxTokensPerPage?: number;
+
+  /**
+   * Maximum postings entries kept for any single token.  When
+   * a token would exceed this, additional pages are silently
+   * dropped from its postings list (the page itself is still
+   * in the manifest).  Default: `10_000`.  Mitigates the
+   * "the" problem — extremely common tokens that match
+   * essentially every page would otherwise produce huge
+   * postings lists with low search value.
+   */
+  readonly maxPostingsPerToken?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Output shapes
+// ─────────────────────────────────────────────────────────────────────
+
+/** One posting — a record that a token appears in a page. */
+export interface Posting {
+  /** The page's id (from `IndexPageInput.id`). */
+  readonly pageId: string;
+  /** Number of occurrences of the token in the page body + title. */
+  readonly freq: number;
+  /** True if the token appeared in the page's title. */
+  readonly titleHit: boolean;
+}
+
+/**
+ * One shard of the inverted index.  A shard groups postings
+ * for all tokens sharing a common prefix (the `shardKey`),
+ * so the browser can load just the shards relevant to a query
+ * instead of the whole index.
+ */
+export interface IndexShard {
+  /** The shared prefix all tokens in this shard start with. */
+  readonly shardKey: string;
+  /**
+   * `token → postings`.  Postings are sorted by descending
+   * `freq` to make top-k retrieval cheap at query time.
+   */
+  readonly postings: ReadonlyMap<string, readonly Posting[]>;
+}
+
+/**
+ * The bootstrap manifest — small JSON the browser loads first
+ * to learn which shards exist and which pages are indexed.
+ */
+export interface IndexManifest {
+  /** Sorted list of all page ids in the index. */
+  readonly pages: readonly string[];
+  /** Sorted list of all shard keys. */
+  readonly shardKeys: readonly string[];
+  /** The `shardPrefix` option used at build time. */
+  readonly shardPrefix: number;
+  /** Whether `filterStopWords` was enabled at build time. */
+  readonly filterStopWords: boolean;
+  /** Whether `stem` was enabled at build time. */
+  readonly stem: boolean;
+  /** Aggregate statistics — useful for build-time reporting. */
+  readonly stats: IndexStats;
+}
+
+export interface IndexStats {
+  /** Total tokens fed into the index across all pages (incl. duplicates). */
+  readonly totalTokens: number;
+  /** Number of unique tokens in the index. */
+  readonly uniqueTokens: number;
+  /** Number of pages indexed. */
+  readonly pageCount: number;
+  /** Number of shards produced. */
+  readonly shardCount: number;
+}
+
+/**
+ * The output of `buildSearchIndex`.
+ */
+export interface BuildIndexOutput {
+  readonly shards: ReadonlyMap<string, IndexShard>;
+  readonly manifest: IndexManifest;
+}

--- a/code/packages/typescript/forme-doc-search-index-builder/tests/builder.test.ts
+++ b/code/packages/typescript/forme-doc-search-index-builder/tests/builder.test.ts
@@ -1,0 +1,381 @@
+/**
+ * builder.test.ts — search-index builder tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildSearchIndex } from "../src/index.js";
+import type { IndexPageInput } from "../src/index.js";
+
+/** Convenience: page builder. */
+function page(id: string, body: string, title?: string): IndexPageInput {
+  return title === undefined ? { id, body } : { id, body, title };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Degenerate inputs
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — degenerate", () => {
+  it("empty input → empty index", () => {
+    const out = buildSearchIndex([]);
+    expect(out.shards.size).toBe(0);
+    expect(out.manifest.pages).toEqual([]);
+    expect(out.manifest.shardKeys).toEqual([]);
+    expect(out.manifest.stats.uniqueTokens).toBe(0);
+    expect(out.manifest.stats.totalTokens).toBe(0);
+    expect(out.manifest.stats.pageCount).toBe(0);
+    expect(out.manifest.stats.shardCount).toBe(0);
+  });
+  it("page with empty body produces no postings but appears in manifest", () => {
+    const out = buildSearchIndex([page("/empty", "")]);
+    expect(out.manifest.pages).toEqual(["/empty"]);
+    expect(out.shards.size).toBe(0);
+    expect(out.manifest.stats.pageCount).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Basic indexing
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — basic indexing", () => {
+  it("single page with single distinct token", () => {
+    // "welcome" → no stop word, stems to "welcom"
+    const out = buildSearchIndex([page("/p", "welcome")]);
+    expect(out.manifest.pages).toEqual(["/p"]);
+    expect(out.shards.size).toBe(1);
+    const shard = out.shards.get("we")!;
+    expect(shard).toBeDefined();
+    expect(shard.postings.has("welcom")).toBe(true);
+    const postings = shard.postings.get("welcom")!;
+    expect(postings).toEqual([{ pageId: "/p", freq: 1, titleHit: false }]);
+  });
+  it("freq counts repeated occurrences", () => {
+    const out = buildSearchIndex([page("/p", "install install install")]);
+    const shard = out.shards.get("in")!;
+    const postings = shard.postings.get("instal")!; // stem
+    expect(postings[0].freq).toBe(3);
+  });
+  it("title hits set titleHit: true", () => {
+    const out = buildSearchIndex([page("/p", "body text", "title")]);
+    const shard = out.shards.get("ti")!;
+    const postings = shard.postings.get("titl")!; // "title" stems to "titl"
+    expect(postings[0].titleHit).toBe(true);
+  });
+  it("title hits AND body hits combine into one posting with titleHit=true", () => {
+    const out = buildSearchIndex([page("/p", "install install", "install")]);
+    const shard = out.shards.get("in")!;
+    const postings = shard.postings.get("instal")!;
+    expect(postings[0].freq).toBe(3); // 2 body + 1 title
+    expect(postings[0].titleHit).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Multi-page indexing
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — multi-page", () => {
+  it("token appearing in two pages → posting list of length 2", () => {
+    const out = buildSearchIndex([
+      page("/a", "install"),
+      page("/b", "install"),
+    ]);
+    const shard = out.shards.get("in")!;
+    const postings = shard.postings.get("instal")!;
+    expect(postings.length).toBe(2);
+    expect(postings.map((p) => p.pageId).sort()).toEqual(["/a", "/b"]);
+  });
+  it("postings sorted by descending freq", () => {
+    const out = buildSearchIndex([
+      page("/a", "install"),
+      page("/b", "install install install"),
+      page("/c", "install install"),
+    ]);
+    const shard = out.shards.get("in")!;
+    const postings = shard.postings.get("instal")!;
+    expect(postings.map((p) => p.pageId)).toEqual(["/b", "/c", "/a"]);
+    expect(postings.map((p) => p.freq)).toEqual([3, 2, 1]);
+  });
+  it("postings tie-break by ascending pageId", () => {
+    const out = buildSearchIndex([
+      page("/zebra", "install"),
+      page("/apple", "install"),
+    ]);
+    const postings = out.shards.get("in")!.postings.get("instal")!;
+    expect(postings.map((p) => p.pageId)).toEqual(["/apple", "/zebra"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Sharding
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — sharding", () => {
+  it("default shardPrefix=2 groups by 2-char prefix", () => {
+    const out = buildSearchIndex([
+      page("/p", "install welcome configure"),
+    ]);
+    // tokens after stemming: instal, welcom, configur
+    // shard keys: "in", "we", "co"
+    expect(out.manifest.shardKeys.sort()).toEqual(["co", "in", "we"]);
+  });
+  it("shardPrefix=1 groups by single char", () => {
+    const out = buildSearchIndex(
+      [page("/p", "install welcome configure")],
+      { shardPrefix: 1 },
+    );
+    expect(out.manifest.shardKeys.sort()).toEqual(["c", "i", "w"]);
+  });
+  it("shardPrefix=3 produces 3-char keys", () => {
+    const out = buildSearchIndex(
+      [page("/p", "install welcome")],
+      { shardPrefix: 3 },
+    );
+    expect(out.manifest.shardKeys.sort()).toEqual(["ins", "wel"]);
+  });
+  it("short tokens use the whole token as key", () => {
+    const out = buildSearchIndex(
+      [page("/p", "go to it")],
+      { shardPrefix: 3, filterStopWords: false, stem: false },
+    );
+    // "go" (2 chars) → shard key "go" (whole token, < 3 chars)
+    // "to" (2 chars) → shard key "to"
+    // "it" (2 chars) → shard key "it"
+    expect(out.manifest.shardKeys.sort()).toEqual(["go", "it", "to"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Options forwarding
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — options forwarding", () => {
+  it("filterStopWords=false keeps stop words", () => {
+    const out = buildSearchIndex(
+      [page("/p", "the cat")],
+      { filterStopWords: false, stem: false },
+    );
+    expect(out.manifest.stats.uniqueTokens).toBe(2); // "the" and "cat"
+  });
+  it("filterStopWords=true (default) drops stop words", () => {
+    const out = buildSearchIndex([page("/p", "the cat")]);
+    expect(out.manifest.stats.uniqueTokens).toBe(1); // just "cat"
+  });
+  it("stem=false preserves morphological variants", () => {
+    const out = buildSearchIndex(
+      [page("/p", "running runs ran")],
+      { filterStopWords: false, stem: false },
+    );
+    expect(out.manifest.stats.uniqueTokens).toBe(3);
+  });
+  it("stem=true (default) collapses variants", () => {
+    // running → run, runs → run, ran → ran (Porter doesn't handle irregulars)
+    const out = buildSearchIndex([page("/p", "running runs ran")]);
+    expect(out.manifest.stats.uniqueTokens).toBe(2); // "run" + "ran"
+  });
+  it("customStopWords overrides built-in", () => {
+    const out = buildSearchIndex(
+      [page("/p", "custom built")],
+      {
+        filterStopWords: true,
+        stem: false,
+        customStopWords: new Set(["custom"]),
+      },
+    );
+    expect(out.manifest.stats.uniqueTokens).toBe(1); // just "built"
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Memory bounds (caps)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — memory caps", () => {
+  it("rejects pages.length > maxPages", () => {
+    const pages = Array.from({ length: 5 }, (_, i) => page(`/p${i}`, "hi"));
+    expect(() => buildSearchIndex(pages, { maxPages: 3 })).toThrow(/maxPages cap/);
+  });
+  it("default maxPages allows 100k", () => {
+    // Smoke-test with a small but representative count.
+    const pages = Array.from({ length: 50 }, (_, i) => page(`/p${i}`, `unique${i}`));
+    expect(() => buildSearchIndex(pages)).not.toThrow();
+  });
+  it("maxTokensPerPage caps unique tokens from one page", () => {
+    // Generate 100 unique tokens; cap at 10.
+    const body = Array.from({ length: 100 }, (_, i) => `term${i}`).join(" ");
+    const out = buildSearchIndex(
+      [page("/p", body)],
+      { filterStopWords: false, stem: false, maxTokensPerPage: 10 },
+    );
+    expect(out.manifest.stats.uniqueTokens).toBeLessThanOrEqual(10);
+  });
+  it("maxPostingsPerToken caps postings list length", () => {
+    // 100 pages, all containing the same token.
+    const pages = Array.from({ length: 100 }, (_, i) =>
+      page(`/p${i}`, "common")
+    );
+    const out = buildSearchIndex(pages, { maxPostingsPerToken: 5 });
+    const shard = out.shards.get("co")!;
+    const postings = shard.postings.get("common")!;
+    expect(postings.length).toBe(5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Validation errors
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — validation", () => {
+  it("duplicate page id throws", () => {
+    expect(() =>
+      buildSearchIndex([page("/p", "a"), page("/p", "b")]),
+    ).toThrow(/duplicate page id/);
+  });
+  it("shardPrefix < 1 throws", () => {
+    expect(() => buildSearchIndex([page("/p", "a")], { shardPrefix: 0 })).toThrow(
+      /shardPrefix/,
+    );
+  });
+  it("shardPrefix NaN throws (no silent degraded-shard behaviour)", () => {
+    expect(() => buildSearchIndex([page("/p", "a")], { shardPrefix: NaN })).toThrow(
+      /shardPrefix/,
+    );
+  });
+  it("shardPrefix Infinity throws", () => {
+    expect(() => buildSearchIndex([page("/p", "a")], { shardPrefix: Infinity })).toThrow(
+      /shardPrefix/,
+    );
+  });
+  it("shardPrefix fractional throws", () => {
+    expect(() => buildSearchIndex([page("/p", "a")], { shardPrefix: 1.5 })).toThrow(
+      /shardPrefix/,
+    );
+  });
+  it("maxPages NaN throws (would otherwise silently disable the cap)", () => {
+    expect(() => buildSearchIndex([page("/p", "a")], { maxPages: NaN })).toThrow(
+      /maxPages/,
+    );
+  });
+  it("maxPages negative throws", () => {
+    expect(() => buildSearchIndex([page("/p", "a")], { maxPages: -1 })).toThrow(
+      /maxPages/,
+    );
+  });
+  it("maxTokensPerPage NaN throws", () => {
+    expect(() =>
+      buildSearchIndex([page("/p", "a")], { maxTokensPerPage: NaN }),
+    ).toThrow(/maxTokensPerPage/);
+  });
+  it("maxPostingsPerToken NaN throws", () => {
+    expect(() =>
+      buildSearchIndex([page("/p", "a")], { maxPostingsPerToken: NaN }),
+    ).toThrow(/maxPostingsPerToken/);
+  });
+});
+
+describe("buildSearchIndex — stats accuracy under caps", () => {
+  it("totalTokens does NOT over-count postings dropped by maxPostingsPerToken", () => {
+    // 5 pages each containing the SAME token.  Cap postings
+    // per token to 2.  Pages 3-5 contribute postings that get
+    // dropped — and those occurrences should NOT count toward
+    // stats.totalTokens.
+    const pages = Array.from({ length: 5 }, (_, i) => page(`/p${i}`, "common"));
+    const out = buildSearchIndex(pages, { maxPostingsPerToken: 2 });
+    // Only 2 postings accepted, so totalTokens should be 2,
+    // NOT 5.
+    expect(out.manifest.stats.totalTokens).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Manifest
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — manifest", () => {
+  it("pages list is sorted", () => {
+    const out = buildSearchIndex([
+      page("/z", "a"),
+      page("/a", "a"),
+      page("/m", "a"),
+    ]);
+    expect(out.manifest.pages).toEqual(["/a", "/m", "/z"]);
+  });
+  it("shardKeys list is sorted", () => {
+    const out = buildSearchIndex([
+      page("/p", "zebra apple mango"),
+    ]);
+    const keys = [...out.manifest.shardKeys];
+    expect(keys).toEqual([...keys].sort());
+  });
+  it("stats accurate", () => {
+    const out = buildSearchIndex([
+      page("/p1", "alpha beta alpha"),
+      page("/p2", "beta gamma"),
+    ], { filterStopWords: false, stem: false });
+    // tokens: alpha, beta, alpha, beta, gamma → 5 total
+    // unique: alpha, beta, gamma → 3
+    expect(out.manifest.stats.totalTokens).toBe(5);
+    expect(out.manifest.stats.uniqueTokens).toBe(3);
+    expect(out.manifest.stats.pageCount).toBe(2);
+    expect(out.manifest.stats.shardCount).toBeGreaterThan(0);
+  });
+  it("records option flags in manifest", () => {
+    const out = buildSearchIndex([page("/p", "test")], {
+      filterStopWords: false,
+      stem: false,
+      shardPrefix: 3,
+    });
+    expect(out.manifest.filterStopWords).toBe(false);
+    expect(out.manifest.stem).toBe(false);
+    expect(out.manifest.shardPrefix).toBe(3);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Determinism + immutability
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — determinism + immutability", () => {
+  it("same input → identical output structure", () => {
+    const pages: IndexPageInput[] = [
+      page("/a", "alpha beta gamma"),
+      page("/b", "beta gamma delta"),
+    ];
+    const a = buildSearchIndex(pages);
+    const b = buildSearchIndex(pages);
+    expect([...a.manifest.pages]).toEqual([...b.manifest.pages]);
+    expect([...a.manifest.shardKeys]).toEqual([...b.manifest.shardKeys]);
+    expect(a.manifest.stats).toEqual(b.manifest.stats);
+  });
+  it("does not mutate input pages array", () => {
+    const pages = [page("/p", "hi")];
+    const snapshot = JSON.stringify(pages);
+    buildSearchIndex(pages);
+    expect(JSON.stringify(pages)).toBe(snapshot);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Realistic
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildSearchIndex — realistic scenario", () => {
+  it("typical 5-page docs site", () => {
+    const out = buildSearchIndex([
+      page("/intro", "Welcome to the documentation. Learn the basics.", "Introduction"),
+      page("/guide/setup", "Install via npm install foo. Configure your environment.", "Setup Guide"),
+      page("/guide/usage", "Common usage patterns and examples.", "Usage Guide"),
+      page("/api/reference", "Full API reference for the foo library.", "API Reference"),
+      page("/faq", "Frequently asked questions about foo.", "FAQ"),
+    ]);
+    expect(out.manifest.pages).toHaveLength(5);
+    expect(out.manifest.stats.pageCount).toBe(5);
+    expect(out.manifest.stats.uniqueTokens).toBeGreaterThan(10);
+    expect(out.shards.size).toBeGreaterThan(0);
+    // "foo" appears in three pages — should have a posting list of length 3.
+    const shard = out.shards.get("fo")!;
+    const postings = shard.postings.get("foo")!;
+    expect(postings.length).toBe(3);
+  });
+});

--- a/code/packages/typescript/forme-doc-search-index-builder/tsconfig.json
+++ b/code/packages/typescript/forme-doc-search-index-builder/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-doc-search-index-builder/vitest.config.ts
+++ b/code/packages/typescript/forme-doc-search-index-builder/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- **New package** `@coding-adventures/forme-doc-search-index-builder` — build-time inverted-index builder. Takes per-page text + metadata, tokenises via the search-tokenizer, builds a `token → postings` inverted index, shards by token-prefix for incremental browser loading, emits `{ shards, manifest }`.
- **Ninth concrete DOC00 v0 package** (after frontmatter PR #3781 → heading-anchors #3829 → toc-extractor #3837 → code-block-decorator #3865 → syntax-highlighter #3867 → sidebar-builder #3873 → page-shell #3883 → search-tokenizer #3894).
- **Capabilities `[]`.** One transitive dep (`forme-doc-search-tokenizer`), itself `[]` and zero-dep.
- **Memory bounds via three configurable caps**: `maxPages` (default 100k, throws over), `maxTokensPerPage` (10k, silent drop), `maxPostingsPerToken` (10k, silent drop — the "the" mitigation).
- **Postings sorted by descending freq** (ascending pageId tiebreak) for cheap top-k retrieval at query time.
- **`titleHit` flag** surfaces in postings for query-time ranking (TF-IDF / BM25 left to consumers).
- **Security review found three LOW input-validation findings, all fixed before push**:
  1. NaN bypasses all numeric caps (because `> NaN` etc. is always false) → fixed with explicit `Number.isFinite` + non-negative checks.
  2. `shardPrefix` NaN / Infinity / fractional silently degraded → fixed with `Number.isInteger + >= 1`.
  3. `stats.totalTokens` over-counted dropped postings → fixed by making `addPosting` return acceptance; caller only bumps stat on accept.
- **Coverage: 99.3% line / 94.8% branch / 100% function** on all executable source files. **39 tests** in one file.

## Test plan

- [x] `npm install && npx vitest run --coverage` — 39/39 pass
- [x] Degenerate inputs, basic indexing, multi-page postings, sharding
- [x] Options forwarding, memory caps (maxPages throws, others silent)
- [x] **9 validation tests** for the LOW findings (NaN/Infinity/fractional/negative on every numeric option)
- [x] **Stats accuracy regression test** for the over-counting fix
- [x] Manifest sorting + flag recording, determinism, immutability, realistic 5-page site
- [x] `/security-review` — three LOW findings, all fixed
- [ ] CI (per babysit cron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)