### PR TITLE
feat(forme-doc-site-emitter): DOC00 v0 site composer (cluster complete)

### DIFF
--- a/code/packages/typescript/forme-doc-site-emitter/BUILD
+++ b/code/packages/typescript/forme-doc-site-emitter/BUILD
@@ -1,0 +1,5 @@
+cd ../forme-doc-search-tokenizer && npm ci --quiet
+cd ../forme-doc-search-index-builder && npm ci --quiet
+cd ../forme-doc-sidebar-builder && npm ci --quiet
+cd ../forme-aot-page-bundle-emitter && npm ci --quiet
+npm install --silent && npx vitest run --coverage

--- a/code/packages/typescript/forme-doc-site-emitter/CHANGELOG.md
+++ b/code/packages/typescript/forme-doc-site-emitter/CHANGELOG.md
@@ -1,0 +1,151 @@
+# Changelog — @coding-adventures/forme-doc-site-emitter
+
+## 0.1.0 — 2026-05-22
+
+Initial release.  **Eleventh and FINAL DOC00 v0 package** —
+closes the DOC00 v0 cluster.  Glue package that composes
+DOC00 per-stage outputs (rendered pages + sidebar tree + search
+manifest/shards/client.js + extras + baseUrl) into a single
+`PageBundleConfig` the FM00 deploy chain consumes unchanged.
+
+Pure transform.  Capabilities: `[]`.  The disk-write capability
+lives with `forme-deploy-runner` downstream — DOC00 itself
+never instantiates an I/O primitive.
+
+### Added
+
+- `emitSite(input): PageBundleConfig` — the main entry.
+- Default constants: `DEFAULT_SIDEBAR_PATH` (`/sidebar.json`),
+  `DEFAULT_SEARCH_BASE_PATH` (`/search`), `DEFAULT_MAX_PAGES`
+  (100_000), `DEFAULT_MAX_SHARDS` (10_000), `DEFAULT_MAX_EXTRAS`
+  (10_000), `CONTENT_TYPE_JSON`, `CONTENT_TYPE_JS`.
+- Types: `DocPage`, `ExtraFile`, `SearchAssets`, `SiteEmitInput`,
+  `SidebarTree`, `PageBundleConfig` (re-exported from the
+  upstream emitter so callers don't need a separate import).
+
+### Spec adherence
+
+Implements DOC00 v0's `forme-doc-site-emitter` per
+`code/specs/DOC00-docs-vision.md` (sections 247 and 419) —
+"top-level composer" that produces a `PageBundleConfig` for
+`forme-aot-page-bundle-emitter`.
+
+**Spec divergence flagged for clarity (no behavioural deviation):**
+
+The babysit-cron prompt that triggered this implementation
+guessed the capability would be `[fs:write]` since the package
+"writes the final site to disk".  Re-reading the spec section 8
+shows the correct answer is `[]` — site-emitter does NOT write
+to disk, it returns a `PageBundleConfig` data structure; the
+disk writes happen downstream in `forme-deploy-runner` (which
+already owns `fs:write` per FM05).  The spec is explicit: "Every
+DOC00 package has `required_capabilities.json` → `capabilities:
+[]`.  **No exceptions in v0.**"  This package follows the spec.
+The cron prompt's guess was wrong; this implementation does NOT
+follow the cron prompt, it follows the spec.
+
+### Behavioural notes
+
+- **Pure transform.**  Capabilities `[]`.  No I/O.
+- **Route validation up-front** — every emitted route is checked
+  against the same rules `forme-aot-page-bundle-emitter`
+  enforces: must start with `/`, no `\`, no `//`, no `..`
+  segment, no control chars, ≤ 8192 chars.  All checks use
+  explicit `charCodeAt` index loops (no regex on user input —
+  matches the project-wide ReDoS-prevention convention).
+- **Duplicate-route detection** — if two inputs would land on
+  the same route, throw rather than silently let one shadow
+  the other.
+- **Deterministic output** — given the same input, the bundle
+  serialises to byte-identical JSON.  Shard tokens are emitted
+  in sorted order; shard iteration follows the manifest's
+  sorted `shardKeys` array (not the input `Map`'s insertion
+  order).
+- **`Object.create(null)` for shard `postings` output** —
+  defends downstream consumers from accidentally inheriting
+  `toString` / `hasOwnProperty` when they `obj[token]` the
+  result.
+- **Manifest tolerance** — if a caller hands us a manifest with
+  no `shardKeys` array, we emit `manifest.json` but skip shard
+  emission rather than throwing on iterator.
+
+### Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver** —
+  pure data manipulation.
+- **No I/O primitives instantiated.**  Capabilities `[]`.
+- **Numeric option validation at the boundary** —
+  `maxPages` / `maxShards` / `maxExtras` checked with
+  `Number.isFinite` AND `Number.isInteger`.  NaN, Infinity,
+  negatives, and floats all throw.  `>= 0` (not `>= 1`) is
+  intentional — `maxPages: 0` is a legitimate assertion.
+- **Route validation up-front** — same rules as the downstream
+  emitter; no regex on user input.
+- **Shard-key validation** — non-empty, ≤ 256 chars, no `/`,
+  no `\`, no control chars.  A shard key with `/` would
+  silently change which directory the shard ends up in.
+- **No prototype pollution** — Map-based lookups throughout;
+  shard `postings` output via `Object.create(null)`.
+- **Duplicate-route detection** — fail-fast.
+- **Bounded input sizes** — three count caps prevent
+  pathological inputs from amplifying into bundle bloat.
+
+### Tests
+
+67 tests in `tests/emitter.test.ts`:
+
+- Input shape (6 validation throws).
+- Route shape (every failure mode + accepted dotted routes).
+- Numeric options (NaN/Infinity/negative/non-integer for all
+  three caps + exceed-cap detection + `maxPages: 0` legitimate
+  case).
+- Pages (single, multiple, preserved order, lastmod forwarded,
+  baseUrl forwarded, duplicate-route throw).
+- Sidebar (default path + override + non-array throw + invalid
+  path throw + collision throw).
+- Search (manifest + shards + clientJs with/without + basePath
+  override + trailing-slash rejection + every shard-validation
+  throw + sorted-token determinism + tolerates missing
+  `shardKeys` array).
+- Extras (happy + all field validations + duplicate-route
+  detection).
+- Determinism (byte-identical bundle JSON on repeat call).
+- Round-trip (output feeds cleanly into `generatePageBundle`).
+- Default constants (sanity check).
+- Realistic (3-page docs site with sidebar + search + favicon
+  + robots).
+
+Coverage: **100% line / 100% branch / 100% function** across
+all source files with logic (`types.ts` is type-only).
+
+### v0 simplifications (documented)
+
+- **No `bytes` variant for extras** — binary files ship as
+  strings (the upstream `PageBundleConfig.PageEntry` uses
+  strings throughout).  v1 may add `Uint8Array`.
+- **No theme / asset bundling** — caller pre-bundles CSS/JS.
+- **No sitemap.xml / RSS generation** — composed downstream by
+  `forme-aot-deploy-manifest-emitter`.
+- **No dev-server integration** — separate program, per spec.
+- **String content only** — no streams.
+
+### DOC00 v0 cluster: COMPLETE
+
+This is the eleventh and final DOC00 v0 package.  Cluster
+membership:
+
+1. `forme-doc-frontmatter`
+2. `forme-doc-heading-anchors`
+3. `forme-doc-toc-extractor`
+4. `forme-doc-code-block-decorator`
+5. `forme-doc-syntax-highlighter`
+6. `forme-doc-sidebar-builder`
+7. `forme-doc-page-shell`
+8. `forme-doc-search-tokenizer`
+9. `forme-doc-search-index-builder`
+10. `forme-doc-search-client-js`
+11. **`forme-doc-site-emitter`** ← this PR
+
+Every one a pure transform; capabilities `[]`; the single
+capability boundary in the entire DOC00 pipeline lives in the
+already-shipped `forme-deploy-runner` (FM00 v0).

--- a/code/packages/typescript/forme-doc-site-emitter/README.md
+++ b/code/packages/typescript/forme-doc-site-emitter/README.md
@@ -1,0 +1,260 @@
+# @coding-adventures/forme-doc-site-emitter
+
+> **Eleventh and FINAL DOC00 v0 package.**  The glue that turns
+> the DOC00 per-stage outputs (rendered pages, sidebar tree,
+> search manifest + shards + client JS) into a `PageBundleConfig`
+> the FM00 deploy chain consumes unchanged.
+
+Pure transform.  Capabilities: `[]`.  Per the DOC00 spec
+(section 8: "Every DOC00 package has
+`required_capabilities.json` → `capabilities: []`.  **No
+exceptions in v0.**"), site-emitter never instantiates any I/O
+primitive.  It returns a data structure.  The actual disk writes
+happen downstream in `forme-aot-page-bundle-emitter` →
+`forme-aot-deploy-manifest-emitter` → `forme-deploy-runner`,
+which already own the relevant capabilities.
+
+## What it does
+
+```ts
+import { emitSite } from "@coding-adventures/forme-doc-site-emitter";
+import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+
+const bundle = emitSite({
+  pages: [
+    { route: "/",           html: indexHtml,  lastmod: "2026-05-22" },
+    { route: "/guide/setup", html: setupHtml, lastmod: "2026-05-22" },
+    { route: "/api",        html: apiHtml,    lastmod: "2026-05-22" },
+  ],
+  sidebar,                       // from forme-doc-sidebar-builder
+  search: {                      // from forme-doc-search-index-builder
+    manifest,
+    shards,
+    clientJs: builtSearchClientBundle,  // caller bundles for browser
+  },
+  extras: [
+    { route: "/favicon.ico", content: faviconBytesString, contentType: "image/x-icon" },
+    { route: "/robots.txt", content: "User-agent: *\nAllow: /\n", contentType: "text/plain" },
+  ],
+  baseUrl: "https://docs.example.com",
+});
+
+// PageBundleConfig — consumable by the FM00 deploy chain.
+const manifestJson = generatePageBundle(bundle);
+```
+
+## Capability flow
+
+```
+DOC00 cluster (all []):                       FM00 cluster:
+
+ frontmatter, heading-anchors, ...
+              ▼
+ page-shell  → DocPage[] ─┐
+ sidebar-builder ─────────┼──► forme-doc-site-emitter (this, [])
+ search-index-builder ────┘                ▼
+                                   PageBundleConfig
+                                           ▼
+                          forme-aot-page-bundle-emitter ([])
+                                           ▼
+                       forme-aot-deploy-manifest-emitter ([])
+                                           ▼
+                              forme-deploy-runner (owns fs:write,
+                                                   net:* for upload)
+                                           ▼
+                                    site on disk / S3 / CDN
+```
+
+The capability boundary is between the deploy runner and
+everything above it.  DOC00 v0 entirely lives in the
+"capabilities: `[]`" half.
+
+## Inputs
+
+| Field         | Type                              | Purpose                                                                          |
+|---------------|-----------------------------------|----------------------------------------------------------------------------------|
+| `pages`       | `DocPage[]`                       | Per-page rendered HTML (from `forme-doc-page-shell`).                            |
+| `sidebar`     | `SidebarTree?`                    | Sidebar nav tree (from `forme-doc-sidebar-builder`).  Emitted as `/sidebar.json`. |
+| `sidebarPath` | `string?`                         | Override default `/sidebar.json` route.                                          |
+| `search`      | `SearchAssets?`                   | Manifest + shards + (optional) client JS.  Emitted under `/search/`.             |
+| `extras`      | `ExtraFile[]?`                    | Favicons, `robots.txt`, `CNAME`, copied assets — arbitrary extra routes.         |
+| `baseUrl`     | `string?`                         | Canonical site URL.  Forwarded into `PageBundleConfig.baseUrl`.                  |
+| `maxPages`    | `number?` (default `100_000`)     | Cap on total pages — defends against pathological inputs.                        |
+| `maxShards`   | `number?` (default `10_000`)      | Cap on shard count.                                                              |
+| `maxExtras`   | `number?` (default `10_000`)      | Cap on extras count.                                                             |
+
+## Route layout (default)
+
+```
+/                              ── pages[0]
+/guide/setup                   ── pages[1]
+/api                           ── pages[2]
+...
+/sidebar.json                  ── sidebar
+/search/manifest.json          ── search.manifest
+/search/<key>.json             ── search.shards[<key>], one per shard
+/search/client.js              ── search.clientJs (if provided)
+/favicon.ico                   ── extras[0]
+/robots.txt                    ── extras[1]
+...
+```
+
+Override the sidebar path with `sidebarPath`, the search root
+with `search.basePath`.
+
+## Route validation (defence-in-depth)
+
+Every emitted route is checked against the same rules
+`forme-aot-page-bundle-emitter.validateRoute` enforces — so a
+malformed route is caught at the boundary closest to the user's
+input, not deep inside the deploy chain:
+
+- Must start with `/`.
+- Must not contain `\` (Windows path separator).
+- Must not contain `//` (protocol-relative URL hint —
+  `//evil.example.com/path` parses as cross-origin).
+- Must not contain `..` segments (path traversal).
+- Must not contain control chars (`< 0x20` or `0x7f`).
+- Length cap: 8192 chars.
+
+All checks use explicit `charCodeAt` index loops — no regex on
+user input.  This matches the project-wide convention
+established after CodeQL's `js/polynomial-redos` flagged
+`+`-quantified regex even when not actually polynomial.
+
+## Duplicate-route detection
+
+If two inputs would land on the same route — e.g. a page at `/`
+and an `ExtraFile` also at `/`, or a sidebar at
+`/search/manifest.json` colliding with a search manifest — the
+emitter throws.  Silent collision-resolution would surface as
+mysterious missing pages at deploy time.
+
+## Determinism
+
+For a fixed input, `emitSite` produces a byte-identical
+`PageBundleConfig`.  This matters for content-addressed deploys
+where unchanged builds should hash identically:
+
+- Page order in the output preserves input order.
+- Sidebar JSON: stable `JSON.stringify` (no `replacer`, no
+  `indent`).
+- Shard JSON: tokens are emitted in **sorted** order — we don't
+  trust the Map's insertion order.
+- Search-shard iteration order follows the manifest's sorted
+  `shardKeys` array, not the input `Map`'s key-iteration order.
+
+## JSON serialisation choices
+
+- **No `indent` argument** to `JSON.stringify` — compact JSON
+  ships smaller and is more diff-stable.
+- **No `replacer`** — avoids the "replacer can mutate / throw on
+  circular" footguns.
+- **`Object.create(null)` for shard `postings`** maps — defends
+  downstream consumers from accidentally inheriting `toString`,
+  `hasOwnProperty`, etc. when they `obj[token]` the result.
+  `JSON.stringify` handles null-prototype objects identically to
+  plain ones.
+
+## Security posture
+
+- **No `eval` / `new Function` / `JSON.parse`-with-reviver** —
+  pure data manipulation.
+- **No I/O primitives instantiated.**  Capabilities `[]`.
+- **Numeric option validation at the boundary** —
+  `maxPages` / `maxShards` / `maxExtras` checked with
+  `Number.isFinite` AND `Number.isInteger`.  NaN, Infinity,
+  negatives, and floats all throw.
+- **Route validation up-front** — same rules as the downstream
+  emitter, applied at the closest-to-user-input point.  No regex
+  on user input (explicit `charCodeAt` loops).
+- **Shard-key validation** — non-empty, ≤ 256 chars, no `/`, no
+  `\`, no control chars.  A shard key with `/` would change
+  which directory the shard ends up in.
+- **No prototype pollution** — Map-based lookups throughout;
+  shard `postings` objects built via `Object.create(null)`.
+- **Duplicate-route detection** — fail-fast rather than letting
+  one entry silently shadow another.
+- **Bounded input sizes** — all three count caps prevent
+  pathological inputs from amplifying into bundle bloat.
+- **Defensive `shardKeys: undefined`** — if a caller hands us a
+  partial manifest with no `shardKeys` array, we emit the
+  manifest but skip shard emission rather than throwing.
+
+## Tests
+
+67 tests in `tests/emitter.test.ts`:
+
+- **Input shape** — happy + null + non-object + non-array pages
+  + non-string html / lastmod / baseUrl.
+- **Route shape** — every failure mode (non-string, empty, no
+  leading slash, backslash, `//`, `..`, control chars, DEL,
+  length cap) + accepted dotted routes.
+- **Numeric options** — NaN / Infinity / negative / non-integer
+  for all three caps, plus exceed-cap detection.
+- **Pages** — single + multiple + preserved order + lastmod
+  forwarded + baseUrl forwarded + duplicate-route throw.
+- **Sidebar** — default path + override + non-array throw +
+  invalid sidebar path throw + collision-with-page throw.
+- **Search** — manifest + shards + clientJs (with and without)
+  + basePath override + trailing-slash rejection + every
+  validation throw (non-Map, missing shard, non-string
+  shardKey, `/` in shardKey, empty shardKey, 256+ char
+  shardKey, exceed-maxShards, null search, null manifest,
+  non-Map postings, non-string shardKey on shard, null shard,
+  non-string token keys) + tolerates missing `shardKeys`
+  array + sorted token iteration.
+- **Extras** — happy + all field validations + duplicate-route
+  detection.
+- **Determinism** — byte-identical bundle JSON on repeat call.
+- **Round-trip** — output feeds cleanly into `generatePageBundle`
+  with all expected `outputPath`s derived correctly.
+- **Constants** — default values sanity check.
+- **Realistic** — 3-page docs site with sidebar + search +
+  favicon + robots.
+
+Coverage: **100% line / 100% branch / 100% function** on all
+source files with logic (`types.ts` is type-only).
+
+## How it fits in the stack
+
+Final DOC00 v0 package.  The cluster after this:
+
+| Package                              | Layer    | Capability |
+|--------------------------------------|----------|------------|
+| `document-ast`                       | shared IR| `[]`       |
+| `forme-doc-frontmatter`              | content  | `[]`       |
+| `forme-doc-heading-anchors`          | content  | `[]`       |
+| `forme-doc-toc-extractor`            | content  | `[]`       |
+| `forme-doc-code-block-decorator`     | content  | `[]`       |
+| `forme-doc-syntax-highlighter`       | content  | `[]`       |
+| `forme-doc-sidebar-builder`          | structure| `[]`       |
+| `forme-doc-page-shell`               | structure| `[]`       |
+| `forme-doc-search-tokenizer`         | search   | `[]`       |
+| `forme-doc-search-index-builder`     | search   | `[]`       |
+| `forme-doc-search-client-js`         | search   | `[]`       |
+| **`forme-doc-site-emitter`**         | **glue** | **`[]`**   |
+| `forme-aot-page-bundle-emitter`      | FM00     | `[]`       |
+| `forme-aot-deploy-manifest-emitter`  | FM00     | `[]`       |
+| `forme-deploy-runner`                | FM00     | `fs:write`, `net:*` |
+
+**Eleven new DOC00 packages, all `capabilities: []`.**  The
+single capability boundary in the entire docs pipeline lives in
+the deploy runner.
+
+## v0 simplifications (documented)
+
+- **No `bytes` variant for extras** — binary files (favicons,
+  images) ship as strings.  Adequate for v0; the upstream
+  `PageBundleConfig.PageEntry` schema uses strings throughout.
+  v1 may add `Uint8Array` support.
+- **No theme/asset bundling** — caller pre-bundles CSS/JS and
+  passes them as `extras` or as part of the `html` body.
+- **No sitemap.xml / RSS generation** — caller composes those
+  as `extras` if wanted.  (`forme-aot-deploy-manifest-emitter`
+  downstream already supports them as separate inputs.)
+- **No dev-server integration** — out of scope per DOC00 spec
+  section 8; a separate `fs:watch` + `net:listen` program.
+- **String content only** — no streams / no async generators.
+  Docs sites are small enough that the entire bundle fits in
+  memory comfortably.

