### PR TITLE
feat(symbolic-vm): Phase 46 — Apart-retry constant-numerator widening

### DIFF
--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 0.70.0 — 2026-05-22
+
+**Phase 46 — Apart-retry constant-numerator widening.**
+
+Closes the constant-numerator gap previously documented as Phase 45's
+``test_phase45_chain_with_outer_constant_numerator`` skip.  The
+Phase 40 Apart-retry path now correctly handles ``Div(c, k(k+1))``
+shapes with arbitrary integer / rational / float constant ``c``, not
+just the unit numerator ``1``.
+
+### Root cause
+
+``Apart(5/(k(k+1)), k)`` returns ``Add(Div(-5, k+1), Div(5, k))`` —
+the negation is folded into the ``Div`` numerator rather than wrapped
+in a top-level ``Neg``.  The previous version of
+``_normalise_add_neg_to_sub`` only matched ``Add(a, Neg(b))`` /
+``Add(Neg(b), a)`` shapes, so the Apart-rewritten summand was
+returned as an unchanged ``Add`` and the Phase 39 telescope detector
+(which keys off ``Sub``) never fired.
+
+### Added
+
+- **`_extract_negation(node) -> IRNode | None`** in
+  ``src/symbolic_vm/cas_handlers.py`` — uniform negation recogniser
+  that returns the positive magnitude of:
+  1. ``Neg(x)`` (top-level wrapper)               → ``x``
+  2. ``Div(c, d)`` with literal ``c < 0`` (numerator-folded sign)
+     → ``Div(|c|, d)``
+  Handles ``IRInteger``, ``IRRational``, and ``IRFloat`` numerators.
+
+### Changed
+
+- ``_normalise_add_neg_to_sub`` now calls ``_extract_negation`` on
+  each side of the two-term ``Add`` rather than checking the ``Neg``
+  head directly.  The case table grows two rows for the new
+  numerator-folded shape but the rewrite logic is identical.
+
+### Added — tests
+
+`tests/test_phase25.py::TestPhase40_ApartTelescope` — 3 new cases (and
+the renamed Phase-45 skip that now passes):
+
+- `test_phase46_chain_with_outer_constant_numerator` — verifies
+  ``∑_{k=1}^∞ 5/(k(k+1)) = 5``.  Previously ``test_phase45_*``
+  skipped; now passes.
+- `test_phase46_negative_constant_numerator` — verifies the sign
+  propagates: ``∑_{k=1}^∞ (-3)/(k(k+1)) = -3``.  Exercises the
+  *opposite* orientation (standard ``g(k+1) − g(k)``) when the
+  outer constant is negative.
+- `test_phase46_rational_outer_constant` — verifies
+  ``∑_{k=1}^∞ (1/2)/(k(k+1)) = 1/2``.  Pins the ``IRRational``
+  numerator path of ``_extract_negation``.
+
+Test sweep: `tests/test_phase25.py` → **68 passed, 10 skipped** (was
+65 passed + 11 skipped; +3 passing, -1 skipped — the Phase-45 skip
+is now a Phase-46 pass).
+
+### Still deferred
+
+- Apart Phase 2: repeated linear factors (``1/(k²(k+1)²)``).
+- Apart Phase 3: shifted-only denominators (``1/((k+1)(k+2))``).
+
 ## 0.69.0 — 2026-05-22
 
 **Phase 45 — End-to-end integration tests for the Apart + telescope

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.69.0"
+version = "0.70.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -4485,43 +4485,91 @@ def _canonicalise_add_operand_order(node: IRNode) -> IRNode:
     return node
 
 
-def _normalise_add_neg_to_sub(node: IRNode) -> IRNode:
-    """Rewrite two-term ``Add`` nodes containing a ``Neg`` into the
-    equivalent ``Sub`` shape, then deep-canonicalise the operand order on
-    every remaining ``Add`` so downstream pattern matchers that key off
-    ``Sub`` (notably the Phase 39 telescope detector in ``cas_summation``)
-    can fire and structural ``==`` comparisons survive operand-order
-    differences between Apart's output and the substituted half.
+def _extract_negation(node: IRNode) -> IRNode | None:
+    """Detect whether ``node`` represents a negation and, if so, return
+    the corresponding positive magnitude (the thing that, prepended with
+    a unary minus, equals ``node``).  Returns ``None`` when ``node`` is
+    not a recognised negation.
 
