### PR TITLE
feat(brainfuck-iir-compiler): wire jit-core into BrainfuckVM (BF05)

### DIFF
--- a/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog — brainfuck-iir-compiler
 
+## [0.2.0] — 2026-05-22 (BF05 — Brainfuck on the LANG VM JIT chain)
+
+### Added — JIT mode (BF05)
+
+`BrainfuckVM::execute_module` now dispatches through
+[`jit_core::core::JITCore`] when constructed with `jit=true`, replacing
+the previous `"jit=true is not yet supported in BF04"` early-error.
+Brainfuck programs now run through the full LANG VM JIT chain
+(`vm-core` + `jit-core`) in the same shape as Dartmouth BASIC's
+`jit_smoke.rs` did after PR #3888.
+
+#### Why this matters (and the careful caveat)
+
+Brainfuck's IIR is already `FullyTyped` from birth — every instruction
+carries a concrete `type_hint` (`"u8"` / `"u32"` / `"void"`).  That
+means the JIT chain *would* eagerly tier-promote `main` to a native
+backend on the very first call (see `JITCore::execute_with_jit` Phase
+1).  In practice, none of the existing JIT backends (NullBackend,
+EchoBackend, future WASM/x86_64 ports) know how to lower Brainfuck's
+custom `load_mem` / `store_mem` opcodes — the tape memory model is
+specific to the Brainfuck wrapper, not part of the standard CIR
+vocabulary.
+
+Compiling with a backend that silently can't handle those opcodes
+would replace `main` with a stub that returns `Null`, producing no
+output.  To prevent that, the wrapper now ships a private
+`InterpOnlyBackend` whose `compile()` always returns `None`, telling
+`JITCore`:
+
+> "I refuse to compile this function — keep it interpreted forever."
+
+The plumbing is real — the same `VMCore` runs the program with all
+five Brainfuck-specific handlers (`putchar`, `getchar`, `load_mem`,
+`store_mem`, `label`), the JIT's tier-up path is observable via
+`JITCore::cache_stats()`, and the `Phase 3` hot-function promotion
+runs (as a no-op against `InterpOnlyBackend`).  When a future backend
+learns Brainfuck's tape memory model, swap it in here and BF programs
+tier-promote automatically — no other changes needed.
+
+#### What about the JIT vs interpreter parity?
+
+The new `tests/jit_smoke.rs` runs every program twice — once with
+`jit=false` (pure interpreter) and once with `jit=true` (JIT chain) —
+and asserts byte-identical output.  If they ever diverge, the wiring
+is broken.
+
+### Tests
+
+- `tests/jit_smoke.rs` (6 tests): runs through `JITCore::execute_with_jit`
+  - `jit_brainfuck_three_increments_print` — `+++.` → chr(3)
+  - `jit_brainfuck_pointer_arithmetic` — `>+<.` → chr(0)
+  - `jit_brainfuck_cat_with_input` — `,[.,]` echoes `"hello"` → `"hello"`
+  - `jit_brainfuck_multiply_2_times_3` — classic BF multiplication idiom → chr(6)
+  - `jit_brainfuck_u8_wraparound` — `-.` (0 - 1 wraps to 255)
+  - `jit_brainfuck_multiple_outputs` — `+.++.+++.` → chr(1) chr(3) chr(6)
+- Updated `vm::tests::jit_true_returns_error_on_run` (which asserted
+  the BF04 early-error) into three new tests that verify the JIT path
+  produces the same results as the interpreter:
+  - `jit_true_runs_simple_program`
+  - `jit_and_interp_paths_agree_on_hello_h`
+  - `jit_handles_loop_with_input`
+
+### Dependencies
+
+- Added `jit-core` as a runtime dependency (was previously not
+  reachable from this crate).
+
+### Compatibility
+
+- **Public API unchanged.**  `BrainfuckVM::new(true, ...)` no longer
+  returns an error on subsequent `run` / `execute_module` calls — that
+  was the only observable behaviour change.  All existing callers that
+  passed `jit=false` continue to behave exactly as before.
+
 ## [0.1.2] — 2026-05-11
 
 ### Fixed (LANG32 — `Operand::Str` exhaustiveness)

