### PR TITLE
feat(nib-iir-compiler): emit typed CIR ops directly

### DIFF
--- a/code/packages/rust/nib-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/nib-iir-compiler/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog — `nib-iir-compiler`
 
+## 0.4.0 — 2026-05-22 (typed CIR ops — unblocks IIR-to-* backends)
+
+Nib's IIR output is now accepted by every IIR-to-* backend
+(`iir-to-wasm`, `iir-to-jvm-class-file`, `iir-to-cil-bytecode`,
+`iir-to-beam`) without needing the AOT pipeline's `pre_lower_aot_builtins`
+pre-pass.
+
+### Background
+
+A 5-frontend × 4-backend probe matrix run after the vm-core `mov`
+dispatch fix (PR #3888) showed that Nib's IIR output was rejected by
+every IIR-to-* backend with the same three errors:
+
+```text
+UntypedInstruction: function "main", op "call_builtin" has type_hint "any"
+UnsupportedOp:      function "main", op "call_builtin" is not supported …
+UntypedInstruction: function "main", op "ret" has type_hint "any"
+```
+
+Root cause: `compile_binary_chain` emitted `call_builtin "<op>"` with
+`type_hint: "any"`, expecting the AOT chain's `pre_lower_aot_builtins`
+pass to rewrite each one to a typed CIR op (`add`, `cmp_eq`, …) before
+the native backends saw it.  That assumption held for `lang-aot`'s AOT
+path but broke every IIR-to-* backend (they validate against concrete
+CIR opcodes).
+
+### Fix
+
+Mirror `oct-iir-compiler::compile_binary` exactly:
+
+- `compile_binary_chain` now emits typed CIR mnemonics directly:
+  `+` → `add`, `-` → `sub`, `==` → `cmp_eq`, `!=` → `cmp_ne`,
+  `<` → `cmp_lt`, `>` → `cmp_gt`, `<=` → `cmp_le`, `>=` → `cmp_ge`.
+- `type_hint` is now `"i64"` for every binary op (Nib's narrow types
+  u4/u8/bool all flow through 64-bit slots at the IIR level — the
+  function's declared Nib return type stays on `IIRFunction`).
+- `return_stmt`'s fallback type_hint is now `"i64"` instead of
+  `"any"` (which leaked through to the IIR-to-* validators).
+
+### What still works
+
+The AOT chain (`lang-aot`) is unchanged.  `pre_lower_aot_builtins`
+becomes a no-op when there's nothing to rewrite, so the typed `add` /
+`cmp_*` ops flow straight through.  All five existing lang-aot Nib
+e2e tests still pass:
+
+- `end_to_end_nib_returns_42_via_lang_aot`
+- `end_to_end_nib_arithmetic_via_lang_aot`
+- `end_to_end_nib_cross_fn_call_returns_42`
+- `end_to_end_nib_print_writes_42`
+- `end_to_end_nib_while_loop_counts_to_10`
+
+### Tests added (5)
+
+`tests/backend_compat.rs`:
+
+- `nib_iir_accepted_by_iir_to_wasm`
+- `nib_iir_accepted_by_iir_to_jvm`
+- `nib_iir_accepted_by_iir_to_clr`
+- `nib_iir_accepted_by_iir_to_beam`
+- `nib_iir_with_comparison_accepted_by_every_backend` — exercises
+  `cmp_lt` (verifies the comparison-operator mapping too).
+
+Plus an updated `tests::compiles_arithmetic` unit test that explicitly
+guards against the old `call_builtin "+"` shape ever leaking back in.
+
+### Helper rename
+
+`builtin_for(text, type_name) -> Option<&str>` → `cir_op_for(text, type_name)`.
+Same callers; the return value is now a typed CIR mnemonic instead of
+the bare operator symbol.
+
 ## 0.3.0 — 2026-05-20 (NIB04 step 3 — while loops)
 
 Closes the third (and final V1) NIB04 step.  Nib programs can now use

--- a/code/packages/rust/nib-iir-compiler/Cargo.toml
+++ b/code/packages/rust/nib-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nib-iir-compiler"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Compile Nib source to InterpreterIR (IIRModule), feeding the LANG-runtime AOT/JIT pipeline."
 
@@ -10,3 +10,9 @@ nib-type-checker = { path = "../nib-type-checker" }
 parser           = { path = "../parser" }
 interpreter-ir   = { path = "../interpreter-ir" }
 type-checker-protocol = { path = "../type-checker-protocol" }
+
+[dev-dependencies]
+iir-to-wasm           = { path = "../iir-to-wasm" }
+iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
+iir-to-cil-bytecode   = { path = "../iir-to-cil-bytecode" }
+iir-to-beam           = { path = "../iir-to-beam" }

--- a/code/packages/rust/nib-iir-compiler/src/lib.rs
+++ b/code/packages/rust/nib-iir-compiler/src/lib.rs
@@ -207,7 +207,17 @@ impl Compiler {
             "return_stmt" => {
                 if let Some(expr) = expression_children(stmt).first() {
                     let v = self.compile_expr(expr, types, env, out)?;
-                    let ty_str = lookup_node_type(expr, types).map(nib_ty_str).unwrap_or("any").to_string();
+                    // Use the expression's inferred type if the type
+                    // checker annotated it; otherwise default to "i64"
+                    // (Nib's u4/u8/bool all materialise as i64 at the
+                    // IIR level — same convention as compile_binary_chain
+                    // and oct-iir-compiler).  Falling back to "any" used
+                    // to leak through to the IIR-to-* backends which
+                    // reject untyped instructions.
+                    let ty_str = lookup_node_type(expr, types)
+                        .map(nib_ty_str)
+                        .unwrap_or("i64")
+                        .to_string();
                     out.push(IIRInstr::new(
                         "ret",
                         None,
@@ -598,22 +608,28 @@ impl Compiler {
             };
 
             let rhs = self.compile_expr(rhs_node, types, env, out)?;
-            let op_name = builtin_for(&op_tok.value, &op_tok.effective_type_name())
+            // Map operator token to a typed CIR mnemonic the IIR-to-*
+            // backends (wasm/jvm/clr/beam) recognise.  Mirrors the
+            // pattern oct-iir-compiler uses — emit `add` / `cmp_eq` etc.
+            // directly instead of `call_builtin "+"` (the latter requires
+            // a downstream `pre_lower_aot_builtins` pass that only runs
+            // in the AOT chain, not in the IIR-to-* backends).
+            let cir_op = cir_op_for(&op_tok.value, &op_tok.effective_type_name())
                 .ok_or_else(|| CompileError::Unsupported(format!("op {:?}", op_tok.value)))?;
 
             let dest = self.fresh_var();
-            // Result type — comparisons produce bool, arithmetic preserves.
-            let ty_str = if is_comparison_op(op_name) { "bool" }
-                         else { lookup_node_type(node, types).map(nib_ty_str).unwrap_or("any") };
+            // At the IIR level Nib's narrow types (u4/u8/bool) all flow
+            // through 64-bit slots — match the pattern in oct-iir-compiler
+            // which uses `"i64"` uniformly.  The function's declared
+            // Nib return type ("u8" / "bool" / "void") stays the source
+            // of truth on the IIRFunction; instruction type_hints are
+            // a separate IIR-level concept and concrete-typing them as
+            // `i64` lets every IIR-to-* validator accept the module.
             out.push(IIRInstr::new(
-                "call_builtin",
+                cir_op,
                 Some(dest.clone()),
-                vec![
-                    Operand::Var(op_name.into()),
-                    Operand::Var(acc),
-                    Operand::Var(rhs),
-                ],
-                ty_str,
+                vec![Operand::Var(acc), Operand::Var(rhs)],
+                "i64",
             ));
             acc = dest;
         }
@@ -801,28 +817,36 @@ fn nib_ty_str(t: &NibType) -> &'static str {
     }
 }
 
-/// Map a Nib operator token to the IIR builtin name `aot-core::specialise`
-/// recognises.
-fn builtin_for(text: &str, type_name: &str) -> Option<&'static str> {
+/// Map a Nib operator token to a typed CIR mnemonic that every IIR
+/// consumer in the workspace recognises (vm-core, aarch64-backend,
+/// x86_64-backend, iir-to-wasm, iir-to-jvm-class-file,
+/// iir-to-cil-bytecode, iir-to-beam).
+///
+/// Pre-NIB04-fix this returned the operator *symbol* (`"+"`, `"=="`)
+/// inside a `call_builtin` instruction, on the assumption that the AOT
+/// chain's `pre_lower_aot_builtins` pass would rewrite each one to a
+/// typed CIR op before the native backends saw it.  That assumption
+/// holds for `lang-aot`'s AOT path but breaks every IIR-to-* backend
+/// (they validate against concrete CIR opcodes and reject
+/// `call_builtin`).  Returning the typed op directly keeps the AOT
+/// path working (the rewrite pass is a no-op when there's nothing to
+/// rewrite) and unblocks the IIR-to-* backends.
+///
+/// Mirrors `oct-iir-compiler::compile_binary` exactly.
+fn cir_op_for(text: &str, type_name: &str) -> Option<&'static str> {
     match (text, type_name) {
         // Arithmetic
-        ("+", _) | (_, "PLUS")        => Some("+"),
-        ("-", _) | (_, "MINUS")       => Some("-"),
+        ("+", _) | (_, "PLUS")        => Some("add"),
+        ("-", _) | (_, "MINUS")       => Some("sub"),
         // Comparisons
-        ("==", _) | (_, "EQ_EQ")      => Some("=="),
-        ("!=", _) | (_, "NEQ")        => Some("!="),
-        ("<",  _) | (_, "LT")         => Some("<"),
-        (">",  _) | (_, "GT")         => Some(">"),
-        ("<=", _) | (_, "LEQ")        => Some("<="),
-        (">=", _) | (_, "GEQ")        => Some(">="),
-        // Logical (passed as comparisons of bool — V1 doesn't fully support)
-        // ("&&", _) | (_, "LAND") => ...
+        ("==", _) | (_, "EQ_EQ")      => Some("cmp_eq"),
+        ("!=", _) | (_, "NEQ")        => Some("cmp_ne"),
+        ("<",  _) | (_, "LT")         => Some("cmp_lt"),
+        (">",  _) | (_, "GT")         => Some("cmp_gt"),
+        ("<=", _) | (_, "LEQ")        => Some("cmp_le"),
+        (">=", _) | (_, "GEQ")        => Some("cmp_ge"),
         _ => None,
     }
-}
-
-fn is_comparison_op(name: &str) -> bool {
-    matches!(name, "==" | "!=" | "<" | "<=" | ">" | ">=")
 }
 
 // ---------------------------------------------------------------------------
@@ -851,14 +875,22 @@ mod tests {
         let src = "fn main() -> u8 { return 30 + 12; }";
         let m = compile_source(src, "test").expect("ok");
         let body = &m.functions[0].instructions;
-        // Expected: const(30), const(12), call_builtin "+", ret
+        // Expected after the typed-CIR fix:
+        //   const _n0 = 30 (u8)
+        //   const _n1 = 12 (u8)
+        //   add   _n2 = _n0, _n1 (i64)   ← was `call_builtin "+"` pre-fix
+        //   ret   _n2 (u8)
         let consts = body.iter().filter(|i| i.op == "const").count();
         assert!(consts >= 2, "got body: {body:?}");
-        assert!(body.iter().any(|i|
+        assert!(body.iter().any(|i| i.op == "add"),
+            "expected typed `add` op (not `call_builtin \"+\"`); got body: {body:?}");
+        // Old behaviour leaked `call_builtin "+"` — verify we no longer do that.
+        assert!(!body.iter().any(|i|
             i.op == "call_builtin" && i.srcs.first().and_then(|s| match s {
                 Operand::Var(n) => Some(n.as_str()),
                 _ => None,
-            }) == Some("+")));
+            }) == Some("+")),
+            "regression: `call_builtin \"+\"` leaked into IIR (would break IIR-to-* backends)");
         assert!(body.iter().any(|i| i.op == "ret"));
     }
 

--- a/code/packages/rust/nib-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/nib-iir-compiler/tests/backend_compat.rs
@@ -1,0 +1,81 @@
+//! Cross-backend compatibility: confirm Nib's IIR output passes the
+//! validators of every IIR-to-* backend in the workspace.
+//!
+//! Before the typed-CIR fix, Nib emitted `call_builtin "+"` with
+//! `type_hint: "any"`, which every IIR-to-* validator rejected:
+//!
+//! ```text
+//! [wasm] 3 errors:
+//!   UntypedInstruction: function "main", op "call_builtin" has type_hint "any"
+//!   UnsupportedOp: function "main", op "call_builtin" …
+//!   UntypedInstruction: function "main", op "ret" has type_hint "any"
+//! ```
+//!
+//! After the fix, Nib emits typed CIR ops directly (`add`, `cmp_eq`,
+//! …) with `type_hint: "i64"`, matching the pattern oct-iir-compiler
+//! uses, and the validators accept the module.
+
+use nib_iir_compiler::compile_source;
+
+#[test]
+fn nib_iir_accepted_by_iir_to_wasm() {
+    let m = compile_source("fn main() -> u8 { return 30 + 12; }", "compat")
+        .expect("Nib must compile to IIR");
+    let errs = iir_to_wasm::validate::validate_for_wasm(&m);
+    assert!(errs.is_empty(),
+        "wasm validator should accept Nib's typed IIR; got errors: {errs:?}");
+}
+
+#[test]
+fn nib_iir_accepted_by_iir_to_jvm() {
+    let m = compile_source("fn main() -> u8 { return 30 + 12; }", "compat")
+        .expect("Nib must compile to IIR");
+    let errs = iir_to_jvm_class_file::validate::validate_for_jvm(&m);
+    assert!(errs.is_empty(),
+        "jvm validator should accept Nib's typed IIR; got errors: {errs:?}");
+}
+
+#[test]
+fn nib_iir_accepted_by_iir_to_clr() {
+    let m = compile_source("fn main() -> u8 { return 30 + 12; }", "compat")
+        .expect("Nib must compile to IIR");
+    let errs = iir_to_cil_bytecode::validate::validate_iir_for_clr(&m);
+    assert!(errs.is_empty(),
+        "clr validator should accept Nib's typed IIR; got errors: {errs:?}");
+}
+
+#[test]
+fn nib_iir_accepted_by_iir_to_beam() {
+    let m = compile_source("fn main() -> u8 { return 30 + 12; }", "compat")
+        .expect("Nib must compile to IIR");
+    let errs = iir_to_beam::validate::validate_for_beam(&m);
+    assert!(errs.is_empty(),
+        "beam validator should accept Nib's typed IIR; got errors: {errs:?}");
+}
+
+/// Comparison operator: `cmp_lt` must be emitted (not `call_builtin "<"`)
+/// so all four backends accept the result-of-a-comparison shape.
+#[test]
+fn nib_iir_with_comparison_accepted_by_every_backend() {
+    let src = "fn main() -> u8 { \
+                 if 5 < 10 { return 1; } else { return 0; } \
+               }";
+    let m = compile_source(src, "compat").expect("Nib must compile");
+
+    // Must contain `cmp_lt`, never `call_builtin "<"`.
+    let ops: Vec<&str> = m.functions[0].instructions.iter()
+        .map(|i| i.op.as_str()).collect();
+    assert!(ops.contains(&"cmp_lt"),
+        "expected `cmp_lt` op; got {ops:?}");
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] expected no validator errors; got {} error(s): {errs:?}",
+            errs.len());
+    }
+}


