### PR TITLE
feat(cas-summation): Phase 43 port to TypeScript and Rust (one PR)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.4.0 — 2026-05-22
+
+**Phase 43 — Transcendental vanishing-at-infinity (Rust port).**
+
+Ports Python `cas-summation` 0.5.0 (PR #3899 in review).  Extends the
+Phase 41/42 denominator recogniser to accept exponentially diverging
+shapes so `∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1` and similar close.
+
+### Added
+
+- **`h_diverges_at_infinity(node, k)`** — union of Phase 41/42
+  positive-degree polynomial check and three transcendental cases:
+  `Exp(h)`, `Pow(b, h)` with rational `|b| > 1`, and `Mul` of such
+  factors.  Each transcendental case requires the polynomial argument
+  ``h`` to have a positive leading coefficient (so it really diverges
+  to ``+∞``, not ``−∞``).
+- **`polynomial_leading_coeff_sign_in_k(node, k) -> Option<i64>`** —
+  returns `Some(1)` / `Some(-1)` for the polynomial's leading
+  coefficient sign in `k`, `None` for non-polynomial / degree-0 /
+  unknown-sign shapes.  Required to refuse `2^(-k)` (it vanishes).
+
+### Changed
+
+- `g_vanishes_at_infinity` Phase 41 fast path now calls
+  `h_diverges_at_infinity` instead of
+  `is_positive_degree_polynomial_in_k` directly.
+
+### Added — tests
+
+`tests/tests.rs` — 6 new `#[test]` functions:
+
+- `phase43_pow_2_diverges_closes` (= 1).
+- `phase43_pow_3_higher_start` (= 1/3).
+- `phase43_base_half_falls_through`.
+- `phase43_mul_polynomial_times_exponential` (= 1/2).
+- `phase43_pow_negative_exponent_polynomial_refuses` (regression).
+- `phase43_pow_neg_wrapper_refuses` (regression, NEG wrapper).
+
+Full suite: **27 passed** (21 prior + 6 net new).
+
+### Still deferred
+
+- Apart-induced telescopes — blocked on porting `Apart` to Rust.
+- Transcendental limit-finder for non-polynomial shapes.
+
 ## 0.3.0 — 2026-05-22
 
 **Phase 41 + Phase 42 — Limit-aware infinite telescope (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -623,6 +623,171 @@ fn polynomial_degree_in_k(node: &IRNode, k: &IRNode) -> Option<i64> {
 ///
 /// Anything else (transcendental, improper rational, non-Div) returns
 /// `false`.
+/// Phase 43 helper: return the sign (+1 / -1) of the leading
+/// coefficient of `node` as a polynomial in `k`, or `None` for
+/// non-polynomial / degree-0 / unknown-sign shapes.
+///
+/// Required by `h_diverges_at_infinity` so we don't claim
+/// `exp(-k)` or `2^(-k)` diverge (they vanish: `Mul(-1, k)` has
+/// negative leading coefficient).
+fn polynomial_leading_coeff_sign_in_k(node: &IRNode, k: &IRNode) -> Option<i64> {
+    if is_constant_in(node, k) {
+        return None;
+    }
+    if node == k {
+        return Some(1);
+    }
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    let head_str = match &apply_node.head {
+        IRNode::Symbol(s) => s.as_str(),
+        _ => return None,
+    };
+    // k^n (n >= 1) → +1.
+    if head_str == POW && apply_node.args.len() == 2 {
+        let base = &apply_node.args[0];
+        let exp = &apply_node.args[1];
+        if base == k {
+            if let IRNode::Integer(n) = exp {
+                if *n >= 1 {
+                    return Some(1);
+                }
+            }
+        }
+        return None;
+    }
+    // Neg(p) flips sign.
+    if head_str == NEG && apply_node.args.len() == 1 {
+        return polynomial_leading_coeff_sign_in_k(&apply_node.args[0], k).map(|s| -s);
+    }
+    // Mul(...): multiply signs of constant + k-bearing factors.
+    if head_str == MUL {
+        let mut sign: i64 = 1;
+        let mut any_k_bearing = false;
+        for arg in &apply_node.args {
+            if is_constant_in(arg, k) {
+                let val = rational_value(arg)?;
+                if val.numer == 0 {
+                    return None;
+                }
+                if val.numer < 0 {
+                    sign = -sign;
+                }
+                continue;
+            }
+            let inner = polynomial_leading_coeff_sign_in_k(arg, k)?;
+            if inner < 0 {
+                sign = -sign;
+            }
+            any_k_bearing = true;
+        }
+        if any_k_bearing {
+            return Some(sign);
+        }
+        return None;
+    }
+    // Add(...): dominated by highest-degree term; tied → refuse.
+    if head_str == ADD {
+        let mut max_deg: i64 = -1;
+        let mut leader_sign: Option<i64> = None;
+        let mut tied_at_max = false;
+        for arg in &apply_node.args {
+            let deg = polynomial_degree_in_k(arg, k)?;
+            if deg == 0 {
+                continue;
+            }
+            match deg.cmp(&max_deg) {
+                Ordering::Greater => {
+                    max_deg = deg;
+                    leader_sign = polynomial_leading_coeff_sign_in_k(arg, k);
+                    tied_at_max = false;
+                }
+                Ordering::Equal => {
+                    tied_at_max = true;
+                }
+                Ordering::Less => {}
+            }
+        }
+        if tied_at_max {
+            return None;
+        }
+        return leader_sign;
+    }
+    None
+}
+
+/// Phase 43: True when `node` provably diverges to ±∞ as `k → ∞`.
+///
+/// Union of Phase 41/42 positive-degree polynomial + three transcendental
+/// cases:
+///   1. `Exp(h(k))` with h positive-degree AND positive leading coeff.
+///   2. `Pow(b, h(k))` with rational |b| > 1 AND h positive-degree with
+///      positive leading coefficient.
+///   3. `Mul(...)` where at least one factor diverges and the rest are
+///      constant-in-k or also diverging.  Recursive.
+fn h_diverges_at_infinity(node: &IRNode, k: &IRNode) -> bool {
+    // Phase 41/42 fast path.
+    if is_positive_degree_polynomial_in_k(node, k) {
+        return true;
+    }
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    let head_str = match &apply_node.head {
+        IRNode::Symbol(s) => s.as_str(),
+        _ => return false,
+    };
+    // Phase 43: Exp(h(k)) with h positive-degree and positive leading coeff.
+    if head_str == EXP && apply_node.args.len() == 1 {
+        let inner = &apply_node.args[0];
+        if is_positive_degree_polynomial_in_k(inner, k) {
+            return polynomial_leading_coeff_sign_in_k(inner, k) == Some(1);
+        }
+        return false;
+    }
+    // Phase 43: Pow(b, h(k)) with |b| > 1 rational and h → +∞.
+    if head_str == POW && apply_node.args.len() == 2 {
+        let base = &apply_node.args[0];
+        let exp = &apply_node.args[1];
+        if is_constant_in(base, k) {
+            if let Some(base_val) = rational_value(base) {
+                // |base| > 1 iff |numer| > denom (denom > 0 in
+                // normalised Rational).  Compare in u64-space so that
+                // `numer == i64::MIN` doesn't truncate after
+                // `unsigned_abs()`.
+                let abs_numer: u64 = base_val.numer.unsigned_abs();
+                let denom_u: u64 = base_val.denom as u64; // denom > 0
+                if abs_numer > denom_u
+                    && is_positive_degree_polynomial_in_k(exp, k)
+                    && polynomial_leading_coeff_sign_in_k(exp, k) == Some(1)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    // Phase 43: Mul(...) — at least one factor diverges; others constant
+    // in k or also diverging.  Recursive.
+    if head_str == MUL && apply_node.args.len() >= 2 {
+        let mut has_divergent = false;
+        for arg in &apply_node.args {
+            if is_constant_in(arg, k) {
+                continue;
+            }
+            if h_diverges_at_infinity(arg, k) {
+                has_divergent = true;
+                continue;
+            }
+            return false;
+        }
+        return has_divergent;
+    }
+    false
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -633,9 +798,10 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     }
     let num = &apply_node.args[0];
     let den = &apply_node.args[1];
-    // Phase 41 fast path: constant numerator + positive-degree denominator.
+    // Phase 41/43 fast path: constant numerator + diverging denominator
+    // (positive-degree polynomial OR exp / b^k transcendental).
     if is_constant_in(num, k) {
-        return is_positive_degree_polynomial_in_k(den, k);
+        return h_diverges_at_infinity(den, k);
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -464,3 +464,143 @@ fn phase42_transcendental_numerator_falls_through() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 43: transcendental vanishing-at-infinity.
+//
+// Extends Phase 41/42 to accept Pow(b, h(k)) with |b| > 1 and h positive-
+// degree with positive leading coefficient.  Sign-aware guard refuses
+// `2^(-k)` and similar (these vanish, not diverge).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase43_pow_2_diverges_closes() {
+    // ∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(sym(DIV), vec![int(1), apply(sym(POW), vec![int(2), k.clone()])]),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(sym(POW), vec![int(2), apply(sym(ADD), vec![k.clone(), int(1)])]),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(0), sym("%inf"), eval), int(1));
+}
+
+#[test]
+fn phase43_pow_3_higher_start() {
+    // ∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = 1/3.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(sym(DIV), vec![int(1), apply(sym(POW), vec![int(3), k.clone()])]),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(sym(POW), vec![int(3), apply(sym(ADD), vec![k.clone(), int(1)])]),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), rat(1, 3));
+}
+
+#[test]
+fn phase43_base_half_falls_through() {
+    // Pow(1/2, k) → 0, not ∞; Phase 43 refuses.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(sym(DIV), vec![int(1), apply(sym(POW), vec![rat(1, 2), k.clone()])]),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(sym(POW), vec![rat(1, 2), apply(sym(ADD), vec![k.clone(), int(1)])]),
+                ],
+            ),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(0), sym("%inf"), eval);
+    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase43_mul_polynomial_times_exponential() {
+    // ∑_{k=1}^∞ [1/(k·2^k) − 1/((k+1)·2^(k+1))] = g(1) = 1/2.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(sym(MUL), vec![k.clone(), apply(sym(POW), vec![int(2), k.clone()])]),
+                ],
+            ),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(sym(MUL), vec![kp1.clone(), apply(sym(POW), vec![int(2), kp1.clone()])]),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), rat(1, 2));
+}
+
+#[test]
+fn phase43_pow_negative_exponent_polynomial_refuses() {
+    // Pow(2, Mul(-1, k)) = 2^(-k) → 0, not ∞.  Sign-aware guard must refuse.
+    let k = sym("k");
+    let neg_k = apply(sym(MUL), vec![int(-1), k.clone()]);
+    let neg_kp1 = apply(sym(MUL), vec![int(-1), apply(sym(ADD), vec![k.clone(), int(1)])]);
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(sym(DIV), vec![int(1), apply(sym(POW), vec![int(2), neg_k])]),
+            apply(sym(DIV), vec![int(1), apply(sym(POW), vec![int(2), neg_kp1])]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(0), sym("%inf"), eval);
+    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase43_pow_neg_wrapper_refuses() {
+    // Pow(2, Neg(k)) — alternate IR for 2^(-k); same refusal.
+    let k = sym("k");
+    let f = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(DIV),
+                vec![int(1), apply(sym(POW), vec![int(2), apply(sym(NEG), vec![k.clone()])])],
+            ),
+            apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(
+                        sym(POW),
+                        vec![int(2), apply(sym(NEG), vec![apply(sym(ADD), vec![k.clone(), int(1)])])],
+                    ),
+                ],
+            ),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(0), sym("%inf"), eval);
+    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.4.0 — 2026-05-22
+
+**Phase 43 — Transcendental vanishing-at-infinity (TypeScript port).**
+
+Ports Python `cas-summation` 0.5.0 (PR #3899 in review).  Extends the
+Phase 41/42 denominator recogniser to accept exponentially diverging
+shapes so `∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1` and similar close.
+
+### Added
+
+- **`hDivergesAtInfinity(node, k)`** — union of Phase 41/42
+  positive-degree polynomial check and three transcendental cases:
+  1. `Exp(h(k))` with h positive-degree AND positive leading coeff.
+  2. `Pow(b, h(k))` with rational `|b| > 1` AND h positive-degree
+     with positive leading coefficient.
+  3. `Mul(...)` where at least one factor diverges and the others
+     are constant-in-k or also diverging.  Recursive.
+- **`polynomialLeadingCoeffSignInK(node, k) -> 1 | -1 | undefined`**
+  — returns the sign of the polynomial's leading coefficient in `k`,
+  or `undefined` for non-polynomial / degree-0 / unknown-sign shapes.
+  Required to refuse `exp(-k)`, `2^(-k)`, etc. (these vanish, not
+  diverge).
+
+### Changed
+
+- `gVanishesAtInfinity` Phase 41 fast path now calls
+  `hDivergesAtInfinity` instead of `isPositiveDegreePolynomialInK`
+  directly, picking up the transcendental cases automatically.
+
+### Added — tests
+
+`tests/cas-summation.test.ts` — new
+`summation: Phase 43 transcendental vanishing-at-infinity` describe
+block with 6 cases:
+
+- `∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1`.
+- `∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = 1/3`.
+- Base 1/2 falls through (`(1/2)^k → 0`, not ∞).
+- `Mul` of polynomial × exponential `k · 2^k` closes (= 1/2).
+- Regression: `2^(-k)` via `Mul(-1, k)` does NOT diverge → refuse.
+- Regression: `2^(Neg(k))` does NOT diverge → refuse (NEG wrapper).
+
+Full suite: **27 passed** (21 prior + 6 net new).
+
+### Still deferred
+
+- Apart-induced telescopes (e.g. `1/(k(k+1))`) — blocked on porting
+  the `Apart` partial-fraction-decomposition handler to TypeScript.
+- Transcendental limit-finder for shapes the polynomial-degree path
+  doesn't cover (e.g. `sin(k)/k²`, `log(k)/k`).
+
 ## 0.3.0 — 2026-05-22
 
 **Phase 41 + Phase 42 — Limit-aware infinite telescope (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -376,14 +376,150 @@ function polynomialDegreeInK(node: IRNode, k: IRNode): number | undefined {
  * ``deg(P) ≥ deg(Q)``, non-Div shapes) returns ``false`` —
  * conservatively refusing keeps the closed-form emission safe.
  */
+/**
+ * Phase 43 helper: return the sign (+1 or -1) of the leading
+ * coefficient of `node` as a polynomial in `k`, or `undefined` for
+ * non-polynomial / degree-0 / unknown-sign shapes.
+ *
+ * Required by `hDivergesAtInfinity` to verify that `Exp(h)` / `Pow(b, h)`
+ * actually drive toward +∞ rather than 0.  Naïve "positive-degree
+ * polynomial" tests accept `Mul(-1, k)` (i.e. `-k`) whose leading
+ * coefficient is negative — without this helper we'd wrongly claim
+ * `exp(-k)` or `2^(-k)` diverge (they vanish).
+ */
+function polynomialLeadingCoeffSignInK(
+  node: IRNode,
+  k: IRNode,
+): 1 | -1 | undefined {
+  if (isConstantIn(node, k)) return undefined;
+  if (equals(node, k)) return 1;
+  if (node.kind !== "apply") return undefined;
+  // k^n (n >= 1)
+  if (equals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    if (equals(base, k) && exp.kind === "integer" && exp.value >= 1n) {
+      return 1;
+    }
+    return undefined;
+  }
+  // Neg(p) flips sign.
+  if (equals(node.head, NEG) && node.args.length === 1) {
+    const inner = polynomialLeadingCoeffSignInK(node.args[0], k);
+    return inner === undefined ? undefined : ((inner === 1 ? -1 : 1) as 1 | -1);
+  }
+  // Mul: multiply signs of constant + k-bearing factors.  Symbolic
+  // constants of unknown sign / zero literals → undefined (refuse).
+  if (equals(node.head, MUL)) {
+    let sign: 1 | -1 = 1;
+    let anyKBearing = false;
+    for (const arg of node.args) {
+      if (isConstantIn(arg, k)) {
+        const val = rationalValue(arg);
+        if (val === undefined) return undefined;
+        if (val.numer === 0n) return undefined;
+        if (val.numer < 0n) sign = (sign === 1 ? -1 : 1) as 1 | -1;
+        continue;
+      }
+      const inner = polynomialLeadingCoeffSignInK(arg, k);
+      if (inner === undefined) return undefined;
+      sign = inner === 1 ? sign : ((sign === 1 ? -1 : 1) as 1 | -1);
+      anyKBearing = true;
+    }
+    return anyKBearing ? sign : undefined;
+  }
+  // Add: dominated by the highest-degree term.  Tied max degrees → refuse
+  // (leading coefficients could cancel).
+  if (equals(node.head, ADD)) {
+    let maxDeg = -1;
+    let leaderSign: 1 | -1 | undefined;
+    let tiedAtMax = false;
+    for (const arg of node.args) {
+      const deg = polynomialDegreeInK(arg, k);
+      if (deg === undefined) return undefined;
+      if (deg === 0) continue;
+      if (deg > maxDeg) {
+        maxDeg = deg;
+        leaderSign = polynomialLeadingCoeffSignInK(arg, k);
+        tiedAtMax = false;
+      } else if (deg === maxDeg) {
+        tiedAtMax = true;
+      }
+    }
+    return tiedAtMax ? undefined : leaderSign;
+  }
+  return undefined;
+}
+
+/**
+ * Phase 43: True when `node` provably diverges to ±∞ as `k → ∞`.
+ *
+ * Union of Phase 41/42 positive-degree polynomial + three transcendental
+ * cases:
+ *   1. `Exp(h(k))` with h positive-degree AND positive leading coeff.
+ *   2. `Pow(b, h(k))` with rational |b| > 1 AND h positive-degree with
+ *      positive leading coefficient.
+ *   3. `Mul(...)` where at least one factor diverges and the rest are
+ *      constant-in-k or also diverging.  Recursive.
+ *
+ * The sign-aware leading-coefficient check is critical: `exp(-k) → 0`
+ * and `2^(-k) → 0`, not ∞.
+ */
+function hDivergesAtInfinity(node: IRNode, k: IRNode): boolean {
+  // Phase 41/42 fast path.
+  if (isPositiveDegreePolynomialInK(node, k)) return true;
+  if (node.kind !== "apply") return false;
+  // Phase 43: Exp(h) with h → +∞.
+  if (equals(node.head, EXP) && node.args.length === 1) {
+    const inner = node.args[0];
+    if (isPositiveDegreePolynomialInK(inner, k)) {
+      return polynomialLeadingCoeffSignInK(inner, k) === 1;
+    }
+    return false;
+  }
+  // Phase 43: Pow(b, h) with |b| > 1 and h → +∞.
+  if (equals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    if (isConstantIn(base, k)) {
+      const baseVal = rationalValue(base);
+      if (baseVal !== undefined) {
+        // |base| > 1 iff |numer| > denom (denom always > 0 in normalised form).
+        const absNumer = baseVal.numer < 0n ? -baseVal.numer : baseVal.numer;
+        if (absNumer > baseVal.denom) {
+          if (isPositiveDegreePolynomialInK(exp, k)) {
+            if (polynomialLeadingCoeffSignInK(exp, k) === 1) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+  // Phase 43: Mul(...) — at least one factor diverges, others constant
+  // in k or also diverging.  Recursive.
+  if (equals(node.head, MUL) && node.args.length >= 2) {
+    let hasDivergent = false;
+    for (const arg of node.args) {
+      if (isConstantIn(arg, k)) continue;
+      if (hDivergesAtInfinity(arg, k)) {
+        hasDivergent = true;
+        continue;
+      }
+      return false;
+    }
+    return hasDivergent;
+  }
+  return false;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
   }
   const [num, den] = g.args;
-  // Phase 41 fast path: constant numerator + positive-degree denominator.
+  // Phase 41/43 fast path: constant numerator + diverging denominator
+  // (positive-degree polynomial OR exp / b^k transcendental).
   if (isConstantIn(num, k)) {
-    return isPositiveDegreePolynomialInK(den, k);
+    return hDivergesAtInfinity(den, k);
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -339,3 +339,75 @@ describe("summation: Phase 41+42 limit-aware infinite telescope", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 43: transcendental vanishing-at-infinity.
+//
+// Extends Phase 41/42 to accept exponentially diverging shapes
+// (Exp(h(k)), Pow(b, h(k)) with |b| > 1, and Mul of such factors).
+// Sign-aware leading-coefficient check refuses `exp(-k)`, `2^(-k)`,
+// and the Mul / NEG-wrapped variants of those (these vanish, not diverge).
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 43 transcendental vanishing-at-infinity", () => {
+  it("∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1 (Pow(2, k) diverges)", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), app(POW, [int(2), k])]),
+      app(DIV, [int(1), app(POW, [int(2), app(ADD, [k, int(1)])])]),
+    ]);
+    expect(evaluateSum(f, k, int(0), sym("%inf"), evalNode)).toEqual(int(1));
+  });
+
+  it("∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = 1/3", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), app(POW, [int(3), k])]),
+      app(DIV, [int(1), app(POW, [int(3), app(ADD, [k, int(1)])])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(rational(1, 3));
+  });
+
+  it("base 1/2 falls through (Pow(1/2, k) → 0, not ∞)", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), app(POW, [rational(1, 2), k])]),
+      app(DIV, [int(1), app(POW, [rational(1, 2), app(ADD, [k, int(1)])])]),
+    ]);
+    const out = evaluateSum(f, k, int(0), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+
+  it("Mul of polynomial × exponential ∑ 1/(k·2^k) − 1/((k+1)·2^(k+1)) = 1/2", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const f = app(SUB, [
+      app(DIV, [int(1), app(MUL, [k, app(POW, [int(2), k])])]),
+      app(DIV, [int(1), app(MUL, [kp1, app(POW, [int(2), kp1])])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(rational(1, 2));
+  });
+
+  it("regression: Pow(2, Mul(-1, k)) = 2^(-k) does NOT diverge — refuse", () => {
+    // Sign-aware leading-coefficient check must catch this.
+    const k = sym("k");
+    const negK = app(MUL, [int(-1), k]);
+    const negKp1 = app(MUL, [int(-1), app(ADD, [k, int(1)])]);
+    const f = app(SUB, [
+      app(DIV, [int(1), app(POW, [int(2), negK])]),
+      app(DIV, [int(1), app(POW, [int(2), negKp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(0), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+
+  it("regression: Pow(2, Neg(k)) does NOT diverge — refuse (NEG wrapper form)", () => {
+    const k = sym("k");
+    const f = app(SUB, [
+      app(DIV, [int(1), app(POW, [int(2), app(NEG, [k])])]),
+      app(DIV, [int(1), app(POW, [int(2), app(NEG, [app(ADD, [k, int(1)])])])]),
+    ]);
+    const out = evaluateSum(f, k, int(0), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Phase 43 (transcendental vanishing-at-infinity — PR #3899) to TypeScript and Rust in a single PR. Extends the Phase 41/42 denominator recogniser to accept exponentially diverging shapes so

$$\sum_{k=0}^{\infty} \left[\frac{1}{2^k} - \frac{1}{2^{k+1}}\right] = 1$$

and similar close end-to-end.

## Recogniser additions

`hDivergesAtInfinity` / `h_diverges_at_infinity` is now the union of the existing positive-degree polynomial check and three transcendental cases:

1. `Exp(h(k))` with h positive-degree AND positive leading coefficient.
2. `Pow(b, h(k))` with rational `|b| > 1` AND h positive-degree with positive leading coefficient.
3. `Mul(...)` where at least one factor diverges and the rest are constant-in-k or also diverging. Recursive.

The sign-aware `polynomialLeadingCoeffSignInK` / `polynomial_leading_coeff_sign_in_k` helper is required to refuse `2^(-k)` and `exp(-k)` (these vanish, not diverge).

## Versions

| Package | Was | Now |
|---|---|---|
| `typescript/cas-summation` | 0.3.0 | 0.4.0 |
| `rust/cas-summation` | 0.3.0 | 0.4.0 |

## Tests

6 new cases per backend mirroring the Python suite:

- `∑_{k=0}^∞ [1/2^k − 1/2^(k+1)] = 1`
- `∑_{k=1}^∞ [1/3^k − 1/3^(k+1)] = 1/3`
- Base 1/2 falls through (`(1/2)^k → 0`).
- `Mul` of polynomial × exponential `k · 2^k` closes (= 1/2).
- Regression: `Pow(2, Mul(-1, k))` does NOT diverge → refuse.
- Regression: `Pow(2, Neg(k))` does NOT diverge → refuse (NEG wrapper form).

| Suite | Was | Now |
|---|---|---|
| TS | 21 passed | **27 passed** |
| Rust | 21 passed | **27 passed** |

## Security / correctness review

- Sign-aware leading-coefficient fix from Python is applied consistently to both backends (Pow + Mul recursion).
- LOW-severity Rust edge case caught and fixed: `i64::MIN.unsigned_abs() as i64` truncation is replaced with a `u64`-space comparison.
- No `unsafe` Rust, no `eval` TS, no new external dependencies.

## Test plan

- [x] All existing Phase 39/41/42 tests still pass in both languages.
- [x] New Phase 43 happy-path tests verify divergence is recognised.
- [x] Sign-aware regression tests pin the leading-coefficient guard.
- [x] Security review passed (LOW finding fixed in the amendment).

## Still deferred

- Apart-induced telescopes (e.g. `1/(k(k+1))`) — blocked on porting `Apart` to TypeScript / Rust.
- Transcendental limit-finder for non-polynomial shapes (`sin(k)/k²`, `log(k)/k`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)