--- a/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
+++ b/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "brainfuck-iir-compiler"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
-description = "BF04 — Brainfuck → InterpreterIR compiler and vm-core wrapper"
+description = "BF04/BF05 — Brainfuck → InterpreterIR compiler, vm-core wrapper, and jit-core JIT chain"
 license = "MIT"
 
 [dependencies]
 brainfuck      = { path = "../brainfuck" }
 interpreter-ir = { path = "../interpreter-ir" }
 vm-core        = { path = "../vm-core" }
+jit-core       = { path = "../jit-core" }
 parser         = { path = "../parser" }
 lexer          = { path = "../lexer" }
 

--- a/code/packages/rust/brainfuck-iir-compiler/README.md
+++ b/code/packages/rust/brainfuck-iir-compiler/README.md
@@ -1,6 +1,8 @@
 # brainfuck-iir-compiler
 
-**BF04** — Rust port of the Brainfuck → InterpreterIR compiler and vm-core wrapper.
+**BF04** — Brainfuck → InterpreterIR compiler and `vm-core` wrapper.
+**BF05** — JIT-chain dispatch (`vm-core` + `jit-core`) wired through
+`BrainfuckVM::new(true, ...)`.
 
 ## What it does
 
@@ -82,15 +84,42 @@ LANG02  vm-core            ← executes IIRModule
 LANG03  jit-core           ← JIT (hot functions → native bytes)
 BF00    brainfuck-lexer    ← tokens
 BF01    brainfuck-parser   ← GrammarASTNode
-BF04    brainfuck-iir-compiler ← THIS CRATE
-BF05    brainfuck-jit-wasm ← JIT via wasm-backend (future)
+BF04    brainfuck-iir-compiler ← THIS CRATE (compiler + interp wrapper)
+BF05    brainfuck-iir-compiler ← THIS CRATE (JIT-chain wiring + smoke)
 ```
 
 ## JIT (BF05)
 
-`BrainfuckVM::new(jit: true, ...)` is accepted but returns an error when
-`run()` is called in BF04.  The JIT path (specialise via `jit-core`,
-compile to WASM via `wasm-backend`) is implemented in BF05.
+`BrainfuckVM::new(jit: true, ...)` routes runs through
+[`jit_core::core::JITCore::execute_with_jit`], the LANG VM's tiered JIT
+engine.  Brainfuck's IIR is `FullyTyped` from birth, so the JIT chain
+inherits the same eager-compile path that powers Dartmouth BASIC, Oct,
+and Nib.
+
+**The careful caveat**: today the wrapper supplies a private
+`InterpOnlyBackend` whose `compile()` always returns `None`, pinning
+every function on the interpreter tier.  Why?  Because Brainfuck's
+`load_mem` / `store_mem` opcodes are wired through *custom* `vm-core`
+opcode handlers, and no existing JIT backend (NullBackend, EchoBackend,
+future WASM/x86_64) knows how to lower them.  Trying to compile with a
+backend that silently can't handle those would replace `main` with a
+stub that returns `Null`, producing no output.  Refusing to compile is
+correct.
+
+**Why ship the wiring anyway?**  Because when a future backend learns
+Brainfuck's tape memory model, swapping the backend in `src/vm.rs` is
+the only change needed for tier promotion to kick in.  Until then, the
+JIT chain runs Brainfuck programs identically to the pure interpreter —
+verified by `tests/jit_smoke.rs`, which runs every program twice and
+asserts byte-identical output.
+
+```rust
+use brainfuck_iir_compiler::BrainfuckVM;
+
+let vm = BrainfuckVM::new(true, 30_000, None).unwrap();  // JIT enabled
+let out = vm.run("+++.", b"").unwrap();
+assert_eq!(out, vec![3u8]);
+```
 
 ## Running tests
 
@@ -98,4 +127,4 @@ compile to WASM via `wasm-backend`) is implemented in BF05.
 cargo test -p brainfuck-iir-compiler
 ```
 
-60 tests total (52 unit + 8 doc-tests).
+69 tests total (55 unit + 8 doc-tests + 6 JIT smoke tests).

--- a/code/packages/rust/brainfuck-iir-compiler/src/vm.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/src/vm.rs
@@ -38,8 +38,27 @@
 //!
 //! ## JIT mode (BF05)
 //!
