### PR TITLE
feat(iir-to-wasm): BF linear memory + I/O imports (Stage 1 of 4)

### DIFF
--- a/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog — brainfuck-iir-compiler
 
+## [0.3.1] — 2026-05-22 (BF → WASM end-to-end test)
+
+### Added — `tests/wasm_e2e.rs`
+
+Stage 1 of 4 for the BF → {wasm, jvm, clr, beam} story.  Walks the new
+IIR-based chain end-to-end:
+
+```text
+BF source → IIRModule → iir-to-wasm validator → lower_iir_to_wasm → .wasm bytes
+```
+
+Before iir-to-wasm 0.4.0, the validator rejected `load_mem` /
+`store_mem` and any `call_builtin` (including BF's `putchar` /
+`getchar`).  With iir-to-wasm 0.4.0 those are accepted, and this
+e2e test locks the path in for Brainfuck:
+
+- `brainfuck_three_increments_lowers_to_wasm_bytes` — `+++.` compiles
+  through, the resulting `WasmModule` has an `env.putchar` import,
+  a 1-page linear memory, and a `main` export.  The encoded bytes
+  start with the canonical WASM magic + version.
+- `brainfuck_loop_lowers_to_wasm_bytes` — `++[-]` (a non-trivial
+  loop) compiles through; declares a memory; no putchar.
+- `brainfuck_input_emits_getchar_import` — `,.` emits both
+  `env.getchar` and `env.putchar` imports.
+- `brainfuck_empty_program_emits_minimal_wasm` — the empty BF
+  program emits no memory and no imports, proving feature detection
+  is conditional (doesn't burden modules that don't need tape/IO).
+
+No source-code changes in this crate — the test runs against the
+existing `compile_source`.  Only the WASM e2e test file is new.
+
+Stages 2–4 (JVM, CLR, BEAM) are queued as follow-on PRs.
+
 ## [0.3.0] — 2026-05-22 (BF05 — real CIR-bytecode JIT backend)
 
 ### Added — `BrainfuckCirJit`, a real `jit_core::backend::Backend`

--- a/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
+++ b/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brainfuck-iir-compiler"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "BF04/BF05 — Brainfuck → InterpreterIR compiler, vm-core wrapper, jit-core JIT chain, and real CIR-bytecode JIT backend"
 license = "MIT"
@@ -14,3 +14,6 @@ parser         = { path = "../parser" }
 lexer          = { path = "../lexer" }
 
 [dev-dependencies]
+iir-to-wasm         = { path = "../iir-to-wasm" }
+wasm-module-encoder = { path = "../wasm-module-encoder" }
+wasm-types          = { path = "../wasm-types" }

