### PR TITLE
feat(ruby-parser): Phase 6d — array `[a, b]` and hash `{a: 1}` literals

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -39,4 +39,7 @@ method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPA
 expression_stmt = expression ;
 expression   = term { ( PLUS | MINUS ) term } ;
 term         = factor { ( STAR | SLASH ) factor } ;
-factor       = NUMBER | STRING | NAME | KEYWORD | LPAREN expression RPAREN ;
+factor       = NUMBER | STRING | NAME | KEYWORD | array_literal | hash_literal | LPAREN expression RPAREN ;
+array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET ;
+hash_literal = LBRACE [ hash_entry { COMMA hash_entry } ] RBRACE ;
+hash_entry   = NAME COLON expression | expression "=>" expression ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.5.0] - 2026-05-20
+
+### Added (Phase 6d — array and hash literals)
+- `array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET`
+- `hash_literal  = LBRACE [ hash_entry { COMMA hash_entry } ] RBRACE`
+- `hash_entry    = NAME COLON expression | expression "=>" expression`
+- `factor` now accepts `array_literal` and `hash_literal` as alternatives, so they can appear anywhere an expression is valid.
+
+### Tests (+4 new, total 21)
+- Array literal `[1, 2, 3]`, empty array `[]`, hash shorthand `{a: 1, b: 2}`, hash rocket `{a => 1}`.
+
 ## [0.4.0] - 2026-05-20
 
 ### Added (Phase 6c — `while … end` / `until … end` loops)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -209,6 +209,8 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                GrammarElement::RuleReference { name: r#"array_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"hash_literal"#.to_string() },
                 GrammarElement::Sequence { elements: vec![
                     GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
@@ -216,6 +218,52 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
             ] },
             line_number: 42,
+        },
+        GrammarRule {
+            name: r#"array_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                            ] }) },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 43,
+        },
+        GrammarRule {
+            name: r#"hash_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"hash_entry"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"hash_entry"#.to_string() },
+                            ] }) },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 44,
+        },
+        GrammarRule {
+            name: r#"hash_entry"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                    GrammarElement::Literal { value: r#"=>"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                ] },
+            ] },
+            line_number: 45,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -321,5 +321,69 @@ mod tests {
         let ast = parse_ruby("while x\nend");
         assert!(find_statement_inner(&ast, "while_statement").is_some());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6d — array and hash literals
+    // -----------------------------------------------------------------------
+
+    /// Walk the AST looking for the first node whose rule_name matches.
+    fn find_descendant<'a>(
+        node: &'a GrammarASTNode,
+        rule: &str,
+    ) -> Option<&'a GrammarASTNode> {
+        for c in &node.children {
+            if let ASTNodeOrToken::Node(n) = c {
+                if n.rule_name == rule {
+                    return Some(n);
+                }
+                if let Some(found) = find_descendant(n, rule) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_parse_array_literal() {
+        let ast = parse_ruby("x = [1, 2, 3]");
+        let arr = find_descendant(&ast, "array_literal")
+            .expect("expected array_literal");
+        // Each element is an `expression` subnode.
+        let elem_count = arr
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression"))
+            .count();
+        assert_eq!(elem_count, 3);
+    }
+
+    #[test]
+    fn test_parse_empty_array_literal() {
+        let ast = parse_ruby("x = []");
+        assert!(find_descendant(&ast, "array_literal").is_some());
+    }
+
+    #[test]
+    fn test_parse_hash_literal_shorthand() {
+        let ast = parse_ruby("x = {a: 1, b: 2}");
+        let h = find_descendant(&ast, "hash_literal").expect("expected hash_literal");
+        let entry_count = h
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "hash_entry"))
+            .count();
+        assert_eq!(entry_count, 2);
+    }
+
+    #[test]
+    fn test_parse_hash_literal_rocket() {
+        let ast = parse_ruby("x = {a => 1}");
+        let h = find_descendant(&ast, "hash_literal").expect("expected hash_literal");
+        assert!(
+            find_descendant(h, "hash_entry").is_some(),
+            "expected hash_entry subnode"
+        );
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.5.0] - 2026-05-20
+
+### Added (Phase 6d — array and hash literal lowering)
+- `lower_array_literal` — `[a, b, c]` → `Expr::SeqLit` with all element expressions lowered recursively.
+- `lower_hash_literal` — `{a: 1, b => 2}` → `Expr::MapLit { entries }`.
+- `lower_hash_entry` handles both syntactic forms:
+  - **Shorthand** (`NAME COLON expression`) — the Name becomes a `SymLit` key (sugar for `:name =>`).
+  - **Hash-rocket** (`expression "=>" expression`) — both sides are lowered as ordinary expressions.
+- `lower_expression` now dispatches `array_literal` and `hash_literal` rule nodes alongside `expression`/`term`/`factor`.
+- Feature tracking extended: `Sequences` declared on SeqLit, `Maps` on MapLit, `Symbols` on the shorthand hash-entry key.
+
+### Tests (+4 new, total 26)
+- `[1, 2, 3]` → `SeqLit` with three items.
+- `[]` → empty `SeqLit`.
+- `{a: 1, b: 2}` → `MapLit` with two entries whose keys are `SymLit("a")` and `SymLit("b")`.
+- Combined array+hash module passes `semantic_ir::validate` (feature manifests align exactly).
+
 ## [0.4.0] - 2026-05-20
 
 ### Added (Phase 6c — `while … end` / `until … end` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -460,6 +460,66 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Phase 6d — array `[a, b, c]` and hash `{a: 1, b => 2}` literals.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn array_literal_lowers_to_seq_lit() {