### PR DESCRIPTION
## Summary

Nib's IIR output is now accepted by **every** IIR-to-* backend (`iir-to-wasm`, `iir-to-jvm-class-file`, `iir-to-cil-bytecode`, `iir-to-beam`) without needing the AOT pipeline's `pre_lower_aot_builtins` pre-pass.  Closes the Nib row in the 5-frontend × 4-backend matrix surfaced after #3888.

### The bug

A probe matrix run after #3888 (vm-core `mov` dispatch) revealed that Nib's IIR output was rejected by every IIR-to-* backend with the same three errors:

```text
UntypedInstruction: function "main", op "call_builtin" has type_hint "any"
UnsupportedOp:      function "main", op "call_builtin" not supported …
UntypedInstruction: function "main", op "ret" has type_hint "any"
```

Root cause: `compile_binary_chain` emitted `call_builtin "<op>"` with `type_hint: "any"`, relying on the AOT chain's `pre_lower_aot_builtins` pass to rewrite each one to a typed CIR op before the native backends saw it.  That assumption held for `lang-aot`'s AOT path but broke every IIR-to-* backend (they validate against concrete CIR opcodes).

This is surprising at first since Nib is statically typed — and indeed the type-checker *does* know both operands are `u8`.  The bug is that `compile_binary_chain` wasn't using the type-checker output to emit typed ops directly.  Oct's frontend already does this right — that's why Oct passes 3/4 backends straight from `oct_iir_compiler::compile_source` (the 4th was the BEAM `mov` gap, fixed in #3898).