--- a/code/packages/rust/brainfuck-iir-compiler/tests/wasm_e2e.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/tests/wasm_e2e.rs
@@ -1,0 +1,158 @@
+//! Brainfuck → WebAssembly end-to-end test.
+//!
+//! Walks the new IIR-based chain:
+//!
+//! ```text
+//! BF source
+//!   │ brainfuck-iir-compiler::compile_source
+//! IIRModule (FullyTyped)
+//!   │ iir_to_wasm::validate::validate_for_wasm   ← must report no errors
+//!   │ iir_to_wasm::lower::lower_iir_to_wasm
+//! WasmModule
+//!   │ wasm_module_encoder::encode_module
+//! Vec<u8> (.wasm bytes)
+//!   │ assert byte layout looks right
+//! ```
+//!
+//! Before this PR, the chain stopped at the validator step — `load_mem`,
+//! `store_mem`, and `call_builtin "putchar"` / `"getchar"` were
+//! unconditionally rejected.  After this PR, the validator accepts them
+//! (memory ops + `CALL_BUILTIN_SUPPORTED_NAMES` whitelist) and the
+//! lowering emits real WASM bytecode (`i32.load8_u`, `i32.store8`,
+//! `call <import_idx>` for `env.putchar` / `env.getchar`).
+//!
+//! This is **Stage 1 of 4** for the full BF→{wasm,jvm,clr,beam} story.
+//! See PR description for the JVM / CLR / BEAM follow-ups.
+
+use brainfuck_iir_compiler::compile_source;
+
+/// Compile `+++.` and assert the IIR-to-WASM chain reaches encoded bytes
+/// without error.
+#[test]
+fn brainfuck_three_increments_lowers_to_wasm_bytes() {
+    let module = compile_source("+++.", "wasm_e2e")
+        .expect("BF source must compile to IIR");
+
+    // ── Validator must accept BF's IIR (memory ops + whitelisted builtins) ─
+    let errs = iir_to_wasm::validate::validate_for_wasm(&module);
+    assert!(
+        errs.is_empty(),
+        "WASM validator should accept BF IIR after the BF→WASM PR; got: {errs:?}",
+    );
+
+    // ── Lower IIR → WasmModule ────────────────────────────────────────────
+    let wasm_module = iir_to_wasm::lower::lower_iir_to_wasm(
+        &module,
+        &iir_to_wasm::lower::IIRWasmConfig::default(),
+    )
+    .expect("IIR → WasmModule lowering must succeed");
+
+    // The module must import `env.putchar` (from BF's `.` command).
+    assert!(
+        wasm_module.imports.iter().any(|i|
+            i.module_name == "env" && i.name == "putchar"
+        ),
+        "expected env.putchar import; imports: {:?}",
+        wasm_module.imports.iter().map(|i| (&i.module_name, &i.name)).collect::<Vec<_>>(),
+    );
+
+    // The module must declare a linear memory (the BF tape).
+    assert!(
+        !wasm_module.memories.is_empty(),
+        "expected at least one linear memory (the BF tape); got 0",
+    );
+    let mem = &wasm_module.memories[0];
+    assert!(mem.limits.min >= 1,
+        "expected at least 1 page of memory; got min={}", mem.limits.min);
+
+    // The module must export `main` as a function.
+    let main_export = wasm_module.exports.iter().find(|e| e.name == "main");
+    assert!(main_export.is_some(),
+        "expected `main` export; exports: {:?}",
+        wasm_module.exports.iter().map(|e| &e.name).collect::<Vec<_>>(),
+    );
+
+    // ── Encode WasmModule → bytes ─────────────────────────────────────────
+    let bytes = wasm_module_encoder::encode_module(&wasm_module)
+        .expect("WasmModule encoding must succeed");
+
+    // The bytes must start with the WASM magic + version: `\0asm\x01\x00\x00\x00`.
+    assert!(bytes.len() >= 8,
+        "encoded module is implausibly short ({} bytes)", bytes.len());
+    assert_eq!(&bytes[0..4], b"\0asm",
+        "first 4 bytes must be the WASM magic; got {:?}", &bytes[0..4]);
+    assert_eq!(&bytes[4..8], &[0x01u8, 0, 0, 0],
+        "next 4 bytes must be WASM version 1; got {:?}", &bytes[4..8]);
+}
+
+/// A loop program — `++[-]` decrements a cell down to zero.  Exercises
+/// `label` / `jmp_if_false` / `jmp` / `load_mem` / `store_mem` /
+/// `const_u8` together through the WASM lowering.
+#[test]
+fn brainfuck_loop_lowers_to_wasm_bytes() {
+    let module = compile_source("++[-]", "wasm_loop")
+        .expect("BF loop must compile to IIR");
+    let errs = iir_to_wasm::validate::validate_for_wasm(&module);
+    assert!(errs.is_empty(), "WASM validator rejected loop IIR: {errs:?}");
+
+    let wm = iir_to_wasm::lower::lower_iir_to_wasm(
+        &module, &iir_to_wasm::lower::IIRWasmConfig::default(),
+    ).expect("lowering must succeed");
+
+    // Linear memory present.
+    assert!(!wm.memories.is_empty(), "loop program should declare a tape memory");
+
+    // No putchar import (no `.` in this program), but the memory section is enough.
+    assert!(!wm.imports.iter().any(|i| i.name == "putchar"),
+        "no putchar expected for `++[-]`");
+
+    let bytes = wasm_module_encoder::encode_module(&wm).expect("encode");
+    assert_eq!(&bytes[0..4], b"\0asm");
+}
+
+/// Confirm BF's I/O `,` (getchar) flows through validation + lowering and
+/// emits an `env.getchar` import.
+#[test]
+fn brainfuck_input_emits_getchar_import() {
+    let module = compile_source(",.", "wasm_input")
+        .expect("BF input/output program must compile to IIR");
+    let errs = iir_to_wasm::validate::validate_for_wasm(&module);
+    assert!(errs.is_empty(),
+        "WASM validator rejected `,.` IIR: {errs:?}");
+
+    let wm = iir_to_wasm::lower::lower_iir_to_wasm(
+        &module, &iir_to_wasm::lower::IIRWasmConfig::default(),
+    ).expect("lowering must succeed");
+
+    assert!(wm.imports.iter().any(|i| i.name == "getchar"),
+        "expected env.getchar import for `,`; imports: {:?}",
+        wm.imports.iter().map(|i| &i.name).collect::<Vec<_>>());
+    assert!(wm.imports.iter().any(|i| i.name == "putchar"),
+        "expected env.putchar import for `.`");
+
+    let bytes = wasm_module_encoder::encode_module(&wm).expect("encode");
+    assert!(bytes.starts_with(b"\0asm"));
+}
+
+/// Confirm the empty BF program (no commands) still produces a valid WASM
+/// module — no memory, no imports, just the empty `main`.  This proves
+/// the BF-specific feature detection is conditional and doesn't force
+/// memory/imports onto programs that don't need them.
+#[test]
+fn brainfuck_empty_program_emits_minimal_wasm() {
+    let module = compile_source("", "wasm_empty")
+        .expect("empty BF must compile to IIR");
+    let errs = iir_to_wasm::validate::validate_for_wasm(&module);
+    assert!(errs.is_empty(), "validator rejected empty BF: {errs:?}");
+
+    let wm = iir_to_wasm::lower::lower_iir_to_wasm(
+        &module, &iir_to_wasm::lower::IIRWasmConfig::default(),
+    ).expect("lowering must succeed");
+
+    // Empty BF has only `const ptr 0; ret_void` — no memory ops, no I/O.
+    assert!(wm.memories.is_empty(),
+        "empty program should not declare a memory; got {:?}", wm.memories);
+    assert!(wm.imports.is_empty(),
+        "empty program should have no imports; got {:?}",
+        wm.imports.iter().map(|i| &i.name).collect::<Vec<_>>());
+}