+        let m = lower("x = [1, 2, 3]\n");
+        let main = main_body(&m);
+        let arr = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value: Expr::SeqLit { items, .. }, .. } => Some(items),
+            _ => None,
+        }).expect("expected SeqLit");
+        assert_eq!(arr.len(), 3);
+        assert!(matches!(arr[0], Expr::IntLit { value: 1, .. }));
+    }
+
+    #[test]
+    fn empty_array_literal_lowers_to_empty_seq_lit() {
+        let m = lower("x = []\n");
+        let main = main_body(&m);
+        let arr = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value: Expr::SeqLit { items, .. }, .. } => Some(items),
+            _ => None,
+        }).expect("expected SeqLit");
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn hash_shorthand_lowers_to_map_lit_with_sym_keys() {
+        let m = lower("x = {a: 1, b: 2}\n");
+        let main = main_body(&m);
+        let entries = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::LetBinding { value: Expr::MapLit { entries, .. }, .. } => Some(entries),
+                _ => None,
+            })
+            .expect("expected MapLit");
+        assert_eq!(entries.len(), 2);
+        // Keys should be SymLit("a") and SymLit("b").
+        assert!(
+            matches!(&entries[0].key, Expr::SymLit { name, .. } if name == "a")
+        );
+        assert!(
+            matches!(&entries[1].key, Expr::SymLit { name, .. } if name == "b")
+        );
+    }
+
+    #[test]
+    fn array_and_hash_modules_pass_sir_validator() {
+        let m = lower("x = [1, 2]\ny = {a: 1}\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn module_with_def_passes_sir_validator() {
         // v0 grammar can't yet parse nested method calls in args

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -104,6 +104,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         Feature::DynamicTyping,
         Feature::MutableBindings,
         Feature::Loops,
+        Feature::Sequences,
+        Feature::Maps,
+        Feature::Symbols,
         Feature::Closures,
     ] {
         if lw.features_used.contains(&f) {
@@ -803,6 +806,8 @@ impl Lowerer {
             "expression" => self.lower_binary_chain(node, &["PLUS", "MINUS"]),
             "term" => self.lower_binary_chain(node, &["STAR", "SLASH"]),
             "factor" => self.lower_factor(node),
+            "array_literal" => self.lower_array_literal(node),
+            "hash_literal" => self.lower_hash_literal(node),
             // The parser sometimes wraps a bare token into an "expression_stmt"
             // when reached as the RHS of an assignment.  Recurse into it.
             "expression_stmt" => {
@@ -880,6 +885,105 @@ impl Lowerer {
     }
 
     /// Lower a `factor` node — the leaves of the expression tree.
+    /// Phase 6d — `[a, b, c]` → `Expr::SeqLit`.
+    fn lower_array_literal(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let items: Vec<Expr> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .map(|n| self.lower_expression(n))
+            .collect::<Result<Vec<_>, _>>()?;
+        // SIR's SeqLit allocates a runtime list — declare the
+        // `sequences` feature so the validator accepts it.
+        self.features_used.insert(Feature::Sequences);
+        Ok(Expr::SeqLit {
+            items,
+            span: self.span_of(node),
+        })
+    }
+
+    /// Phase 6d — `{a: 1, b => 2}` → `Expr::MapLit`.  Both the
+    /// `NAME COLON expression` shorthand and the `expression => expression`
+    /// hash-rocket form lower to the same node — the key becomes a
+    /// `SymLit` for the shorthand (since `a:` is sugar for `:a =>`)
+    /// or whatever the LHS expression evaluates to for the rocket
+    /// form.
+    fn lower_hash_literal(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let entry_nodes: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "hash_entry" => Some(n),
+                _ => None,
+            })
+            .collect();
+        let mut entries: Vec<semantic_ir::nodes::MapEntry> = Vec::with_capacity(entry_nodes.len());
+        for ent in &entry_nodes {
+            entries.push(self.lower_hash_entry(ent)?);
+        }
+        self.features_used.insert(Feature::Maps);
+        Ok(Expr::MapLit {
+            entries,
+            span: self.span_of(node),
+        })
+    }
+
+    fn lower_hash_entry(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<semantic_ir::nodes::MapEntry, RubyLowerError> {
+        // Two shapes are possible:
+        //   1. `NAME COLON expression` — shorthand.  The Name token
+        //      is the symbol key.
+        //   2. `expression "=>" expression` — hash-rocket.  Two
+        //      `expression` rule children.
+        let expression_subnodes: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .collect();
+        if expression_subnodes.len() == 2 {
+            // Rocket form.
+            let key = self.lower_expression(expression_subnodes[0])?;
+            let value = self.lower_expression(expression_subnodes[1])?;
+            return Ok(semantic_ir::nodes::MapEntry { key, value });
+        }
+        // Shorthand form — find the leading Name token.
+        let key_tok = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+            _ => None,
+        });
+        let key_tok = key_tok.ok_or_else(|| RubyLowerError {
+            message: "hash_entry missing key Name token".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })?;
+        let key = Expr::SymLit {
+            name: key_tok.value.clone(),
+            span: self.span_of_token(key_tok),
+        };
+        self.features_used.insert(Feature::Symbols);
+        let value_node = expression_subnodes.first().ok_or_else(|| RubyLowerError {
+            message: "hash_entry shorthand missing value expression".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })?;
+        let value = self.lower_expression(value_node)?;
+        Ok(semantic_ir::nodes::MapEntry { key, value })
+    }
+
     fn lower_factor(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // factor ::= NUMBER | STRING | NAME | KEYWORD | LPAREN expression RPAREN
         for child in &node.children {


### PR DESCRIPTION
## Summary

Fourth parser-grammar extension.  Adds Ruby's container literals to the grammar and lowers them to `semantic_ir::Expr::SeqLit` / `Expr::MapLit`.

## Parser

\`\`\`
array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET
hash_literal  = LBRACE [ hash_entry { COMMA hash_entry } ] RBRACE
hash_entry    = NAME COLON expression
              | expression "=>" expression
\`\`\`

Both literals are added as alternatives in `factor`.

## SIR lowering

- `Expr::SeqLit` for arrays (declares `Feature::Sequences`).
- `Expr::MapLit` for hashes (declares `Feature::Maps`).
- Hash-entry shorthand `NAME COLON expression` produces a `SymLit` key (sugar for `:name =>`, declares `Feature::Symbols`).
- Hash-rocket `expression "=>" expression` lowers both sides as ordinary expressions.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — 103 passed (unchanged).
- [x] `cargo test -p coding-adventures-ruby-parser` — 21 passed (was 17; +4 new).
- [x] `cargo test -p ruby-to-semantic-ir` — 26 passed (was 22; +4 new, including validator pass).

## What's next

Last merged was [Phase 4e lexer](https://github.com/adhithyan15/coding-adventures/pull/3902); this is parser.  Next: Phase 4f — 2.1 numeric suffixes `r`/`i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)