### PR TITLE
feat(symbolic-vm): Phase 47 — nested-Add flattening (TS+Rust port)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.12.0] — 2026-05-22
+
+**Phase 47 — Nested-Add flattening (Rust port).**
+
+Ports the Python ``symbolic-vm`` 0.71.0 Add-handler fix.  When either
+binary ``Add`` operand is itself an ``Add(...)`` apply, the handler
+now flattens the tree, sums numeric literals once, and rebuilds a
+left-associated chain.  Example:
+
+    Add(Add(k, 1), 1)  →  Add(k, 2)
+    Add(Add(Add(k, 1), 1), 1)  →  Add(k, 3)
+
+### Added
+
+- **`flatten_add_leaves(node: &IRNode, out: &mut Vec<IRNode>)`** in
+  ``src/handlers.rs`` — recursive walker that appends every
+  non-``Add`` leaf of a nested ``Add`` tree to the ``out`` vector.
+
+### Changed
+
+- ``add_handler(simplify=true)`` now pre-checks whether either binary
+  operand is an ``Add`` apply.  If so, it collects all non-``Add``
+  leaves via ``flatten_add_leaves``, partitions into numerics vs
+  symbolics, sums the numerics into a single ``Numeric`` via
+  ``Add for Numeric``, and rebuilds a left-associated chain
+  ``Add(...non_literals, lit_sum)`` — dropping the literal if it's
+  zero, collapsing to a bare leaf if only one operand remains.
+  Strict mode (``simplify=false``) keeps the original binary
+  semantics.
+
+### Added — tests
+
+`tests/test_vm.rs` — 6 new ``phase47_*`` cases:
+
+- ``phase47_nested_add_flattens``: ``Add(Add(k, 1), 1)`` → ``Add(k, 2)``.
+- ``phase47_triply_nested_add``: 3-level flattening.
+- ``phase47_add_constants_fold``: ``Add(Add(k, 2), 3)`` → ``Add(k, 5)``.
+- ``phase47_constants_cancel_to_bare_symbol``: ``Add(Add(k, 1), -1)``
+  → bare ``k``.
+- ``phase47_non_nested_add_untouched``: ``Add(k, 1)`` — no rebuild.
+- ``phase47_add_zero_still_simplifies``: regression for the existing
+  ``x + 0 → x`` identity.
+
+Full suite: **194 passed** (was 188; +6 net new).
+
 ## [0.11.0] — 2026-05-20
 
 ### Added — Phase 38: Weierstrass closed forms lifted to linear trig arguments

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -274,8 +274,94 @@ fn is_truthy(node: &IRNode) -> Option<bool> {
 // Arithmetic handlers
 // ---------------------------------------------------------------------------
 
+/// Phase 47 (Rust port): walk a nested `Add` tree and append every
+/// non-`Add` leaf to `out`.  Used by the `Add` handler's flattening
+/// path.
+fn flatten_add_leaves(node: &IRNode, out: &mut Vec<IRNode>) {
+    match node {
+        IRNode::Apply(apply_node) if matches!(&apply_node.head, IRNode::Symbol(s) if s == ADD) => {
+            for arg in &apply_node.args {
+                flatten_add_leaves(arg, out);
+            }
+        }
+        _ => out.push(node.clone()),
+    }
+}
+
 fn add_handler(simplify: bool) -> Handler {
     std::sync::Arc::new(move |_vm: &mut VM, expr: IRApply| -> IRNode {
+        // Phase 47: nested-Add flattening for the symbolic backend.
+        // When either binary Add operand is itself an Add(...) apply,
+        // gather every non-Add leaf, sum the numeric literals once,
+        // and rebuild a left-associated chain.  This makes Add
+        // canonical for any consumer that compares trees structurally
+        // — most importantly the cas-summation telescope detector.
+        if simplify && expr.args.len() == 2 {
+            let a_is_add = matches!(
+                &expr.args[0],
+                IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == ADD)
+            );
+            let b_is_add = matches!(
+                &expr.args[1],
+                IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == ADD)
+            );
+            if a_is_add || b_is_add {
+                let mut leaves: Vec<IRNode> = Vec::new();
+                flatten_add_leaves(&expr.args[0], &mut leaves);
+                flatten_add_leaves(&expr.args[1], &mut leaves);
+                // Re-evaluation guard: only rebuild when flattening
+                // actually changed the operand list (saves a needless
+                // round-trip when neither side was nested).
+                let rebuilt = leaves.len() != 2
+                    || leaves.iter().any(|leaf| {
+                        matches!(
+                            leaf,
+                            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == ADD)
+                        )
+                    });
+                if rebuilt {
+                    let mut lit_acc: Option<Numeric> = None;
+                    let mut non_literals: Vec<IRNode> = Vec::new();
+                    for leaf in leaves {
+                        match to_numeric(&leaf) {
+                            Some(n) => {
+                                lit_acc = Some(match lit_acc {
+                                    Some(acc) => acc + n,
+                                    None => n,
+                                });
+                            }
+                            None => non_literals.push(leaf),
+                        }
+                    }
+                    if non_literals.is_empty() {
+                        let total = lit_acc.unwrap_or(Numeric::Int(0));
+                        return from_numeric(total);
+                    }
+                    let lit_is_zero = match lit_acc {
+                        None => true,
+                        Some(n) => n.is_zero(),
+                    };
+                    let mut final_args = non_literals;
+                    if !lit_is_zero {
+                        final_args.push(from_numeric(lit_acc.unwrap()));
+                    }
+                    if final_args.len() == 1 {
+                        return final_args.into_iter().next().unwrap();
+                    }
+                    // Left-associate the chain.
+                    let mut iter = final_args.into_iter();
+                    let mut out = iter.next().unwrap();
+                    for nxt in iter {
+                        out = IRNode::Apply(Box::new(IRApply {
+                            head: IRNode::Symbol(ADD.to_string()),
+                            args: vec![out, nxt],
+                        }));
+                    }
+                    return out;
+                }
+            }
+        }
+
         let (a, b) = match binary_args(&expr) {
             Some(p) => p,
             None => return IRNode::Apply(Box::new(expr)),

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -3022,3 +3022,85 @@ fn phase38_fallthrough_symbolic_alpha() {
     let result = integrate(integrand);
     assert!(is_unevaluated_integrate(&result));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 47 (Rust port): Nested-Add flattening.
+//
+// Ports the Python Phase 47 fix.  When either binary Add operand is itself
+// an Add(...) apply, the handler flattens the tree, sums numeric literals
+// once, and rebuilds a left-associated chain.  Makes Add canonical for
+// any consumer comparing trees structurally.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase47_nested_add_flattens() {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    let k = sym("k");
+    let nested = apply(sym(ADD), vec![
+        apply(sym(ADD), vec![k.clone(), int(1)]),
+        int(1),
+    ]);
+    let out = vm.eval(nested);
+    let expected = apply(sym(ADD), vec![k, int(2)]);
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn phase47_triply_nested_add() {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    let k = sym("k");
+    let nested = apply(sym(ADD), vec![
+        apply(sym(ADD), vec![
+            apply(sym(ADD), vec![k.clone(), int(1)]),
+            int(1),
+        ]),
+        int(1),
+    ]);
+    let out = vm.eval(nested);
+    let expected = apply(sym(ADD), vec![k, int(3)]);
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn phase47_add_constants_fold() {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    let k = sym("k");
+    let nested = apply(sym(ADD), vec![
+        apply(sym(ADD), vec![k.clone(), int(2)]),
+        int(3),
+    ]);
+    let out = vm.eval(nested);
+    let expected = apply(sym(ADD), vec![k, int(5)]);
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn phase47_constants_cancel_to_bare_symbol() {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    let k = sym("k");
+    let nested = apply(sym(ADD), vec![
+        apply(sym(ADD), vec![k.clone(), int(1)]),
+        int(-1),
+    ]);
+    let out = vm.eval(nested);
+    // Constants sum to zero → drop the literal → bare k.
+    assert_eq!(out, k);
+}
+
+#[test]
+fn phase47_non_nested_add_untouched() {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    let k = sym("k");
+    let flat = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let out = vm.eval(flat);
+    let expected = apply(sym(ADD), vec![k, int(1)]);
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn phase47_add_zero_still_simplifies() {
+    let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+    let x = sym("x");
+    let out = vm.eval(apply(sym(ADD), vec![int(0), x.clone()]));
+    assert_eq!(out, x);
+}

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [0.12.0] — 2026-05-22
+
+**Phase 47 — Nested-Add flattening (TypeScript port).**
+
+Ports the Python ``symbolic-vm`` 0.71.0 Add-handler fix.  When either
+binary ``Add`` operand is itself an ``Add(...)`` apply, the handler
+now flattens the tree, sums numeric literals once, and rebuilds a
+left-associated chain.  Example:
+
+    Add(Add(k, 1), 1)  →  Add(k, 2)
+    Add(Add(Add(k, 1), 1), 1)  →  Add(k, 3)
+
+Why it matters: makes ``Add`` canonical for any consumer that
+compares trees structurally.  In particular, downstream
+``cas-summation`` users get reliable structural-equality matches in
+the telescope detector even when ``Apart`` (in Python) or hand-
+written shifted summands (anywhere) produce nested ``Add`` forms.
+
+### Changed
+
+- ``buildHandlerTable``'s ``ADD`` entry now wraps the existing
+  ``binaryNumeric`` handler with a pre-pass that:
+  1. Detects nested ``Add`` operands.
+  2. Walks the tree via the existing ``flattenAddTerms`` helper.
+  3. Partitions leaves into numerics vs symbolics.
+  4. Sums numerics once (priority handled by ``addNumeric``).
+  5. Rebuilds a left-associated chain
+     ``Add(...non_literals, lit_sum)`` (dropping the literal if it's
+     zero, collapsing to the bare symbol if only one operand remains).
+
+Strict mode (``simplify=false``) keeps the original binary
+semantics.
+
+### Added — tests
+
+`tests/symbolic-vm.test.ts` — new ``Phase 47: nested-Add flattening``
+describe block with 7 cases:
+
+- ``Add(Add(k, 1), 1)`` → ``Add(k, 2)``.
+- Triply-nested ``Add(Add(Add(k, 1), 1), 1)`` → ``Add(k, 3)``.
+- ``Add(Add(k, 2), 3)`` → ``Add(k, 5)`` (constant folding).
+- ``Add(Add(k, 1), -1)`` → bare ``k`` (literal zeroes out).
+- ``Add(Add(x, y), z)`` — no literals — stays as left-associated
+  chain (pin: no spurious reordering).
+- ``Add(k, 1)`` — non-nested — untouched (no rebuild).
+- Regression: ``Add(0, x)`` still simplifies to ``x``.
+
+Full suite: **161 passed** (was 154; +7 net new).
+
 ## [0.11.0] — 2026-05-20
 
 ### Added — Phase 38: Weierstrass closed forms lifted to linear trig arguments

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -440,11 +440,69 @@ const _ABS_HEAD = sym("Abs");
 
 function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   const table = new Map<string, Handler>();
-  table.set(ADD.name, binaryNumeric("Add", simplify, (a, b) => addNumeric(a, b), (expr, a, b) => {
+  // Phase 47 (TypeScript port): nested-Add flattening.  When either
+  // binary Add operand is itself an Add(...) apply, gather every
+  // non-Add leaf via the existing `flattenAddTerms` walker, sum the
+  // numeric literals once, and rebuild a left-associated chain.
+  // Without this, the structural-equality check inside cas-summation's
+  // telescope detector misses telescopes whose denominators contain
+  // (k + a) shifts produced by Apart (e.g. ∑ 1/((k+1)(k+2))).
+  // Strict mode (simplify=false) keeps the original binary semantics.
+  const addBinary = binaryNumeric("Add", simplify, (a, b) => addNumeric(a, b), (expr, a, b) => {
     if (isZero(a)) return b;
     if (isZero(b)) return a;
     return expr;
-  }));
+  });
+  table.set(ADD.name, (vm, expr) => {
+    if (simplify && expr.args.length === 2) {
+      const [aPre, bPre] = expr.args;
+      const aIsAdd = aPre.kind === "apply" && equals(aPre.head, ADD);
+      const bIsAdd = bPre.kind === "apply" && equals(bPre.head, ADD);
+      if (aIsAdd || bIsAdd) {
+        const leaves = [...flattenAddTerms(aPre), ...flattenAddTerms(bPre)];
+        // Re-evaluation guard: only rewrite when flattening actually
+        // changed the operand list (saves a needless rebuild when
+        // flattenAddTerms walked through a SUB it normalised).
+        const rebuilt =
+          leaves.length !== 2 ||
+          leaves.some((leaf) => leaf.kind === "apply" && equals(leaf.head, ADD));
+        if (rebuilt) {
+          // Sum numeric leaves once; collect symbolic ones in order.
+          let litAcc: Numeric | undefined;
+          const nonLiterals: IRNode[] = [];
+          for (const leaf of leaves) {
+            const n = toNumeric(leaf);
+            if (n === undefined) {
+              nonLiterals.push(leaf);
+            } else {
+              litAcc = litAcc === undefined ? n : addNumeric(litAcc, n);
+            }
+          }
+          if (nonLiterals.length === 0) {
+            // Whole expression folded to a single numeric literal.
+            return fromNumeric(litAcc ?? { kind: "int", value: 0n });
+          }
+          const litIsZero =
+            litAcc === undefined ||
+            (litAcc.kind === "int" && litAcc.value === 0n) ||
+            (litAcc.kind === "rat" && litAcc.numer === 0n);
+          const finalArgs = litIsZero
+            ? nonLiterals
+            : [...nonLiterals, fromNumeric(litAcc!)];
+          if (finalArgs.length === 1) {
+            return finalArgs[0];
+          }
+          // Left-associate the chain for predictable structural equality.
+          let out: IRNode = finalArgs[0];
+          for (let i = 1; i < finalArgs.length; i += 1) {
+            out = app(ADD, [out, finalArgs[i]]);
+          }
+          return out;
+        }
+      }
+    }
+    return addBinary(vm, expr);
+  });
   table.set(SUB.name, binaryNumeric("Sub", simplify, (a, b) => subNumeric(a, b), (expr, _a, b) => {
     if (isZero(b)) return expr.args[0];
     return expr;

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -1437,3 +1437,65 @@ describe("Phase 33: Trig π-multiple exact values", () => {
     expect(vm.eval(app(TAN, [int(0)]))).toEqual(int(0));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 47 (TypeScript port): Nested-Add flattening.
+//
+// Ports the Python Phase 47 fix.  When either binary Add operand is itself
+// an Add(...) apply, the handler flattens the tree, sums numeric literals
+// once, and rebuilds a left-associated chain.  Makes Add canonical for
+// any consumer comparing trees structurally.
+// ---------------------------------------------------------------------------
+
+describe("Phase 47: nested-Add flattening", () => {
+  const vm = new VM(new SymbolicBackend());
+  const k = sym("k");
+
+  it("Add(Add(k, 1), 1) flattens to Add(k, 2)", () => {
+    const nested = app(ADD, [app(ADD, [k, int(1)]), int(1)]);
+    const out = vm.eval(nested);
+    expect(out).toEqual(app(ADD, [k, int(2)]));
+  });
+
+  it("triply-nested Add(Add(Add(k, 1), 1), 1) → Add(k, 3)", () => {
+    const nested = app(ADD, [
+      app(ADD, [app(ADD, [k, int(1)]), int(1)]),
+      int(1),
+    ]);
+    const out = vm.eval(nested);
+    expect(out).toEqual(app(ADD, [k, int(3)]));
+  });
+
+  it("Add(Add(k, 2), 3) folds the constants", () => {
+    const nested = app(ADD, [app(ADD, [k, int(2)]), int(3)]);
+    const out = vm.eval(nested);
+    expect(out).toEqual(app(ADD, [k, int(5)]));
+  });
+
+  it("Add(Add(k, 1), -1) cancels the constants → bare k", () => {
+    const nested = app(ADD, [app(ADD, [k, int(1)]), int(-1)]);
+    const out = vm.eval(nested);
+    expect(out).toEqual(k);
+  });
+
+  it("Add(Add(x, y), z) leaves order alone when no literals present", () => {
+    const x = sym("x");
+    const y = sym("y");
+    const z = sym("z");
+    const nested = app(ADD, [app(ADD, [x, y]), z]);
+    const out = vm.eval(nested);
+    // Should rebuild as left-associated Add(Add(x, y), z) with same args.
+    expect(out).toEqual(app(ADD, [app(ADD, [x, y]), z]));
+  });
+
+  it("non-nested Add(k, 1) is untouched (no rebuild)", () => {
+    const flat = app(ADD, [k, int(1)]);
+    const out = vm.eval(flat);
+    expect(out).toEqual(flat);
+  });
+
+  it("regression: Add(0, x) still simplifies to x", () => {
+    const x = sym("x");
+    expect(vm.eval(app(ADD, [int(0), x]))).toEqual(x);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python ``symbolic-vm`` 0.71.0 Add-handler fix (PR #3922) to
TypeScript and Rust ``symbolic-vm``.  When either binary ``Add``
operand is itself an ``Add(...)`` apply, the handler now flattens the
tree, sums numeric literals once, and rebuilds a left-associated
chain:

    Add(Add(k, 1), 1)          →  Add(k, 2)
    Add(Add(Add(k, 1), 1), 1)  →  Add(k, 3)
    Add(Add(k, 1), -1)         →  k        (literal zeroes out)

Bumps:
- ``@coding-adventures/symbolic-vm``  0.11.0 → 0.12.0
- ``symbolic-vm`` (Rust)              0.11.0 → 0.12.0

### Why this is more general than a "telescope detector" fix

The nested-Add flattening is a **substrate** fix — it makes ``Add``
canonical for ANY consumer that compares trees structurally.  The
telescope detector is one such consumer; other CAS modules that
pattern-match on ``Add(k, c)`` shapes benefit automatically.

### Changes

| File | Change |
|---|---|
| ``typescript/symbolic-vm/src/index.ts`` | ADD handler wraps ``binaryNumeric`` with a Phase 47 pre-pass; uses existing ``flattenAddTerms`` walker |
| ``typescript/symbolic-vm/tests/symbolic-vm.test.ts`` | +7 ``Phase 47: nested-Add flattening`` cases |
| ``rust/symbolic-vm/src/handlers.rs`` | New ``flatten_add_leaves`` helper; ``add_handler`` grows a Phase 47 pre-pass |
| ``rust/symbolic-vm/tests/test_vm.rs`` | +6 ``phase47_*`` cases |
| Both CHANGELOGs | New ``0.12.0`` entry |

## Test plan

- [x] TS: ``npm test`` → 161 passed (was 154; +7)
- [x] Rust: ``cargo test`` → 194 passed (was 188; +6)
- [x] No regressions in either language
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

## Closes the alternation

Phase 47 Python landed in PR #3922 (in flight).  This PR ports its
Add-handler fix to TS+Rust, keeping the three-language pipeline in
sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)