### PR TITLE
feat(ruby-parser): Phase 6e — symbol literals `:foo` / `:"bar"`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -39,7 +39,8 @@ method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPA
 expression_stmt = expression ;
 expression   = term { ( PLUS | MINUS ) term } ;
 term         = factor { ( STAR | SLASH ) factor } ;
-factor       = NUMBER | STRING | NAME | KEYWORD | array_literal | hash_literal | LPAREN expression RPAREN ;
+factor       = NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN ;
+symbol_literal = COLON ( NAME | KEYWORD | STRING ) ;
 array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET ;
 hash_literal = LBRACE [ hash_entry { COMMA hash_entry } ] RBRACE ;
 hash_entry   = NAME COLON expression | expression "=>" expression ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.6.0] - 2026-05-20
+
+### Added (Phase 6e — symbol literals `:foo` / `:"bar"`)
+- `symbol_literal = COLON ( NAME | KEYWORD | STRING ) ;`
+- Added as a `factor` alternative so symbols can appear wherever an expression is valid.
+- Quoted symbols (`:"hello world"`) reuse the existing STRING token shape — the lexer strips the quotes, so the symbol's name is the inner content directly.
+
+### Tests (+3 new, total 24)
+- `:foo` (name), `:def` (keyword name — names can be Ruby keywords), `:"hello world"` (quoted).
+
 ## [0.5.0] - 2026-05-20
 
 ### Added (Phase 6d — array and hash literals)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -209,6 +209,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::RuleReference { name: r#"array_literal"#.to_string() },
                 GrammarElement::RuleReference { name: r#"hash_literal"#.to_string() },
                 GrammarElement::Sequence { elements: vec![
@@ -218,6 +219,18 @@ pub fn parser_grammar() -> ParserGrammar {
                 ] },
             ] },
             line_number: 42,
+        },
+        GrammarRule {
+            name: r#"symbol_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 43,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -232,7 +245,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 43,
+            line_number: 44,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -247,7 +260,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 44,
+            line_number: 45,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -263,7 +276,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 45,
+            line_number: 46,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -385,5 +385,45 @@ mod tests {
             "expected hash_entry subnode"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6e — symbol literals `:foo`, `:"bar"`
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_symbol_name() {
+        let ast = parse_ruby("x = :foo");
+        let sym = find_descendant(&ast, "symbol_literal").expect("expected symbol_literal");
+        // The grammar puts COLON then NAME under the rule.
+        let name_tok = sym.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Name) => {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        });
+        assert_eq!(name_tok, Some("foo"));
+    }
+
+    #[test]
+    fn test_parse_symbol_keyword() {
+        // `:def` — the symbol name happens to be a Ruby keyword.
+        let ast = parse_ruby("x = :def");
+        assert!(find_descendant(&ast, "symbol_literal").is_some());
+    }
+
+    #[test]
+    fn test_parse_symbol_quoted() {
+        let ast = parse_ruby(r#"x = :"hello world""#);
+        let sym = find_descendant(&ast, "symbol_literal").expect("expected symbol_literal");
+        let str_tok = sym.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t)
+                if matches!(t.type_, lexer::token::TokenType::String) =>
+            {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        });
+        assert_eq!(str_tok, Some("hello world"));
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.6.0] - 2026-05-20
+
+### Added (Phase 6e — symbol-literal lowering)
+- `lower_symbol_literal` — picks the first Name / Keyword / String token under the `symbol_literal` node and emits an `Expr::SymLit` with that lexeme as the symbol name.  Quoted symbols (`:"hello world"`) work transparently because the String token's value already has the surrounding quotes stripped.
+- Declares `Feature::Symbols` on every symbol literal (same feature the hash-shorthand entries already used).
+
+### Tests (+4 new, total 30)
+- `:foo` → `SymLit("foo")`.
+- `:"hello world"` → `SymLit("hello world")` (spaces preserved).
+- `:def` (keyword-shaped name) → `SymLit("def")`.
+- Symbol-containing module passes `semantic_ir::validate`.
+
 ## [0.5.0] - 2026-05-20
 
 ### Added (Phase 6d — array and hash literal lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -520,6 +520,55 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Phase 6e — symbol literals `:foo` / `:"bar"`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn symbol_lowers_to_sym_lit() {
