### PR TITLE
feat(cas-summation): Phase 44 port to TypeScript and Rust (one PR)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.5.0 — 2026-05-22
+
+**Phase 44 — Log divergence recogniser (Rust port).**
+
+Ports Python `cas-summation` 0.6.0 (PR #3909).  Extends Phase 43's
+`h_diverges_at_infinity` to also accept `Log(h(k))` where `h(k) → +∞`.
+
+### Added
+
+- New **Log branch** in `h_diverges_at_infinity` with three sub-cases:
+  1. Polynomial inner: positive leading coefficient required.
+  2. `Exp(h')` inner: always positive; defer.
+  3. `Pow(b, h')` inner: require base `b > 1` *strictly positive*.
+
+### Added — tests
+
+4 new `#[test]` functions:
+- `phase44_log_of_polynomial_recognised`.
+- `phase44_log_of_exp_recognised`.
+- `phase44_log_of_pow_negative_base_refuses` (regression).
+- `phase44_log_of_negative_polynomial_refuses` (regression).
+
+Full suite: **31 passed** (27 prior + 4 net new).
+
 ## 0.4.0 — 2026-05-22
 
 **Phase 43 — Transcendental vanishing-at-infinity (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, EXP, MUL, NEG, POW, SUB};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, EXP, LOG, MUL, NEG, POW, SUB};
 
 pub const SUM: &str = "Sum";
 pub const PRODUCT: &str = "Product";
@@ -784,6 +784,40 @@ fn h_diverges_at_infinity(node: &IRNode, k: &IRNode) -> bool {
             return false;
         }
         return has_divergent;
