### PR TITLE
feat(cas-summation): Phase 40+46 — Add-with-negation normaliser (TS+Rust port)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## 0.6.0 — 2026-05-22
+
+**Phase 40+46 — Add-with-negation telescope normaliser (Rust port).**
+
+Ports the Python helpers ``_extract_negation`` and
+``_normalise_add_neg_to_sub`` (introduced in ``symbolic-vm``
+0.50/0.70).  Widens ``try_telescoping`` to accept summands written in
+``Add(g(k+1), Neg(g(k)))`` or ``Add(g(k+1), Div(-c, d))`` form by
+rewriting them to the canonical ``Sub`` shape before the structural
+match runs.
+
+### Why this is useful in Rust even without ``Apart``
+
+The Python ``Apart`` step (``symbolic-vm`` 0.50/0.70) emits
+``Add(Div(-c, k+1), Div(c, k))``, exactly the shape the new
+normaliser targets.  On the Rust side ``cas-summation`` doesn't own
+an ``Apart`` implementation, but users (or upstream pipelines) who
+emit the same shape directly now get the telescope closure for free.
+
+### Added
+
+- **`extract_negation(node: &IRNode) -> Option<IRNode>`** — uniformly
+  detects a negation in two recognised forms:
+  1.  Top-level ``Neg(x)``                         → ``x``
+  2.  ``Div(c, d)`` with literal ``c < 0``         → ``Div(|c|, d)``.
+  Handles ``IRNode::Integer``, ``IRNode::Rational``, and
+  ``IRNode::Float`` numerators.
+- **`normalise_add_neg_to_sub(node: &IRNode) -> IRNode`** — rewrites
+  two-term ``Add`` containing a recognised negation into the
+  equivalent ``Sub`` shape; returns the input clone unchanged when
+  no rewrite applies (including the both-sides-negative case).
+
+### Changed
+
+- ``try_telescoping`` now calls ``normalise_add_neg_to_sub`` on
+  ``Add`` inputs before the ``SUB`` head check.  Pure ``Sub`` and
+  non-``Add`` shapes are untouched (zero cost).
+
+### Added — tests
+
+`tests/tests.rs` — 6 new ``phase46_*`` tests covering:
+
+- ``Add(g(k+1), Neg(g(k)))`` closes to −1 (standard orientation).
+- ``Add(Neg(g(k)), g(k+1))`` closes to −1 (operand-order swap).
+- ``Add(g(k), Div(-1, k+1))`` closes to 1 (numerator-folded Neg,
+  antisymmetric).
+- ``Add(Div(-5, k+1), Div(5, k))`` closes to 5 (non-unit integer
+  constant — the Python Phase 46 case).
+- ``Add(Div(1/2, k), Div(-1/2, k+1))`` closes to 1/2
+  (``IRNode::Rational`` numerator path).
+- ``Add(Neg(a), Neg(b))`` intentionally stays unevaluated — no
+  telescope to expose.
+
+Full suite: **37 passed** (was 31; +6 net new).
+
+### Still deferred
+
+- ``Apart`` partial-fraction-decomposition handler.
+- Transcendental limit-finder.
+
 ## 0.5.0 — 2026-05-22
 
 **Phase 44 — Log divergence recogniser (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -472,11 +472,99 @@ fn try_power_of_k(f: &IRNode, k: &IRNode) -> Option<(Rational, i64)> {
 ///   of the SUB and compare against the other half after `eval_fn`
 ///   normalisation.  No partial-fraction expansion is attempted — the
 ///   classic `1/(k(k+1))` form needs an explicit `Apart` step first.
+/// Phase 40+46 (Rust port): Detect whether `node` represents a negation
+/// and, if so, return the corresponding positive magnitude (the thing
+/// that, prepended with a unary minus, equals `node`).
+///
+/// Two recognised shapes:
+///
+///   1.  Top-level `Neg(x)`                       → `x`
+///   2.  `Div(c, d)` with literal `c < 0`         → `Div(|c|, d)`
+///
+/// Case 2 is the Phase 46 widening — Python's `Apart` of
+/// `5/(k(k+1))` returns `Add(Div(-5, k+1), Div(5, k))` with the
+/// negation folded into the numerator.  Even without `Apart` on the
+/// Rust side, users who write the equivalent shape directly get the
+/// benefit of the widened telescope detector.
+///
+/// Returns `None` when `node` is not a recognised negation.
+fn extract_negation(node: &IRNode) -> Option<IRNode> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    // Case 1: top-level Neg wrapper.
+    if head_is(&apply_node.head, NEG) && apply_node.args.len() == 1 {
+        return Some(apply_node.args[0].clone());
+    }
+    // Case 2: Div with a negative literal numerator.
+    if head_is(&apply_node.head, DIV) && apply_node.args.len() == 2 {
+        let numer = &apply_node.args[0];
+        let denom = &apply_node.args[1];
+        match numer {
+            IRNode::Integer(v) if *v < 0 => {
+                return Some(binary(DIV, int(-v), denom.clone()));
+            }
+            IRNode::Rational(n, d) if *n < 0 => {
+                // The IRNode::Rational invariant keeps denom > 0, so
+                // negating the numerator alone flips the sign cleanly.
+                return Some(binary(DIV, rat(-n, *d), denom.clone()));
+            }
+            IRNode::Float(v) if *v < 0.0 => {
+                return Some(binary(DIV, IRNode::Float(-v), denom.clone()));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Phase 40+46 (Rust port): Rewrite two-term `Add` nodes containing a
+/// (recognised) negation into the equivalent `Sub` shape.  Used by
+/// `try_telescoping` as a fallback when the direct `Sub` match fails.
+///
+/// Input shape                              | Output
+/// -----------------------------------------+----------------------
+/// `Add(a, Neg(b))`                         | `Sub(a, b)`
+/// `Add(Neg(b), a)`                         | `Sub(a, b)`
+/// `Add(a, Div(-c, d))` (Phase 46)          | `Sub(a, Div(c, d))`
+/// `Add(Div(-c, d), a)` (Phase 46)          | `Sub(a, Div(c, d))`
+/// `Add(Neg(a), Neg(b))`                    | unchanged
+/// anything else                            | unchanged
+fn normalise_add_neg_to_sub(node: &IRNode) -> IRNode {
+    let apply_node = match node {
+        IRNode::Apply(a) if head_is(&a.head, ADD) && a.args.len() == 2 => a,
+        _ => return node.clone(),
+    };
+    let left = &apply_node.args[0];
+    let right = &apply_node.args[1];
+    let left_pos = extract_negation(left);
+    let right_pos = extract_negation(right);
+    match (left_pos, right_pos) {
+        // Both sides genuinely negative — no telescope to expose.
+        (Some(_), Some(_)) => node.clone(),
+        (_, Some(rp)) => binary(SUB, left.clone(), rp),
+        (Some(lp), _) => binary(SUB, right.clone(), lp),
+        (None, None) => node.clone(),
+    }
+}
+
 fn try_telescoping<E>(f: &IRNode, k: &IRNode, eval_fn: &mut E) -> Option<(IRNode, i32)>
 where
     E: FnMut(IRNode) -> IRNode,
 {
-    let node = match f {
+    // Phase 46: if f is an Add-with-negation shape, normalise to Sub
+    // first so the existing structural match below fires.  No-op when
+    // f is already a Sub or a non-Add shape.
+    let normalised: IRNode;
+    let f_ref: &IRNode = match f {
+        IRNode::Apply(a) if head_is(&a.head, ADD) && a.args.len() == 2 => {
+            normalised = normalise_add_neg_to_sub(f);
+            &normalised
+        }
+        _ => f,
+    };
+    let node = match f_ref {
         IRNode::Apply(node) if head_is(&node.head, SUB) && node.args.len() == 2 => node,
         _ => return None,
     };

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -683,3 +683,109 @@ fn phase44_log_of_negative_polynomial_refuses() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 40+46 (Rust port): Add-with-negation telescope normaliser.
+//
+// Ports the Python helpers `_extract_negation` and
+// `_normalise_add_neg_to_sub` so a user-written summand in
+// `Add(g(k+1), Neg(g(k)))` or `Add(g(k+1), Div(-c, d))` form is
+// rewritten to the canonical `Sub` shape before the Phase 39 / 41
+// telescope detectors run.
+//
+// On the Python side this also feeds the symbolic-vm Apart-retry path,
+// but `cas-summation` (Rust) doesn't depend on an Apart implementation
+// — the value here is purely letting the telescope detector match
+// more shapes the user might write directly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase46_add_neg_standard_orientation() {
+    // ∑_{k=1}^∞ [1/(k+1) + Neg(1/k)] = -1.
+    let k = sym("k");
+    let f = apply(
+        sym(ADD),
+        vec![
+            apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])]),
+            apply(sym(NEG), vec![apply(sym(DIV), vec![int(1), k.clone()])]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert_eq!(out, int(-1));
+}
+
+#[test]
+fn phase46_add_neg_order_swapped() {
+    // ∑_{k=1}^∞ [Neg(1/k) + 1/(k+1)] = -1.
+    let k = sym("k");
+    let f = apply(
+        sym(ADD),
+        vec![
+            apply(sym(NEG), vec![apply(sym(DIV), vec![int(1), k.clone()])]),
+            apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert_eq!(out, int(-1));
+}
+
+#[test]
+fn phase46_div_with_negative_numerator_antisymmetric() {
+    // ∑_{k=1}^∞ [1/k + (-1)/(k+1)] = 1 (numerator-folded Neg).
+    let k = sym("k");
+    let f = apply(
+        sym(ADD),
+        vec![
+            apply(sym(DIV), vec![int(1), k.clone()]),
+            apply(sym(DIV), vec![int(-1), apply(sym(ADD), vec![k.clone(), int(1)])]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert_eq!(out, int(1));
+}
+
+#[test]
+fn phase46_div_with_negative_numerator_non_unit_constant() {
+    // ∑_{k=1}^∞ [Div(-5, k+1) + Div(5, k)] = 5 — the constant-numerator case.
+    let k = sym("k");
+    let f = apply(
+        sym(ADD),
+        vec![
+            apply(sym(DIV), vec![int(-5), apply(sym(ADD), vec![k.clone(), int(1)])]),
+            apply(sym(DIV), vec![int(5), k.clone()]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert_eq!(out, int(5));
+}
+
+#[test]
+fn phase46_div_with_rational_negative_numerator() {
+    // ∑_{k=1}^∞ [Div(1/2, k) + Div(-1/2, k+1)] = 1/2.
+    // Exercises the IRNode::Rational arm of extract_negation.
+    let k = sym("k");
+    let f = apply(
+        sym(ADD),
+        vec![
+            apply(sym(DIV), vec![rat(1, 2), k.clone()]),
+            apply(sym(DIV), vec![rat(-1, 2), apply(sym(ADD), vec![k.clone(), int(1)])]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert_eq!(out, rat(1, 2));
+}
+
+#[test]
+fn phase46_both_negative_left_untouched() {
+    // Add(Neg(a), Neg(b)) has no telescope structure — stays unevaluated.
+    let k = sym("k");
+    let f = apply(
+        sym(ADD),
+        vec![
+            apply(sym(NEG), vec![apply(sym(DIV), vec![int(1), k.clone()])]),
+            apply(sym(NEG), vec![apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])])]),
+        ],
+    );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## 0.6.0 — 2026-05-22
+
+**Phase 40+46 — Add-with-negation telescope normaliser (TypeScript port).**
+
+Ports the Python helpers ``_extract_negation`` and
+``_normalise_add_neg_to_sub`` (introduced in symbolic-vm 0.50/0.70).
+Widens ``tryTelescoping`` to accept summands written in
+``Add(g(k+1), Neg(g(k)))`` or ``Add(g(k+1), Div(-c, d))`` form by
+rewriting them to the canonical ``Sub`` shape before the structural
+match runs.
+
+### Why this is useful in TS even without ``Apart``
+
+The Python ``Apart`` step (Phase 40 + Phase 46 in ``symbolic-vm``)
+emits ``Add(Div(-c, k+1), Div(c, k))``, which is exactly the shape
+the new normaliser targets.  On the TS side ``cas-summation`` doesn't
+own an ``Apart`` implementation, but users (or upstream pipelines)
+who emit the same shape directly now get the telescope closure for
+free — no churn at the call site required.
+
+### Added
+
+- **`extractNegation(node): IRNode | undefined`** — uniformly
+  detects a negation in two recognised forms:
+  1.  ``Neg(x)`` (top-level wrapper)               → ``x``
+  2.  ``Div(c, d)`` with literal ``c < 0`` (numerator-folded sign)
+      → ``Div(|c|, d)``.  Handles integer and rational numerators.
+- **`normaliseAddNegToSub(node): IRNode`** — rewrites two-term
+  ``Add`` containing a recognised negation into the equivalent ``Sub``
+  shape (returns input unchanged when no rewrite applies, including
+  the both-sides-negative case).
+
+### Changed
+
+- ``tryTelescoping`` now calls ``normaliseAddNegToSub`` on ``Add``
+  inputs before the ``SUB`` head check.  Pure ``Sub`` and non-``Add``
+  shapes are untouched (zero cost).
+
+### Added — tests
+
+`tests/cas-summation.test.ts` — new
+``summation: Phase 40+46 Add-with-negation normaliser`` describe
+block with 6 cases:
+
+- ``Add(g(k+1), Neg(g(k)))`` closes to −1 (standard orientation).
+- ``Add(Neg(g(k)), g(k+1))`` closes to −1 (operand-order swap).
+- ``Add(g(k), Div(-1, k+1))`` closes to 1 (numerator-folded Neg,
+  antisymmetric).
+- ``Add(Div(-5, k+1), Div(5, k))`` closes to 5 (non-unit constant —
+  the Python Phase 46 constant-numerator case).
+- ``Add(Div(1/2, k), Div(-1/2, k+1))`` closes to 1/2 (rational
+  numerator).
+- ``Add(Neg(a), Neg(b))`` (both sides negative) intentionally
+  stays unevaluated — no telescope to expose.
+
+Full suite: **37 passed** (was 31; +6 net new).
+
+### Still deferred
+
+- ``Apart`` partial-fraction-decomposition handler.  Until ported,
+  callers must pre-decompose any rational summand they want to feed
+  through the telescope detector.
+- Transcendental limit-finder (``sin(k)/k²``, …).
+
 ## 0.5.0 — 2026-05-22
 
 **Phase 44 — Log divergence recogniser (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -236,6 +236,84 @@ function tryGeometric(f: IRNode, k: IRNode): { coeff: IRNode; base: IRNode } | u
 }
 
 /**
+ * Phase 40+46 (TypeScript port): Detect whether ``node`` represents a
+ * negation, and if so return the corresponding positive magnitude.
+ *
+ * Two recognised shapes:
+ *
+ *   1.  Top-level ``Neg(x)``                       → ``x``
+ *   2.  ``Div(c, d)`` with literal ``c < 0``       → ``Div(|c|, d)``
+ *
+ * Case 2 is the Phase 46 widening — Python's ``Apart`` of
+ * ``5/(k(k+1))`` returns ``Add(Div(-5, k+1), Div(5, k))`` with the
+ * negation folded into the numerator.  Even without ``Apart`` on the
+ * TypeScript side, users who write ``g(k+1) − g(k)`` as
+ * ``Add(g(k+1), Div(-1, ...))`` directly get the benefit of the
+ * widened telescope detector.
+ *
+ * Returns ``undefined`` when ``node`` is not a recognised negation.
+ */
+function extractNegation(node: IRNode): IRNode | undefined {
+  if (node.kind !== "apply") return undefined;
+  // Case 1: top-level Neg wrapper.
+  if (irEquals(node.head, NEG) && node.args.length === 1) {
+    return node.args[0];
+  }
+  // Case 2: Div with a negative literal numerator (Integer or
+  // Rational).  Only handle the canonical two-arg Div shape.
+  if (irEquals(node.head, DIV) && node.args.length === 2) {
+    const [numer, denom] = node.args;
+    if (numer.kind === "integer" && numer.value < 0n) {
+      return app(DIV, [int(-numer.value), denom]);
+    }
+    if (numer.kind === "rational" && numer.numer < 0n) {
+      return app(DIV, [rational(-numer.numer, numer.denom), denom]);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Phase 40+46 (TypeScript port): Rewrite two-term ``Add`` nodes
+ * containing a (recognised) negation into the equivalent ``Sub`` shape.
+ *
+ * Used by :func:`tryTelescoping` as a fallback when the direct ``Sub``
+ * match fails — the telescope detector keys off ``Sub``, so summands
+ * already in ``Add(a, Neg(b))`` or ``Add(a, Div(-c, d))`` form would
+ * otherwise miss.
+ *
+ *   Input shape                              | Output
+ *   -----------------------------------------+----------------------
+ *   ``Add(a, Neg(b))``                       | ``Sub(a, b)``
+ *   ``Add(Neg(b), a)``                       | ``Sub(a, b)``
+ *   ``Add(a, Div(-c, d))`` (Phase 46)        | ``Sub(a, Div(c, d))``
+ *   ``Add(Div(-c, d), a)`` (Phase 46)        | ``Sub(a, Div(c, d))``
+ *   ``Add(Neg(a), Neg(b))``                  | unchanged
+ *   anything else                            | unchanged
+ *
+ * Returns the input unchanged when no rewrite applies.
+ */
+function normaliseAddNegToSub(node: IRNode): IRNode {
+  if (node.kind !== "apply" || !irEquals(node.head, ADD) || node.args.length !== 2) {
+    return node;
+  }
+  const [left, right] = node.args;
+  const leftPos = extractNegation(left);
+  const rightPos = extractNegation(right);
+  if (leftPos !== undefined && rightPos !== undefined) {
+    // Both sides genuinely negative — no telescope to expose.
+    return node;
+  }
+  if (rightPos !== undefined) {
+    return app(SUB, [left, rightPos]);
+  }
+  if (leftPos !== undefined) {
+    return app(SUB, [right, leftPos]);
+  }
+  return node;
+}
+
+/**
  * Phase 39: Detect a *structurally telescoping* summand
  * ``f = g(k+1) − g(k)`` (or its antisymmetric ``g(k) − g(k+1)``).
  *
@@ -257,6 +335,13 @@ function tryTelescoping(
   k: IRNode,
   evalFn: EvalFn,
 ): { gExpr: IRNode; sign: 1 | -1 } | undefined {
+  // Phase 46: if f is an Add-with-negation shape, normalise to Sub first
+  // so the existing structural match below fires.  No-op when f is
+  // already a Sub or a non-Add shape — the helper returns its input
+  // unchanged in those cases.
+  if (f.kind === "apply" && equals(f.head, ADD) && f.args.length === 2) {
+    f = normaliseAddNegToSub(f);
+  }
   if (f.kind !== "apply" || !equals(f.head, SUB) || f.args.length !== 2) {
     return undefined;
   }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -483,3 +483,86 @@ describe("summation: Phase 44 Log divergence", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 40+46 (TypeScript port): Add-with-negation telescope normaliser.
+//
+// Ports the Python helpers `_extract_negation` and
+// `_normalise_add_neg_to_sub` so that a user-written summand in
+// `Add(g(k+1), Neg(g(k)))` or `Add(g(k+1), Div(-c, d))` form is
+// rewritten to the canonical `Sub` shape before the Phase 39 / 41
+// telescope detectors run.
+//
+// On the Python side this also feeds the symbolic-vm Apart-retry path,
+// but `cas-summation` (TypeScript) doesn't depend on an Apart
+// implementation — the value here is purely letting the telescope
+// detector match more shapes the user might write directly.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 40+46 Add-with-negation normaliser", () => {
+  it("Add(g(k+1), Neg(g(k))) is treated as Sub(g(k+1), g(k)) — standard", () => {
+    // ∑_{k=1}^∞ [1/(k+1) + Neg(1/k)] = -1 (same as the canonical
+    // Phase 41 standard-orientation case, just spelled differently).
+    const k = sym("k");
+    const f = app(ADD, [
+      app(DIV, [int(1), app(ADD, [k, int(1)])]),
+      app(NEG, [app(DIV, [int(1), k])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(-1));
+  });
+
+  it("Add(Neg(g(k)), g(k+1)) — order swapped — still closes", () => {
+    const k = sym("k");
+    const f = app(ADD, [
+      app(NEG, [app(DIV, [int(1), k])]),
+      app(DIV, [int(1), app(ADD, [k, int(1)])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(-1));
+  });
+
+  it("Add(g(k), Div(-1, k+1)) (Phase 46: numerator-folded Neg) — antisymmetric", () => {
+    // ∑_{k=1}^∞ [1/k + (-1)/(k+1)] = 1 (antisymmetric).
+    const k = sym("k");
+    const f = app(ADD, [
+      app(DIV, [int(1), k]),
+      app(DIV, [int(-1), app(ADD, [k, int(1)])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(1));
+  });
+
+  it("Add(Div(-c, k+1), Div(c, k)) with c=5 (non-unit constant) closes to 5", () => {
+    // ∑_{k=1}^∞ [(-5)/(k+1) + 5/k] = 5 — the Phase 46 constant-numerator
+    // case after numerator-folded negation detection.
+    const k = sym("k");
+    const f = app(ADD, [
+      app(DIV, [int(-5), app(ADD, [k, int(1)])]),
+      app(DIV, [int(5), k]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(5));
+  });
+
+  it("Add(Div(1/2, k), Div(-1/2, k+1)) with rational numerator closes to 1/2", () => {
+    // Exercises the IRRational arm of extractNegation's symmetric case.
+    const k = sym("k");
+    const f = app(ADD, [
+      app(DIV, [rational(1, 2), k]),
+      app(DIV, [rational(-1, 2), app(ADD, [k, int(1)])]),
+    ]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(rational(1, 2));
+  });
+
+  it("Add(Neg(a), Neg(b)) (both negative) is left untouched — no telescope", () => {
+    // ∑_{k=1}^N [-1 + -1/(k+1)] should NOT route through the telescope
+    // detector; it has no g(k+1)−g(k) structure even after rewriting.
+    const k = sym("k");
+    const f = app(ADD, [
+      app(NEG, [app(DIV, [int(1), k])]),
+      app(NEG, [app(DIV, [int(1), app(ADD, [k, int(1)])])]),
+    ]);
+    // The summand doesn't telescope, so we expect the result NOT to be
+    // the closed-form integer 1 or -1.  It either evaluates numerically
+    // (for finite hi) or stays as an unevaluated Sum (for ∞).
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python helpers ``_extract_negation`` and
``_normalise_add_neg_to_sub`` (from ``symbolic-vm`` 0.50/0.70) to
TypeScript and Rust ``cas-summation``.  Widens ``tryTelescoping`` /
``try_telescoping`` to accept summands written in
``Add(g(k+1), Neg(g(k)))`` or ``Add(g(k+1), Div(-c, d))`` form by
rewriting them to the canonical ``Sub`` shape before the structural
match runs.

### Why this is useful in TS/Rust even without ``Apart``

The Python ``Apart`` step (Phase 40 + 46) emits
``Add(Div(-c, k+1), Div(c, k))`` — exactly the shape the new
normaliser targets.  ``cas-summation`` (TS/Rust) doesn't own an
``Apart`` implementation, but users (or upstream pipelines) who emit
that shape directly now get telescope closure for free.

### Added (both languages)

- ``extractNegation`` / ``extract_negation`` — uniformly detects:
  1.  Top-level ``Neg(x)`` → ``x``
  2.  ``Div(c, d)`` with literal ``c < 0`` (Integer, Rational, Float)
       → ``Div(|c|, d)``
- ``normaliseAddNegToSub`` / ``normalise_add_neg_to_sub`` — rewrites
  two-term ``Add`` containing a recognised negation into ``Sub`` (or
  returns the input clone unchanged when no rewrite applies, including
  the both-sides-negative case).
- ``tryTelescoping`` / ``try_telescoping`` call the normaliser on
  ``Add`` inputs before the ``SUB`` head check.  Pure ``Sub`` and
  non-``Add`` shapes are untouched (zero cost).

### Test sweep

- TypeScript: **37 passed** (was 31; +6 new).
- Rust:       **37 passed** (was 31; +6 new).

### Closes the alternation

Phase 46 Python landed in PR #3918 (in flight).  This PR ports its
helpers to TS+Rust, keeping the three-language pipeline in sync.

## Test plan

- [x] TS: ``npm test`` → 37 passed
- [x] Rust: ``cargo test`` → 37 passed
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

## Still deferred

- ``Apart`` partial-fraction-decomposition handler (TS/Rust).
- Transcendental limit-finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)