### The fix

Mirror `oct-iir-compiler::compile_binary` exactly:

- `compile_binary_chain` emits typed CIR mnemonics directly:
  - `+` → `add`, `-` → `sub`
  - `==` → `cmp_eq`, `!=` → `cmp_ne`
  - `<` → `cmp_lt`, `>` → `cmp_gt`, `<=` → `cmp_le`, `>=` → `cmp_ge`
- `type_hint: "i64"` for every binary op (Nib's narrow types u4/u8/bool all flow through 64-bit slots at the IIR level — the function's declared Nib return type stays on `IIRFunction`).
- `return_stmt`'s fallback type_hint is now `"i64"` instead of `"any"`.
- Helper rename: `builtin_for` → `cir_op_for`.

### AOT chain unchanged

The `lang-aot` AOT chain still works — `pre_lower_aot_builtins` becomes a no-op when there's nothing to rewrite, so the typed `add` / `cmp_*` ops flow straight through.

## Test plan

- [x] `cargo test -p nib-iir-compiler` — 11 lib tests pass (1 updated to assert no `call_builtin "+"` regression) + 5 new tests in `tests/backend_compat.rs` that exercise every IIR-to-* validator
- [x] `cargo test -p lang-aot --test end_to_end_smoke end_to_end_nib` — all 5 Nib e2e tests still pass locally on Windows (AOT chain unchanged)
- [x] Security review: cleared — pure IIR-emission change; no new `unsafe`/FFI/I/O/deps; type_hint tightening from `"any"` to `"i64"` is defense-in-depth
- [ ] CI: Linux + Windows + macOS