+        let m = lower("x = :foo\n");
+        let main = main_body(&m);
+        let sym = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value: Expr::SymLit { name, .. }, .. } => Some(name.as_str()),
+            _ => None,
+        });
+        assert_eq!(sym, Some("foo"));
+    }
+
+    #[test]
+    fn quoted_symbol_lowers_to_sym_lit_with_spaces() {
+        let m = lower(r#"x = :"hello world""#);
+        let main = main_body(&m);
+        let sym = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value: Expr::SymLit { name, .. }, .. } => Some(name.as_str()),
+            _ => None,
+        });
+        assert_eq!(sym, Some("hello world"));
+    }
+
+    #[test]
+    fn keyword_symbol_lowers_cleanly() {
+        // `:def` — the symbol name happens to be a Ruby keyword.
+        let m = lower("x = :def\n");
+        let main = main_body(&m);
+        let sym = main.stmts.iter().find_map(|s| match s {
+            Stmt::LetBinding { value: Expr::SymLit { name, .. }, .. } => Some(name.as_str()),
+            _ => None,
+        });
+        assert_eq!(sym, Some("def"));
+    }
+
+    #[test]
+    fn symbol_module_passes_sir_validator() {
+        let m = lower("x = :foo\ny = :bar\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn module_with_def_passes_sir_validator() {
         // v0 grammar can't yet parse nested method calls in args

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -808,6 +808,7 @@ impl Lowerer {
             "factor" => self.lower_factor(node),
             "array_literal" => self.lower_array_literal(node),
             "hash_literal" => self.lower_hash_literal(node),
+            "symbol_literal" => self.lower_symbol_literal(node),
             // The parser sometimes wraps a bare token into an "expression_stmt"
             // when reached as the RHS of an assignment.  Recurse into it.
             "expression_stmt" => {
@@ -885,6 +886,38 @@ impl Lowerer {
     }
 
     /// Lower a `factor` node — the leaves of the expression tree.
+    /// Phase 6e — `:foo` / `:"bar"` → `Expr::SymLit`.  The leading
+    /// COLON is the syntactic marker; the symbol's *name* is the
+    /// Name/Keyword/String token that follows.  For quoted forms
+    /// (`:"hello world"`) the String token's value already strips
+    /// the surrounding quotes, so we use it verbatim.
+    fn lower_symbol_literal(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let name_tok = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t)
+                if matches!(
+                    t.type_,
+                    TokenType::Name | TokenType::Keyword | TokenType::String
+                ) =>
+            {
+                Some(t)
+            }
+            _ => None,
+        });
+        let name_tok = name_tok.ok_or_else(|| RubyLowerError {
+            message: "symbol_literal missing payload token".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })?;
+        self.features_used.insert(Feature::Symbols);
+        Ok(Expr::SymLit {
+            name: name_tok.value.clone(),
+            span: self.span_of(node),
+        })
+    }
+
     /// Phase 6d — `[a, b, c]` → `Expr::SeqLit`.
     fn lower_array_literal(
         &mut self,


### PR DESCRIPTION
## Summary

Fifth parser-grammar extension.  Adds symbol literals (`:foo`, `:def`, `:"hello world"`) and lowers them to `semantic_ir::Expr::SymLit`.

## Parser

\`\`\`
symbol_literal = COLON ( NAME | KEYWORD | STRING )
\`\`\`

Added as a `factor` alternative.

## SIR lowering

`lower_symbol_literal` emits `Expr::SymLit` with the lexeme as the symbol name.  Quoted forms work transparently because the STRING token already strips quotes.  Declares `Feature::Symbols`.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` — 108 passed (unchanged).
- [x] `cargo test -p coding-adventures-ruby-parser` — 24 passed (was 21; +3 new).
- [x] `cargo test -p ruby-to-semantic-ir` — 30 passed (was 26; +4 new).

## What's next

Last merged was [Phase 4f lexer](https://github.com/adhithyan15/coding-adventures/pull/3912); this is parser.  Next: Phase 4g — 2.0 percent literals `%i[]` / `%I[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)