### PR TITLE
feat(forme-doc-search-client-js): DOC00 v0 browser search client logic

### DIFF
--- a/code/packages/typescript/forme-doc-search-client-js/BUILD
+++ b/code/packages/typescript/forme-doc-search-client-js/BUILD
@@ -1,0 +1,3 @@
+cd ../forme-doc-search-tokenizer && npm ci --quiet
+cd ../forme-doc-search-index-builder && npm ci --quiet
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-doc-search-client-js/CHANGELOG.md
+++ b/code/packages/typescript/forme-doc-search-client-js/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog — @coding-adventures/forme-doc-search-client-js
+
+## 0.1.0 — 2026-05-22
+
+Initial release.  Tenth concrete DOC00 v0 package —
+browser-side search client logic.  Consumes the manifest from
+`forme-doc-search-index-builder` plus an INJECTED shard-fetcher
+callback; loads shards on demand, tokenises queries via
+`forme-doc-search-tokenizer`, merges postings, ranks results.
+
+Pure transform / class.  Capabilities: `[]`.  The shard-fetcher
+capability (`net:fetch` in the browser, `fs:read` on Node) lives
+with the CALLER — this package itself never instantiates any
+I/O primitive.
+
+### Added
+
+- `SearchClient` class.  Constructor takes
+  `{ manifest, fetchShard, maxCachedShards?, titleBoost? }`.
+- `client.search(query, options?): Promise<SearchResult[]>` —
+  the main entry.
+- `client.prefetchShards(keys): Promise<void>` — pre-warm the
+  cache.
+- `client.clearCache(): void` — empty the cache.
+- `client.cacheSize: number` — getter for the current cache size.
+- Types: `ShardFetcher`, `SearchClientOptions`,
+  `SearchQueryOptions`, `SearchResult`.
+
+### Spec adherence
+
+Implements DOC00 v0's `forme-doc-search-client-js` per
+`code/specs/DOC00-docs-vision.md` — browser-side search client
+that loads the manifest at boot, fetches shards on-demand,
+runs the query through the same tokeniser pipeline, returns
+ranked results.
+
+Decision: ship as a PURE LIBRARY with an INJECTED fetcher
+rather than a self-contained browser bundle.  The browser-side
+glue (script tag, IIFE wrapper, fetch wrapper) belongs in
+`forme-doc-site-emitter` / `forme-aot-page-bundle-emitter`,
+not here.  Keeping the fetcher injected makes the class
+trivially testable (in-memory mock) and reusable in non-browser
+contexts.
+
+### Behavioural notes
+
+- **Pure transform / class.**  No global state; no I/O
+  primitives instantiated; no `eval`.
+- **Capability `[]`.**  The shard-fetcher capability lives
+  with the caller.  This package only ever calls the
+  user-supplied callback.
+- **Manifest-driven tokenisation.**  Client tokenises queries
+  using the manifest's `filterStopWords` and `stem` flags —
+  so client and index agree without the caller needing to
+  pass them twice.
+- **LRU shard cache.**  Default `maxCachedShards = 50`.
+  Implemented via Map insertion-order: every `.get()` does
+  `delete-then-insert` to refresh recency; eviction removes
+  the iterator's first entry.
+- **In-flight deduplication.**  Concurrent searches for the
+  same shard share one Promise — no duplicate network requests.
+- **Degrade gracefully.**  If `fetchShard` rejects or returns
+  a malformed shape, the client skips that shard.  Search
+  continues with whatever other shards loaded successfully.
+- **Deterministic** for a fixed manifest + shard set.
+
+### Ranking (v0)
+
+Simple sum-of-(freq × titleBoost-when-titleHit) per page.
+No TF-IDF, no BM25, no recency boost.  v1 may add weighting
+schemes; v0 surfaces only the raw inputs.  Tied scores break
+alphabetically by `pageId`.
+
+### Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver** —
+  pure data manipulation; the caller's `fetchShard` is
+  responsible for deserialisation.
+- **No I/O primitives instantiated.**  Capabilities `[]`.
+- **Numeric option validation at construction** —
+  `maxCachedShards` and `titleBoost` checked with
+  `Number.isFinite`; NaN/Infinity/negative throws.  Same for
+  `limit` at search time.
+- **Bounded memory** via LRU cache cap.
+- **No prototype pollution** — all `Map<string, *>` lookups use
+  internal slots; pageId/shardKey treated as opaque strings.
+- **Malformed-shard guard** — `isLikelyShard` verifies basic
+  shape; a malformed response is treated as a fetch failure
+  (no type-confusion at use site).
+- **Deterministic comparator** with total ordering — defensive
+  `return 0` for impossible (same pageId twice in scores) case
+  marked `/* v8 ignore */`.
+
+### Tests
+
+32 tests in `client.test.ts`:
+
+- Construction (happy + 4 invalid-option-type throws).
+- Basic search (matching page, title boost, multi-token
+  accumulation, matchedTokens).
+- Empty results (empty query, all-stop-words, no-shard match,
+  shard match but no token match).
+- Limit option (default 20, custom, < 0 throws, NaN throws).
+- Caching (caches, LRU evicts, clearCache, prefetchShards
+  warms, prefetch unknown skipped).
+- In-flight dedup (concurrent searches share fetch).
+- Graceful failure (rejecting fetcher → empty results, malformed
+  shard → treated as missing, partial failure → partial results).
+- Ranking (freq → score, custom titleBoost, tied → alphabetical).
+- Index/query option consistency (manifest's filterStopWords
+  and stem flags honoured).
+- Realistic 5-page docs query.
+
+Coverage: **99.3% line / 94.4% branch / 100% function** across
+all source files with logic (`types.ts` is type-only).  The
+remaining branch is a defensive `return 0` in the result
+comparator marked `/* v8 ignore */`.
+
+### v0 simplifications (documented)
+
+- **No fuzzy matching** — exact-token match only.
+- **No query syntax** (`+`/`-`/`"..."`/field-specific).
+- **No incremental streaming** — single Promise per `.search()`.
+- **No "instant search" / debouncing** — caller's UI concern.
+- **No analytics** — left to v1+.
+- **No result highlighting** — `matchedTokens` is surfaced;
+  the caller does the actual HTML markup.