-//! The `jit` flag is accepted but raises an error in BF04.  The JIT path
-//! (wiring `jit-core` + a WASM backend) is implemented in BF05.
+//! When `jit=true`, [`BrainfuckVM::execute_module`] dispatches through
+//! [`jit_core::core::JITCore`] instead of calling [`VMCore::execute`]
+//! directly.  Brainfuck IIR is `FullyTyped` from birth (see
+//! `compiler.rs`), so the JIT chain *would* eagerly tier-promote the
+//! `main` function to a native backend on the very first call — except
+//! none of the existing JIT backends (NullBackend, EchoBackend, future
+//! WASM/x86_64 backends) know how to lower Brainfuck's custom
+//! `load_mem` / `store_mem` opcodes yet.  Until a backend learns
+//! Brainfuck's tape memory model, we wire `JITCore` with the
+//! private [`InterpOnlyBackend`] (whose `compile()` always returns
+//! `None`), which forces every function to stay on the interpreter
+//! tier.  The plumbing is real — the same `VMCore` runs the program,
+//! the same `putchar` / `getchar` / `load_mem` / `store_mem` / `label`
+//! handlers are wired up, and the tier-up path is observable via
+//! `JITCore::cache_stats()` — there's just no native code generated
+//! today.
+//!
+//! That gives Brainfuck access to the LANG VM's JIT chain in the
+//! same shape as Dartmouth BASIC's `jit_smoke.rs`: any future backend
+//! that grows support for `load_mem` / `store_mem` automatically
+//! tier-promotes BF programs without touching this wrapper.
 //!
 //! ## Fuel cap
 //!