+    }
+    // Phase 44: Log(h(k)) where h(k) → +∞.  Three sub-cases:
+    //   - Polynomial h: positive leading coefficient required.
+    //   - Exp inner: always positive; defer to recursion.
+    //   - Pow(b, h') inner: require b > 1 strictly (Pow(-2, k) value
+    //     oscillates in sign, log((-2)^k) not real).
+    // Anything else (Log(const), Log(Sin), Log(Mul(...))) refused.
+    if head_str == LOG && apply_node.args.len() == 1 {
+        let inner = &apply_node.args[0];
+        if is_positive_degree_polynomial_in_k(inner, k) {
+            return polynomial_leading_coeff_sign_in_k(inner, k) == Some(1);
+        }
+        if let IRNode::Apply(inner_apply) = inner {
+            let inner_head = match &inner_apply.head {
+                IRNode::Symbol(s) => s.as_str(),
+                _ => return false,
+            };
+            if inner_head == EXP {
+                return h_diverges_at_infinity(inner, k);
+            }
+            if inner_head == POW && inner_apply.args.len() == 2 {
+                let base = &inner_apply.args[0];
+                if is_constant_in(base, k) {
+                    if let Some(base_val) = rational_value(base) {
+                        // Strictly positive base > 1: numer > denom AND
+                        // numer > 0 (denom > 0 in normalised Rational).
+                        if base_val.numer > base_val.denom && base_val.numer > 0 {
+                            return h_diverges_at_infinity(inner, k);
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
     false
 }

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2,7 +2,7 @@ use cas_summation::{
     evaluate_product, evaluate_product_expr, evaluate_sum, faulhaber_ir, geometric_sum_ir,
     poly_sum_ir, rational_value, try_special_infinite, Rational, GAMMA_FUNC, PRODUCT, SUM,
 };
-use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, EXP, MUL, NEG, POW, SUB};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, EXP, LOG, MUL, NEG, POW, SUB};
 
 fn eval(node: IRNode) -> IRNode {
     match node {
@@ -603,4 +603,83 @@ fn phase43_pow_neg_wrapper_refuses() {
     );
     let out = evaluate_sum(f, k, int(0), sym("%inf"), eval);
     assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 44: Log divergence in vanishing-at-infinity recogniser.
+// ---------------------------------------------------------------------------
+
+fn substitute_kp1(node: &IRNode, k: &IRNode, kp1: &IRNode) -> IRNode {
+    if node == k {
+        return kp1.clone();
+    }
+    if let IRNode::Apply(apply_node) = node {
+        let new_args: Vec<IRNode> = apply_node
+            .args
+            .iter()
+            .map(|a| substitute_kp1(a, k, kp1))
+            .collect();
+        return apply(apply_node.head.clone(), new_args);
+    }
+    node.clone()
+}
+
+#[test]
+fn phase44_log_of_polynomial_recognised() {
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let g_k = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(LOG), vec![kp1.clone()])],
+    );
+    let g_kp1 = substitute_kp1(&g_k, &k, &kp1);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase44_log_of_exp_recognised() {
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let g_k = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(LOG), vec![apply(sym(POW), vec![int(2), k.clone()])]),
+        ],
+    );
+    let g_kp1 = substitute_kp1(&g_k, &k, &kp1);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase44_log_of_pow_negative_base_refuses() {
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let g_k = apply(
+        sym(DIV),
+        vec![
+            int(1),
+            apply(sym(LOG), vec![apply(sym(POW), vec![int(-2), k.clone()])]),
+        ],
+    );
+    let g_kp1 = substitute_kp1(&g_k, &k, &kp1);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase44_log_of_negative_polynomial_refuses() {
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let neg_k = apply(sym(MUL), vec![int(-1), k.clone()]);
+    let g_k = apply(sym(DIV), vec![int(1), apply(sym(LOG), vec![neg_k])]);
+    let g_kp1 = substitute_kp1(&g_k, &k, &kp1);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.5.0 — 2026-05-22
+
+**Phase 44 — Log divergence recogniser (TypeScript port).**
+
+Ports Python `cas-summation` 0.6.0 (PR #3909).  Extends Phase 43's
+`hDivergesAtInfinity` to also accept `Log(h(k))` where `h(k) → +∞`.
+
+### Added
+
+- New **Log branch** in `hDivergesAtInfinity` with three sub-cases:
+  1. Polynomial inner: positive leading coefficient required.
+  2. `Exp(h')` inner: always positive; defer.
+  3. `Pow(b, h')` inner: require base `b > 1` *strictly positive*
+     (not just `|b| > 1`; `Pow(-2, k)` value oscillates so
+     `log((-2)^k)` not real-valued).
+
+### Added — tests
+
+4 new cases:
+- `Log(k+1)` recognised.
+- `Log(2^k)` recognised via Phase 43 Pow delegation.
+- Regression: `Log(Pow(-2, k))` refused.
+- Regression: `Log(Mul(-1, k))` refused.
+
+Full suite: **31 passed** (27 prior + 4 net new).
+
 ## 0.4.0 — 2026-05-22
 
 **Phase 43 — Transcendental vanishing-at-infinity (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2,6 +2,7 @@ import {
   ADD,
   DIV,
   EXP,
+  LOG,
   MUL,
   NEG,
   POW,
@@ -507,6 +508,44 @@ function hDivergesAtInfinity(node: IRNode, k: IRNode): boolean {
       return false;
     }
     return hasDivergent;
+  }
+  // Phase 44: Log(h(k)) where h(k) → +∞.  Two requirements:
+  //   (a) h(k) → +∞ (not just |h| → ∞)
+  //   (b) h(k) > 0 for k sufficiently large
+  // so log(h) is real-valued and diverges to +∞.
+  //
+  // Three sub-cases:
+  //   - Polynomial h: require positive leading coefficient explicitly.
+  //   - Exp(h'): always positive; defer to hDivergesAtInfinity recursion.
+  //   - Pow(b, h'): require strictly positive base b > 1 (not just
+  //     |b| > 1; Pow(-2, k) oscillates in sign so log((-2)^k) is
+  //     not real-valued).
+  // Other shapes (Log(const), Log(Sin), Log(Mul(...))) refused.
+  if (equals(node.head, LOG) && node.args.length === 1) {
+    const inner = node.args[0];
+    if (isPositiveDegreePolynomialInK(inner, k)) {
+      return polynomialLeadingCoeffSignInK(inner, k) === 1;
+    }
+    if (inner.kind === "apply" && equals(inner.head, EXP)) {
+      return hDivergesAtInfinity(inner, k);
+    }
+    if (
+      inner.kind === "apply" &&
+      equals(inner.head, POW) &&
+      inner.args.length === 2
+    ) {
+      const base = inner.args[0];
+      if (isConstantIn(base, k)) {
+        const baseVal = rationalValue(base);
+        if (baseVal !== undefined) {
+          // base > 1 strictly: numer > denom AND numer > 0 (denom > 0).
+          if (baseVal.numer > baseVal.denom && baseVal.numer > 0n) {
+            return hDivergesAtInfinity(inner, k);
+          }
+        }
+      }
+    }
+    return false;
   }
   return false;
 }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3,6 +3,7 @@ import {
   ADD,
   DIV,
   EXP,
+  LOG,
   MUL,
   NEG,
   POW,
@@ -408,6 +409,77 @@ describe("summation: Phase 43 transcendental vanishing-at-infinity", () => {
       app(DIV, [int(1), app(POW, [int(2), app(NEG, [app(ADD, [k, int(1)])])])]),
     ]);
     const out = evaluateSum(f, k, int(0), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 44: Log divergence in vanishing-at-infinity recogniser.
+//
+// Extends Phase 43 to accept `Log(h(k))` where h(k) → +∞ (so log(h) → +∞).
+// Sign-aware guards:
+//   - Polynomial inner: positive leading coefficient required.
+//   - Exp inner: always positive; defer.
+//   - Pow inner: base > 1 strictly required (not just |b| > 1).
+//
+// The telescope detector compares `g(k+1)` (via k→k+1 substitution in g)
+// against the supplied `g_kp1`.  The stub VM doesn't canonicalise
+// `Add(Add(k,1), 1) ↔ Add(k, 2)`, so we build `g_kp1` via substitution
+// from `g_k` so the structural `==` comparison succeeds.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 44 Log divergence", () => {
+  // Helper: substitute k → k+1 in `node` to build the shifted half.
+  function substitute(node: IRNode, from: IRNode, to: IRNode): IRNode {
+    if (node.kind === "apply") {
+      return app(node.head, node.args.map((a) => substitute(a, from, to)));
+    }
+    if (node.kind === "symbol" && from.kind === "symbol" && node.name === from.name) {
+      return to;
+    }
+    return node;
+  }
+
+  it("Log(k+1) recognised → telescope closes", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const gK = app(DIV, [int(1), app(LOG, [kp1])]);
+    const gKp1 = substitute(gK, k, kp1);
+    const f = app(SUB, [gK, gKp1]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // Must not stay as Sum(...) — closed form will be a symbolic
+    // 1/log(2) expression that the stub VM can't fold further.
+    expect(out.kind === "apply" && out.head === SUM).toBe(false);
+  });
+
+  it("Log(2^k) recognised via Phase 43 Pow delegation", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const gK = app(DIV, [int(1), app(LOG, [app(POW, [int(2), k])])]);
+    const gKp1 = substitute(gK, k, kp1);
+    const f = app(SUB, [gK, gKp1]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" && out.head === SUM).toBe(false);
+  });
+
+  it("regression: Log(Pow(-2, k)) refused — negative base", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const gK = app(DIV, [int(1), app(LOG, [app(POW, [int(-2), k])])]);
+    const gKp1 = substitute(gK, k, kp1);
+    const f = app(SUB, [gK, gKp1]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+
+  it("regression: Log(Mul(-1, k)) refused — negative leading polynomial", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const negK = app(MUL, [int(-1), k]);
+    const gK = app(DIV, [int(1), app(LOG, [negK])]);
+    const gKp1 = substitute(gK, k, kp1);
+    const f = app(SUB, [gK, gKp1]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });


### PR DESCRIPTION
## Summary

Ports the Python Phase 44 (Log divergence recogniser — PR #3909) to TypeScript and Rust in a single PR. Extends Phase 43's `hDivergesAtInfinity` / `h_diverges_at_infinity` to also accept `Log(h(k))` shapes where `h(k) → +∞`.

## Sign-aware Log branch (three sub-cases)

1. **Polynomial `h`**: requires positive leading coefficient via `polynomialLeadingCoeffSignInK` / `polynomial_leading_coeff_sign_in_k`. The Phase 41/42 magnitude check accepts `Mul(-1, k)` whose value goes to `-∞` — that's safe for `1/poly` denominators (magnitude diverges) but wrong for `log` where the value needs to be a real positive number.
2. **`Exp(h')` inner**: always positive by construction; defer to `hDivergesAtInfinity` recursion.
3. **`Pow(b, h')` inner**: require **strictly positive base `b > 1`** (not just `|b| > 1`). Phase 43's Pow case accepts negative `|b| > 1` for `c/b^k → 0` (correct by magnitude), but `log((-2)^k)` is complex / undefined.

Any other inner shape is conservatively refused.

## Versions

| Package | Was | Now |
|---|---|---|
| `typescript/cas-summation` | 0.4.0 | **0.5.0** |
| `rust/cas-summation` | 0.4.0 | **0.5.0** |

## Tests

4 new cases per backend:

- `Log(k+1)` recognised.
- `Log(2^k)` recognised via Phase 43 Pow delegation.
- Regression: `Log(Pow(-2, k))` refused (caught by the Python security review).
- Regression: `Log(Mul(-1, k))` refused.

| Suite | Was | Now |
|---|---|---|
| TS | 27 passed | **31 passed** |
| Rust | 27 passed | **31 passed** |

## Test plan

- [x] All Phase 39/41/42/43 tests still pass.
- [x] New Phase 44 happy-path tests verify Log divergence is recognised.
- [x] Sign-aware regression tests pin the negative-base / negative-poly refusal.
- [x] Security review passed (matches the Python fix verbatim).

## Still deferred

- `Log` of non-polynomial non-Exp/Pow shapes.
- Apart-induced telescopes — blocked on porting `Apart` to TS / Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)