--- a/code/packages/typescript/forme-doc-search-client-js/README.md
+++ b/code/packages/typescript/forme-doc-search-client-js/README.md
@@ -1,0 +1,227 @@
+# @coding-adventures/forme-doc-search-client-js
+
+> Tenth DOC00 v0 package — browser-side search client logic.
+> Consumes the manifest from `forme-doc-search-index-builder`
+> plus an injected shard-fetcher callback; loads shards on
+> demand, tokenises queries, merges postings, ranks results.
+
+Pure transform. Capabilities: `[]`. The shard-fetcher
+capability (`net:fetch` in the browser, `fs:read` on Node) lives
+with the **caller** — this package itself never instantiates
+any I/O primitive.
+
+## What it does
+
+```ts
+import { SearchClient } from "@coding-adventures/forme-doc-search-client-js";
+
+// Caller injects fetch — capability lives with them, not us.
+const client = new SearchClient({
+  manifest,                                 // from build-time index-builder
+  fetchShard: async (key) => {
+    const r = await fetch(`/search/${key}.json`);
+    return await r.json();
+  },
+});
+
+const results = await client.search("install");
+// → [
+//     { pageId: "/guide/setup", score: 4, matchedTokens: ["instal"] },
+//     { pageId: "/intro",       score: 2, matchedTokens: ["instal"] },
+//   ]
+```
+
+## Why injected fetch?
+
+The standard advice "to do a network request, call `fetch()`" is
+fine for app code. For a **library** in this repo's
+capability-system, it would force the library to declare
+`net:fetch` — which would then cascade as a required capability
+into every consumer of the search client.
+
+By injecting the fetcher, this package stays `[]`. The browser
+caller (and only the browser caller) deals with `net:fetch`. A
+Node-side caller can use `fs.readFile` instead. A unit-test
+caller can use an in-memory map. Same code, different fetchers.
+
+## Capability flow
+
+```
+Browser app code        ── has net:fetch ──┐
+                                            ▼
+                                  forme-aot-page-bundle-emitter
+                                            ▼
+                                       <script> wrapper
+                                            ▼
+                            new SearchClient({ fetchShard: fetch-wrapper, ... })
+                                            ▼
+                                     SearchClient class ── capability [] ──┐
+                                            ▼                              │
+                                    .search(query) ────────────────────────┘
+```
+
+The arrow into `SearchClient` is the capability boundary. The
+class itself is pure.
+
+## Lifecycle
+
+```
+construct  →  manifest in memory; no shards loaded.
+.search(q) →  tokenise q (using manifest.filterStopWords and
+              manifest.stem so client tokens match the index);
+              for each unique query token:
+                derive shardKey via token.slice(0, manifest.shardPrefix);
+                if shard cached, look up;
+                else if shard key is in manifest.shardKeys:
+                  call fetchShard(shardKey), cache (LRU);
+                else (shard key not in manifest), skip;
+                look up postings, accumulate score per pageId
+                  (score += freq * (titleHit ? titleBoost : 1));
+              sort pageIds desc by score (ascending pageId tiebreak);
+              return top `limit`.
+```
+
+## Public API
+
+| Export                  | Purpose                                                                  |
+|-------------------------|--------------------------------------------------------------------------|
+| `SearchClient`          | Main class. `new SearchClient({ manifest, fetchShard, ... })`.            |
+| `client.search(q, opts?)` | Run a query.  Returns `SearchResult[]`.                                  |
+| `client.prefetchShards(keys)` | Pre-warm the cache.                                                |
+| `client.clearCache()`   | Empty the cache.                                                          |
+| `client.cacheSize`      | Current cache size (read-only).                                           |
+| Types                   | `ShardFetcher`, `SearchClientOptions`, `SearchQueryOptions`, `SearchResult`. |
+
+## Ranking (v0)
+
+Simple and predictable:
+
+```
+score(page) = Σ over matched query tokens:
+                postings[token][page].freq × (titleHit ? titleBoost : 1)
+```
+
+- `titleBoost` default: `2.0` — title matches count double.
+- No TF-IDF, no BM25, no recency boost. v1 may add weighting
+  schemes; v0 surfaces only the inputs (`freq` + `titleHit`).
+- Tied scores break alphabetically by `pageId`.
+
+## LRU cache
+
+- Default `maxCachedShards = 50` (most sites have fewer
+  shards than this; sites with more get LRU eviction).
+- Cache is implemented as a `Map` — JS's insertion-order
+  iteration doubles as LRU recency: every `.get()` does
+  `delete-then-insert` to mark the entry as most-recently-used.
+- Eviction removes the iterator's first (oldest) entry.
+
+## Degrade gracefully
+
+If `fetchShard` rejects (network error, 404, bad JSON, etc.) or
+returns a malformed shape, the client **skips that shard**.
+Search continues with whatever other shards loaded
+successfully. A single broken shard doesn't blank out an
+entire search session.
+
+Callers wanting visibility into failures should wrap their own
+`fetchShard` with logging/reporting before re-throwing.
+
+## In-flight deduplication
+
+Two concurrent `.search()` calls that both need shard `"in"`
+share **one** outstanding fetch (via the `inflight` map).
+Duplicate network requests for the same shard never fire.
+
+## Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver.**
+  Pure data manipulation; the caller's `fetchShard` is
+  responsible for deserialisation.
+- **No I/O primitives instantiated.** This is the whole point
+  of the injected-fetcher pattern. Capabilities `[]`.
+- **Numeric option validation at construction** — `maxCachedShards`
+  and `titleBoost` are checked with `Number.isFinite`; NaN /
+  Infinity / negative values throw immediately. Same for
+  `limit` at search time.
+- **Bounded memory.** LRU cap prevents the cache from growing
+  unboundedly even on adversarial input.
+- **No prototype pollution.** All `Map<string, *>` lookups use
+  internal slots (not bracket-notation on plain objects);
+  pageId / shardKey values are treated as opaque strings.
+- **Malformed-shard guard.** Returning the wrong shape from
+  `fetchShard` is treated as a fetch failure (caller's bug
+  fails closed, not via type-confusion at use site).
+- **Deterministic** for a fixed manifest + shard set — same
+  query gives the same ranked output, modulo fetcher latency
+  which only affects ordering of concurrent fetches not
+  search results themselves.
+
+## Tests
+
+32 tests in `client.test.ts`:
+
+- **Construction** — happy path, `maxCachedShards` < 1 / NaN
+  throws, `titleBoost` negative / NaN throws.
+- **Basic search** — matching page, title boost, multi-token
+  score accumulation, `matchedTokens` populated.
+- **Empty results** — empty query, all-stop-words query,
+  query matching no shards, query matching shard but no token.
+- **Limit option** — default 20, custom limit honoured, < 0
+  throws, NaN throws.
+- **Caching** — caches fetched shards, LRU evicts at cap,
+  `clearCache` empties, `prefetchShards` warms, unknown shard
+  keys silently skipped.
+- **In-flight dedup** — concurrent searches for same shard
+  share fetch.
+- **Graceful failure** — rejecting fetcher → empty results
+  (no throw), malformed shard treated as missing, partial
+  failure → partial results.
+- **Ranking** — higher freq → higher score, custom
+  `titleBoost` overrides default, tied scores alphabetical
+  pageId tiebreak.
+- **Index/query option consistency** — uses manifest's
+  `filterStopWords` and `stem` flags so client and index
+  agree.
+- **Realistic** — typical 5-page docs query.
+
+Coverage: **99.3% line / 94.4% branch / 100% function** on all
+source files with logic (`types.ts` is type-only). The
+remaining branch is a defensive `return 0` in the result
+comparator marked `/* v8 ignore */` — unreachable because
+pageIds are unique within the score accumulator.
+
+## How it fits in the stack
+
+Tenth concrete DOC00 v0 package. Sits at runtime in the
+browser, consuming both the tokeniser (for query
+normalisation) and the index builder (for type shapes only —
+the actual index data arrives at runtime via `fetchShard`):
+
+```
+build time                      runtime (browser)
+────────────────────             ───────────────────────
+search-index-builder          ┌─►  manifest.json  ──►   SearchClient (this package)
+        │                     │                              │
+        ▼                     │                              │
+   shards/*.json   ◄──────────┘    user query  ──────────────┤
+                                                             ▼
+                                               results UI (consumer)
+```
+
+Final DOC00 v0 package: `forme-doc-site-emitter` (writes shards
+to disk and wires the SearchClient into the page-shell's
+search input).
+
+## v0 simplifications (documented)
+
+- **No fuzzy matching** — exact-token match only. Typo
+  tolerance (Levenshtein distance, etc.) is left to v1.
+- **No query syntax** — no `+`, `-`, `"..."`, field-specific
+  searches. Just whitespace-separated keywords.
+- **No incremental result streaming** — `.search()` returns a
+  single Promise resolving with the full result list.
+- **No "instant search" / debouncing** — caller's UI concern.
+- **No analytics / popular-queries tracking** — caller's
+  concern; v1+ may add a privacy-preserving variant.
+- **No search-result highlighting** — `matchedTokens` is
+  surfaced but the caller does the actual HTML markup.