## Version bump

- `nib-iir-compiler`: 0.3.0 → 0.4.0

## After this lands

The 5-frontend × 4-backend matrix becomes:

```
┌──────────────────┬────────┬────────┬────────┬────────┐
│ frontend         │ wasm   │ jvm    │ clr    │ beam   │
├──────────────────┼────────┼────────┼────────┼────────┤
│ Twig             │ ERR×5  │ ERR×5  │ ERR×5  │ ERR×5  │
│ Nib              │  ok    │  ok    │  ok    │  ok    │  ← THIS PR
│ Brainfuck        │ ERR×8  │ ERR×8  │ ERR×8  │ ERR×8  │
│ DartmouthBasic   │  ok    │  ok    │  ok    │  ok    │  ← #3898 fixed beam
│ Oct              │  ok    │  ok    │  ok    │  ok    │  ← #3898 fixed beam
└──────────────────┴────────┴────────┴────────┴────────┘
```

Twig and Brainfuck still need follow-ups — they emit pre-specialisation IIR that the AOT pipeline lowers before the backends see it; the IIR-to-* backends require already-typed IIR.  The cleanest fix for both is a reusable `iir-pretype` helper that runs the AOT-style lowering as a public pass, which any frontend can opt into (Nib and Oct don't need it because they emit typed IIR upfront, like this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)