--- a/code/packages/typescript/forme-doc-site-emitter/package-lock.json
+++ b/code/packages/typescript/forme-doc-site-emitter/package-lock.json
@@ -1,0 +1,2348 @@
+{
+  "name": "@coding-adventures/forme-doc-site-emitter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/forme-doc-site-emitter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-aot-page-bundle-emitter": "file:../forme-aot-page-bundle-emitter",
+        "@coding-adventures/forme-doc-search-index-builder": "file:../forme-doc-search-index-builder",
+        "@coding-adventures/forme-doc-sidebar-builder": "file:../forme-doc-sidebar-builder"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-aot-page-bundle-emitter": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-doc-search-index-builder": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../forme-doc-sidebar-builder": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/forme-aot-page-bundle-emitter": {
+      "resolved": "../forme-aot-page-bundle-emitter",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-search-index-builder": {
+      "resolved": "../forme-doc-search-index-builder",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-sidebar-builder": {
+      "resolved": "../forme-doc-sidebar-builder",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/forme-doc-site-emitter/package.json
+++ b/code/packages/typescript/forme-doc-site-emitter/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@coding-adventures/forme-doc-site-emitter",
+  "version": "0.1.0",
+  "description": "Glue package for the DOC00 documentation-site cluster: composes per-page HTML + sidebar tree + search-engine outputs (manifest + shards + client JS) + site config into a PageBundleConfig that the FM00 deploy chain (forme-aot-page-bundle-emitter, forme-aot-deploy-manifest-emitter, forme-deploy-runner) consumes unchanged.  Pure transform; capabilities []; the disk-write capability lives downstream in the deploy runner, not here.  ELEVENTH AND FINAL DOC00 v0 package — closes the cluster.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/forme-doc-sidebar-builder": "file:../forme-doc-sidebar-builder",
+    "@coding-adventures/forme-doc-search-index-builder": "file:../forme-doc-search-index-builder",
+    "@coding-adventures/forme-aot-page-bundle-emitter": "file:../forme-aot-page-bundle-emitter"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/forme-doc-site-emitter/required_capabilities.json
+++ b/code/packages/typescript/forme-doc-site-emitter/required_capabilities.json
@@ -1,0 +1,4 @@
+{
+  "capabilities": [],
+  "rationale": "forme-doc-site-emitter is a pure transform: it takes per-page rendered HTML, the sidebar tree, the search manifest+shards, and site config; it returns a PageBundleConfig data structure for forme-aot-page-bundle-emitter to consume.  No I/O primitive is instantiated here.  The actual disk writes happen downstream in the FM00 deploy chain (forme-aot-page-bundle-emitter -> forme-aot-deploy-manifest-emitter -> forme-deploy-runner), which already own the relevant capabilities.  Per DOC00 spec section 8: 'Every DOC00 package has required_capabilities.json -> capabilities: []. No exceptions in v0.'"
+}

--- a/code/packages/typescript/forme-doc-site-emitter/src/emitter.ts
+++ b/code/packages/typescript/forme-doc-site-emitter/src/emitter.ts
@@ -1,0 +1,504 @@
+/**
+ * emitter.ts — the `emitSite` transform.
+ *
+ * Composes DOC00 per-stage outputs into a `PageBundleConfig` for
+ * `forme-aot-page-bundle-emitter`.  Pure data manipulation;
+ * deterministic; capability `[]`.
+ *
+ * # The composition step in pictures
+ *
+ * ```
+ *    pages: [{route, html}, ...]   ── as-is, one PageEntry each
+ *                ▼
+ *    sidebar (tree)                ── one PageEntry: /sidebar.json
+ *                ▼
+ *    search.manifest               ── one PageEntry: /search/manifest.json
+ *    search.shards                 ── one PageEntry per shard:
+ *                                       /search/<key>.json
+ *    search.clientJs               ── one PageEntry: /search/client.js
+ *                ▼
+ *    extras: [{route, content}]    ── one PageEntry each
+ *                ▼
+ *           PageBundleConfig  →  forme-aot-page-bundle-emitter
+ *                              →  forme-aot-deploy-manifest-emitter
+ *                              →  forme-deploy-runner  (writes to disk)
+ * ```
+ *
+ * Routes are deduplicated upfront — any collision throws a
+ * `TypeError` rather than silently letting one entry win.  This
+ * catches author mistakes like accidentally putting two pages at
+ * the same URL, or a sidebar at `/search/sidebar.json` colliding
+ * with a search shard.
+ *
+ * # JSON serialisation choices (deterministic on purpose)
+ *
+ *   - **No `indent` argument** to `JSON.stringify` — compact JSON
+ *     ships smaller and is also easier to diff in content-hashed
+ *     deploys (an indented file's hash changes whenever any nested
+ *     value moves around).
+ *
+ *   - **Sorted keys** for manifest objects with arbitrary key sets
+ *     (the shards-by-key emission iterates `manifest.shardKeys`
+ *     which is already sorted by the upstream builder; we don't
+ *     trust shard insertion order).
+ *
+ *   - **Maps → plain objects via `Object.create(null)`** — defends
+ *     downstream consumers against unexpected prototype-chain
+ *     properties when they `obj[key]` the result.  Then
+ *     `JSON.stringify` happens to handle null-prototype objects
+ *     identically to plain objects.
+ *
+ * @module emitter
+ */
+
+import type {
+  PageBundleConfig,
+  PageEntry,
+} from "@coding-adventures/forme-aot-page-bundle-emitter";
+import type {
+  DocPage,
+  ExtraFile,
+  SearchAssets,
+  SiteEmitInput,
+} from "./types.js";
+
+/**
+ * Default sentinel values — exported for callers that want to
+ * reference them or override consistently.
+ */
+export const DEFAULT_SIDEBAR_PATH = "/sidebar.json";
+export const DEFAULT_SEARCH_BASE_PATH = "/search";
+export const DEFAULT_MAX_PAGES = 100_000;
+export const DEFAULT_MAX_SHARDS = 10_000;
+export const DEFAULT_MAX_EXTRAS = 10_000;
+export const CONTENT_TYPE_JSON = "application/json; charset=utf-8";
+export const CONTENT_TYPE_JS = "application/javascript; charset=utf-8";
+
+/**
+ * Compose the input into a `PageBundleConfig`.
+ *
+ * Validates inputs up-front; deterministic in output order.
+ *
+ * @throws `TypeError` for invalid routes, duplicate routes,
+ *         out-of-range counts, or malformed inputs.
+ */
+export function emitSite(input: SiteEmitInput): PageBundleConfig {
+  if (input === null || typeof input !== "object") {
+    throw new TypeError("emitSite: input must be an object");
+  }
+
+  // -------- 1. Numeric option validation -------------------------
+  // Always `Number.isFinite` — `>`/`>=` silently pass NaN.
+  const maxPages = resolveLimit(input.maxPages, DEFAULT_MAX_PAGES, "maxPages");
+  const maxShards = resolveLimit(input.maxShards, DEFAULT_MAX_SHARDS, "maxShards");
+  const maxExtras = resolveLimit(input.maxExtras, DEFAULT_MAX_EXTRAS, "maxExtras");
+
+  // -------- 2. Pages validation ---------------------------------
+  if (!Array.isArray(input.pages)) {
+    throw new TypeError("emitSite: input.pages must be an array");
+  }
+  if (input.pages.length > maxPages) {
+    throw new TypeError(
+      `emitSite: ${input.pages.length} pages exceeds maxPages=${maxPages}`,
+    );
+  }
+
+  // Output accumulator + the seen-route set for duplicate detection.
+  const out: PageEntry[] = [];
+  const seenRoutes = new Set<string>();
+
+  for (let i = 0; i < input.pages.length; i++) {
+    const page = input.pages[i]!;
+    if (page === null || typeof page !== "object") {
+      throw new TypeError(`emitSite: pages[${i}] must be an object`);
+    }
+    validateRouteShape(page.route, `pages[${i}].route`);
+    if (typeof page.html !== "string") {
+      throw new TypeError(`emitSite: pages[${i}].html must be a string`);
+    }
+    if (page.lastmod !== undefined && typeof page.lastmod !== "string") {
+      throw new TypeError(`emitSite: pages[${i}].lastmod must be a string`);
+    }
+    pushUnique(out, seenRoutes, makePageEntry(page));
+  }
+
+  // -------- 3. Sidebar ------------------------------------------
+  if (input.sidebar !== undefined) {
+    const sidebarPath = input.sidebarPath ?? DEFAULT_SIDEBAR_PATH;
+    validateRouteShape(sidebarPath, "sidebarPath");
+    if (!Array.isArray(input.sidebar)) {
+      throw new TypeError("emitSite: input.sidebar must be an array");
+    }
+    pushUnique(out, seenRoutes, {
+      route: sidebarPath,
+      html: stableJsonStringify(input.sidebar),
+      contentType: CONTENT_TYPE_JSON,
+    });
+  }
+
+  // -------- 4. Search ------------------------------------------
+  if (input.search !== undefined) {
+    appendSearchEntries(out, seenRoutes, input.search, maxShards);
+  }
+
+  // -------- 5. Extras ------------------------------------------
+  if (input.extras !== undefined) {
+    if (!Array.isArray(input.extras)) {
+      throw new TypeError("emitSite: input.extras must be an array");
+    }
+    if (input.extras.length > maxExtras) {
+      throw new TypeError(
+        `emitSite: ${input.extras.length} extras exceeds maxExtras=${maxExtras}`,
+      );
+    }
+    for (let i = 0; i < input.extras.length; i++) {
+      const extra = input.extras[i]!;
+      validateExtra(extra, i);
+      pushUnique(out, seenRoutes, makeExtraEntry(extra));
+    }
+  }
+
+  // -------- 6. Build the final PageBundleConfig ----------------
+  const cfg: { pages: PageEntry[]; baseUrl?: string } = { pages: out };
+  if (input.baseUrl !== undefined) {
+    if (typeof input.baseUrl !== "string") {
+      throw new TypeError("emitSite: input.baseUrl must be a string");
+    }
+    cfg.baseUrl = input.baseUrl;
+  }
+  return cfg;
+}
+
+// =====================================================================
+// HELPERS
+// =====================================================================
+
+/**
+ * Validate a numeric limit option.  `undefined` returns the
+ * default; anything else must be a finite integer ≥ 0.  NaN,
+ * Infinity, negatives, and non-integers all throw.
+ *
+ * The `>= 0` check (not `>= 1`) is intentional: a caller setting
+ * `maxPages: 0` is asserting "I want this build to refuse any
+ * pages" — that's a meaningful assertion, not a bug.
+ */
+function resolveLimit(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new TypeError(
+      `emitSite: ${name} must be a non-negative integer (got ${String(value)})`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Reject obviously dangerous / wrong-shaped routes BEFORE the
+ * downstream emitter sees them — fail-fast at the boundary
+ * closest to the user's input.  These checks mirror the rules
+ * `forme-aot-page-bundle-emitter.validateRoute` enforces, with
+ * the same rejection criteria, so feeding our output into the
+ * downstream emitter never surprises with a late throw.
+ *
+ *   - Must be a string.
+ *   - Must start with `/`.
+ *   - Must not contain `\`        — Windows path separator.
+ *   - Must not contain `//`       — protocol-relative URL hint
+ *                                   (`//evil.example.com/page`
+ *                                   parses as cross-origin).
+ *   - Must not contain `..`       — path-traversal segment.
+ *   - Must not contain control chars (< 0x20 or 0x7f).
+ *   - Length cap (8192) — same as `forme-doc-sidebar-builder`'s
+ *                         path cap; defends against pathological
+ *                         long inputs.
+ */
+function validateRouteShape(route: unknown, what: string): asserts route is string {
+  if (typeof route !== "string") {
+    throw new TypeError(`emitSite: ${what} must be a string`);
+  }
+  if (route.length === 0 || route.charCodeAt(0) !== 0x2f /* "/" */) {
+    throw new TypeError(`emitSite: ${what} must start with "/" (got ${JSON.stringify(route)})`);
+  }
+  if (route.length > 8192) {
+    throw new TypeError(`emitSite: ${what} exceeds 8192 chars`);
+  }
+  // Explicit char-by-char loop (no regex) — keeps this trivially
+  // ReDoS-free and matches the project-wide convention established
+  // by sidebar-builder and page-shell.
+  for (let i = 0; i < route.length; i++) {
+    const c = route.charCodeAt(i);
+    if (c === 0x5c /* "\" */) {
+      throw new TypeError(`emitSite: ${what} must not contain "\\"`);
+    }
+    if (c < 0x20 || c === 0x7f) {
+      throw new TypeError(`emitSite: ${what} must not contain control chars`);
+    }
+    // `//`  — adjacent slash check (other than allowed leading "/")
+    if (i > 0 && c === 0x2f && route.charCodeAt(i - 1) === 0x2f) {
+      throw new TypeError(`emitSite: ${what} must not contain "//"`);
+    }
+  }
+  // `..` segment check — explicit segment walk (no regex).
+  let segStart = 1; // skip leading "/"
+  for (let i = 1; i <= route.length; i++) {
+    if (i === route.length || route.charCodeAt(i) === 0x2f) {
+      const segLen = i - segStart;
+      if (segLen === 2
+          && route.charCodeAt(segStart) === 0x2e
+          && route.charCodeAt(segStart + 1) === 0x2e) {
+        throw new TypeError(`emitSite: ${what} must not contain ".." segment`);
+      }
+      segStart = i + 1;
+    }
+  }
+}
+
+/**
+ * Push an entry only after confirming the route hasn't already
+ * been claimed.  Duplicates throw — the caller almost certainly
+ * has a bug, and silently dropping data would surface as
+ * mysterious missing pages at deploy time.
+ */
+function pushUnique(
+  out: PageEntry[],
+  seen: Set<string>,
+  entry: PageEntry,
+): void {
+  if (seen.has(entry.route)) {
+    throw new TypeError(
+      `emitSite: duplicate route ${JSON.stringify(entry.route)}`,
+    );
+  }
+  seen.add(entry.route);
+  out.push(entry);
+}
+
+/**
+ * Convert a `DocPage` into a `PageEntry`.  Pure data shape
+ * rearrangement; HTML is passed through verbatim (the upstream
+ * page-shell + html-doc-emitter own escaping correctness).
+ */
+function makePageEntry(page: DocPage): PageEntry {
+  const entry: { route: string; html: string; lastmod?: string } = {
+    route: page.route,
+    html: page.html,
+  };
+  if (page.lastmod !== undefined) entry.lastmod = page.lastmod;
+  return entry;
+}
+
+/**
+ * Convert an `ExtraFile` into a `PageEntry`.  The
+ * `PageBundleConfig.PageEntry` schema uses `html` as the body
+ * field for any content type — naming is a holdover from the
+ * common-case, not a content-type assertion.
+ */
+function makeExtraEntry(extra: ExtraFile): PageEntry {
+  const entry: { route: string; html: string; contentType: string; lastmod?: string } = {
+    route: extra.route,
+    html: extra.content,
+    contentType: extra.contentType,
+  };
+  if (extra.lastmod !== undefined) entry.lastmod = extra.lastmod;
+  return entry;
+}
+
+/**
+ * Validate an `ExtraFile` before we trust its fields.
+ */
+function validateExtra(extra: unknown, i: number): asserts extra is ExtraFile {
+  if (extra === null || typeof extra !== "object") {
+    throw new TypeError(`emitSite: extras[${i}] must be an object`);
+  }
+  const e = extra as { route?: unknown; content?: unknown; contentType?: unknown; lastmod?: unknown };
+  validateRouteShape(e.route, `extras[${i}].route`);
+  if (typeof e.content !== "string") {
+    throw new TypeError(`emitSite: extras[${i}].content must be a string`);
+  }
+  if (typeof e.contentType !== "string") {
+    throw new TypeError(`emitSite: extras[${i}].contentType must be a string`);
+  }
+  if (e.lastmod !== undefined && typeof e.lastmod !== "string") {
+    throw new TypeError(`emitSite: extras[${i}].lastmod must be a string`);
+  }
+}
+
+/**
+ * Append the search-related `PageEntry`s into `out`.  Order:
+ *
+ *   1. `<basePath>/manifest.json`
+ *   2. `<basePath>/<shardKey>.json` — one per shard, iterated in
+ *      sorted `manifest.shardKeys` order for determinism.
+ *   3. `<basePath>/client.js` (only if `clientJs` is provided).
+ */
+function appendSearchEntries(
+  out: PageEntry[],
+  seen: Set<string>,
+  search: SearchAssets,
+  maxShards: number,
+): void {
+  if (search === null || typeof search !== "object") {
+    throw new TypeError("emitSite: search must be an object");
+  }
+  if (search.manifest === null || typeof search.manifest !== "object") {
+    throw new TypeError("emitSite: search.manifest must be an object");
+  }
+  if (!(search.shards instanceof Map)) {
+    throw new TypeError("emitSite: search.shards must be a Map");
+  }
+  if (search.shards.size > maxShards) {
+    throw new TypeError(
+      `emitSite: ${search.shards.size} shards exceeds maxShards=${maxShards}`,
+    );
+  }
+  const basePath = search.basePath ?? DEFAULT_SEARCH_BASE_PATH;
+  validateBasePath(basePath);
+
+  // 1. manifest.json
+  pushUnique(out, seen, {
+    route: `${basePath}/manifest.json`,
+    html: stableJsonStringify(search.manifest),
+    contentType: CONTENT_TYPE_JSON,
+  });
+
+  // 2. shards/*.json — iterate by manifest's sorted shardKeys for
+  //    determinism (we don't trust the Map's insertion order).
+  const manifestShardKeys = Array.isArray(search.manifest.shardKeys)
+    ? search.manifest.shardKeys
+    : [];
+  for (let i = 0; i < manifestShardKeys.length; i++) {
+    const key = manifestShardKeys[i]!;
+    if (typeof key !== "string") {
+      throw new TypeError(
+        `emitSite: search.manifest.shardKeys[${i}] must be a string`,
+      );
+    }
+    validateShardKey(key, i);
+    const shard = search.shards.get(key);
+    if (shard === undefined) {
+      throw new TypeError(
+        `emitSite: search.shards missing entry for shardKey ${JSON.stringify(key)}`,
+      );
+    }
+    pushUnique(out, seen, {
+      route: `${basePath}/${key}.json`,
+      html: stableJsonStringify(serialiseShard(shard)),
+      contentType: CONTENT_TYPE_JSON,
+    });
+  }
+
+  // 3. client.js (optional)
+  if (search.clientJs !== undefined) {
+    if (typeof search.clientJs !== "string") {
+      throw new TypeError("emitSite: search.clientJs must be a string");
+    }
+    pushUnique(out, seen, {
+      route: `${basePath}/client.js`,
+      html: search.clientJs,
+      contentType: CONTENT_TYPE_JS,
+    });
+  }
+}
+
+/**
+ * Validate `search.basePath`:
+ *   - Same route-shape rules (leading `/`, no `..`, etc.).
+ *   - PLUS: no trailing `/`.  We build paths as
+ *     `${basePath}/${key}.json`; a trailing slash would yield
+ *     `//`.  Forbid it up front rather than papering over with a
+ *     normalisation.
+ */
+function validateBasePath(basePath: string): void {
+  validateRouteShape(basePath, "search.basePath");
+  if (basePath.length > 1
+      && basePath.charCodeAt(basePath.length - 1) === 0x2f /* "/" */) {
+    throw new TypeError(
+      `emitSite: search.basePath must not end with "/" (got ${JSON.stringify(basePath)})`,
+    );
+  }
+}
+
+/**
+ * Shard keys are URL path segments — they must NOT contain `/`
+ * (would change which directory the shard ends up in) or any of
+ * the forbidden chars from route validation.  Empty shard keys
+ * are also rejected (would produce `/search/.json`).
+ *
+ * Explicit char-by-char loop — same pattern as
+ * `validateRouteShape`.
+ */
+function validateShardKey(key: string, i: number): void {
+  if (key.length === 0) {
+    throw new TypeError(`emitSite: search.manifest.shardKeys[${i}] must not be empty`);
+  }
+  if (key.length > 256) {
+    throw new TypeError(`emitSite: search.manifest.shardKeys[${i}] exceeds 256 chars`);
+  }
+  for (let p = 0; p < key.length; p++) {
+    const c = key.charCodeAt(p);
+    if (c === 0x2f /* "/" */
+        || c === 0x5c /* "\" */
+        || c < 0x20
+        || c === 0x7f) {
+      throw new TypeError(
+        `emitSite: search.manifest.shardKeys[${i}] contains forbidden char (${JSON.stringify(key)})`,
+      );
+    }
+  }
+}
+
+/**
+ * Convert an `IndexShard` (whose `postings` is a `Map`) into a
+ * JSON-friendly plain shape.  Token iteration order is the
+ * sorted token list — so the output bytes are stable between
+ * builds with the same input even if the Map's internal
+ * insertion order differs.
+ */
+function serialiseShard(shard: unknown): { shardKey: string; postings: Record<string, unknown> } {
+  if (shard === null || typeof shard !== "object") {
+    throw new TypeError("emitSite: shard must be an object");
+  }
+  const s = shard as { shardKey?: unknown; postings?: unknown };
+  if (typeof s.shardKey !== "string") {
+    throw new TypeError("emitSite: shard.shardKey must be a string");
+  }
+  if (!(s.postings instanceof Map)) {
+    throw new TypeError("emitSite: shard.postings must be a Map");
+  }
+  // Pull tokens out, sort, then iterate — deterministic order.
+  const tokens: string[] = [];
+  for (const tok of s.postings.keys()) {
+    if (typeof tok !== "string") {
+      throw new TypeError("emitSite: shard.postings keys must be strings");
+    }
+    tokens.push(tok);
+  }
+  tokens.sort();
+  // `Object.create(null)` — no inherited prototype, so a
+  // downstream consumer doing `obj[token]` can't accidentally
+  // pick up `toString` / `hasOwnProperty` etc.  JSON.stringify
+  // handles null-prototype objects identically to plain ones.
+  const postingsOut = Object.create(null) as Record<string, unknown>;
+  for (const tok of tokens) {
+    postingsOut[tok] = s.postings.get(tok);
+  }
+  return { shardKey: s.shardKey, postings: postingsOut };
+}
+
+/**
+ * Wrapper around `JSON.stringify` that:
+ *   - Uses no `indent` (compact output → smaller bundles, stable
+ *     hashes when nested values change shape).
+ *   - Uses no `replacer` (avoids the "replacer can mutate" footgun
+ *     and the equally-real "replacer can throw on circular" one).
+ *
+ * Centralised so any future tweaks (e.g. enforcing sorted keys
+ * across the board) land in one place.
+ */
+function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(value);
+}

--- a/code/packages/typescript/forme-doc-site-emitter/src/index.ts
+++ b/code/packages/typescript/forme-doc-site-emitter/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @coding-adventures/forme-doc-site-emitter
+ *
+ * Eleventh and FINAL DOC00 v0 package — the GLUE that turns
+ * DOC00's per-stage outputs into a `PageBundleConfig` for the
+ * FM00 deploy chain.
+ *
+ * Pure transform.  Capabilities: `[]`.  Per DOC00 spec section 8:
+ * "Every DOC00 package has required_capabilities.json ->
+ * capabilities: []. No exceptions in v0."  Site-emitter never
+ * instantiates any I/O primitive — it returns a data structure.
+ * The actual disk writes happen downstream in
+ * `forme-aot-page-bundle-emitter` ->
+ * `forme-aot-deploy-manifest-emitter` -> `forme-deploy-runner`,
+ * which already own the relevant capabilities.
+ *
+ * ```ts
+ * import { emitSite } from "@coding-adventures/forme-doc-site-emitter";
+ * import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+ *
+ * const bundle = emitSite({
+ *   pages: [
+ *     { route: "/",           html: indexHtml },
+ *     { route: "/guide/setup", html: setupHtml, lastmod: "2026-05-22" },
+ *   ],
+ *   sidebar,                       // from forme-doc-sidebar-builder
+ *   search: { manifest, shards },  // from forme-doc-search-index-builder
+ *   baseUrl: "https://example.com",
+ * });
+ *
+ * const manifestJson = generatePageBundle(bundle);
+ * // → JSON manifest with sorted routes; deploy runner consumes
+ * //   it and writes the files.
+ * ```
+ *
+ * @module index
+ */
+
+export { emitSite } from "./emitter.js";
+export {
+  DEFAULT_SIDEBAR_PATH,
+  DEFAULT_SEARCH_BASE_PATH,
+  DEFAULT_MAX_PAGES,
+  DEFAULT_MAX_SHARDS,
+  DEFAULT_MAX_EXTRAS,
+  CONTENT_TYPE_JSON,
+  CONTENT_TYPE_JS,
+} from "./emitter.js";
+export type {
+  DocPage,
+  ExtraFile,
+  SearchAssets,
+  SiteEmitInput,
+  SidebarTree,
+  PageBundleConfig,
+} from "./types.js";

--- a/code/packages/typescript/forme-doc-site-emitter/src/types.ts
+++ b/code/packages/typescript/forme-doc-site-emitter/src/types.ts
@@ -1,0 +1,149 @@
+/**
+ * types.ts — public signatures for the documentation-site emitter.
+ *
+ * Site-emitter is the GLUE PACKAGE for the DOC00 cluster: it takes
+ * the per-stage outputs (rendered HTML pages from page-shell, the
+ * sidebar tree from sidebar-builder, the search manifest + shards
+ * from search-index-builder, optionally a pre-bundled browser
+ * client.js for forme-doc-search-client-js) and composes a single
+ * `PageBundleConfig` that the FM00 deploy chain consumes unchanged.
+ *
+ * Why a separate package?  Because each upstream package solves one
+ * problem; tying them together with consistent route conventions,
+ * deterministic JSON shapes, and validation belongs in one place,
+ * not scattered across the caller.
+ *
+ * Pure transform.  No I/O primitive instantiated — the disk-write
+ * capability lives with the deploy runner downstream.
+ *
+ * @module types
+ */
+
+import type { SidebarEntry } from "@coding-adventures/forme-doc-sidebar-builder";
+import type {
+  IndexManifest,
+  IndexShard,
+} from "@coding-adventures/forme-doc-search-index-builder";
+
+/**
+ * The sidebar tree shape — `SidebarEntry[]` from the upstream
+ * `forme-doc-sidebar-builder` (re-aliased for clarity at the
+ * site-emitter API boundary).
+ */
+export type SidebarTree = readonly SidebarEntry[];
+
+/**
+ * One rendered documentation page — what the caller has after
+ * running the content pipeline through `forme-doc-page-shell` (and
+ * before that, parsing markdown, applying heading anchors, the TOC
+ * extractor, code-block decorator, and the syntax highlighter).
+ *
+ *   - `route`    — root-relative URL path (e.g. `"/"`, `"/guide/setup"`).
+ *                  MUST start with `/`; MUST NOT contain `..`, `//`,
+ *                  or `\`.  This is the route the FM00 deploy chain
+ *                  installs the page at.
+ *   - `html`     — the complete HTML document for the page (output
+ *                  of `forme-doc-page-shell` wrapped by
+ *                  `forme-aot-html-doc-emitter`, typically).
+ *                  Passed through as a string — site-emitter never
+ *                  parses or modifies the HTML.
+ *   - `lastmod`  — optional ISO 8601 timestamp; forwarded into the
+ *                  `PageEntry.lastmod` field on the bundle.
+ */
+export interface DocPage {
+  readonly route: string;
+  readonly html: string;
+  readonly lastmod?: string;
+}
+
+/**
+ * Inputs to the search engine slice.
+ *
+ *   - `manifest` — the small bootstrap manifest the browser loads
+ *                  first.  Serialised to `<basePath>/manifest.json`.
+ *   - `shards`   — the inverted-index shards.  Each shard becomes
+ *                  `<basePath>/<shardKey>.json`.  Order in the
+ *                  output bundle is by sorted `shardKey` for
+ *                  determinism.
+ *   - `clientJs` — optional pre-bundled browser JS for the
+ *                  search client.  Caller-provided because the
+ *                  bundling step lives outside the DOC00 cluster.
+ *                  Emitted as `<basePath>/client.js` when present.
+ *   - `basePath` — optional URL path prefix; defaults to
+ *                  `"/search"`.  Leading slash required, trailing
+ *                  slash forbidden.  This MUST line up with the
+ *                  client-side `fetch("/search/${key}.json")` glue
+ *                  the caller writes — the path is part of the
+ *                  contract.
+ */
+export interface SearchAssets {
+  readonly manifest: IndexManifest;
+  readonly shards: ReadonlyMap<string, IndexShard>;
+  readonly clientJs?: string;
+  readonly basePath?: string;
+}
+
+/**
+ * One arbitrary additional file the caller wants in the bundle —
+ * for favicons, `robots.txt`, copied images, `CNAME`, etc.
+ *
+ *   - `route`        — root-relative URL.  Same rules as `DocPage.route`.
+ *   - `content`      — body, as a string.  Binary files are not
+ *                      supported in v0 (the upstream
+ *                      `PageBundleConfig.PageEntry` schema takes
+ *                      strings); for v1 we may add a `bytes` variant.
+ *   - `contentType`  — MIME type.  No allowlist — pure pass-through
+ *                      string (the page-bundle-emitter accepts any
+ *                      string for content-type).
+ *   - `lastmod`      — optional ISO 8601 timestamp.
+ */
+export interface ExtraFile {
+  readonly route: string;
+  readonly content: string;
+  readonly contentType: string;
+  readonly lastmod?: string;
+}
+
+/**
+ * The complete site-emit input.
+ *
+ *   - `pages`    — the documentation pages.  May be empty (will
+ *                  produce a bundle with only the sidebar / search
+ *                  / extras, which is unusual but legal).
+ *   - `sidebar`  — optional sidebar tree.  When provided, emitted
+ *                  as `<sidebarPath>` (default `/sidebar.json`).
+ *                  Same shape as `forme-doc-sidebar-builder`
+ *                  returns.
+ *   - `sidebarPath` — override default sidebar route.  Leading `/`
+ *                  required; pathname only (no `?` / `#`).
+ *   - `search`   — optional search-engine assets.  Omitted entirely
+ *                  if the site doesn't ship search.
+ *   - `extras`   — optional additional files (favicons, robots, ...).
+ *   - `baseUrl`  — optional canonical site URL.  Validated only as
+ *                  "starts with `http://` or `https://`" — same rule
+ *                  page-bundle-emitter applies.  Forwarded into the
+ *                  output `PageBundleConfig.baseUrl`.
+ *
+ *   - `maxPages`     — optional cap (default 100_000).  Inputs
+ *                      beyond this throw.  Defends against
+ *                      pathological / runaway inputs.
+ *   - `maxShards`    — optional cap (default 10_000).
+ *   - `maxExtras`    — optional cap (default 10_000).
+ */
+export interface SiteEmitInput {
+  readonly pages: readonly DocPage[];
+  readonly sidebar?: SidebarTree;
+  readonly sidebarPath?: string;
+  readonly search?: SearchAssets;
+  readonly extras?: readonly ExtraFile[];
+  readonly baseUrl?: string;
+  readonly maxPages?: number;
+  readonly maxShards?: number;
+  readonly maxExtras?: number;
+}
+
+/**
+ * Re-export the upstream type so callers don't need a separate
+ * `import { PageBundleConfig }` from page-bundle-emitter.
+ */
+export type { PageBundleConfig } from "@coding-adventures/forme-aot-page-bundle-emitter";

--- a/code/packages/typescript/forme-doc-site-emitter/tests/emitter.test.ts
+++ b/code/packages/typescript/forme-doc-site-emitter/tests/emitter.test.ts
@@ -1,0 +1,577 @@
+/**
+ * emitter.test.ts — tests for forme-doc-site-emitter.
+ *
+ * Coverage strategy:
+ *   - Happy paths for every composable input slice (pages,
+ *     sidebar, search, extras, baseUrl).
+ *   - Every validation throw — one test per failure mode so a
+ *     regression points at exactly what slipped.
+ *   - Determinism — emit twice, assert byte-identical bundle JSON.
+ *   - End-to-end realism — feed the result through the actual
+ *     downstream `generatePageBundle` to confirm round-trip
+ *     compatibility (the manifest the deploy runner will see is
+ *     well-formed).
+ */
+
+import { describe, it, expect } from "vitest";
+import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+import {
+  emitSite,
+  DEFAULT_SIDEBAR_PATH,
+  DEFAULT_SEARCH_BASE_PATH,
+  DEFAULT_MAX_PAGES,
+  DEFAULT_MAX_SHARDS,
+  DEFAULT_MAX_EXTRAS,
+  CONTENT_TYPE_JSON,
+  CONTENT_TYPE_JS,
+} from "../src/index.js";
+import type {
+  DocPage,
+  SearchAssets,
+  ExtraFile,
+  SiteEmitInput,
+} from "../src/index.js";
+
+// -- Test fixtures ------------------------------------------------
+
+const PAGE_A: DocPage = { route: "/", html: "<html>A</html>" };
+const PAGE_B: DocPage = { route: "/about", html: "<html>B</html>", lastmod: "2026-05-22" };
+
+const SIDEBAR = [
+  { kind: "page" as const, label: "Home", path: "index.md", position: 1 },
+];
+
+function makeShard(key: string, tokens: Record<string, Array<{ pageId: string; freq: number; titleHit: boolean }>>) {
+  const postings = new Map<string, Array<{ pageId: string; freq: number; titleHit: boolean }>>();
+  for (const [tok, posts] of Object.entries(tokens)) postings.set(tok, posts);
+  return { shardKey: key, postings };
+}
+
+function makeSearch(): SearchAssets {
+  return {
+    manifest: {
+      pages: ["/", "/about"],
+      shardKeys: ["a", "b"],
+      shardPrefix: 1,
+      filterStopWords: true,
+      stem: true,
+      stats: { totalTokens: 4, uniqueTokens: 2, pageCount: 2, shardCount: 2 },
+    },
+    shards: new Map([
+      ["a", makeShard("a", { apple: [{ pageId: "/", freq: 2, titleHit: false }] })],
+      ["b", makeShard("b", { banana: [{ pageId: "/about", freq: 1, titleHit: true }] })],
+    ]),
+  };
+}
+
+// =====================================================================
+// 1. Construction / input-shape validation
+// =====================================================================
+
+describe("emitSite — input shape", () => {
+  it("throws on null/undefined input", () => {
+    expect(() => emitSite(null as unknown as SiteEmitInput)).toThrow(TypeError);
+    expect(() => emitSite("hi" as unknown as SiteEmitInput)).toThrow(TypeError);
+  });
+
+  it("throws when pages is not an array", () => {
+    expect(() => emitSite({ pages: "x" } as unknown as SiteEmitInput)).toThrow(/pages must be an array/);
+  });
+
+  it("throws when a page is not an object", () => {
+    expect(() => emitSite({ pages: [null] } as unknown as SiteEmitInput)).toThrow(/pages\[0\] must be an object/);
+  });
+
+  it("throws when page.html is not a string", () => {
+    expect(() => emitSite({ pages: [{ route: "/", html: 5 } as unknown as DocPage] })).toThrow(/pages\[0\].html/);
+  });
+
+  it("throws when page.lastmod is not a string", () => {
+    expect(() => emitSite({ pages: [{ route: "/", html: "h", lastmod: 5 } as unknown as DocPage] })).toThrow(/lastmod must be a string/);
+  });
+
+  it("throws when baseUrl is non-string", () => {
+    expect(() =>
+      emitSite({ pages: [PAGE_A], baseUrl: 5 } as unknown as SiteEmitInput),
+    ).toThrow(/baseUrl must be a string/);
+  });
+});
+
+// =====================================================================
+// 2. Route validation
+// =====================================================================
+
+describe("emitSite — route shape", () => {
+  it("rejects non-string route", () => {
+    expect(() => emitSite({ pages: [{ route: 5, html: "x" } as unknown as DocPage] })).toThrow(/route must be a string/);
+  });
+  it("rejects empty route", () => {
+    expect(() => emitSite({ pages: [{ route: "", html: "x" }] })).toThrow(/must start with "\/"/);
+  });
+  it("rejects route without leading slash", () => {
+    expect(() => emitSite({ pages: [{ route: "about", html: "x" }] })).toThrow(/must start with "\/"/);
+  });
+  it("rejects backslash", () => {
+    expect(() => emitSite({ pages: [{ route: "/foo\\bar", html: "x" }] })).toThrow(/must not contain "\\"/);
+  });
+  it("rejects // protocol-relative hint", () => {
+    expect(() => emitSite({ pages: [{ route: "//evil.example.com/path", html: "x" }] })).toThrow(/must not contain "\/\/"/);
+  });
+  it("rejects .. segment", () => {
+    expect(() => emitSite({ pages: [{ route: "/foo/../bar", html: "x" }] })).toThrow(/must not contain "\.\." segment/);
+  });
+  it("rejects control chars", () => {
+    expect(() => emitSite({ pages: [{ route: "/foo\x01bar", html: "x" }] })).toThrow(/must not contain control chars/);
+  });
+  it("rejects DEL char (0x7f)", () => {
+    expect(() => emitSite({ pages: [{ route: "/foo\x7fbar", html: "x" }] })).toThrow(/must not contain control chars/);
+  });
+  it("rejects routes longer than 8192 chars", () => {
+    const longRoute = "/" + "a".repeat(8192);
+    expect(() => emitSite({ pages: [{ route: longRoute, html: "x" }] })).toThrow(/exceeds 8192 chars/);
+  });
+  it("accepts a route with a dot in the middle (e.g. /file.html)", () => {
+    const bundle = emitSite({ pages: [{ route: "/file.html", html: "x" }] });
+    expect(bundle.pages[0]!.route).toBe("/file.html");
+  });
+  it("accepts a single-segment dot (not ..) like /. notation", () => {
+    // ".foo" is a single segment that starts with a dot but isn't "..", should pass.
+    const bundle = emitSite({ pages: [{ route: "/.dotted", html: "x" }] });
+    expect(bundle.pages[0]!.route).toBe("/.dotted");
+  });
+});
+
+// =====================================================================
+// 3. Numeric option validation
+// =====================================================================
+
+describe("emitSite — numeric options", () => {
+  it("rejects NaN maxPages", () => {
+    expect(() => emitSite({ pages: [], maxPages: NaN })).toThrow(/maxPages/);
+  });
+  it("rejects Infinity maxPages", () => {
+    expect(() => emitSite({ pages: [], maxPages: Infinity })).toThrow(/maxPages/);
+  });
+  it("rejects negative maxPages", () => {
+    expect(() => emitSite({ pages: [], maxPages: -1 })).toThrow(/maxPages/);
+  });
+  it("rejects non-integer maxPages", () => {
+    expect(() => emitSite({ pages: [], maxPages: 2.5 })).toThrow(/maxPages/);
+  });
+  it("rejects non-integer maxShards", () => {
+    expect(() => emitSite({ pages: [], maxShards: 2.5 })).toThrow(/maxShards/);
+  });
+  it("rejects non-integer maxExtras", () => {
+    expect(() => emitSite({ pages: [], maxExtras: 2.5 })).toThrow(/maxExtras/);
+  });
+  it("rejects when pages exceeds maxPages", () => {
+    expect(() => emitSite({ pages: [PAGE_A, PAGE_B], maxPages: 1 })).toThrow(/exceeds maxPages=1/);
+  });
+  it("rejects when extras exceeds maxExtras", () => {
+    const xs: ExtraFile[] = [
+      { route: "/a.txt", content: "1", contentType: "text/plain" },
+      { route: "/b.txt", content: "2", contentType: "text/plain" },
+    ];
+    expect(() => emitSite({ pages: [], extras: xs, maxExtras: 1 })).toThrow(/exceeds maxExtras=1/);
+  });
+  it("accepts maxPages: 0 with an empty pages list (legitimate assertion)", () => {
+    const bundle = emitSite({ pages: [], maxPages: 0 });
+    expect(bundle.pages).toEqual([]);
+  });
+});
+
+// =====================================================================
+// 4. Happy-path pages
+// =====================================================================
+
+describe("emitSite — pages", () => {
+  it("emits a single page as a PageEntry", () => {
+    const bundle = emitSite({ pages: [PAGE_A] });
+    expect(bundle.pages).toEqual([{ route: "/", html: "<html>A</html>" }]);
+    expect(bundle.baseUrl).toBeUndefined();
+  });
+
+  it("preserves lastmod when present", () => {
+    const bundle = emitSite({ pages: [PAGE_B] });
+    expect(bundle.pages[0]).toEqual({ route: "/about", html: "<html>B</html>", lastmod: "2026-05-22" });
+  });
+
+  it("emits multiple pages preserving input order", () => {
+    const bundle = emitSite({ pages: [PAGE_B, PAGE_A] });
+    expect(bundle.pages.map((p) => p.route)).toEqual(["/about", "/"]);
+  });
+
+  it("forwards baseUrl unchanged", () => {
+    const bundle = emitSite({ pages: [PAGE_A], baseUrl: "https://docs.example.com" });
+    expect(bundle.baseUrl).toBe("https://docs.example.com");
+  });
+
+  it("rejects duplicate routes among pages", () => {
+    expect(() =>
+      emitSite({ pages: [PAGE_A, { route: "/", html: "<html>A2</html>" }] }),
+    ).toThrow(/duplicate route "\/"/);
+  });
+});
+
+// =====================================================================
+// 5. Sidebar
+// =====================================================================
+
+describe("emitSite — sidebar", () => {
+  it("emits sidebar at the default path with JSON content-type", () => {
+    const bundle = emitSite({ pages: [PAGE_A], sidebar: SIDEBAR });
+    const sidebarEntry = bundle.pages.find((p) => p.route === DEFAULT_SIDEBAR_PATH)!;
+    expect(sidebarEntry).toBeDefined();
+    expect(sidebarEntry.contentType).toBe(CONTENT_TYPE_JSON);
+    expect(JSON.parse(sidebarEntry.html)).toEqual(SIDEBAR);
+  });
+
+  it("honours sidebarPath override", () => {
+    const bundle = emitSite({ pages: [], sidebar: SIDEBAR, sidebarPath: "/nav.json" });
+    expect(bundle.pages.find((p) => p.route === "/nav.json")).toBeDefined();
+    expect(bundle.pages.find((p) => p.route === DEFAULT_SIDEBAR_PATH)).toBeUndefined();
+  });
+
+  it("throws when sidebar is not an array", () => {
+    expect(() => emitSite({ pages: [], sidebar: "x" } as unknown as SiteEmitInput)).toThrow(/sidebar must be an array/);
+  });
+
+  it("throws when sidebarPath is invalid", () => {
+    expect(() => emitSite({ pages: [], sidebar: SIDEBAR, sidebarPath: "nav.json" })).toThrow(/sidebarPath must start with "\/"/);
+  });
+
+  it("throws when sidebar route collides with a page", () => {
+    expect(() =>
+      emitSite({ pages: [{ route: "/sidebar.json", html: "<html>X</html>" }], sidebar: SIDEBAR }),
+    ).toThrow(/duplicate route "\/sidebar.json"/);
+  });
+});
+
+// =====================================================================
+// 6. Search
+// =====================================================================
+
+describe("emitSite — search", () => {
+  it("emits manifest + shards + (no client by default)", () => {
+    const bundle = emitSite({ pages: [PAGE_A], search: makeSearch() });
+    const routes = bundle.pages.map((p) => p.route);
+    expect(routes).toContain("/search/manifest.json");
+    expect(routes).toContain("/search/a.json");
+    expect(routes).toContain("/search/b.json");
+    expect(routes).not.toContain("/search/client.js");
+  });
+
+  it("emits client.js when provided", () => {
+    const search = { ...makeSearch(), clientJs: "console.log('ok');" };
+    const bundle = emitSite({ pages: [], search });
+    const client = bundle.pages.find((p) => p.route === "/search/client.js")!;
+    expect(client.contentType).toBe(CONTENT_TYPE_JS);
+    expect(client.html).toBe("console.log('ok');");
+  });
+
+  it("honours basePath override", () => {
+    const search = { ...makeSearch(), basePath: "/idx" };
+    const bundle = emitSite({ pages: [], search });
+    expect(bundle.pages.find((p) => p.route === "/idx/manifest.json")).toBeDefined();
+    expect(bundle.pages.find((p) => p.route === "/idx/a.json")).toBeDefined();
+  });
+
+  it("rejects basePath with trailing slash", () => {
+    const search = { ...makeSearch(), basePath: "/search/" };
+    expect(() => emitSite({ pages: [], search })).toThrow(/search.basePath must not end with "\/"/);
+  });
+
+  it("rejects clientJs that isn't a string", () => {
+    const search = { ...makeSearch(), clientJs: 5 } as unknown as SearchAssets;
+    expect(() => emitSite({ pages: [], search })).toThrow(/clientJs must be a string/);
+  });
+
+  it("rejects non-Map shards", () => {
+    const search = {
+      manifest: makeSearch().manifest,
+      shards: { a: "x" } as unknown as Map<string, never>,
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/shards must be a Map/);
+  });
+
+  it("rejects when shards is missing an entry the manifest lists", () => {
+    const search: SearchAssets = {
+      manifest: makeSearch().manifest, // lists "a" and "b"
+      shards: new Map([["a", makeShard("a", { x: [] })]]), // missing "b"
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/missing entry for shardKey "b"/);
+  });
+
+  it("rejects non-string shardKey in manifest", () => {
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: [5 as unknown as string] },
+      shards: new Map(),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/shardKeys\[0\] must be a string/);
+  });
+
+  it("rejects shardKey containing /", () => {
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a/b"] },
+      shards: new Map([["a/b", makeShard("a/b", {})]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/forbidden char/);
+  });
+
+  it("rejects empty shardKey", () => {
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: [""] },
+      shards: new Map([["", makeShard("", {})]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/must not be empty/);
+  });
+
+  it("rejects shardKey longer than 256 chars", () => {
+    const long = "x".repeat(257);
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: [long] },
+      shards: new Map([[long, makeShard(long, {})]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/exceeds 256 chars/);
+  });
+
+  it("rejects shards Map size > maxShards", () => {
+    const shards = new Map<string, ReturnType<typeof makeShard>>();
+    for (let i = 0; i < 3; i++) shards.set(String.fromCharCode(0x61 + i), makeShard(String.fromCharCode(0x61 + i), {}));
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a", "b", "c"] },
+      shards,
+    };
+    expect(() => emitSite({ pages: [], search, maxShards: 2 })).toThrow(/exceeds maxShards=2/);
+  });
+
+  it("rejects null search", () => {
+    expect(() => emitSite({ pages: [], search: null } as unknown as SiteEmitInput)).toThrow(/search must be an object/);
+  });
+
+  it("rejects null manifest", () => {
+    const search = { manifest: null, shards: new Map() } as unknown as SearchAssets;
+    expect(() => emitSite({ pages: [], search })).toThrow(/manifest must be an object/);
+  });
+
+  it("rejects shard with non-Map postings", () => {
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a"] },
+      shards: new Map([["a", { shardKey: "a", postings: {} } as unknown as ReturnType<typeof makeShard>]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/shard.postings must be a Map/);
+  });
+
+  it("rejects shard with non-string shardKey", () => {
+    const badShard = { shardKey: 5, postings: new Map() } as unknown as ReturnType<typeof makeShard>;
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a"] },
+      shards: new Map([["a", badShard]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/shard.shardKey must be a string/);
+  });
+
+  it("rejects null shard", () => {
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a"] },
+      shards: new Map([["a", null as unknown as ReturnType<typeof makeShard>]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/shard must be an object/);
+  });
+
+  it("rejects shard.postings with non-string token keys", () => {
+    const postings = new Map<unknown, unknown>();
+    postings.set(5, []);
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a"] },
+      shards: new Map([["a", { shardKey: "a", postings } as unknown as ReturnType<typeof makeShard>]]),
+    };
+    expect(() => emitSite({ pages: [], search })).toThrow(/postings keys must be strings/);
+  });
+
+  it("tolerates a manifest whose shardKeys is not an array (emits no shards)", () => {
+    // Defensive: if a caller hands us a partial/odd manifest, we
+    // still emit manifest.json and skip shard emission rather than
+    // throwing on the iterator.
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: undefined as unknown as string[] },
+      shards: new Map(),
+    };
+    const bundle = emitSite({ pages: [], search });
+    expect(bundle.pages.find((p) => p.route === "/search/manifest.json")).toBeDefined();
+    expect(bundle.pages.find((p) => p.route?.startsWith("/search/") && p.route !== "/search/manifest.json")).toBeUndefined();
+  });
+
+  it("serialises shard tokens in sorted order (determinism)", () => {
+    const postings = new Map<string, Array<{ pageId: string; freq: number; titleHit: boolean }>>();
+    // Insert in reverse alphabetical order.
+    postings.set("zebra", [{ pageId: "/", freq: 1, titleHit: false }]);
+    postings.set("apple", [{ pageId: "/", freq: 1, titleHit: false }]);
+    postings.set("mango", [{ pageId: "/", freq: 1, titleHit: false }]);
+    const search: SearchAssets = {
+      manifest: { ...makeSearch().manifest, shardKeys: ["a"] },
+      shards: new Map([["a", { shardKey: "a", postings }]]),
+    };
+    const bundle = emitSite({ pages: [], search });
+    const shardEntry = bundle.pages.find((p) => p.route === "/search/a.json")!;
+    const parsed = JSON.parse(shardEntry.html) as { postings: Record<string, unknown> };
+    expect(Object.keys(parsed.postings)).toEqual(["apple", "mango", "zebra"]);
+  });
+});
+
+// =====================================================================
+// 7. Extras
+// =====================================================================
+
+describe("emitSite — extras", () => {
+  it("emits extras with declared content-type and lastmod", () => {
+    const extras: ExtraFile[] = [
+      { route: "/robots.txt", content: "User-agent: *\nAllow: /\n", contentType: "text/plain", lastmod: "2026-05-22" },
+    ];
+    const bundle = emitSite({ pages: [PAGE_A], extras });
+    const robots = bundle.pages.find((p) => p.route === "/robots.txt")!;
+    expect(robots.contentType).toBe("text/plain");
+    expect(robots.html).toContain("User-agent: *");
+    expect(robots.lastmod).toBe("2026-05-22");
+  });
+
+  it("throws when extras is not an array", () => {
+    expect(() => emitSite({ pages: [], extras: "x" } as unknown as SiteEmitInput)).toThrow(/extras must be an array/);
+  });
+
+  it("throws when an extra is not an object", () => {
+    expect(() => emitSite({ pages: [], extras: [null] } as unknown as SiteEmitInput)).toThrow(/extras\[0\] must be an object/);
+  });
+
+  it("throws when extra.content is not a string", () => {
+    const extras = [{ route: "/x", content: 5, contentType: "text/plain" }] as unknown as ExtraFile[];
+    expect(() => emitSite({ pages: [], extras })).toThrow(/content must be a string/);
+  });
+
+  it("throws when extra.contentType is not a string", () => {
+    const extras = [{ route: "/x", content: "y", contentType: 5 }] as unknown as ExtraFile[];
+    expect(() => emitSite({ pages: [], extras })).toThrow(/contentType must be a string/);
+  });
+
+  it("throws when extra.lastmod is not a string", () => {
+    const extras = [{ route: "/x", content: "y", contentType: "text/plain", lastmod: 5 }] as unknown as ExtraFile[];
+    expect(() => emitSite({ pages: [], extras })).toThrow(/lastmod must be a string/);
+  });
+
+  it("rejects duplicate route between extra and page", () => {
+    const extras: ExtraFile[] = [{ route: "/", content: "robot", contentType: "text/plain" }];
+    expect(() => emitSite({ pages: [PAGE_A], extras })).toThrow(/duplicate route "\/"/);
+  });
+});
+
+// =====================================================================
+// 8. Determinism + downstream round-trip
+// =====================================================================
+
+describe("emitSite — determinism and round-trip", () => {
+  it("produces byte-identical JSON when called twice with the same input", () => {
+    const input: SiteEmitInput = {
+      pages: [PAGE_B, PAGE_A],
+      sidebar: SIDEBAR,
+      search: makeSearch(),
+      extras: [{ route: "/robots.txt", content: "User-agent: *", contentType: "text/plain" }],
+      baseUrl: "https://docs.example.com",
+    };
+    const bundle1 = emitSite(input);
+    const bundle2 = emitSite(input);
+    expect(JSON.stringify(bundle1)).toBe(JSON.stringify(bundle2));
+  });
+
+  it("feeds cleanly into generatePageBundle (no late validation throws)", () => {
+    const bundle = emitSite({
+      pages: [PAGE_A, PAGE_B],
+      sidebar: SIDEBAR,
+      search: makeSearch(),
+      baseUrl: "https://docs.example.com",
+    });
+    const manifestJson = generatePageBundle(bundle);
+    const manifest = JSON.parse(manifestJson) as {
+      version: 1;
+      baseUrl?: string;
+      routes: Record<string, { route: string; outputPath: string; contentType: string; sizeBytes: number; sha256: string }>;
+    };
+    expect(manifest.version).toBe(1);
+    expect(manifest.baseUrl).toBe("https://docs.example.com");
+    // Every PageEntry we emitted is present.
+    for (const p of bundle.pages) {
+      expect(manifest.routes[p.route]).toBeDefined();
+    }
+    // The downstream emitter derives outputPath deterministically;
+    // sidebar.json keeps its extension.
+    expect(manifest.routes["/sidebar.json"]!.outputPath).toBe("sidebar.json");
+    expect(manifest.routes["/search/manifest.json"]!.outputPath).toBe("search/manifest.json");
+    expect(manifest.routes["/search/a.json"]!.outputPath).toBe("search/a.json");
+  });
+});
+
+// =====================================================================
+// 9. Default constants — sanity check (also bumps line coverage)
+// =====================================================================
+
+describe("emitSite — default constants", () => {
+  it("exports the documented defaults", () => {
+    expect(DEFAULT_SIDEBAR_PATH).toBe("/sidebar.json");
+    expect(DEFAULT_SEARCH_BASE_PATH).toBe("/search");
+    expect(DEFAULT_MAX_PAGES).toBe(100_000);
+    expect(DEFAULT_MAX_SHARDS).toBe(10_000);
+    expect(DEFAULT_MAX_EXTRAS).toBe(10_000);
+    expect(CONTENT_TYPE_JSON).toBe("application/json; charset=utf-8");
+    expect(CONTENT_TYPE_JS).toBe("application/javascript; charset=utf-8");
+  });
+});
+
+// =====================================================================
+// 10. Realistic 3-page docs site
+// =====================================================================
+
+describe("emitSite — realistic", () => {
+  it("composes a 3-page docs site with sidebar + search + favicon", () => {
+    const pages: DocPage[] = [
+      { route: "/", html: "<html><body>home</body></html>", lastmod: "2026-05-20" },
+      { route: "/guide/setup", html: "<html><body>setup</body></html>", lastmod: "2026-05-21" },
+      { route: "/api", html: "<html><body>api</body></html>", lastmod: "2026-05-22" },
+    ];
+    const sidebar = [
+      { kind: "page" as const, label: "Home", path: "index.md", position: 1 },
+      { kind: "group" as const, label: "Guide", path: "guide/index.md", position: 2, children: [
+        { kind: "page" as const, label: "Setup", path: "guide/setup.md", position: 1 },
+      ] },
+      { kind: "page" as const, label: "API", path: "api.md", position: 3 },
+    ];
+    const search = makeSearch();
+    const extras: ExtraFile[] = [
+      { route: "/favicon.ico", content: "<binary>", contentType: "image/x-icon" },
+      { route: "/robots.txt", content: "User-agent: *\nAllow: /\n", contentType: "text/plain" },
+    ];
+    const bundle = emitSite({
+      pages,
+      sidebar,
+      search: { ...search, clientJs: "/* search client */" },
+      extras,
+      baseUrl: "https://docs.example.com",
+    });
+
+    // Expected route set.
+    const routes = bundle.pages.map((p) => p.route).sort();
+    expect(routes).toEqual([
+      "/",
+      "/api",
+      "/favicon.ico",
+      "/guide/setup",
+      "/robots.txt",
+      "/search/a.json",
+      "/search/b.json",
+      "/search/client.js",
+      "/search/manifest.json",
+      "/sidebar.json",
+    ]);
+    // Round-trip through generatePageBundle.
+    const manifest = JSON.parse(generatePageBundle(bundle)) as { routes: Record<string, { outputPath: string }> };
+    expect(Object.keys(manifest.routes).length).toBe(10);
+  });
+});

--- a/code/packages/typescript/forme-doc-site-emitter/tsconfig.json
+++ b/code/packages/typescript/forme-doc-site-emitter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/forme-doc-site-emitter/vitest.config.ts
+++ b/code/packages/typescript/forme-doc-site-emitter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

**Eleventh and FINAL DOC00 v0 package — the cluster is complete.** Glue that composes DOC00 per-stage outputs (rendered pages + sidebar tree + search manifest/shards/client.js + extras + baseUrl) into a single `PageBundleConfig` the FM00 deploy chain consumes unchanged.

Pure transform. Capabilities: `[]`. Per DOC00 spec section 8: "Every DOC00 package has `required_capabilities.json` → `capabilities: []`. **No exceptions in v0.**" Site-emitter never instantiates any I/O primitive — it returns a data structure; the disk writes happen downstream in `forme-deploy-runner` (FM00).

## Spec divergence flagged (no behavioural deviation)

The babysit-cron prompt that triggered this implementation guessed capabilities would be `[fs:write]` since the package "writes the final site to disk". Re-reading spec section 8 shows the correct answer is `[]` — site-emitter does NOT write to disk; it returns a `PageBundleConfig`. The disk writes happen in `forme-deploy-runner` downstream (which already owns `fs:write` per FM05). **This implementation follows the spec, not the cron prompt's guess.**

## Public API

- `emitSite(input: SiteEmitInput): PageBundleConfig` — main entry
- Default constants: `DEFAULT_SIDEBAR_PATH` (`/sidebar.json`), `DEFAULT_SEARCH_BASE_PATH` (`/search`), `DEFAULT_MAX_PAGES/_SHARDS/_EXTRAS`, `CONTENT_TYPE_JSON/_JS`
- Types: `DocPage`, `ExtraFile`, `SearchAssets`, `SiteEmitInput`, `SidebarTree`, `PageBundleConfig` (re-exported from upstream)

## Behavioural notes

- **Route validation up-front** — same rules as `forme-aot-page-bundle-emitter` (must start with `/`, no `\`, no `//`, no `..` segment, no control chars, ≤ 8192 chars). All checks use explicit `charCodeAt` index loops; no regex on user input (matches the project-wide ReDoS-prevention convention).
- **Shard-key validation** — non-empty, ≤ 256 chars, no `/`, no `\`, no control chars.
- **Duplicate-route detection** — fail-fast rather than letting one entry shadow another.
- **Deterministic** — for a fixed input, the bundle serialises to byte-identical JSON. Shard tokens emitted in sorted order; shard iteration follows the manifest's sorted `shardKeys` array (not the Map's insertion order).
- **Manifest tolerance** — if a caller hands us a manifest with no `shardKeys` array, we emit `manifest.json` but skip shard emission rather than throwing on the iterator.
- **Object.create(null)** for shard postings output — defends downstream consumers from accidentally inheriting `toString` / `hasOwnProperty` when they `obj[token]` the result.

## Security posture

- No `eval` / `new Function` / `JSON.parse`-with-reviver.
- No I/O primitives instantiated. Capabilities `[]`.
- `Number.isFinite` + `Number.isInteger` validation for all three caps (`maxPages` / `maxShards` / `maxExtras`); NaN / Infinity / negative / non-integer all throw.
- Route validation at the boundary closest to user input; no regex on user input.
- Bounded input sizes — caps applied BEFORE iteration / JSON.stringify, so adversarial inputs fail fast.
- No prototype pollution — Map-based lookups; shard postings via `Object.create(null)`.
- Duplicate-route detection.

**Security review: clean** — no HIGH/MEDIUM/LOW findings across all twelve review categories (capability isolation, route validation completeness, numeric validation, prototype pollution, ReDoS, duplicate-route detection, JSON serialization safety, defensive shape checks, path-traversal, bounded input sizes, length cap, locale leak).

## Coverage

**100% line / 100% branch / 100% function** on all source files with logic (`types.ts` is type-only). 67 tests in `tests/emitter.test.ts`.

## DOC00 v0 cluster: COMPLETE

1. `forme-doc-frontmatter`
2. `forme-doc-heading-anchors`
3. `forme-doc-toc-extractor`
4. `forme-doc-code-block-decorator`
5. `forme-doc-syntax-highlighter`
6. `forme-doc-sidebar-builder`
7. `forme-doc-page-shell`
8. `forme-doc-search-tokenizer`
9. `forme-doc-search-index-builder`
10. `forme-doc-search-client-js`
11. **`forme-doc-site-emitter`** ← this PR

**Eleven new packages, all `capabilities: []`.** The single capability boundary in the entire DOC00 pipeline lives in the already-shipped `forme-deploy-runner` (FM00 v0). Zero new capabilities required for the entire docs cluster.

## v0 simplifications

- No `bytes` variant for extras (strings only; v1 may add `Uint8Array`)
- No theme / asset bundling (caller pre-bundles CSS/JS)
- No sitemap.xml / RSS generation (composed downstream by `forme-aot-deploy-manifest-emitter`)
- No dev-server integration (separate program per spec)
- String content only (no streams)

## Test plan

- [x] `npx vitest run --coverage` — 67/67 pass; 100% line / 100% branch / 100% function on `emitter.ts` + `index.ts`
- [x] `/security-review` — clean (no HIGH/MEDIUM/LOW)
- [x] Round-trip: output verified to feed cleanly into `forme-aot-page-bundle-emitter.generatePageBundle` (no late validation throws)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)