--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,72 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.0] — 2026-05-22 (Brainfuck — linear memory + I/O imports)
+
+### Added — Brainfuck `load_mem` / `store_mem` / `call_builtin` lowering
+
+#### Validator changes
+
+- `validate_for_wasm` now **accepts** `load_mem` and `store_mem` — they
+  were previously in `UNSUPPORTED_OPS`.  Both lower to WASM linear-memory
+  ops (`i32.load8_u`, `i32.store8`) over a module-defined memory.
+- `call_builtin` is now **conditionally** accepted: the builtin name
+  carried in `srcs[0]` must be in the new
+  `CALL_BUILTIN_SUPPORTED_NAMES` whitelist.  Today's whitelist covers
+  Brainfuck's two I/O builtins (`putchar`, `getchar`); extending it
+  takes three steps documented in the constant's doc comment.
+- Unknown builtin names still produce a clear `UnsupportedOp` error
+  with the builtin name and the whitelist included.
+
+#### Lowering changes
+
+- New `ModuleFeatures` struct collected by `collect_module_features`
+  (replaces the narrower `collect_globals_and_io`).  Captures
+  `uses_io_out`, `uses_putchar`, `uses_getchar`, and `uses_memory`
+  flags in a single module walk.
+- When `uses_putchar`: inject `env.putchar : (i32) -> ()` host import.
+- When `uses_getchar`: inject `env.getchar : () -> i32` host import.
+- When `uses_memory`: inject a single 1-page (64 KiB) linear `Memory`
+  — the Brainfuck tape.  Programs that don't use memory ops get no
+  memory section, preserving binary compatibility with existing
+  non-BF callers (Twig, BASIC, Oct, Nib, Lispy).
+- Function-index space: imports occupy the first slots in
+  declaration order — `env.__print_i64` (LANG32, when used),
+  then `env.putchar`, then `env.getchar`.  Defined functions follow.
+- New `emit_instr` arms:
+  - `load_mem` → `local.get addr; i32.load8_u; local.set dest`
+  - `store_mem` → `local.get addr; local.get val; i32.store8`
+  - `call_builtin "putchar"` → `local.get val; call <putchar_idx>`
+  - `call_builtin "getchar"` → `call <getchar_idx>; local.set dest`
+
+#### Why this matters
+
+After this PR, Brainfuck's IIR — including `+++.` (memory + putchar),
+`,[.,]` (cat), and the multiplication idiom — flows through the
+*same* `iir-to-wasm` backend that Twig, BASIC, Oct, Nib, and Lispy
+use.  Stage 1 of 4 for the BF→{wasm,jvm,clr,beam} story; the JVM,
+CLR, and BEAM lowerings are queued behind this PR.
+
+#### Tests
+
+- `validate.rs::tests` — 5 new unit tests for the validator changes:
+  - `load_mem_accepted_for_bf`
+  - `store_mem_accepted_for_bf`
+  - `call_builtin_putchar_accepted`
+  - `call_builtin_getchar_accepted`
+  - `call_builtin_unknown_name_rejected`
+- Existing `unsupported_ops_rejected` updated: `load_mem`, `store_mem`,
+  `call_builtin` removed from the unconditional-reject list; comments
+  point readers to the new tests.
+- Existing `tests/test_backend.rs::validate_memory_ops_rejected`
+  renamed → `validate_memory_ops_accepted` and updated to assert the
+  promotion.
+- Doc-tests unchanged.
+
+Total: 45 lib + 88 integration tests pass.
+
+---
+
 ## [0.3.0] — 2026-05-12
 
 ### Added (LANG35 — Closure Backend Integration)

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule without compiler-ir"
+description = "IIR → WASM backend — lowers IIRModule to WasmModule (now with Brainfuck linear-memory + I/O imports)"
 
 [lib]
 name = "iir_to_wasm"

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -167,6 +167,44 @@ use crate::validate::validate_for_wasm;
 /// `global.get` pushes the current value of module-level global variable at
 /// index `idx` onto the WASM value stack.  The global must already exist in
 /// the module's global section (or be imported).