-    +---------------------------------+----------------+
-    | Input shape                     | Output         |
-    +=================================+================+
-    | ``Add(a, Neg(b))``              | ``Sub(a, b)``  |
-    | ``Add(Neg(b), a)``              | ``Sub(a, b)``  |
-    | ``Add(Neg(a), Neg(b))``         | left untouched |
-    | other (Add with 3+ args, etc.)  | left untouched |
-    +---------------------------------+----------------+
+    Two recognised shapes:
+
+    1.  Top-level ``Neg(x)``                           → ``x``
+    2.  ``Div(c, d)`` with literal ``c < 0`` (numerator carrying the
+        sign)                                          → ``Div(|c|, d)``
+
+    Case 2 is the Phase 46 widening — ``Apart`` of ``5/(k(k+1))`` is
+    ``Add(Div(-5, k+1), Div(5, k))``, with the ``-5`` folded into the
+    numerator rather than a top-level ``Neg`` wrapper.  Without this
+    extraction, ``_normalise_add_neg_to_sub`` can't see the negation
+    and the telescope retry misses.
+    """
+    # Case 1: top-level Neg wrapper.
+    if isinstance(node, IRApply) and node.head == NEG and len(node.args) == 1:
+        return node.args[0]
+    # Case 2: Div with a negative literal numerator.  Only handle the
+    # two-arg ``Div(numer, denom)`` shape — Apart always produces
+    # exactly this shape, and we don't want to over-trigger on other
+    # arities.
+    if isinstance(node, IRApply) and node.head == DIV and len(node.args) == 2:
+        numer, denom = node.args
+        if isinstance(numer, IRInteger) and numer.value < 0:
+            pos = IRInteger(-numer.value)
+            return IRApply(DIV, (pos, denom))
+        if isinstance(numer, IRRational) and numer.numer < 0:
+            pos = IRRational(-numer.numer, numer.denom)
+            return IRApply(DIV, (pos, denom))
+        if isinstance(numer, IRFloat) and numer.value < 0:
+            pos = IRFloat(-numer.value)
+            return IRApply(DIV, (pos, denom))
+    return None
+
+
+def _normalise_add_neg_to_sub(node: IRNode) -> IRNode:
+    """Rewrite two-term ``Add`` nodes containing a (recognised) negation
+    into the equivalent ``Sub`` shape, then deep-canonicalise the
+    operand order on every remaining ``Add`` so downstream pattern
+    matchers that key off ``Sub`` (notably the Phase 39 telescope
+    detector in ``cas_summation``) can fire and structural ``==``
+    comparisons survive operand-order differences between Apart's
+    output and the substituted half.
+
+    +-----------------------------------------+----------------+
+    | Input shape                             | Output         |
+    +=========================================+================+
+    | ``Add(a, Neg(b))``                      | ``Sub(a, b)``  |
+    | ``Add(Neg(b), a)``                      | ``Sub(a, b)``  |
+    | ``Add(a, Div(-c, d))`` (Phase 46)       | ``Sub(a, Div(c, d))`` |
+    | ``Add(Div(-c, d), a)`` (Phase 46)       | ``Sub(a, Div(c, d))`` |
+    | ``Add(Neg(a), Neg(b))``                 | left untouched |
+    | other (Add with 3+ args, etc.)          | left untouched |
+    +-----------------------------------------+----------------+
 
     Only the top-level ``Add`` is rewritten to ``Sub``; the deep ADD
     operand canonicalisation runs everywhere underneath via
     :func:`_canonicalise_add_operand_order`.