--- a/code/packages/typescript/forme-doc-search-client-js/package-lock.json
+++ b/code/packages/typescript/forme-doc-search-client-js/package-lock.json
@@ -1,0 +1,2334 @@
+{
+  "name": "@coding-adventures/forme-doc-search-client-js",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-doc-search-client-js",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-doc-search-index-builder": "file:../forme-doc-search-index-builder",
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-doc-search-index-builder": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-doc-search-tokenizer": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-doc-search-index-builder": {
+      "resolved": "../forme-doc-search-index-builder",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-search-tokenizer": {
+      "resolved": "../forme-doc-search-tokenizer",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-doc-search-client-js/package.json
+++ b/code/packages/typescript/forme-doc-search-client-js/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@coding-adventures/forme-doc-search-client-js",
+  "version": "0.1.0",
+  "description": "Browser-side search client logic for the documentation-site search.  Consumes the manifest from forme-doc-search-index-builder + an INJECTED shard-fetcher callback; loads shards on demand, tokenises queries via forme-doc-search-tokenizer (must match index-time options), merges postings, ranks results.  Pure transform; capabilities []; the shard-fetcher capability (net:fetch in the browser) lives with the caller, not this package.  DOC00 v0 search-engine package.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer",
+    "@coding-adventures/forme-doc-search-index-builder": "file:../forme-doc-search-index-builder"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-doc-search-client-js/required_capabilities.json
+++ b/code/packages/typescript/forme-doc-search-client-js/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-doc-search-client-js",
+  "capabilities": [],
+  "justification": "Pure transform: query string + manifest + injected shard-fetcher → ranked SearchResult[].  The shard-fetcher capability (net:fetch in the browser, or file:read on Node for tests) lives with the caller — they pass in an `(shardKey) => Promise<IndexShard>` callback.  This package never instantiates `fetch`, `XMLHttpRequest`, or any I/O primitive itself.  No eval, no Function, no JSON.parse-with-reviver.  Both transitive dependencies (forme-doc-search-tokenizer, forme-doc-search-index-builder) are []-capability and zero/one-dep."
+}