+/// Emit `i32.load8_u offset=0 align=0` — read one byte from linear memory.
+///
+/// The address is the top of the operand stack (i32, byte offset into the
+/// module's default memory).  The result is the zero-extended `u8` value
+/// as an `i32` on the stack.
+///
+/// # WASM binary layout
+///
+/// ```text
+/// 0x2D  <align:LEB128 u32>  <offset:LEB128 u32>
+/// ```
+///
+/// For Brainfuck we use natural alignment 0 (1-byte access) and zero
+/// offset — addresses are passed dynamically, never as an immediate.
+///
+/// Result encoding: `[0x2D, 0x00, 0x00]` — opcode + align byte + offset byte.
+fn encode_i32_load8_u() -> Vec<u8> {
+    // `0x2D` = i32.load8_u; align = 0 (LEB128); offset = 0 (LEB128).
+    vec![0x2Du8, 0x00u8, 0x00u8]
+}
+
+/// Emit `i32.store8 offset=0 align=0` — write the low byte of an i32 to memory.
+///
+/// Pops `value` then `addr` from the stack (in that order — same as every
+/// WASM store opcode), and stores `value & 0xFF` at `mem[addr]`.
+///
+/// # WASM binary layout
+///
+/// ```text
+/// 0x3A  <align:LEB128 u32>  <offset:LEB128 u32>
+/// ```
+///
+/// Result encoding: `[0x3A, 0x00, 0x00]`.
+fn encode_i32_store8() -> Vec<u8> {
+    // `0x3A` = i32.store8; align = 0; offset = 0.
+    vec![0x3Au8, 0x00u8, 0x00u8]
+}
+
 fn encode_global_get(idx: u32) -> Vec<u8> {
     use wasm_leb128::encode_unsigned;
     let mut bytes = vec![0x23u8]; // global.get opcode
@@ -646,6 +684,8 @@ fn emit_instr(
     lispy_pair_type_idx: Option<u32>,
     global_map: &HashMap<String, u32>,
     print_fn_idx: Option<u32>,
+    putchar_fn_idx: Option<u32>,
+    getchar_fn_idx: Option<u32>,
 ) -> Result<(), IIRWasmError> {
     // Helper closures to resolve variable names.
     let get_reg = |var: &str| -> Result<u32, IIRWasmError> {
@@ -1500,6 +1540,148 @@ fn emit_instr(
             code.extend(encode_call(fn_idx));
         }
 
+        // ── load_mem → i32.load8_u offset=0 align=0 ──────────────────────────
+        //
+        // `load_mem  v  ptr   u8`  → read tape byte at address `ptr` into `v`.
+        //
+        // The WASM linear memory is a flat `Vec<u8>` from the host's
+        // perspective.  `i32.load8_u` reads one byte at the address on top
+        // of the stack and pushes the zero-extended `u8` value as `i32`.
+        // Brainfuck's `ptr` register holds a `u32` (encoded as `i32` in
+        // WASM), so the address is already on the stack in the right type.
+        //
+        // The tape itself is allocated by `lower_iir_to_wasm` when the
+        // module uses memory ops (see the `uses_memory` injection step).
+        // Out-of-bounds reads trap at the WASM layer — Brainfuck's
+        // interpreter chose the "oob read = 0" lazy-tape convention, but
+        // WASM has no zero-fill-on-trap; programs that walk the pointer
+        // outside `[0, tape_size)` will fail at runtime.  The brainfuck
+        // frontend allocates a 30,000-cell tape by default, which fits
+        // comfortably in one 64 KiB page.
+        "load_mem" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: "load_mem must have a dest".to_string(),
+            })?;
+            let rd = get_reg(dest)?;
+            let addr_var = match instr.srcs.first() {
+                Some(Operand::Var(v)) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "load_mem requires Operand::Var(addr) as src[0]".to_string(),
+                }),
+            };
+            let addr_slot = get_reg(addr_var)?;
+            code.extend(encode_local_get(addr_slot));
+            code.extend(encode_i32_load8_u());
+            code.extend(encode_local_set(rd));
+        }
+
+        // ── store_mem → i32.store8 offset=0 align=0 ──────────────────────────
+        //
+        // `store_mem   ptr  v   u8`  → write low byte of `v` to tape[ptr].
+        //
+        // WASM `i32.store8` pops the value (top of stack) and then the
+        // address (next on stack), then stores `value & 0xFF` at
+        // `mem[addr]`.  We push `addr` first, then `val`, so the stack at
+        // call time is `[addr, val]` (addr deeper, val on top) — exactly
+        // what i32.store8 expects.
+        //
+        // Out-of-bounds writes trap, terminating the WASM module.  The
+        // bf-iir-compiler's `BrainfuckVM::execute_module` raises a
+        // structured `BrainfuckError` for the same case in the interpreter
+        // path; the JIT path's `store_mem` handler does the same.  The
+        // WASM path's "trap and abort" is the standard memory-safe
+        // alternative.
+        "store_mem" => {
+            if instr.srcs.len() < 2 {
+                return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_mem requires 2 srcs: [addr, val]".to_string(),
+                });
+            }
+            let addr_var = match &instr.srcs[0] {
+                Operand::Var(v) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_mem src[0] must be Operand::Var(addr)".to_string(),
+                }),
+            };
+            let val_var = match &instr.srcs[1] {
+                Operand::Var(v) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_mem src[1] must be Operand::Var(val)".to_string(),
+                }),
+            };
+            let addr_slot = get_reg(addr_var)?;
+            let val_slot  = get_reg(val_var)?;
+            code.extend(encode_local_get(addr_slot));
+            code.extend(encode_local_get(val_slot));
+            code.extend(encode_i32_store8());
+        }
+
+        // ── call_builtin → call $env.<name> ──────────────────────────────────
+        //
+        // Dispatch on `srcs[0]` (the builtin name, carried as Var) to the
+        // corresponding host import.  The validator (validate.rs) has
+        // already rejected any name not in `CALL_BUILTIN_SUPPORTED_NAMES`,
+        // so the inner match here only handles whitelisted names; falling
+        // off the match indicates a validator/lowerer drift and returns
+        // `UnsupportedOp` as a safety net.
+        //
+        // | Builtin   | Host import       | Operand layout                        |
+        // |-----------|-------------------|----------------------------------------|
+        // | `putchar` | `env.putchar(i32)` | srcs = [Var("putchar"), Var(val)]      |
+        // | `getchar` | `env.getchar() → i32` | srcs = [Var("getchar")]; dest = byte |
+        "call_builtin" => {
+            let name = match instr.srcs.first() {
+                Some(Operand::Var(s)) => s.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "call_builtin: srcs[0] must be the builtin name as Operand::Var".to_string(),
+                }),
+            };
+            match name {
+                "putchar" => {
+                    let val_var = match instr.srcs.get(1) {
+                        Some(Operand::Var(v)) => v.as_str(),
+                        _ => return Err(IIRWasmError::InvalidOperand {
+                            function: fn_name.to_string(),
+                            detail: "call_builtin \"putchar\" requires srcs[1] = Operand::Var(val)".to_string(),
+                        }),
+                    };
+                    let val_slot = get_reg(val_var)?;
+                    let fn_idx = putchar_fn_idx.ok_or_else(|| IIRWasmError::UnsupportedOp {
+                        function: fn_name.to_string(),
+                        op: "call_builtin \"putchar\": no env.putchar import registered (internal error)".to_string(),
+                    })?;
+                    code.extend(encode_local_get(val_slot));
+                    code.extend(encode_call(fn_idx));
+                }
+                "getchar" => {
+                    let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
+                        function: fn_name.to_string(),
+                        detail: "call_builtin \"getchar\" requires a dest register".to_string(),
+                    })?;
+                    let rd = get_reg(dest)?;
+                    let fn_idx = getchar_fn_idx.ok_or_else(|| IIRWasmError::UnsupportedOp {
+                        function: fn_name.to_string(),
+                        op: "call_builtin \"getchar\": no env.getchar import registered (internal error)".to_string(),
+                    })?;
+                    code.extend(encode_call(fn_idx));
+                    code.extend(encode_local_set(rd));
+                }
+                _ => {
+                    // Validator should have rejected this; defense in depth.
+                    return Err(IIRWasmError::UnsupportedOp {
+                        function: fn_name.to_string(),
+                        op: format!("call_builtin {:?}: not in WASM backend whitelist", name),
+                    });
+                }
+            }
+        }
+
         // ── Unknown op ────────────────────────────────────────────────────────
         _ => {
             return Err(IIRWasmError::UnsupportedOp {
@@ -1572,6 +1754,8 @@ fn lower_function(
     lispy_pair_type_idx: Option<u32>,
     global_map: &HashMap<String, u32>,
     print_fn_idx: Option<u32>,
+    putchar_fn_idx: Option<u32>,
+    getchar_fn_idx: Option<u32>,
 ) -> Result<FunctionBody, IIRWasmError> {
     let param_count = fn_.params.len() as u32;
     let reg_map = build_register_map(fn_);
@@ -1650,6 +1834,8 @@ fn lower_function(
                     lispy_pair_type_idx,
                     global_map,
                     print_fn_idx,
+                    putchar_fn_idx,
+                    getchar_fn_idx,
                 )?;
             }
 
@@ -1704,6 +1890,8 @@ fn lower_function(
                 lispy_pair_type_idx,
                 global_map,
                 print_fn_idx,
+                putchar_fn_idx,
+                getchar_fn_idx,
             )?;
         }
     }
@@ -1767,7 +1955,38 @@ fn make_lispy_pair_struct_type() -> StructType {
 ///   position in the vec determines their WASM global section index.
 /// - `uses_io_out` — `true` if any instruction in any function has the
 ///   `"io_out"` opcode.  Triggers injection of the `env.__print_i64` import.
-fn collect_globals_and_io(module: &IIRModule) -> (Vec<String>, bool) {
+/// Features the WASM lowering must materialize as imports / sections.
+///
+/// Populated by [`collect_module_features`] from a single pass over the
+/// module.  Each boolean field gates an injection step in
+/// [`lower_iir_to_wasm`]:
+///
+/// | Field            | Trigger                              | What it injects |
+/// |------------------|--------------------------------------|-----------------|
+/// | `global_names`   | `global_load` / `global_store`        | `Global` entries (one per name, i64, mutable) |
+/// | `uses_io_out`    | `io_out`                              | `env.__print_i64` import |
+/// | `uses_putchar`   | `call_builtin` with name `"putchar"`  | `env.putchar` import   |
+/// | `uses_getchar`   | `call_builtin` with name `"getchar"`  | `env.getchar` import   |
+/// | `uses_memory`    | `load_mem` / `store_mem`              | A 1-page linear `Memory` |
+///
+/// All combinations are valid — the eventual import order is documented
+/// in [`lower_iir_to_wasm`].
+struct ModuleFeatures {
+    /// Deduplicated global names, in first-seen order.  Position in the
+    /// vec = WASM global-section index.
+    global_names: Vec<String>,
+    uses_io_out: bool,
+    uses_putchar: bool,
+    uses_getchar: bool,
+    /// True when the module reads or writes Brainfuck's tape memory.
+    /// Triggers the addition of a single 1-page linear memory to the
+    /// module's `Memory` section.
+    uses_memory: bool,
+}
+
+/// Walk the module once to collect everything the lowering needs to know
+/// for module-level decisions (imports, sections, fn-index offsets).
+fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
     // Use a HashSet for O(1) deduplication checks, preserving first-seen order
     // in the Vec.  Without the set, deduplication would be O(M × N) where M is
     // the number of global accesses and N the number of distinct names —
@@ -1775,6 +1994,9 @@ fn collect_globals_and_io(module: &IIRModule) -> (Vec<String>, bool) {
     let mut global_names: Vec<String> = Vec::new();
     let mut global_names_seen: HashSet<String> = HashSet::new();
     let mut uses_io_out = false;
+    let mut uses_putchar = false;
+    let mut uses_getchar = false;
+    let mut uses_memory = false;
     for fn_ in &module.functions {
         for instr in &fn_.instructions {
             match instr.op.as_str() {
@@ -1788,11 +2010,33 @@ fn collect_globals_and_io(module: &IIRModule) -> (Vec<String>, bool) {
                 "io_out" => {
                     uses_io_out = true;
                 }
+                "load_mem" | "store_mem" => {
+                    uses_memory = true;
+                }
+                "call_builtin" => {
+                    // The builtin name is in srcs[0] as Var.
+                    if let Some(Operand::Var(name)) = instr.srcs.first() {
+                        match name.as_str() {
+                            "putchar" => uses_putchar = true,
+                            "getchar" => uses_getchar = true,
+                            // Other builtin names are rejected by the
+                            // validator before we get here — be defensive
+                            // and don't crash on unknown ones at compile time.
+                            _ => {}
+                        }
+                    }
+                }
                 _ => {}
             }
         }
     }
-    (global_names, uses_io_out)
+    ModuleFeatures {
+        global_names,
+        uses_io_out,
+        uses_putchar,
+        uses_getchar,
+        uses_memory,
+    }
 }
 
 /// Lower an `IIRModule` to a `WasmModule`, with WasmGC struct types.
@@ -1841,16 +2085,26 @@ pub fn lower_iir_to_wasm(
     // collected.
     let uses_lispy_pair = module_uses_lispy_pair(module);
 
-    // ── Step 2b: Collect global variable names and io_out usage ──────────────
+    // ── Step 2b: Collect globals, io_out, and Brainfuck features ─────────────
     //
     // `global_names` is a deduplicated list of all global variable names
     // referenced by `global_load`/`global_store` instructions, in first-seen
     // order.  Position in the vec = WASM global section index.
     //
-    // `uses_io_out` triggers injection of the `env.__print_i64(i64)` host
-    // import, which occupies function index 0 in the WASM function index
-    // space (imports come before defined functions).
-    let (global_names, uses_io_out) = collect_globals_and_io(module);
+    // `uses_io_out` triggers injection of the `env.__print_i64(i64)` host import.
+    // `uses_putchar` / `uses_getchar` trigger injection of `env.putchar(i32)` /
+    // `env.getchar() -> i32` host imports — Brainfuck's I/O builtins.
+    // `uses_memory` triggers injection of a 1-page linear memory (the BF tape).
+    //
+    // Imports occupy the first slots of the WASM function-index space, in
+    // declaration order; defined functions are then shifted up by the
+    // import count.
+    let features = collect_module_features(module);
+    let global_names = features.global_names.clone();
+    let uses_io_out  = features.uses_io_out;
+    let uses_putchar = features.uses_putchar;
+    let uses_getchar = features.uses_getchar;
+    let uses_memory  = features.uses_memory;
 
     // Map each global name to its WASM global section index.
     let global_map: HashMap<String, u32> = global_names
@@ -1861,12 +2115,24 @@ pub fn lower_iir_to_wasm(
 
     // ── Step 3: Build function index map ─────────────────────────────────────
     //
-    // WASM function indices are contiguous starting from 0.  When a
-    // `$__print_i64` import is present it occupies index 0, so all defined
-    // functions are shifted up by 1.
+    // WASM function indices are contiguous starting from 0.  Imports occupy
+    // the first slots, in declaration order.  Defined functions follow.
     //
-    // `fn_idx_base` is 1 when the print import is injected, 0 otherwise.
-    let fn_idx_base: u32 = if uses_io_out { 1 } else { 0 };
+    // Import order (mirrored when building `imports` below):
+    //   0. env.__print_i64   (if uses_io_out)
+    //   1. env.putchar       (if uses_putchar)
+    //   2. env.getchar       (if uses_getchar)
+    let mut next_import_idx: u32 = 0;
+    let print_fn_idx: Option<u32> = if uses_io_out {
+        let i = next_import_idx; next_import_idx += 1; Some(i)
+    } else { None };
+    let putchar_fn_idx: Option<u32> = if uses_putchar {
+        let i = next_import_idx; next_import_idx += 1; Some(i)
+    } else { None };
+    let getchar_fn_idx: Option<u32> = if uses_getchar {
+        let i = next_import_idx; next_import_idx += 1; Some(i)
+    } else { None };
+    let fn_idx_base: u32 = next_import_idx;
 
     let fn_map: HashMap<String, u32> = module
         .functions
@@ -1929,35 +2195,58 @@ pub fn lower_iir_to_wasm(
         None
     };
 
-    // Add the $__print_i64 import type and import entry if io_out is used.
+    // Add host-import types & entries for any enabled features.
     //
-    // The print import type is pushed AFTER all defined-function FuncTypes and
-    // after the optional LispyPair struct type, so its type index is
-    // `types.len() + struct_types_count`.  Since struct_types are encoded in
-    // the same WASM type section after func types, the print type index is
-    // `types.len() + (1 if uses_lispy_pair else 0)`.
+    // Each FuncType is appended to `types` after defined-function FuncTypes
+    // and after the optional LispyPair struct type.  The struct type, when
+    // present, occupies one slot between the function types and the
+    // imports' function types.
     //
-    // `print_fn_idx` is always 0 (the import occupies the first function slot).
-    let print_fn_idx: Option<u32>;
-    let print_imports: Vec<Import>;
+    // Imports are pushed to `host_imports` in the same order their
+    // function indices were assigned earlier in Step 3:
+    //   0. env.__print_i64   (if uses_io_out)
+    //   1. env.putchar       (if uses_putchar)
+    //   2. env.getchar       (if uses_getchar)
+    //
+    // The function index that emit_instr uses is the one we assigned earlier
+    // (print_fn_idx / putchar_fn_idx / getchar_fn_idx).  Here we just need
+    // to push the type and import entries in matching order.
+    let mut host_imports: Vec<Import> = Vec::new();
+    let struct_type_offset: u32 = if uses_lispy_pair { 1 } else { 0 };
     if uses_io_out {
-        // The print type goes after function types and the optional struct type.
-        let print_type_idx =
-            types.len() as u32 + if uses_lispy_pair { 1 } else { 0 };
-        types.push(FuncType {
-            params: vec![ValueType::I64],
-            results: vec![],
-        });
-        print_fn_idx = Some(0u32);
-        print_imports = vec![Import {
+        // env.__print_i64(i64) -> ()
+        let type_idx = types.len() as u32 + struct_type_offset;
+        types.push(FuncType { params: vec![ValueType::I64], results: vec![] });
+        host_imports.push(Import {
             module_name: "env".to_string(),
             name: "__print_i64".to_string(),
             kind: ExternalKind::Function,
-            type_info: ImportTypeInfo::Function(print_type_idx),
-        }];
-    } else {
-        print_fn_idx = None;
-        print_imports = vec![];
+            type_info: ImportTypeInfo::Function(type_idx),
+        });
+    }
+    if uses_putchar {
+        // env.putchar(i32) -> ()
+        let type_idx = types.len() as u32 + struct_type_offset;
+        types.push(FuncType { params: vec![ValueType::I32], results: vec![] });
+        host_imports.push(Import {
+            module_name: "env".to_string(),
+            name: "putchar".to_string(),
+            kind: ExternalKind::Function,
+            type_info: ImportTypeInfo::Function(type_idx),
+        });
+    }
+    if uses_getchar {
+        // env.getchar() -> i32  (returns the next byte, or -1 / 0 for EOF
+        // depending on host convention — Brainfuck's interpreter convention
+        // is 0 for EOF, which matches the lazy-tape semantics).
+        let type_idx = types.len() as u32 + struct_type_offset;
+        types.push(FuncType { params: vec![], results: vec![ValueType::I32] });
+        host_imports.push(Import {
+            module_name: "env".to_string(),
+            name: "getchar".to_string(),
+            kind: ExternalKind::Function,
+            type_info: ImportTypeInfo::Function(type_idx),
+        });
     }
 
     // Build WASM Global entries — one mutable i64 per named global,
@@ -1990,8 +2279,12 @@ pub fn lower_iir_to_wasm(
         });
 
         // Lower the function body, passing GC type index, global map, and
-        // the print import index if io_out is used.
-        let body = lower_function(fn_, &fn_map, lispy_pair_type_idx, &global_map, print_fn_idx)?;
+        // the host-import indices (print / putchar / getchar) so emit_instr
+        // can `call <import_idx>` directly.
+        let body = lower_function(
+            fn_, &fn_map, lispy_pair_type_idx, &global_map,
+            print_fn_idx, putchar_fn_idx, getchar_fn_idx,
+        )?;
         code.push(body);
     }
 
@@ -2004,11 +2297,27 @@ pub fn lower_iir_to_wasm(
         vec![]
     };
 
+    // Brainfuck tape: a single 1-page linear memory.  Each WASM memory page is
+    // 64 KiB = 65,536 bytes, comfortably larger than Brainfuck's default 30,000
+    // -cell tape.  The memory is module-defined (not imported); a future
+    // extension can add an `import` variant if the host wants to provide
+    // the buffer.  Modules that don't use `load_mem`/`store_mem` get no
+    // memory section, preserving binary compatibility with the existing
+    // non-BF callers (Twig, BASIC, Oct, Nib, Lispy).
+    let memories: Vec<wasm_types::MemoryType> = if uses_memory {
+        vec![wasm_types::MemoryType {
+            limits: wasm_types::Limits { min: 1, max: Some(1) },
+        }]
+    } else {
+        vec![]
+    };
+
     Ok(WasmModule {
         types,
         struct_types,
         functions,
-        imports: print_imports,
+        imports: host_imports,
+        memories,
         globals: wasm_globals,
         exports,
         code,

--- a/code/packages/rust/iir-to-wasm/src/validate.rs
+++ b/code/packages/rust/iir-to-wasm/src/validate.rs
@@ -97,18 +97,41 @@ const GC_OPS: &[&str] = &["alloc", "field_load", "field_store", "is_null"];
 // - `global_load`   — lowered to `global.get <idx>` (WASM global section).
 
 const UNSUPPORTED_OPS: &[&str] = &[
-    "call_builtin",
+    // `call_builtin` is *conditionally* unsupported — handled below.  See
+    // `CALL_BUILTIN_SUPPORTED_NAMES` and the call_builtin branch in the
+    // per-instruction loop.  Whitelisting specific builtins (`putchar`,
+    // `getchar`) lets Brainfuck flow through this backend while still
+    // rejecting unknown / unsafe builtin names.
     "io_in",
     // "io_out"       — LANG32: now supported (host import $__print_i64).
     // "global_store" — LANG32: now supported (WASM global.set).
     // "global_load"  — LANG32: now supported (WASM global.get).
     "cast",
-    "load_mem",
-    "store_mem",
+    // "load_mem"     — Brainfuck: now supported (i32.load8_u over linear memory).
+    // "store_mem"    — Brainfuck: now supported (i32.store8 over linear memory).
     "box",
     "unbox",
     "safepoint",
 ];
+
+/// Builtin names that the WASM backend can lower via a host import.
+///
+/// Each entry maps to a `(env, name)` WASM import pair that the host
+/// environment is expected to supply.  Today's list covers the
+/// Brainfuck I/O builtins:
+///
+/// | Builtin     | Host import       | Signature |
+/// |-------------|-------------------|-----------|
+/// | `"putchar"` | `env.putchar`     | `(i32) -> ()`     |
+/// | `"getchar"` | `env.getchar`     | `() -> i32`       |
+///
+/// Adding a new builtin requires:
+///   1. Listing it here so the validator accepts it.
+///   2. Adding a matching `case` to `lower.rs::emit_instr`'s
+///      `call_builtin` branch that emits the right WASM call.
+///   3. Injecting the import entry in `lower_iir_to_wasm` (see the
+///      analogous wiring for `io_out` → `env.__print_i64`).
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar"];
 
 // ---------------------------------------------------------------------------
 // validate_for_wasm
@@ -260,12 +283,42 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
             // NOT in UNSUPPORTED_OPS — they are accepted when paired with
             // `ref<LispyPair>`.  Reject them here only when the type hint
             // is NOT a supported reference type.
+            //
+            // `call_builtin` is conditionally accepted: the builtin name
+            // (carried in `srcs[0]` as `Operand::Var`) must be in
+            // [`CALL_BUILTIN_SUPPORTED_NAMES`].  This lets Brainfuck's
+            // `putchar` / `getchar` flow through while still rejecting
+            // unknown / unsafe builtins.
             if UNSUPPORTED_OPS.contains(&instr.op.as_str()) {
                 errors.push(format!(
                     "UnsupportedOp: function {:?}, op {:?} is not supported by \
                      the WASM backend; it requires a host import or runtime support",
                     func.name, instr.op
                 ));
+            } else if instr.op == "call_builtin" {
+                // Inspect srcs[0] for the builtin name.  IIR carries it as
+                // `Operand::Var(name)` (Rust's IIR has no separate string
+                // operand kind — names and var refs share `Var`).
+                let name: Option<&str> = match instr.srcs.first() {
+                    Some(interpreter_ir::Operand::Var(s)) => Some(s.as_str()),
+                    _ => None,
+                };
+                match name {
+                    Some(n) if CALL_BUILTIN_SUPPORTED_NAMES.contains(&n) => {
+                        // Accepted — emit_instr will lower it to a call into
+                        // the corresponding host import.
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"call_builtin\" with \
+                             builtin name {:?} is not in the WASM backend's host-import \
+                             whitelist (supported: {:?}); add the builtin to \
+                             CALL_BUILTIN_SUPPORTED_NAMES and the lowering rule in \
+                             lower.rs to extend coverage",
+                            func.name, name, CALL_BUILTIN_SUPPORTED_NAMES
+                        ));
+                    }
+                }
             } else if instr.op == "alloc" || instr.op == "field_load" || instr.op == "field_store" {
                 // These GC ops require the instruction's type_hint to be a
                 // supported reference type.  They allocate or access fields
@@ -420,12 +473,14 @@ mod tests {
         // These ops are unconditionally rejected.
         // Note: `io_out`, `global_store`, `global_load` are NOT in this list —
         // they were promoted to supported in LANG32.
+        // `load_mem`, `store_mem` are NOT in this list — Brainfuck linear-
+        // memory lowering promoted them to supported in the BF→WASM PR.
+        // `call_builtin` is NOT in this list — it's conditionally accepted
+        // for builtin names in `CALL_BUILTIN_SUPPORTED_NAMES`; see the
+        // call_builtin_*_tests below.
         for op in &[
-            "call_builtin",
             "io_in",
             "cast",
-            "load_mem",
-            "store_mem",
             "box",
             "unbox",
             "safepoint",
@@ -443,6 +498,108 @@ mod tests {
                 errs
             );
         }
+    }
+
+    // ─── BF lowering: load_mem / store_mem now pass ─────────────────────────
+
+    #[test]
+    fn load_mem_accepted_for_bf() {
+        let errs = validate_for_wasm(&module_with(vec![
+            // load_mem v ptr [u8]  — read tape cell into v.
+            IIRInstr::new(
+                "load_mem",
+                Some("v".into()),
+                vec![Operand::Var("ptr".into())],
+                "u8",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "load_mem should be accepted by WASM validator for Brainfuck \
+             linear-memory lowering; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn store_mem_accepted_for_bf() {
+        let errs = validate_for_wasm(&module_with(vec![
+            // store_mem ptr v [u8]  — write v into tape[ptr].
+            IIRInstr::new(
+                "store_mem",
+                None,
+                vec![Operand::Var("ptr".into()), Operand::Var("v".into())],
+                "u8",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "store_mem should be accepted by WASM validator; got: {:?}",
+            errs
+        );
+    }
+
+    // ─── BF lowering: call_builtin whitelist (putchar / getchar) ─────────────
+
+    #[test]
+    fn call_builtin_putchar_accepted() {
+        let errs = validate_for_wasm(&module_with(vec![
+            // call_builtin putchar v [void]  — write v as a byte to stdout.
+            IIRInstr::new(
+                "call_builtin",
+                None,
+                vec![
+                    Operand::Var("putchar".into()),
+                    Operand::Var("v".into()),
+                ],
+                "void",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "call_builtin \"putchar\" should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn call_builtin_getchar_accepted() {
+        let errs = validate_for_wasm(&module_with(vec![
+            // call_builtin v getchar [u8]  — read a byte from stdin into v.
+            IIRInstr::new(
+                "call_builtin",
+                Some("v".into()),
+                vec![Operand::Var("getchar".into())],
+                "u8",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "call_builtin \"getchar\" should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn call_builtin_unknown_name_rejected() {
+        // An arbitrary builtin name not in the whitelist must still fail
+        // validation so unknown / unsafe builtins can't slip through.
+        let errs = validate_for_wasm(&module_with(vec![IIRInstr::new(
+            "call_builtin",
+            None,
+            vec![Operand::Var("system_exec".into())],
+            "void",
+        )]));
+        assert!(
+            errs.iter().any(|e| e.contains("UnsupportedOp")
+                && e.contains("system_exec")),
+            "unknown call_builtin name should be rejected; got: {:?}",
+            errs
+        );
     }
 
     #[test]

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -222,21 +222,28 @@ fn validate_io_out_accepted() {
 
 // Test 1.12
 #[test]
-fn validate_memory_ops_rejected() {
-    // load_mem and store_mem are unconditionally rejected (no linear memory).
-    // alloc with a non-ref type hint is rejected (needs ref<LispyPair>).
+fn validate_memory_ops_accepted() {
+    // After the BF→WASM lowering, `load_mem` and `store_mem` are
+    // accepted — they lower to `i32.load8_u` and `i32.store8` over the
+    // module's linear memory (a single 1-page WASM memory injected when
+    // any memory op is used).  See iir-to-wasm/src/lower.rs.
+    //
+    // Note: validate.rs's per-instruction errors are emitted independently,
+    // so we tolerate other errors (e.g. UndefinedVariable) here — only the
+    // `UnsupportedOp` check is relevant for the memory-op promotion.
     for op in &["load_mem", "store_mem"] {
         let m = module_one("f", vec![], "void", vec![
-            IIRInstr::new(*op, None, vec![], "void"),
+            IIRInstr::new(*op, None, vec![], "u8"),
         ]);
         let errs = validate_for_wasm(&m);
         assert!(
-            errs.iter().any(|e| e.contains("UnsupportedOp")),
-            "expected UnsupportedOp for {:?}",
-            op
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "{:?} should no longer be UnsupportedOp; errs: {:?}",
+            op, errs
         );
     }
-    // alloc with i32 type is rejected.
+    // `alloc` with a non-ref type hint is still rejected — GC ops require a
+    // supported ref<...> type.
     {
         let m = module_one("f", vec![], "void", vec![
             IIRInstr::new("alloc", None, vec![], "i32"),


### PR DESCRIPTION
## Summary

Stage 1 of 4 for getting Brainfuck through the universal IIR-to-* backends.  Adds `load_mem`, `store_mem`, and `call_builtin \"putchar\"` / `\"getchar\"` lowering to **iir-to-wasm**, so Brainfuck's IIR validates and compiles to real \`.wasm\` bytes through the same backend that Twig, BASIC, Oct, Nib, and Lispy already use.

After this PR, Brainfuck programs walk the new IIR chain end-to-end:

\`\`\`
BF source → IIRModule
         → iir-to-wasm validator (accepts)
         → lower_iir_to_wasm
         → encode_module
         → \0asm\x01\x00\x00\x00 … (real .wasm bytes)
\`\`\`

## What's in this PR

**Validator** (\`iir-to-wasm/src/validate.rs\`):
- \`load_mem\` / \`store_mem\` removed from \`UNSUPPORTED_OPS\`
- New \`CALL_BUILTIN_SUPPORTED_NAMES\` whitelist (currently \`[\"putchar\", \"getchar\"]\`); unknown builtin names still rejected with a clear error that includes the whitelist
- 5 new unit tests

**Lowering** (\`iir-to-wasm/src/lower.rs\`):
- New \`encode_i32_load8_u\` / \`encode_i32_store8\` helpers
- New \`ModuleFeatures\` struct + \`collect_module_features\` (one-pass detection of putchar/getchar/memory usage)
- Injects \`env.putchar : (i32) -> ()\` and \`env.getchar : () -> i32\` imports when used
- Injects a single 1-page (64 KiB) linear memory when memory ops are present — programs that don't use memory get no memory section, preserving binary compat for Twig/BASIC/Oct/Nib/Lispy
- 4 new \`emit_instr\` arms (load_mem, store_mem, call_builtin putchar/getchar)

**End-to-end test** (\`brainfuck-iir-compiler/tests/wasm_e2e.rs\`):
- \`+++.\` lowers to a module with putchar import + memory + main export + valid WASM magic header
- \`++[-]\` loop compiles cleanly with memory but no putchar
- \`,.\` emits both getchar and putchar imports
- Empty program emits no memory and no imports (conditional feature detection)

## What's not in this PR

- **Stage 2 (JVM)** — \`byte[]\` field + \`System.in\` / \`System.out\` lowering
- **Stage 3 (CLR)** — \`byte[]\` + \`System.Console\` lowering
- **Stage 4 (BEAM)** — NIF or \`io:put_chars\` lowering (harder fit — BEAM is purely functional)
- **Runtime execution test** — we encode the bytes but don't instantiate them with a host runtime.  Validating that requires wiring \`HostFunction\` impls for putchar/getchar.  That's a 60-line follow-up, kept out of this PR's scope.

## Compatibility

| Crate | Tests | Status |
|---|---|---|
| iir-to-wasm | 45 lib + 88 integration | all pass |
| iir-codegen-adapters | 28 + 34 | all pass (regression-clean) |
| nib-iir-compiler | 11 + 5 | all pass |
| brainfuck-iir-compiler | 63 + 9 JIT + **4 WASM e2e** | all pass |

## Version bumps

- iir-to-wasm: 0.3.0 → 0.4.0
- brainfuck-iir-compiler: 0.3.0 → 0.3.1 (e2e test only, no API change)

## Test plan

- [x] \`cargo test -p iir-to-wasm\` (133 pass)
- [x] \`cargo test -p brainfuck-iir-compiler --tests\` (76 pass)
- [x] \`cargo test -p iir-codegen-adapters --tests\` (62 pass — regression check)
- [x] \`cargo test -p nib-iir-compiler --tests\` (16 pass — regression check)
- [x] \`/security-review\` passed
- [ ] CI green across macOS / Ubuntu / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)