+
+    Phase 46 — constant-numerator Apart-retry widening
+    ----------------------------------------------------
+    Before Phase 46 only the top-level ``Neg`` wrapper was recognised,
+    so summands like ``5/(k(k+1))`` — whose ``Apart`` output folds the
+    sign into the ``Div`` numerator (``Div(-5, k+1)``) — fell through
+    the Apart-retry path.  The :func:`_extract_negation` helper now
+    detects both forms uniformly.
     """
     if not isinstance(node, IRApply) or node.head != ADD or len(node.args) != 2:
         return _canonicalise_add_operand_order(node)
     left, right = node.args
-    left_is_neg = isinstance(left, IRApply) and left.head == NEG and len(left.args) == 1
-    right_is_neg = (
-        isinstance(right, IRApply) and right.head == NEG and len(right.args) == 1
-    )
-    if left_is_neg and right_is_neg:
-        # ``Add(Neg(a), Neg(b))`` is genuinely negative on both sides;
-        # leaving it alone preserves the structural identity.
+    left_pos = _extract_negation(left)
+    right_pos = _extract_negation(right)
+    if left_pos is not None and right_pos is not None:
+        # Both sides genuinely negative; leaving alone preserves the
+        # structural identity (no telescope to expose).
         return _canonicalise_add_operand_order(node)
-    if right_is_neg:
-        rewritten = IRApply(SUB, (left, right.args[0]))
+    if right_pos is not None:
+        rewritten = IRApply(SUB, (left, right_pos))
         return _canonicalise_add_operand_order(rewritten)
-    if left_is_neg:
-        rewritten = IRApply(SUB, (right, left.args[0]))
+    if left_pos is not None:
+        rewritten = IRApply(SUB, (right, left_pos))
         return _canonicalise_add_operand_order(rewritten)
     return _canonicalise_add_operand_order(node)
 

--- a/code/packages/python/symbolic-vm/tests/test_phase25.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase25.py
@@ -656,36 +656,74 @@ class TestPhase40_ApartTelescope:
             f"Expected scalar 1; got {result!r}"
         )
 
-    def test_phase45_chain_with_outer_constant_numerator(self):
-        """``∑_{k=1}^∞ 5/(k(k+1)) = 5`` — known gap: documents that the
-        Phase 40 Apart-retry doesn't currently fan a non-unit constant
-        numerator through to the telescope branch.
+    def test_phase46_chain_with_outer_constant_numerator(self):
+        """``∑_{k=1}^∞ 5/(k(k+1)) = 5`` — Phase 46 closure of the
+        constant-numerator gap previously documented as
+        ``test_phase45_chain_with_outer_constant_numerator``.
 
-        Mathematically Apart gives ``5/k − 5/(k+1)`` (an antisymmetric
-        telescope with ``g(k) = 5/k``) which Phase 41 closes to
-        ``g(1) = 5``.  The current canonicaliser only recognises the
-        ``Div(1, k(k+1))`` shape with a literal unit numerator.
-
-        Documents the gap so a future Apart-retry generalisation (or a
-        pre-pass that factors out outer constants) can drop the skip
-        and the test will pass automatically with result == 5.
+        Apart returns ``Add(Div(-5, k+1), Div(5, k))`` (note: the
+        ``-5`` is folded into the numerator rather than a top-level
+        ``Neg``).  Phase 46 extends ``_normalise_add_neg_to_sub`` to
+        also recognise ``Div(negative_literal, denom)`` as a negation,
+        so the rewrite ``Add(a, Div(-c, d)) → Sub(a, Div(c, d))`` now
+        fires.  The result threads into the Phase 41 antisymmetric
+        telescope ``g(k) = 5/k`` and closes to ``g(1) = 5``.
         """
-        import pytest
-
         denom = IRApply(MUL, (K, IRApply(ADD, (K, _int(1)))))
         f = IRApply(DIV, (_int(5), denom))
         result = _sum(f, _int(1), INF)
-        if _is_unevaluated_sum(result):
-            pytest.skip(
-                "Apart-retry only matches Div(1, k(k+1)) shape with a "
-                "unit numerator; non-unit constants like 5/(k(k+1)) "
-                "fall through.  When the retry path generalises (or a "
-                "constant-factor pre-pass lands), remove this skip."
-            )
-        # If the gap is closed, the chain closes to 5.
         assert isinstance(result, IRInteger) and result.value == 5, (
             f"Expected scalar 5; got {result!r}"
         )