--- a/code/packages/typescript/forme-doc-search-client-js/src/client.ts
+++ b/code/packages/typescript/forme-doc-search-client-js/src/client.ts
@@ -1,0 +1,331 @@
+/**
+ * client.ts — the `SearchClient` class.
+ *
+ * =============================================================================
+ * THE LIFECYCLE
+ * =============================================================================
+ *
+ *   construct  →  manifest in memory, no shards loaded yet
+ *   .search(q) →  tokenise q via search-tokenizer (using flags
+ *                 baked into the manifest);
+ *                 for each unique token:
+ *                   - derive shardKey via token.slice(0, manifest.shardPrefix)
+ *                   - if shard cached, look it up;
+ *                     else if shard key is in manifest.shardKeys,
+ *                       call fetchShard(shardKey), cache it (LRU);
+ *                     else (shard key not in manifest) skip;
+ *                   - look up postings for the token in the shard;
+ *                   - accumulate score per pageId
+ *                     (score += freq * (titleHit ? titleBoost : 1));
+ *                 sort pageIds by descending score;
+ *                 return top `limit`.
+ *
+ * =============================================================================
+ * CAPABILITY MODEL
+ * =============================================================================
+ *
+ * Critical: this package has capabilities `[]`.  The
+ * shard-fetcher is INJECTED — the caller provides the actual
+ * `fetch()` (browser) or `fs.readFile` (Node test) wrapper.
+ * The SearchClient itself doesn't instantiate any I/O primitive.
+ *
+ * That keeps this library testable (mock fetcher in tests) AND
+ * means it can be reused in non-browser contexts (a CLI search
+ * tool, a Node server-side search endpoint, etc.) without
+ * forking.
+ *
+ * =============================================================================
+ * SHARD-FETCH FAILURES
+ * =============================================================================
+ *
+ * If a `fetchShard` call rejects (network error, 404, bad JSON,
+ * etc.), the client logs nothing (no logger dependency) and
+ * SKIPS that shard.  Search continues with whatever other shards
+ * loaded successfully.  This is the "degrade gracefully"
+ * principle — a single broken shard shouldn't blank out an
+ * entire search session.
+ *
+ * Callers who want failure visibility can wrap their own
+ * `fetchShard` to log/report errors before re-throwing.
+ *
+ * @module client
+ */
+
+import { tokenize } from "@coding-adventures/forme-doc-search-tokenizer";
+import type {
+  IndexShard,
+  Posting,
+} from "@coding-adventures/forme-doc-search-index-builder";
+
+import type {
+  ShardFetcher,
+  SearchClientOptions,
+  SearchQueryOptions,
+  SearchResult,
+} from "./types.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// Defaults
+// ─────────────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_CACHED_SHARDS = 50;
+const DEFAULT_TITLE_BOOST = 2.0;
+const DEFAULT_QUERY_LIMIT = 20;
+
+// ─────────────────────────────────────────────────────────────────────
+// SearchClient class
+// ─────────────────────────────────────────────────────────────────────
+
+export class SearchClient {
+  private readonly manifest: SearchClientOptions["manifest"];
+  private readonly fetchShard: ShardFetcher;
+  private readonly maxCachedShards: number;
+  private readonly titleBoost: number;
+  private readonly shardKeys: Set<string>;
+
+  /**
+   * LRU shard cache.  `Map` insertion-order doubles as the LRU
+   * recency order: every `.get()` deletes-and-reinserts so the
+   * most-recently-used shard becomes the newest in the iterator.
+   * Eviction removes the oldest (first) entry.
+   */
+  private readonly cache: Map<string, IndexShard>;
+
+  /**
+   * In-flight shard fetches.  Multiple concurrent `.search()`
+   * calls for the same shard share one Promise so we don't
+   * fire duplicate network requests.
+   */
+  private readonly inflight: Map<string, Promise<IndexShard | null>>;
+
+  constructor(options: SearchClientOptions) {
+    this.manifest = options.manifest;
+    this.fetchShard = options.fetchShard;
+    this.maxCachedShards = options.maxCachedShards ?? DEFAULT_MAX_CACHED_SHARDS;
+    this.titleBoost = options.titleBoost ?? DEFAULT_TITLE_BOOST;
+    // Validate numeric options at construction so misconfigurations
+    // surface immediately (not on the first search call).
+    if (!Number.isFinite(this.maxCachedShards) || this.maxCachedShards < 1) {
+      throw new TypeError(
+        `forme-doc-search-client-js: maxCachedShards must be a finite number >= 1 (got ${this.maxCachedShards})`,
+      );
+    }
+    if (!Number.isFinite(this.titleBoost) || this.titleBoost < 0) {
+      throw new TypeError(
+        `forme-doc-search-client-js: titleBoost must be a finite non-negative number (got ${this.titleBoost})`,
+      );
+    }
+    this.shardKeys = new Set(this.manifest.shardKeys);
+    this.cache = new Map();
+    this.inflight = new Map();
+  }
+
+  /**
+   * Run a search.  Tokenises the query using the same flags
+   * the index was built with, fetches the relevant shards (via
+   * the injected `fetchShard`), merges postings, and returns
+   * the top results sorted by descending score.
+   *
+   * @param query - The user's query string.
+   * @param options - `{ limit? }`.
+   * @returns Ranked search results.  An empty array if the
+   *          query produced no recognised tokens (e.g. all
+   *          stop-words) or no matched postings.
+   */
+  async search(query: string, options: SearchQueryOptions = {}): Promise<SearchResult[]> {
+    const limit = options.limit ?? DEFAULT_QUERY_LIMIT;
+    if (!Number.isFinite(limit) || limit < 0) {
+      throw new TypeError(
+        `forme-doc-search-client-js: limit must be a finite non-negative number (got ${limit})`,
+      );
+    }
+
+    // Tokenise the query using the manifest's flags so client
+    // and index agree.
+    const tokens = tokenize(query, {
+      filterStopWords: this.manifest.filterStopWords,
+      stem: this.manifest.stem,
+    });
+    if (tokens.length === 0) return [];
+
+    // Deduplicate query tokens — repeating "install install" in
+    // the query shouldn't double-count.
+    const uniqueTokens = Array.from(new Set(tokens));
+
+    // Score accumulator: pageId → { score, matchedTokens }.
+    const scores = new Map<string, { score: number; matchedTokens: Set<string> }>();
+
+    // Fetch all relevant shards in parallel.  Distinct shards
+    // are fetched concurrently; the same shard requested
+    // multiple times shares an in-flight Promise.
+    const shardKeysNeeded = new Set<string>();
+    for (const tok of uniqueTokens) {
+      const key = this.shardKeyFor(tok);
+      if (this.shardKeys.has(key)) {
+        shardKeysNeeded.add(key);
+      }
+    }
+    const shardEntries = await Promise.all(
+      Array.from(shardKeysNeeded).map(
+        async (key) => [key, await this.loadShard(key)] as const,
+      ),
+    );
+    const shardsByKey = new Map<string, IndexShard>();
+    for (const [key, shard] of shardEntries) {
+      if (shard !== null) shardsByKey.set(key, shard);
+    }
+
+    // For each query token, look up its postings and accumulate
+    // scores.
+    for (const tok of uniqueTokens) {
+      const key = this.shardKeyFor(tok);
+      const shard = shardsByKey.get(key);
+      if (shard === undefined) continue; // shard missing or fetch failed
+      const postings = shard.postings.get(tok);
+      if (postings === undefined) continue; // token not in index
+      for (const p of postings) {
+        const contribution = this.scoreFor(p);
+        const entry = scores.get(p.pageId);
+        if (entry === undefined) {
+          scores.set(p.pageId, {
+            score: contribution,
+            matchedTokens: new Set([tok]),
+          });
+        } else {
+          entry.score += contribution;
+          entry.matchedTokens.add(tok);
+        }
+      }
+    }
+
+    // Materialise + sort.
+    const results: SearchResult[] = [];
+    for (const [pageId, { score, matchedTokens }] of scores) {
+      results.push({
+        pageId,
+        score,
+        matchedTokens: Array.from(matchedTokens).sort(),
+      });
+    }
+    results.sort(compareResults);
+    return results.slice(0, limit);
+  }
+
+  /**
+   * Pre-warm the cache with a set of shards.  Useful for
+   * predictable load — e.g. fetching common shards eagerly
+   * after page load so the first user query feels instant.
+   *
+   * Shards not in the manifest are silently skipped.
+   * Failures from `fetchShard` are silently swallowed.
+   */
+  async prefetchShards(shardKeys: readonly string[]): Promise<void> {
+    await Promise.all(shardKeys.map((key) => this.loadShard(key)));
+  }
+
+  /**
+   * Empty the shard cache.  Useful if the caller wants to
+   * force a fresh fetch on the next query (e.g. after a
+   * background index rebuild).
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /** Current number of cached shards. */
+  get cacheSize(): number {
+    return this.cache.size;
+  }
+
+  // ───────────────────────────────────────────────────────────
+  // Internal helpers
+  // ───────────────────────────────────────────────────────────
+
+  /**
+   * Compute the shard key for a token, matching the
+   * index-builder's algorithm exactly.
+   */
+  private shardKeyFor(token: string): string {
+    return token.slice(0, this.manifest.shardPrefix);
+  }
+
+  /**
+   * Fetch a shard, using the LRU cache + in-flight dedup.
+   * Returns `null` on shard-key-not-in-manifest or fetch
+   * failure (caller skips the shard).
+   */
+  private async loadShard(shardKey: string): Promise<IndexShard | null> {
+    if (!this.shardKeys.has(shardKey)) return null;
+    // Cache hit?  Promote to most-recently-used.
+    const cached = this.cache.get(shardKey);
+    if (cached !== undefined) {
+      this.cache.delete(shardKey);
+      this.cache.set(shardKey, cached);
+      return cached;
+    }
+    // Already fetching?  Share the promise.
+    const existing = this.inflight.get(shardKey);
+    if (existing !== undefined) return existing;
+    // New fetch.
+    const promise = this.fetchAndCache(shardKey);
+    this.inflight.set(shardKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inflight.delete(shardKey);
+    }
+  }
+
+  private async fetchAndCache(shardKey: string): Promise<IndexShard | null> {
+    try {
+      const shard = await this.fetchShard(shardKey);
+      // Defensive: the fetcher could return a malformed shape.
+      // We trust its type at the boundary but verify the
+      // structural properties we need.
+      if (!isLikelyShard(shard)) return null;
+      // Evict LRU if at capacity.
+      if (this.cache.size >= this.maxCachedShards) {
+        const oldest = this.cache.keys().next().value;
+        if (oldest !== undefined) {
+          this.cache.delete(oldest);
+        }
+      }
+      this.cache.set(shardKey, shard);
+      return shard;
+    } catch {
+      // Degrade gracefully: skip this shard, let search continue.
+      return null;
+    }
+  }
+
+  private scoreFor(p: Posting): number {
+    return p.titleHit ? p.freq * this.titleBoost : p.freq;
+  }
+}
+
+/**
+ * Compare two `SearchResult`s for descending-score, then
+ * ascending-pageId stable ordering.
+ */
+function compareResults(a: SearchResult, b: SearchResult): number {
+  if (a.score !== b.score) return b.score - a.score;
+  if (a.pageId < b.pageId) return -1;
+  if (a.pageId > b.pageId) return 1;
+  /* v8 ignore next 2 */
+  // Unreachable: pageIds are unique within `scores` (Map keyed by pageId).
+  return 0;
+}
+
+/**
+ * Defensive shape check on a fetched shard.  Lets us skip
+ * malformed responses without crashing the client.
+ *
+ * @internal
+ */
+function isLikelyShard(s: unknown): s is IndexShard {
+  if (s === null || typeof s !== "object") return false;
+  const obj = s as { shardKey?: unknown; postings?: unknown };
+  if (typeof obj.shardKey !== "string") return false;
+  if (!(obj.postings instanceof Map)) return false;
+  return true;
+}

