### PR TITLE
feat(ruby-parser): Phase 6f — `class Foo … end` / `module Foo … end`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,8 +25,14 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | if_statement | unless_statement | while_statement | until_statement | assignment | method_call | expression_stmt ;
+statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | assignment | method_call | expression_stmt ;
 def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
+# Phase 6f — class/module namespace declarations.  The body is a
+# sequence of statements (which may include nested `def`s).  Like
+# `def_statement`, the body repetition uses a negative lookahead so it
+# stops at the closing `end` keyword instead of greedily consuming it.
+class_statement  = "class"  NAME { !"end" statement } "end" ;
+module_statement = "module" NAME { !"end" statement } "end" ;
 params       = NAME { COMMA NAME } ;
 if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
 elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.7.0] - 2026-05-22
+
+### Added (Phase 6f — `class Foo … end` / `module Foo … end` namespace declarations)
+- `class_statement  = "class"  NAME { !"end" statement } "end" ;`
+- `module_statement = "module" NAME { !"end" statement } "end" ;`
+- Added as alternatives in `statement` right after `def_statement`, so the dispatch order is: def → class → module → if → unless → while → until → assignment → method_call → expression_stmt.
+- The body's `Repetition { statement }` uses the same negative-lookahead `!"end"` as `def_statement` so the closing `end` doesn't get eaten by `expression_stmt → factor → KEYWORD`.
+- Regenerated `src/_grammar.rs` via `grammar-tools compile-grammar`.
+
+### Tests (+4 new, total 28)
+- `test_parse_empty_class` — `class Foo\nend` parses and the first Name token is `"Foo"`.
+- `test_parse_class_with_method_body` — `class Foo\n  def bar\n  end\nend` produces a class with at least one body `statement` (the nested `def`).
+- `test_parse_empty_module` — `module M\nend` parses to a `module_statement` subnode.
+- `test_parse_module_with_assignment_body` — `module M\n  x = 1\nend` keeps the body assignment under the module.
+
 ## [0.6.0] - 2026-05-20
 
 ### Added (Phase 6e — symbol literals `:foo` / `:"bar"`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -19,6 +19,8 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"statement"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
                 GrammarElement::RuleReference { name: r#"def_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"class_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"module_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"if_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"unless_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"while_statement"#.to_string() },
@@ -48,6 +50,32 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 29,
         },
         GrammarRule {
+            name: r#"class_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"class"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 34,
+        },
+        GrammarRule {
+            name: r#"module_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"module"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 35,
+        },
+        GrammarRule {
             name: r#"params"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
@@ -56,7 +84,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 30,
+            line_number: 36,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -73,7 +101,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 31,
+            line_number: 37,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -87,7 +115,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 32,
+            line_number: 38,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -98,7 +126,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 33,
+            line_number: 39,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -113,7 +141,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 34,
+            line_number: 40,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -126,7 +154,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 35,
+            line_number: 41,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -139,7 +167,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 36,
+            line_number: 42,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -148,7 +176,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 37,
+            line_number: 43,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -167,12 +195,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 38,
+            line_number: 44,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 39,
+            line_number: 45,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
@@ -186,7 +214,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 40,
+            line_number: 46,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -200,7 +228,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 41,
+            line_number: 47,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -218,7 +246,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 42,
+            line_number: 48,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -230,7 +258,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 43,
+            line_number: 49,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -245,7 +273,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 44,
+            line_number: 50,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -260,7 +288,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 45,
+            line_number: 51,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -276,7 +304,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 46,
+            line_number: 52,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -425,5 +425,64 @@ mod tests {
         });
         assert_eq!(str_tok, Some("hello world"));
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6f — `class Foo … end` / `module Foo … end`
+    // -----------------------------------------------------------------------
+    //
+    // Like `def_statement`, the body of a class/module is a repetition of
+    // `statement` with a negative-lookahead `!"end"` so the closing keyword
+    // doesn't get eaten as a bare `expression_stmt → factor → KEYWORD`.
+
+    #[test]
+    fn test_parse_empty_class() {
+        let ast = parse_ruby("class Foo\nend");
+        assert_program_root(&ast);
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        // Class name is the first Name token.
+        let name_tok = cls.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Name) => {
+                Some(t.value.as_str())
+            }
+            _ => None,
+        });
+        assert_eq!(name_tok, Some("Foo"));
+    }
+
+    #[test]
+    fn test_parse_class_with_method_body() {
+        // A class with a nested `def` — the inner statement is itself a
+        // `def_statement` under the class body.
+        let ast = parse_ruby("class Foo\n  def bar\n  end\nend");
+        let cls = find_statement_inner(&ast, "class_statement")
+            .expect("expected class_statement");
+        // The body has at least one `statement` child.
+        let body_count = cls
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert!(body_count >= 1, "expected at least one body statement");
+    }
+
+    #[test]
+    fn test_parse_empty_module() {
+        let ast = parse_ruby("module M\nend");
+        assert!(find_statement_inner(&ast, "module_statement").is_some());
+    }
+
+    #[test]
+    fn test_parse_module_with_assignment_body() {
+        let ast = parse_ruby("module M\n  x = 1\nend");
+        let m = find_statement_inner(&ast, "module_statement")
+            .expect("expected module_statement");
+        let body_count = m
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "statement"))
+            .count();
+        assert!(body_count >= 1);
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.7.0] - 2026-05-22
+
+### Added (Phase 6f — class/module lowering with nested-def hoisting)
+- `lower_statement_inner` dispatches `class_statement` / `module_statement` rule nodes.  In v0, SIR has no native `class` / `namespace` node, so the declaration itself lowers to a no-op `Stmt::ExprStmt(NilLit)` — same shape used for already-hoisted `def_statement`s.
+- New `collect_def_statements_from_body(node)` helper recursively walks a class/module body and hoists every nested `def_statement` to a top-level `Function` (same machinery as the program-level pre-pass).  Nested class/module declarations are recursed into so deeply-nested `def`s still hoist.
+- Each `def` body is lowered with a fresh `declared_locals` + `current_params` scope (snapshot/restore in `lower_def_statement`), so locals from sibling methods or the surrounding class don't leak across method boundaries.
+
+### Documented v0 caveat
+The hoisted methods land at top-level, *not* nested under the class name.  In real Ruby, `class Foo; def bar` makes `bar` an instance method of `Foo`; v0 SIR collapses the namespace.  The validator still accepts the result because every function has a unique name across the lowered module, and `main` remains the only export.  Proper namespace handling lands when SIR grows a `class` / `namespace` node in a future phase.
+
+### Tests (+4 new, total 34)
+- `class_with_method_hoists_def_to_top_level` — `class Foo; def greet; end; end` exposes `greet` on `m.functions`.
+- `empty_class_lowers_cleanly` — `class Foo; end` produces a module with only `main` plus a no-op `Stmt::ExprStmt(NilLit)` in the main body.
+- `module_with_def_hoists_def_to_top_level` — `module M; def helper; end; end` exposes `helper`.
+- `class_module_lowering_passes_sir_validator` — a combined class+module module passes `semantic_ir::validate`.
+
 ## [0.6.0] - 2026-05-20
 
 ### Added (Phase 6e — symbol-literal lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -569,6 +569,76 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Phase 6f — `class Foo … end` / `module Foo … end`.