+
+    def test_phase46_negative_constant_numerator(self):
+        """``∑_{k=1}^∞ (-3)/(k(k+1)) = -3`` — sign of the outer constant
+        propagates through Apart + telescope.
+
+        Apart yields ``Add(Div(3, k+1), Div(-3, k))`` (signs flipped
+        from the positive case), and the same Phase 46 widening
+        rewrites it to ``Sub(Div(3, k+1), Div(3, k))`` — the *standard*
+        orientation ``g(k+1) − g(k)`` with ``g(k) = 3/k``, which
+        Phase 41 closes to ``−g(1) = −3``.
+        """
+        from fractions import Fraction
+        from symbolic_ir import IRRational
+
+        denom = IRApply(MUL, (K, IRApply(ADD, (K, _int(1)))))
+        f = IRApply(DIV, (_int(-3), denom))
+        result = _sum(f, _int(1), INF)
+        if isinstance(result, IRInteger):
+            assert result.value == -3, f"got {result!r}"
+        else:
+            assert isinstance(result, IRRational)
+            assert Fraction(result.numer, result.denom) == Fraction(-3, 1), (
+                f"got {result!r}"
+            )
+
+    def test_phase46_rational_outer_constant(self):
+        """``∑_{k=1}^∞ (1/2)/(k(k+1)) = 1/2`` — IRRational numerator
+        case, exercising the rational-literal arm of
+        :func:`_extract_negation`'s mirror.
+
+        Here the outer constant is positive so no negation logic fires
+        for the numerator itself; this pins that Phase 46 didn't
+        accidentally over-trigger on positive rational numerators.
+        Apart returns ``Add(Div(-1/2, k+1), Div(1/2, k))`` which the
+        new widening rewrites to the standard ``Sub`` shape.
+        """
+        from fractions import Fraction
+        from symbolic_ir import IRRational
+
+        denom = IRApply(MUL, (K, IRApply(ADD, (K, _int(1)))))
+        f = IRApply(DIV, (IRRational(1, 2), denom))
+        result = _sum(f, _int(1), INF)
+        if isinstance(result, IRInteger):
+            assert result.value * 2 == 1, f"got {result!r}"
+        else:
+            assert isinstance(result, IRRational)
+            assert Fraction(result.numer, result.denom) == Fraction(1, 2), (
+                f"got {result!r}"
+            )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Closes the constant-numerator gap previously documented as Phase 45's
``test_phase45_chain_with_outer_constant_numerator`` skip.  The Phase 40
Apart-retry path now correctly handles ``Div(c, k(k+1))`` shapes with
arbitrary integer / rational / float constant ``c``, not just the unit
numerator.

### Root cause

``Apart(5/(k(k+1)), k)`` returns ``Add(Div(-5, k+1), Div(5, k))`` — the
negation is folded into the ``Div`` numerator rather than wrapped in a
top-level ``Neg``.  The previous ``_normalise_add_neg_to_sub`` only
matched ``Add(a, Neg(b))`` / ``Add(Neg(b), a)`` shapes, so the
rewritten summand stayed as ``Add`` and Phase 39's ``Sub``-keyed
telescope detector never fired.

### Fix

New helper ``_extract_negation(node)`` recognises both forms:
1. ``Neg(x)`` → ``x`` (top-level wrapper)
2. ``Div(c, d)`` with literal ``c < 0`` → ``Div(|c|, d)`` (numerator-folded)

Handles ``IRInteger`` / ``IRRational`` / ``IRFloat``.

``_normalise_add_neg_to_sub`` now calls this helper instead of checking
``node.head == NEG`` directly. The rewrite logic is identical; only
the recogniser widens.

### Closes a documented skip

The Phase 45 PR (#3914) intentionally landed a ``pytest.skip`` with a
"drop me when the retry generalises" hint. This PR removes that skip
(renamed ``test_phase45_*`` → ``test_phase46_*``) and the test now passes.

## Test plan

- [x] `pytest tests/test_phase25.py -k "phase46"` → 3 passed
- [x] `pytest tests/test_phase25.py` → 68 passed, 10 skipped
      (was 65 passed + 11 skipped; +3 passing, -1 skipped)
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [x] No regressions on pre-existing tests
- [ ] CI green on all platforms

## Still deferred

- Apart Phase 2: repeated linear factors (``1/(k²(k+1)²)``)
- Apart Phase 3: shifted-only denominators (``1/((k+1)(k+2))``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)