--- a/code/packages/typescript/forme-doc-search-client-js/src/index.ts
+++ b/code/packages/typescript/forme-doc-search-client-js/src/index.ts
@@ -1,0 +1,46 @@
+/**
+ * @coding-adventures/forme-doc-search-client-js
+ *
+ * Browser-side search client logic for the documentation-site
+ * search.  Consumes the manifest from
+ * `forme-doc-search-index-builder` plus an INJECTED
+ * shard-fetcher callback; loads shards on demand, tokenises
+ * queries via `forme-doc-search-tokenizer` (using the flags
+ * baked into the manifest so client and index agree), merges
+ * postings, ranks results, returns the top N.
+ *
+ * The shard-fetcher is INJECTED — the caller provides the
+ * actual `fetch()` (browser) or `fs.readFile` (Node test)
+ * wrapper.  This package has capabilities `[]` — the
+ * net:fetch / fs:read capability lives with the caller.
+ *
+ * ```ts
+ * import { SearchClient } from "@coding-adventures/forme-doc-search-client-js";
+ *
+ * const client = new SearchClient({
+ *   manifest,                                 // from build time
+ *   fetchShard: async (key) => {              // browser caller injects fetch
+ *     const r = await fetch(`/search/${key}.json`);
+ *     return await r.json();
+ *   },
+ * });
+ *
+ * const results = await client.search("install");
+ * // → [{ pageId, score, matchedTokens }, ...]
+ * ```
+ *
+ * Tenth concrete DOC00 v0 package (after frontmatter,
+ * heading-anchors, toc-extractor, code-block-decorator,
+ * syntax-highlighter, sidebar-builder, page-shell,
+ * search-tokenizer, search-index-builder).
+ *
+ * @module index
+ */
+
+export { SearchClient } from "./client.js";
+export type {
+  ShardFetcher,
+  SearchClientOptions,
+  SearchQueryOptions,
+  SearchResult,
+} from "./types.js";