@@ -63,6 +82,9 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use interpreter_ir::module::IIRModule;
+use jit_core::backend::Backend;
+use jit_core::cir::CIRInstr;
+use jit_core::core::JITCore;
 use vm_core::{
     core::VMCore,
     dispatch::OpcodeHandler,
@@ -199,12 +221,6 @@ impl BrainfuckVM {
         module: &IIRModule,
         input_bytes: &[u8],
     ) -> Result<Vec<u8>, BrainfuckError> {
-        if self.jit_enabled {
-            return Err(BrainfuckError::new(
-                "jit=true is not yet supported in BF04; see BF05",
-            ));
-        }
-
         // Shared output buffer — written by `putchar`, returned at the end.
         // Capacity capped at MAX_OUTPUT_BYTES to prevent OOM.
         let output: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
@@ -358,14 +374,25 @@ impl BrainfuckVM {
         );
 
         // ---- Execute --------------------------------------------------
+        // The two execution paths share the same `VMCore` (with all five
+        // Brainfuck-specific handlers registered above).  The only difference
+        // is whether we drive that VM through `VMCore::execute` (pure
+        // interpreter) or `JITCore::execute_with_jit` (interpreter +
+        // tier-promotion hook).  See the JIT mode section in this module's
+        // top-level docs for why the JIT path uses `InterpOnlyBackend`.
         let mut module_clone = module.clone();
-        vm.execute(&mut module_clone, "main", &[])
-            .map_err(|e| {
-                // Translate VMError back to BrainfuckError for out-of-bounds
-                // and fuel-cap cases.
-                let msg = e.to_string();
-                BrainfuckError::new(msg)
-            })?;
+        let exec_result = if self.jit_enabled {
+            let mut jit = JITCore::new(&mut vm, Box::new(InterpOnlyBackend));
+            jit.execute_with_jit(&mut vm, &mut module_clone, "main", &[])
+                .map(|_| ())
+        } else {
+            vm.execute(&mut module_clone, "main", &[]).map(|_| ())
+        };
+        exec_result.map_err(|e| {
+            // Translate VMError back to BrainfuckError for out-of-bounds
+            // and fuel-cap cases (both paths surface VMError on failure).
+            BrainfuckError::new(e.to_string())
+        })?;
 
         // Recover from poisoned mutex on final read.
         let result = output.lock().unwrap_or_else(|e| e.into_inner()).clone();
@@ -448,6 +475,56 @@ fn resolve_value(
 }
 
 // ---------------------------------------------------------------------------
+// InterpOnlyBackend — pin BF on the interpreter tier of jit-core
+// ---------------------------------------------------------------------------
+
+/// A [`Backend`] that refuses to compile, forcing `JITCore` to fall back to
+/// the interpreter for every function.
+///
+/// # Why this exists
+///
+/// Brainfuck's IIR is `FullyTyped` from birth, which means
+/// [`JITCore::execute_with_jit`] would eagerly compile `main` on the first
+/// call (see Phase 1 in its docs).  That's normally good — but no current
+/// backend (NullBackend, EchoBackend, future WASM/x86_64 ports) knows how
+/// to lower Brainfuck's custom `load_mem` / `store_mem` opcodes.  Compiling
+/// with a backend that can't handle those would silently replace `main` with
+/// a stub that returns `Null`, producing no output.
+///
+/// Returning `None` from [`Backend::compile`] tells `JITCore`:
+///
+/// > "I refuse to compile this function — keep it interpreted forever."
+///
+/// All five Brainfuck-specific handlers (`putchar`, `getchar`, `load_mem`,
+/// `store_mem`, `label`) live on the underlying `VMCore`, so the interpreter
+/// path still works correctly.  When a future backend learns Brainfuck's
+/// tape memory model, swap this out for that backend and the same `BrainfuckVM`
+/// wrapper tier-promotes automatically.
+///
+/// # Why kept private
+///
+/// Out-of-crate callers should use `BrainfuckVM::new(jit, ...)`; this struct
+/// is an implementation detail of the JIT-mode wiring.
+struct InterpOnlyBackend;
+
+impl Backend for InterpOnlyBackend {
+    fn name(&self) -> &str {
+        "brainfuck-interp-only"
+    }
+
+    fn compile(&self, _ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        // Refusing to compile is the *point* — see the docs above.
+        None
+    }
+
+    fn run(&self, _binary: &[u8], _args: &[Value]) -> Value {
+        // Unreachable: `compile()` returns None, so `JITCore` never builds
+        // a cache entry and never calls `run()`.  Return Null defensively.
+        Value::Null
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -506,12 +583,38 @@ mod tests {
         }
     }
 
-    // --- JIT not yet supported ---
+    // --- JIT mode produces equivalent results to the interpreter ---
+    //
+    // Before BF05 these tests asserted that `jit=true` returned an error.
+    // After BF05 the JIT path is wired through `jit-core` with
+    // `InterpOnlyBackend`, so the program runs to completion via the
+    // interpreter tier and produces the same output as `jit=false`.
 
     #[test]
-    fn jit_true_returns_error_on_run() {
+    fn jit_true_runs_simple_program() {
+        // `+++.` should print chr(3) regardless of execution tier.
         let v = BrainfuckVM::new(true, 100, None).unwrap();
-        assert!(v.run("+", b"").is_err());
+        let out = v.run("+++.", b"").unwrap();
+        assert_eq!(out, vec![3u8]);
+    }
+
+    #[test]
+    fn jit_and_interp_paths_agree_on_hello_h() {
+        // Set cell[0] to 72 ('H') and print.  JIT and interpreter must agree.
+        let inc72 = "+".repeat(72);
+        let src = format!("{inc72}.");
+        let interp = BrainfuckVM::new(false, 100, None).unwrap().run(&src, b"").unwrap();
+        let jit    = BrainfuckVM::new(true,  100, None).unwrap().run(&src, b"").unwrap();
+        assert_eq!(interp, jit, "JIT path must produce identical output to interpreter");
+        assert_eq!(jit, vec![72u8]);
+    }
+
+    #[test]
+    fn jit_handles_loop_with_input() {
+        // `,[.,]` cat: read bytes and echo until EOF.
+        let v = BrainfuckVM::new(true, 30_000, Some(10_000)).unwrap();
+        let out = v.run(",[.,]", b"abc").unwrap();
+        assert_eq!(out, b"abc");
     }
 
     // --- Simple execution ---

--- a/code/packages/rust/brainfuck-iir-compiler/tests/jit_smoke.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/tests/jit_smoke.rs
@@ -1,0 +1,158 @@
+//! JIT smoke test — prove a Brainfuck program executes correctly when
+//! dispatched through the LANG VM's JIT chain (`vm-core` + `jit-core`)
+//! rather than through `VMCore::execute` directly.
+//!
+//! ## What this actually proves
+//!
+//! These tests run BF programs through [`BrainfuckVM`] with `jit=true`,
+//! which routes the run through
+//! [`jit_core::core::JITCore::execute_with_jit`].  The wrapper supplies an
+//! `InterpOnlyBackend` (see `src/vm.rs`) so no native code is generated
+//! yet — Brainfuck's `load_mem` / `store_mem` opcodes have no native
+//! lowering in any current backend (NullBackend, EchoBackend, future
+//! WASM/x86_64).  The point of the smoke test is to lock in the
+//! *wiring*: when a future backend learns BF's memory model, swapping
+//! the backend in the wrapper is the only change needed for tier
+//! promotion to kick in.
+//!
+//! Each test runs the same source twice — once with `jit=false` (pure
+//! interpreter) and once with `jit=true` (JIT chain) — and asserts the
+//! outputs are byte-identical.  If they ever diverge, the JIT wiring is
+//! broken regardless of whether anyone reads the output.
+//!
+//! ## Pipeline exercised
+//!
+//! ```text
+//! Brainfuck source
+//!     │
+//!     ▼ brainfuck-iir-compiler::compile_source
+//! IIRModule (FullyTyped)
+//!     │
+//!     ▼ JITCore::execute_with_jit
+//!   • Phase 1: try to compile FullyTyped fns via InterpOnlyBackend → None
+//!     (no native handlers installed)
+//!   • Phase 2: vm-core interprets `main`, firing the registered
+//!     putchar / getchar / load_mem / store_mem / label handlers
+//!   • Phase 3: promote_hot_functions (no-op — InterpOnlyBackend refuses)
+//!     │
+//!     ▼ collected stdout
+//! Vec<u8>
+//! ```
+
+use brainfuck_iir_compiler::BrainfuckVM;
+
+/// Run `src` through both execution paths and assert they agree.
+/// Returns the (interpreter, jit) byte vectors so the caller can also
+/// assert the exact expected bytes.
+fn run_both(src: &str, input: &[u8], tape_size: usize, max_steps: Option<u64>)
+    -> (Vec<u8>, Vec<u8>)
+{
+    let interp = BrainfuckVM::new(false, tape_size, max_steps).unwrap()
+        .run(src, input).unwrap();
+    let jit    = BrainfuckVM::new(true,  tape_size, max_steps).unwrap()
+        .run(src, input).unwrap();
+    assert_eq!(
+        interp, jit,
+        "JIT path must produce identical output to the interpreter\n\
+         interpreter: {interp:?}\njit:         {jit:?}\nsource:      {src:?}",
+    );
+    (interp, jit)
+}
+
+// ---------------------------------------------------------------------------
+// Trivial smoke: `+++.` → chr(3)
+// ---------------------------------------------------------------------------
+
+/// `+++.` increments cell[0] three times and prints it.  The smallest
+/// program that exercises `store_mem`, `load_mem`, and `call_builtin
+/// "putchar"` together.
+#[test]
+fn jit_brainfuck_three_increments_print() {
+    let (_, jit) = run_both("+++.", b"", 100, None);
+    assert_eq!(jit, vec![3u8],
+        "expected [3] from `+++.`, got {jit:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Pointer arithmetic: cell[1]=1, move back, read cell[0]=0 → print 0
+// ---------------------------------------------------------------------------
+
+/// `>+<.` moves right, increments cell[1], moves back, prints cell[0].
+/// Exercises the data-pointer arithmetic in `load_mem` / `store_mem`.
+#[test]
+fn jit_brainfuck_pointer_arithmetic() {
+    let (_, jit) = run_both(">+<.", b"", 100, None);
+    assert_eq!(jit, vec![0u8],
+        "expected [0] from `>+<.`, got {jit:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Loop + input: classic `cat` until EOF
+// ---------------------------------------------------------------------------
+
+/// `,[.,]` reads a byte and echoes it until EOF.  Exercises:
+/// - `call_builtin "getchar"`  (input)
+/// - `call_builtin "putchar"`  (output)
+/// - `jmp_if_false` / `jmp` / `label` (the canonical BF loop shape)
+/// - The `label`-crossings fuel cap (must not falsely fire on a
+///   short input).
+#[test]
+fn jit_brainfuck_cat_with_input() {
+    let (_, jit) = run_both(",[.,]", b"hello", 30_000, Some(10_000));
+    assert_eq!(jit, b"hello",
+        "expected `hello` echoed back, got {jit:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Nested loop arithmetic: cell[0]=2, cell[1]=3, multiply into cell[2]=6
+// ---------------------------------------------------------------------------
+
+/// Multiplication by repeated addition: `cell[0] * cell[1] → cell[2]`.
+/// A classic BF idiom that exercises nested loops, multiple cells, and
+/// data movement.  Setup: cell[0]=2, cell[1]=3, then the loop runs
+/// `cell[0]` times, adding `cell[1]` to `cell[2]` each iteration (and
+/// restoring cell[1] from cell[3]).  Finally prints `cell[2]` (= 6).
+///
+/// Source breakdown:
+/// - `++>+++<`              cell[0]=2, cell[1]=3, return to cell[0]
+/// - `[`                   outer loop while cell[0] != 0
+/// -   `>[->+>+<<]`        cell[1] → cell[2]+cell[3], cell[1]=0
+/// -   `>>[-<<+>>]`        cell[3] → cell[1]
+/// -   `<<<-`              cell[0] -= 1
+/// - `]`                   end outer loop
+/// - `>>.`                  move to cell[2] and print
+#[test]
+fn jit_brainfuck_multiply_2_times_3() {
+    let src = "++>+++<[>[->+>+<<]>>[-<<+>>]<<<-]>>.";
+    let (interp, jit) = run_both(src, b"", 30_000, Some(100_000));
+    assert_eq!(jit, vec![6u8],
+        "expected [6] from 2*3, got jit={jit:?} interp={interp:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Wrap-around: 0 - 1 == 255 under u8 semantics
+// ---------------------------------------------------------------------------
+
+/// `-.` decrements cell[0] (from 0 to 255 with u8 wraparound) and prints.
+/// Confirms the JIT path inherits the `VMCore::with_u8_wrap` semantics
+/// configured by the wrapper.
+#[test]
+fn jit_brainfuck_u8_wraparound() {
+    let (_, jit) = run_both("-.", b"", 100, None);
+    assert_eq!(jit, vec![255u8],
+        "expected [255] from `-.` with u8 wraparound, got {jit:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Multiple prints in sequence
+// ---------------------------------------------------------------------------
+
+/// `+.++.+++.` prints 1, 3, 6 — three separate `putchar` calls
+/// interleaved with arithmetic.  Confirms the JIT chain doesn't
+/// accidentally batch or reorder I/O.
+#[test]
+fn jit_brainfuck_multiple_outputs() {
+    let (_, jit) = run_both("+.++.+++.", b"", 100, None);
+    assert_eq!(jit, vec![1u8, 3u8, 6u8],
+        "expected [1,3,6] from `+.++.+++.`, got {jit:?}");
+}


### PR DESCRIPTION
## Summary

- `BrainfuckVM::execute_module` now dispatches through `jit_core::core::JITCore::execute_with_jit` when constructed with `jit=true`, replacing the BF04 early-error.
- Brainfuck programs now run through the full LANG VM JIT chain (`vm-core` + `jit-core`) — same wiring shape Dartmouth BASIC got in PR #3888.
- Adds a private `InterpOnlyBackend` (its `compile()` returns `None`) that pins every function on the interpreter tier, because no current backend can lower BF's custom `load_mem` / `store_mem` opcodes.  When a future backend learns BF's tape memory model, swapping it in is the only change needed for tier promotion to kick in.
- 6 new JIT smoke tests + 3 new unit tests confirm byte-identical output between the JIT path and the pure-interpreter path.

## Why this matters

Brainfuck's IIR has been `FullyTyped` from birth since BF04 — every instruction carries a concrete `type_hint`.  That made it *more* JIT-ready than BASIC, which has Untyped IIR.  But the BF04 wrapper rejected `jit=true` with `"jit=true is not yet supported in BF04; see BF05"`.  This is BF05: the wiring lands.

The caveat (also spelled out in CHANGELOG and README): no native code is generated today.  The point of the smoke test is to lock in the wiring so a future backend (WASM with memory ops, an x86_64 backend that grows `load_mem`/`store_mem` lowering) tier-promotes BF programs without touching this wrapper.

## What's now demonstrated

After this PR, the LANG VM JIT chain has been driven end-to-end for:

| Frontend | JIT smoke test |
|---|---|
| Dartmouth BASIC | `dartmouth-basic-iir-compiler/tests/jit_smoke.rs` (4 tests) |
| Brainfuck       | `brainfuck-iir-compiler/tests/jit_smoke.rs` (6 tests, **NEW**) |

(Oct and Nib could be added next — both already produce IIR that vm-core happily interprets.)

## Test plan

- [x] `cargo test -p brainfuck-iir-compiler --tests` — 55 unit + 6 JIT smoke pass
- [x] `cargo test -p brainfuck-iir-compiler --doc` — 8 doc-tests pass
- [x] `cargo build -p brainfuck-iir-compiler` — clean
- [x] `/security-review` passed (read-only diff review by sub-agent)
- [ ] CI green across macOS/Ubuntu/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)