+    //
+    // v0 lowering collapses the namespace: nested `def`s are hoisted
+    // to top-level Functions (same machinery as program-level `def`
+    // hoisting), and the class/module declaration itself emits a
+    // no-op `Stmt::ExprStmt(NilLit)`.  This is documented in the
+    // CHANGELOG as a known v0 limitation that lands properly when
+    // SIR grows a `class` / `namespace` node.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn class_with_method_hoists_def_to_top_level() {
+        // The nested `def greet … end` should appear as a top-level
+        // `greet` function on the resulting module, exactly as
+        // `def greet … end` at the program top level would.
+        let m = lower("class Foo\n  def greet\n  end\nend\n");
+        let greet = m.functions.iter().find(|f| f.name == "greet");
+        assert!(
+            greet.is_some(),
+            "expected `greet` to be hoisted to top-level functions, got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        // `main` is still present (no top-level statements were lost).
+        assert!(m.functions.iter().any(|f| f.name == "main"));
+    }
+
+    #[test]
+    fn empty_class_lowers_cleanly() {
+        // `class Foo; end` with no body should produce a module that
+        // still has `main` and no extra user functions.
+        let m = lower("class Foo\nend\n");
+        // Only `main` exists.
+        assert_eq!(m.functions.len(), 1);
+        assert_eq!(m.functions[0].name, "main");
+        // The class declaration lowered to a no-op stmt in main.
+        let main = main_body(&m);
+        assert_eq!(main.stmts.len(), 1);
+        assert!(matches!(
+            &main.stmts[0],
+            Stmt::ExprStmt { expr: Expr::NilLit { .. }, .. }
+        ));
+    }
+
+    #[test]
+    fn module_with_def_hoists_def_to_top_level() {
+        let m = lower("module M\n  def helper\n  end\nend\n");
+        assert!(m.functions.iter().any(|f| f.name == "helper"));
+    }
+
+    #[test]
+    fn class_module_lowering_passes_sir_validator() {
+        let m = lower(concat!(
+            "class Foo\n",
+            "  def bar\n",
+            "  end\n",
+            "end\n",
+            "module M\n",
+            "  def helper\n",
+            "  end\n",
+            "end\n",
+        ));
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected our output: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn module_with_def_passes_sir_validator() {
         // v0 grammar can't yet parse nested method calls in args

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -293,6 +293,33 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "class_statement" | "module_statement" => {
+                // Phase 6f: class/module declarations parse but don't
+                // yet introduce a real namespace in SIR v0 (SIR has no
+                // `class` / `namespace` node — that lands in a later
+                // phase together with method dispatch).  We walk the
+                // body so nested `def` declarations *are* hoisted to
+                // top-level Functions (matching the def_statement
+                // behaviour at the program level), then emit a no-op
+                // ExprStmt(NilLit) in place of the class/module so
+                // the main-body statement stream stays in sync with
+                // the source line count.
+                //
+                // Caveat (documented for backends): the hoisted
+                // methods land at top-level, not nested under the
+                // class name.  In real Ruby, `class Foo; def bar`
+                // makes `bar` an instance method of `Foo`.  v0 SIR
+                // collapses the namespace; the validator still
+                // accepts the result because every function has a
+                // unique name and `main` is the only export.
+                self.collect_def_statements_from_body(node)?;
+                Ok(Stmt::ExprStmt {
+                    expr: Expr::NilLit {
+                        span: self.span_of(node),
+                    },
+                    span: self.span_of(node),
+                })
+            }
             "if_statement" | "unless_statement" => {
                 // Phase 6b: SIR's `Expr::If` is an *expression* — it
                 // always yields a value.  We wrap it in `Stmt::ExprStmt`
@@ -556,6 +583,42 @@ impl Lowerer {
             }
             let func = self.lower_def_statement(inner)?;
             self.user_functions.push(func);
+        }
+        Ok(())
+    }
+
+    /// Phase 6f: walk the body of a `class_statement` / `module_statement`
+    /// and hoist every nested `def_statement` to a top-level `Function`
+    /// on `self.user_functions`.  This mirrors the program-level
+    /// `collect_def_statements` pre-pass — same hoisting semantics,
+    /// same scope-isolation behaviour (each method body gets a fresh
+    /// `declared_locals` / `current_params`).  Called from
+    /// `lower_statement_inner` when the class/module is first reached,
+    /// not from the global pre-pass, so each nested `def` is hoisted
+    /// exactly once.
+    fn collect_def_statements_from_body(
+        &mut self,
+        body_owner: &GrammarASTNode,
+    ) -> Result<(), RubyLowerError> {
+        for child in &body_owner.children {
+            let stmt = match child {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => n,
+                _ => continue,
+            };
+            let inner = match self.first_node_child(stmt) {
+                Some(n) => n,
+                None => continue,
+            };
+            if inner.rule_name == "def_statement" {
+                let func = self.lower_def_statement(inner)?;
+                self.user_functions.push(func);
+            } else if inner.rule_name == "class_statement"
+                || inner.rule_name == "module_statement"
+            {
+                // Nested class/module — recurse so deeply-nested
+                // `def`s still get hoisted.
+                self.collect_def_statements_from_body(inner)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Phase 6f of the [Ruby parser project](code/specs/ruby-parser.md) — adds `class Foo … end` and `module Foo … end` namespace declarations to the grammar plus matching `ruby-to-semantic-ir` lowering.

- **Grammar**: two new rules added to `code/grammars/ruby.grammar` and `_grammar.rs` regenerated via `grammar-tools compile-grammar`.
- **SIR lowering**: class/module declarations emit a no-op `Stmt::ExprStmt(NilLit)` (v0 SIR has no native namespace node) but the body is walked to hoist every nested `def` to a top-level `Function` on `user_functions` — same machinery as the program-level pre-pass.
- **Documented v0 caveat**: hoisted methods land at top-level, not nested under the class name. Proper namespace handling lands when SIR grows a `class` / `namespace` node.

Builds on:
- #3879 Phase 6a (def_statement)
- #3892 Phase 6b (if/unless)
- #3900 Phase 6c (while/until)
- #3907 Phase 6d (array/hash literals)
- #3916 Phase 6e (symbol literals)

## Test plan

- [x] `cargo test -p coding-adventures-ruby-parser` — 28 tests pass (4 new for Phase 6f).
- [x] `cargo test -p ruby-to-semantic-ir` — 34 tests pass (4 new for Phase 6f).
- [x] `cargo test -p coding-adventures-ruby-lexer` — 112 tests still pass (no lexer changes).
- [x] Combined class+module module passes `semantic_ir::validate`.
- [x] `/security-review` sub-agent — passed (recursion bounded by parser depth).

## Files changed

- `code/grammars/ruby.grammar` — +6 lines (two new rules + comment).
- `code/packages/rust/ruby-parser/src/_grammar.rs` — auto-regenerated.
- `code/packages/rust/ruby-parser/src/lib.rs` — +4 tests.
- `code/packages/rust/ruby-to-semantic-ir/src/lower.rs` — `lower_statement_inner` dispatch + new `collect_def_statements_from_body` helper.
- `code/packages/rust/ruby-to-semantic-ir/src/lib.rs` — +4 tests.
- Both CHANGELOGs bumped to 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)