--- a/code/packages/typescript/forme-doc-search-client-js/src/types.ts
+++ b/code/packages/typescript/forme-doc-search-client-js/src/types.ts
@@ -1,0 +1,74 @@
+/**
+ * types.ts — public signatures for the browser search client.
+ *
+ * @module types
+ */
+
+import type {
+  IndexShard,
+  IndexManifest,
+} from "@coding-adventures/forme-doc-search-index-builder";
+
+/**
+ * Async callback the caller provides to fetch one shard.  In
+ * the browser this typically wraps `fetch()`; on Node (for
+ * tests) it can wrap `fs.readFile` or just look up an
+ * in-memory map.  The `net:fetch` / `fs:read` capability lives
+ * with the CALLER — this package itself stays `[]`.
+ *
+ * @param shardKey - The shard key from the manifest.
+ * @returns The IndexShard for that key.  Reject with an Error
+ *          if the shard can't be loaded; the search client
+ *          catches and continues with whatever it has.
+ */
+export type ShardFetcher = (shardKey: string) => Promise<IndexShard>;
+
+/**
+ * Options for constructing a `SearchClient`.
+ */
+export interface SearchClientOptions {
+  /** The bootstrap manifest from `forme-doc-search-index-builder`. */
+  readonly manifest: IndexManifest;
+  /** Async callback to fetch one shard.  See `ShardFetcher`. */
+  readonly fetchShard: ShardFetcher;
+  /**
+   * LRU cache size for loaded shards.  Default: `50` (most
+   * sites have far fewer shards than this; sites with more get
+   * least-recently-used eviction when the cap is hit).
+   */
+  readonly maxCachedShards?: number;
+  /**
+   * Score multiplier applied to postings with `titleHit: true`.
+   * Default: `2.0` — title matches double a query's contribution
+   * to the page's score.  Set to `1.0` to disable title
+   * boosting; set higher for stronger title-bias rankings.
+   */
+  readonly titleBoost?: number;
+}
+
+/**
+ * Options for a single `.search()` call.
+ */
+export interface SearchQueryOptions {
+  /**
+   * Maximum number of results to return.  Default: `20`.
+   * Results are sorted by descending score; the top `limit`
+   * are returned.
+   */
+  readonly limit?: number;
+}
+
+/**
+ * One search result.
+ */
+export interface SearchResult {
+  /** The page id (from the index manifest's `pages` list). */
+  readonly pageId: string;
+  /** Aggregate score across all matched query tokens. */
+  readonly score: number;
+  /**
+   * Which of the user's (normalised) query tokens matched
+   * this page.  Useful for highlighting in the UI.
+   */
+  readonly matchedTokens: readonly string[];
+}

--- a/code/packages/typescript/forme-doc-search-client-js/tests/client.test.ts
+++ b/code/packages/typescript/forme-doc-search-client-js/tests/client.test.ts
@@ -1,0 +1,412 @@
+/**
+ * client.test.ts — SearchClient integration tests.
+ *
+ * Builds a small in-memory index via forme-doc-search-index-builder
+ * to get a realistic manifest + shards; wires that into the
+ * SearchClient via an in-memory fetcher.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { SearchClient } from "../src/index.js";
+import type { ShardFetcher } from "../src/index.js";
+import { buildSearchIndex } from "@coding-adventures/forme-doc-search-index-builder";
+import type {
+  IndexShard,
+  IndexPageInput,
+  IndexManifest,
+} from "@coding-adventures/forme-doc-search-index-builder";
+
+// ─────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────
+
+/** Build an index from a small fixture corpus. */
+function buildFixture(pages: IndexPageInput[]) {
+  const out = buildSearchIndex(pages);
+  return {
+    manifest: out.manifest,
+    shards: out.shards,
+    fetchShard: createMemFetcher(out.shards),
+  };
+}
+
+/** In-memory fetcher: shard map → ShardFetcher. */
+function createMemFetcher(
+  shards: ReadonlyMap<string, IndexShard>,
+): ShardFetcher {
+  return async (shardKey: string) => {
+    const shard = shards.get(shardKey);
+    if (shard === undefined) {
+      throw new Error(`shard not found: ${shardKey}`);
+    }
+    return shard;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Construction + validation
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — construction", () => {
+  it("constructs from a valid manifest + fetcher", () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    expect(client.cacheSize).toBe(0);
+  });
+  it("maxCachedShards < 1 throws", () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    expect(
+      () => new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard, maxCachedShards: 0 }),
+    ).toThrow(/maxCachedShards/);
+  });
+  it("maxCachedShards NaN throws", () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    expect(
+      () => new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard, maxCachedShards: NaN }),
+    ).toThrow(/maxCachedShards/);
+  });
+  it("titleBoost negative throws", () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    expect(
+      () => new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard, titleBoost: -1 }),
+    ).toThrow(/titleBoost/);
+  });
+  it("titleBoost NaN throws", () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    expect(
+      () => new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard, titleBoost: NaN }),
+    ).toThrow(/titleBoost/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Basic search
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — basic search", () => {
+  it("returns matching page", async () => {
+    const f = buildFixture([
+      { id: "/p1", body: "install foo" },
+      { id: "/p2", body: "configure foo" },
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install");
+    expect(results.length).toBe(1);
+    expect(results[0].pageId).toBe("/p1");
+  });
+  it("scores titleHit higher (titleBoost=2 default)", async () => {
+    const f = buildFixture([
+      { id: "/p1", body: "install install" }, // body-only, freq=2
+      { id: "/p2", body: "install", title: "Install" }, // title hit, freq=2 * boost
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install");
+    // /p2: titleHit + freq=2 → score 4
+    // /p1: body-only + freq=2 → score 2
+    expect(results[0].pageId).toBe("/p2");
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+  it("multiple query tokens accumulate score", async () => {
+    const f = buildFixture([
+      { id: "/p1", body: "install configure" }, // matches both
+      { id: "/p2", body: "install only" },       // matches one
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install configure");
+    expect(results[0].pageId).toBe("/p1");
+    expect(results[0].matchedTokens.length).toBeGreaterThan(results[1].matchedTokens.length);
+  });
+  it("returns matchedTokens for each result", async () => {
+    const f = buildFixture([{ id: "/p1", body: "install configure" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install configure");
+    // After stemming: "instal", "configur"
+    expect(results[0].matchedTokens.sort()).toEqual(["configur", "instal"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Empty / no-match cases
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — empty results", () => {
+  it("empty query → []", async () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    expect(await client.search("")).toEqual([]);
+  });
+  it("all-stop-words query → []", async () => {
+    const f = buildFixture([{ id: "/p", body: "hello" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    // Default index has filterStopWords=true; "the and of" all filter out.
+    expect(await client.search("the and of")).toEqual([]);
+  });
+  it("query matching no shards → []", async () => {
+    const f = buildFixture([{ id: "/p", body: "alpha" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    // "zzzzz" doesn't share shard with anything in the index
+    expect(await client.search("zzzzz")).toEqual([]);
+  });
+  it("query matching shard but no token → []", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    // "infinite" → "in" shard (matches), but "infinit" not in postings
+    expect(await client.search("infinite")).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// limit option
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — limit option", () => {
+  it("default limit is 20", async () => {
+    const pages = Array.from({ length: 30 }, (_, i) => ({
+      id: `/p${i}`,
+      body: "common",
+    }));
+    const f = buildFixture(pages);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("common");
+    expect(results.length).toBe(20);
+  });
+  it("custom limit honoured", async () => {
+    const pages = Array.from({ length: 30 }, (_, i) => ({
+      id: `/p${i}`,
+      body: "common",
+    }));
+    const f = buildFixture(pages);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("common", { limit: 5 });
+    expect(results.length).toBe(5);
+  });
+  it("limit < 0 throws", async () => {
+    const f = buildFixture([{ id: "/p", body: "x" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    await expect(client.search("x", { limit: -1 })).rejects.toThrow(/limit/);
+  });
+  it("limit NaN throws", async () => {
+    const f = buildFixture([{ id: "/p", body: "x" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    await expect(client.search("x", { limit: NaN })).rejects.toThrow(/limit/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Caching
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — shard caching", () => {
+  it("caches fetched shards", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const fetchSpy = vi.fn(f.fetchShard);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: fetchSpy });
+    await client.search("install");
+    const beforeCount = fetchSpy.mock.calls.length;
+    expect(beforeCount).toBe(1);
+    // Second search for same token should NOT re-fetch.
+    await client.search("install");
+    expect(fetchSpy.mock.calls.length).toBe(beforeCount);
+  });
+  it("LRU evicts when cap exceeded", async () => {
+    // Build an index with 5+ distinct shards (default prefix=2).
+    const f = buildFixture([
+      { id: "/p1", body: "alpha bravo charlie delta echo foxtrot" },
+      { id: "/p2", body: "alpha bravo charlie delta echo foxtrot" },
+    ]);
+    const client = new SearchClient({
+      manifest: f.manifest,
+      fetchShard: f.fetchShard,
+      maxCachedShards: 2,
+    });
+    await client.search("alpha bravo charlie delta echo foxtrot");
+    expect(client.cacheSize).toBe(2);
+  });
+  it("clearCache empties the cache", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    await client.search("install");
+    expect(client.cacheSize).toBeGreaterThan(0);
+    client.clearCache();
+    expect(client.cacheSize).toBe(0);
+  });
+  it("prefetchShards warms the cache", async () => {
+    const f = buildFixture([
+      { id: "/p", body: "install configure deploy" },
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    await client.prefetchShards(f.manifest.shardKeys);
+    expect(client.cacheSize).toBe(f.manifest.shardKeys.length);
+  });
+  it("prefetchShards silently skips unknown shard keys", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    await client.prefetchShards(["zz", "xx", "yy"]);
+    expect(client.cacheSize).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Inflight deduplication
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — inflight deduplication", () => {
+  it("concurrent searches share in-flight shard fetches", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const fetchSpy = vi.fn(async (key: string) => {
+      // Simulate latency.
+      await new Promise((r) => setTimeout(r, 5));
+      const shard = f.shards.get(key);
+      if (shard === undefined) throw new Error(`shard not found: ${key}`);
+      return shard;
+    });
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: fetchSpy });
+    // Fire two concurrent searches before the first resolves.
+    const [r1, r2] = await Promise.all([
+      client.search("install"),
+      client.search("install"),
+    ]);
+    expect(fetchSpy.mock.calls.length).toBe(1); // dedupe worked
+    expect(r1).toEqual(r2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Failure handling
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — degrade gracefully on fetch failure", () => {
+  it("rejecting fetcher does NOT crash search", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const failingFetcher: ShardFetcher = async () => {
+      throw new Error("network fail");
+    };
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: failingFetcher });
+    const results = await client.search("install");
+    expect(results).toEqual([]); // no results, but no exception
+  });
+  it("malformed shard from fetcher is treated as missing", async () => {
+    const f = buildFixture([{ id: "/p", body: "install" }]);
+    const badFetcher: ShardFetcher = (async () =>
+      ({ wrong: "shape" } as unknown)) as ShardFetcher;
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: badFetcher });
+    const results = await client.search("install");
+    expect(results).toEqual([]);
+  });
+  it("partial failure: one shard fails, others succeed → partial results", async () => {
+    const f = buildFixture([
+      { id: "/p1", body: "install" },     // "in" shard
+      { id: "/p2", body: "configure" },   // "co" shard
+    ]);
+    // Fail only the "in" shard.
+    const partialFetcher: ShardFetcher = async (key) => {
+      if (key === "in") throw new Error("fail");
+      const shard = f.shards.get(key);
+      if (shard === undefined) throw new Error(`not found: ${key}`);
+      return shard;
+    };
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: partialFetcher });
+    const results = await client.search("install configure");
+    // Only /p2 should match (the "co" shard succeeded).
+    expect(results.length).toBe(1);
+    expect(results[0].pageId).toBe("/p2");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Ranking
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — ranking", () => {
+  it("higher freq → higher score", async () => {
+    const f = buildFixture([
+      { id: "/p1", body: "install" },
+      { id: "/p2", body: "install install install" },
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install");
+    expect(results[0].pageId).toBe("/p2");
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+  it("custom titleBoost overrides default", async () => {
+    const f = buildFixture([
+      { id: "/p1", body: "install", title: "Install" },
+      { id: "/p2", body: "install install install install install" },
+    ]);
+    // With titleBoost=10, /p1's score = 2 * 10 = 20 (title freq=1, body freq=1)
+    // /p2's score = 5
+    const client = new SearchClient({
+      manifest: f.manifest,
+      fetchShard: f.fetchShard,
+      titleBoost: 10,
+    });
+    const results = await client.search("install");
+    expect(results[0].pageId).toBe("/p1");
+  });
+  it("tied scores sort alphabetically by pageId", async () => {
+    const f = buildFixture([
+      { id: "/zebra", body: "install" },
+      { id: "/apple", body: "install" },
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install");
+    expect(results[0].pageId).toBe("/apple");
+    expect(results[1].pageId).toBe("/zebra");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Stop-word & stemmer consistency
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — index/query option consistency", () => {
+  it("uses manifest's filterStopWords flag", async () => {
+    // Build index without stop-word filter; "the" gets indexed.
+    const out = buildSearchIndex([{ id: "/p", body: "the answer" }], {
+      filterStopWords: false,
+    });
+    const client = new SearchClient({
+      manifest: out.manifest,
+      fetchShard: createMemFetcher(out.shards),
+    });
+    // Client should ALSO not filter stop words (per manifest).
+    const results = await client.search("the");
+    expect(results.length).toBe(1);
+  });
+  it("uses manifest's stem flag", async () => {
+    // Build index without stemming.  "installing" stays as-is.
+    const out = buildSearchIndex([{ id: "/p", body: "installing" }], {
+      stem: false,
+    });
+    const client = new SearchClient({
+      manifest: out.manifest,
+      fetchShard: createMemFetcher(out.shards),
+    });
+    // Query "installing" should match (no stemming on either side).
+    const r1 = await client.search("installing");
+    expect(r1.length).toBe(1);
+    // Query "install" should NOT match (different tokens).
+    const r2 = await client.search("install");
+    expect(r2.length).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Realistic
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SearchClient — realistic", () => {
+  it("typical docs query", async () => {
+    const f = buildFixture([
+      { id: "/intro", body: "Welcome to the documentation. Learn the basics.", title: "Introduction" },
+      { id: "/guide/setup", body: "Install via npm install foo. Configure your environment.", title: "Setup Guide" },
+      { id: "/guide/usage", body: "Common usage patterns and examples.", title: "Usage Guide" },
+      { id: "/api/reference", body: "Full API reference for the foo library.", title: "API Reference" },
+      { id: "/faq", body: "Frequently asked questions about foo.", title: "FAQ" },
+    ]);
+    const client = new SearchClient({ manifest: f.manifest, fetchShard: f.fetchShard });
+    const results = await client.search("install");
+    // /guide/setup mentions "install" twice (body) — should win.
+    expect(results[0].pageId).toBe("/guide/setup");
+  });
+});

--- a/code/packages/typescript/forme-doc-search-client-js/tsconfig.json
+++ b/code/packages/typescript/forme-doc-search-client-js/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-doc-search-client-js/vitest.config.ts
+++ b/code/packages/typescript/forme-doc-search-client-js/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Tenth concrete DOC00 v0 package — pure browser-side search client. Consumes the manifest from `forme-doc-search-index-builder` plus an **injected** shard-fetcher callback; loads shards on demand, tokenises queries via `forme-doc-search-tokenizer` (using the manifest's flags so client and index agree), merges postings, ranks results.

Capabilities: `[]`. The shard-fetcher capability (`net:fetch` in the browser, `fs:read` on Node) lives with the **caller**. This package itself never instantiates any I/O primitive — passing fetch in as a callback keeps it from cascading into every consumer.

## Public API

- `SearchClient` class — `new SearchClient({ manifest, fetchShard, maxCachedShards?, titleBoost? })`
- `client.search(query, options?): Promise<SearchResult[]>` — main entry
- `client.prefetchShards(keys): Promise<void>` — pre-warm cache
- `client.clearCache(): void` — empty cache
- `client.cacheSize: number` — current cache size

## Behavioural notes

- **LRU shard cache** (default `maxCachedShards = 50`) via `Map` insertion-order + delete-then-insert recency refresh; eviction removes oldest entry at cap.
- **In-flight Promise dedup** — concurrent searches for the same shard share one outstanding fetch.
- **Degrades gracefully** — rejecting / malformed fetcher → skip that shard; search continues with whatever loaded successfully.
- **Deterministic** for a fixed manifest + shard set; tied scores break alphabetically by `pageId`.
- **Manifest-driven tokenisation** — client tokenises queries using the manifest's `filterStopWords` and `stem` flags so client and index agree without the caller needing to pass them twice.

## Ranking (v0)

Simple sum-of-`(freq × titleBoost-when-titleHit)` per page. No TF-IDF / BM25 / recency. v1 may add weighting schemes; v0 surfaces only the raw inputs (`freq` + `titleHit`).

## Security posture

- No `eval` / `new Function` / `JSON.parse`-with-reviver — pure data manipulation; caller's `fetchShard` does deserialisation.
- No I/O primitives instantiated. Capabilities `[]`.
- Numeric option validation with `Number.isFinite` — NaN / Infinity / negative throws at construction (`maxCachedShards`, `titleBoost`) or at search time (`limit`).
- Bounded memory via LRU cap.
- No prototype pollution — `Map<string, *>` lookups everywhere; `pageId` / `shardKey` / `token` treated as opaque strings.
- Malformed-shard guard via `isLikelyShard` — wrong shape from `fetchShard` is treated as a fetch failure rather than causing type-confusion at use site.
- No regex on user input — shard-key derivation via `String.slice`.
- Deterministic comparator with total ordering; defensive `return 0` for impossible same-`pageId` tie marked `/* v8 ignore */`.

**Security review: clean** — no HIGH / MEDIUM / LOW findings across capability isolation, LRU bounds, in-flight dedup, malformed defence, numeric validation, prototype pollution, ReDoS, ranking determinism, graceful degradation, and locale leak.

## Coverage

99.3% line / 94.4% branch / 100% function on source files with logic (`types.ts` is type-only). 32 tests in `client.test.ts`.

## v0 simplifications

- No fuzzy matching (exact-token match only)
- No query syntax (`+` / `-` / `"..."` / field-specific)
- No incremental streaming (single Promise per `.search()`)
- No instant-search debouncing (caller's UI concern)
- No analytics
- No result highlighting (`matchedTokens` surfaced; caller marks up HTML)

## Test plan

- [x] `npx vitest run --coverage` — 32/32 pass; 99.3% line / 94.4% branch / 100% function on `client.ts`
- [x] `/security-review` — clean (no HIGH/MEDIUM/LOW)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)