### PR TITLE
feat(iir-to-jvm-class-file): BF tape + I/O via env/BFRuntime (Stage 2 of 4)

### DIFF
--- a/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog — brainfuck-iir-compiler
 
+## [0.3.2] — 2026-05-22 (BF → JVM end-to-end test)
+
+### Added — `tests/jvm_e2e.rs`
+
+Stage 2 of 4 for the BF → {wasm, jvm, clr, beam} story.  Walks the new
+IIR-based chain through the JVM backend:
+
+```text
+BF source → IIRModule → iir-to-jvm-class-file validator → lower_iir_to_jvm
+          → JvmClassFile → serialize_jvm_class_file → .class bytes
+```
+
+Before iir-to-jvm-class-file 0.5.0, the validator rejected `load_mem` /
+`store_mem` and any `call_builtin` (including BF's `putchar` /
+`getchar`).  With 0.5.0 those are accepted, and this e2e test locks
+the path in for Brainfuck:
+
+- `brainfuck_three_increments_lowers_to_jvm_class` — `+++.` compiles
+  through; the resulting `JvmClassFile` has constant-pool entries
+  referencing `env/BFRuntime`, and the serialized bytes start with the
+  canonical `CAFEBABE` magic.
+- `brainfuck_loop_lowers_to_jvm_class` — `++[-]` (a non-trivial loop)
+  compiles through; serialized bytes have the right magic.
+- `brainfuck_input_emits_getchar_methodref` — `,.` emits both
+  `getchar` and `putchar` method references into the constant pool.
+- `brainfuck_empty_program_emits_minimal_jvm` — the empty BF program
+  emits a class with **no** `env/BFRuntime` references, proving the
+  CP injection is correctly conditional (no burden on non-BF callers).
+
+No source-code changes in this crate — the test runs against the
+existing `compile_source`.  Only the JVM e2e test file is new.
+
+Stages 3 (CLR) and the BEAM-rejection doc are queued as follow-on
+work items.
+
 ## [0.3.1] — 2026-05-22 (BF → WASM end-to-end test)
 
 ### Added — `tests/wasm_e2e.rs`

--- a/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
+++ b/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brainfuck-iir-compiler"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "BF04/BF05 — Brainfuck → InterpreterIR compiler, vm-core wrapper, jit-core JIT chain, and real CIR-bytecode JIT backend"
 license = "MIT"
@@ -14,6 +14,7 @@ parser         = { path = "../parser" }
 lexer          = { path = "../lexer" }
 
 [dev-dependencies]
-iir-to-wasm         = { path = "../iir-to-wasm" }
-wasm-module-encoder = { path = "../wasm-module-encoder" }
-wasm-types          = { path = "../wasm-types" }
+iir-to-wasm           = { path = "../iir-to-wasm" }
+iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
+wasm-module-encoder   = { path = "../wasm-module-encoder" }
+wasm-types            = { path = "../wasm-types" }

--- a/code/packages/rust/brainfuck-iir-compiler/tests/jvm_e2e.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/tests/jvm_e2e.rs
@@ -1,0 +1,163 @@
+//! Brainfuck → JVM class file end-to-end test.
+//!
+//! Walks the new IIR-based chain through the JVM backend:
+//!
+//! ```text
+//! BF source
+//!   │ brainfuck-iir-compiler::compile_source
+//! IIRModule (FullyTyped)
+//!   │ iir_to_jvm_class_file::validate_for_jvm   ← must report no errors
+//!   │ iir_to_jvm_class_file::lower_iir_to_jvm
+//! JvmClassFile
+//!   │ iir_to_jvm_class_file::serialize_jvm_class_file
+//! Vec<u8> (.class bytes)
+//!   │ assert magic header + class file layout
+//! ```
+//!
+//! Before this PR (Stage 2 of BF→{wasm,jvm,clr,beam}), the validator
+//! rejected `load_mem` / `store_mem` and any `call_builtin`.  After
+//! this PR, the validator accepts them (memory ops + the
+//! `CALL_BUILTIN_SUPPORTED_NAMES` whitelist of `putchar` / `getchar`)
+//! and the lowering emits real JVM bytecode (`baload` / `bastore`
+//! over `env/BFRuntime.__tape : [B`, `invokestatic
+//! env/BFRuntime.putchar(I)V` / `env/BFRuntime.getchar()I`).
+
+use brainfuck_iir_compiler::compile_source;
+use iir_to_jvm_class_file::{
+    validate_for_jvm, lower_iir_to_jvm, serialize_jvm_class_file, IIRJvmConfig,
+};
+
+/// Compile `+++.` and assert the IIR→JVM chain succeeds from source to
+/// encoded `.class` bytes.
+#[test]
+fn brainfuck_three_increments_lowers_to_jvm_class() {
+    let module = compile_source("+++.", "jvm_e2e")
+        .expect("BF source must compile to IIR");
+
+    // ── Validator must accept BF's IIR ────────────────────────────────────
+    let errs = validate_for_jvm(&module);
+    assert!(
+        errs.is_empty(),
+        "JVM validator should accept BF IIR after the BF→JVM PR; got: {errs:?}",
+    );
+
+    // ── Lower IIR → JvmClassFile ──────────────────────────────────────────
+    let cfg = IIRJvmConfig::new("BrainfuckProgram");
+    let class = lower_iir_to_jvm(&module, &cfg)
+        .expect("IIR → JvmClassFile lowering must succeed");
+
+    // Class metadata: public class, super java/lang/Object.
+    assert_eq!(class.this_class_name, "BrainfuckProgram");
+    assert_eq!(class.super_class_name, "java/lang/Object");
+    assert!(!class.methods.is_empty(), "expected at least the `main` method");
+
+    // The lowered class must include constant-pool entries that reference
+    // the host helper class `env/BFRuntime`.  We confirm by looking for any
+    // `Utf8` entry whose string is the runtime class name — that's the
+    // simplest invariant that proves the BF lowering actually wired up the
+    // host bridge.
+    let cp_contains_runtime = class.constant_pool.iter().any(|opt| {
+        match opt {
+            Some(entry) => format!("{entry:?}").contains("env/BFRuntime"),
+            None => false,
+        }
+    });
+    assert!(
+        cp_contains_runtime,
+        "expected constant-pool to reference env/BFRuntime; pool: {:?}",
+        class.constant_pool,
+    );
+
+    // ── Serialize to .class bytes ─────────────────────────────────────────
+    let bytes = serialize_jvm_class_file(&class);
+    assert!(bytes.len() >= 10,
+        "encoded class file is implausibly short ({} bytes)", bytes.len());
+    // The first 4 bytes of every `.class` file are the magic number CAFEBABE.
+    assert_eq!(
+        &bytes[0..4],
+        &[0xCAu8, 0xFE, 0xBA, 0xBE],
+        "first 4 bytes must be the JVM magic (CAFEBABE); got {:?}",
+        &bytes[0..4],
+    );
+}
+
+/// A loop program — `++[-]` decrements a cell to zero.  Exercises
+/// `label` / `jmp_if_false` / `jmp` / `load_mem` / `store_mem` /
+/// `const_u8` together through the JVM lowering.
+#[test]
+fn brainfuck_loop_lowers_to_jvm_class() {
+    let module = compile_source("++[-]", "jvm_loop")
+        .expect("BF loop must compile to IIR");
+    let errs = validate_for_jvm(&module);
+    assert!(errs.is_empty(),
+        "JVM validator rejected loop IIR: {errs:?}");
+
+    let class = lower_iir_to_jvm(&module, &IIRJvmConfig::new("LoopProgram"))
+        .expect("lowering must succeed");
+    let bytes = serialize_jvm_class_file(&class);
+    assert_eq!(&bytes[0..4], &[0xCAu8, 0xFE, 0xBA, 0xBE]);
+}
+
+/// Confirm BF's I/O `,` (getchar) emits a method reference to
+/// `env/BFRuntime.getchar`.
+#[test]
+fn brainfuck_input_emits_getchar_methodref() {
+    let module = compile_source(",.", "jvm_input")
+        .expect("BF input/output program must compile to IIR");
+    let errs = validate_for_jvm(&module);
+    assert!(errs.is_empty(),
+        "JVM validator rejected `,.` IIR: {errs:?}");
+
+    let class = lower_iir_to_jvm(&module, &IIRJvmConfig::new("InputProgram"))
+        .expect("lowering must succeed");
+
+    // The constant pool must reference both `getchar` and `putchar` as
+    // method names (the BF runtime helper methods).  We use the pretty-
+    // printed Debug output as a cheap match — the names are short and
+    // unambiguous, and the structural assertion (existence of the names
+    // in the pool) is what we care about for this regression test.
+    let cp_dump = format!("{:?}", class.constant_pool);
+    assert!(
+        cp_dump.contains("getchar"),
+        "expected getchar method reference in CP; dump: {cp_dump}",
+    );
+    assert!(
+        cp_dump.contains("putchar"),
+        "expected putchar method reference in CP; dump: {cp_dump}",
+    );
+
+    let bytes = serialize_jvm_class_file(&class);
+    assert_eq!(&bytes[0..4], &[0xCAu8, 0xFE, 0xBA, 0xBE]);
+}
+
+/// The empty BF program should still lower to a valid class file with no
+/// references to BF runtime symbols — proving the feature detection /
+/// CP injection is correctly conditional on actual BF op usage.
+///
+/// Note: even the "empty" BF program emits `const ptr 0 u32` + `ret_void`,
+/// so the method body isn't truly empty — but it uses no `load_mem`,
+/// `store_mem`, or `call_builtin`, so the CP should NOT reference
+/// `env/BFRuntime`.
+#[test]
+fn brainfuck_empty_program_emits_minimal_jvm() {
+    let module = compile_source("", "jvm_empty")
+        .expect("empty BF must compile to IIR");
+    let errs = validate_for_jvm(&module);
+    assert!(errs.is_empty(), "validator rejected empty BF: {errs:?}");
+
+    let class = lower_iir_to_jvm(&module, &IIRJvmConfig::new("EmptyProgram"))
+        .expect("lowering must succeed");
+
+    // The empty BF program must NOT reference env/BFRuntime — no
+    // memory ops, no I/O.  This proves the BF lowering is "pay for what
+    // you use" — non-BF callers (Twig, BASIC, Oct, Nib) aren't burdened
+    // with unused host-class references.
+    let cp_dump = format!("{:?}", class.constant_pool);
+    assert!(
+        !cp_dump.contains("env/BFRuntime"),
+        "empty BF program should not reference env/BFRuntime; dump: {cp_dump}",
+    );
+
+    let bytes = serialize_jvm_class_file(&class);
+    assert_eq!(&bytes[0..4], &[0xCAu8, 0xFE, 0xBA, 0xBE]);
+}

--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,87 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0] — 2026-05-22 (Brainfuck — `byte[]` tape + I/O via env/BFRuntime)
+
+### Added — Brainfuck `load_mem` / `store_mem` / `call_builtin` lowering
+
+Stage 2 of 4 for the BF→{wasm,jvm,clr,beam} story.  Mirrors the WASM PR
+(iir-to-wasm 0.4.0) for the JVM target.  Lets BF's IIR — including
+`load_mem`, `store_mem`, and `call_builtin "putchar"`/`"getchar"` —
+flow through the same universal `iir-to-jvm-class-file` backend that
+Twig, BASIC, Oct, and Nib already use.
+
+#### Validator changes
+
+- `load_mem` and `store_mem` removed from `UNSUPPORTED_OPS` (previously
+  hard-rejected).  Both lower to JVM `baload` / `bastore` over a
+  host-provided byte array — see `BF_RUNTIME_CLASS` below.
+- `call_builtin` is now **conditionally** accepted: the builtin name
+  carried in `srcs[0]` as `Operand::Var` must be in the new
+  `CALL_BUILTIN_SUPPORTED_NAMES` whitelist.  Today's whitelist covers
+  Brainfuck's two I/O builtins (`putchar`, `getchar`); extending it
+  takes three steps documented in the constant's doc comment.
+- Unknown builtin names still produce a clear `UnsupportedOp` error
+  with the rejected name and the whitelist included.
+
+#### Lowering changes
+
+- New `BALOAD` / `BASTORE` opcode constants (0x33 / 0x54) for JVM byte
+  array access.
+- New `BF_RUNTIME_CLASS` constant `"env/BFRuntime"` — the host helper
+  class providing the tape and I/O methods.  Picking a fixed host
+  class keeps BF-compiled `.class` files self-contained: no `<clinit>`
+  required on the BF side, no per-program tape size baked into the
+  bytecode, and the host can dial the tape size without recompiling.
+- New `emit_instr` arms:
+  - `load_mem v ptr` → `getstatic env/BFRuntime.__tape : [B; iload ptr;
+    baload; sipush 0x00FF; iand; istore v`.  The `sipush 0x00FF; iand`
+    masks the sign-extension that `baload` performs, so the int result
+    is properly `0..=255` (matching BF's unsigned u8 cell semantics).
+  - `store_mem ptr v` → `getstatic env/BFRuntime.__tape : [B; iload ptr;
+    iload v; bastore`.  `bastore` truncates the int value to a byte
+    automatically, matching BF's u8 wraparound.
+  - `call_builtin "putchar" v` → `iload v; invokestatic
+    env/BFRuntime.putchar(I)V`.
+  - `call_builtin "getchar" -> v` → `invokestatic
+    env/BFRuntime.getchar()I; istore v`.
+
+#### Host class contract
+
+The host (Java runtime / launcher) must provide a class with binary name
+`env/BFRuntime` containing:
+
+| Symbol                  | JVM descriptor | Purpose                           |
+|-------------------------|----------------|-----------------------------------|
+| `public static byte[] __tape` | `[B`     | The BF tape (typically 30,000 B). |
+| `public static void putchar(int)` | `(I)V` | Write one byte to stdout.         |
+| `public static int getchar()`     | `()I`  | Read one byte from stdin; convention is 0 / -1 on EOF. |
+
+This is the JVM analog of the WASM backend's `env` import namespace —
+same pattern, different ABI.
+
+### Tests
+
+- 5 new validator unit tests covering the new acceptance:
+  `load_mem_accepted_for_bf`, `store_mem_accepted_for_bf`,
+  `call_builtin_putchar_accepted`, `call_builtin_getchar_accepted`,
+  `call_builtin_unknown_name_rejected`.
+- The existing `unsupported_ops_rejected` test updated: `load_mem`,
+  `store_mem`, `call_builtin` removed from the unconditional-reject
+  list with a comment pointing to the new tests.
+- 43 lib + 86 integration tests pass.
+- 4 new BF→JVM e2e tests in `brainfuck-iir-compiler/tests/jvm_e2e.rs`
+  exercise the full chain from source to `.class` bytes.
+
+### Compatibility
+
+- Non-BF frontends (Twig, BASIC, Oct, Nib) are unchanged — they don't
+  emit `load_mem` / `store_mem` or `call_builtin`, so the new code
+  paths are only reached for BF.
+- Modules without BF features get no `env/BFRuntime` constant-pool
+  entries, preserving binary equivalence with pre-0.5.0 output for
+  every non-BF caller.
+
 ## [0.4.1] — 2026-05-13
 
 ### Fixed (Multi-backend demo — fib(10)=55)

--- a/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
+++ b/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-jvm-class-file"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile without compiler-ir"
+description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile (now with Brainfuck tape + I/O via env/BFRuntime)"
 
 [lib]
 name = "iir_to_jvm_class_file"

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -180,6 +180,29 @@ const INVOKEVIRTUAL: u8 = 0xB6;  // invoke instance method (2-byte CP index)
 // ── Field access ────────────────────────────────────────────────────────────
 const GETSTATIC: u8 = 0xB2; // get value of static field (2-byte CP index)
 
+// JVM byte-array access opcodes — used by Brainfuck `load_mem` / `store_mem`.
+// BALOAD pops [arrayref, index] and pushes the byte at that index, sign-extended
+// to an int.  BASTORE pops [arrayref, index, value] and stores `value & 0xFF`
+// at `arrayref[index]`.  These match Brainfuck's u8 tape semantics exactly,
+// modulo the sign-extension on load (we mask with `& 0xFF` after BALOAD).
+const BALOAD: u8 = 0x33;
+const BASTORE: u8 = 0x54;
+
+/// Host class name for Brainfuck's I/O builtins and tape storage.
+///
+/// The host (Java runtime / launcher) must provide a class with this binary
+/// name (slash-separated) containing:
+///
+///   * `public static byte[] __tape` — the BF tape (typically 30,000 bytes)
+///   * `public static void putchar(int)` — write one byte to stdout
+///   * `public static int  getchar()`    — read one byte from stdin, or `-1` / `0`
+///                                          on EOF (BF's interpreter convention is `0`)
+///
+/// Picking a fixed host class keeps the BF-compiled class self-contained:
+/// no `<clinit>` required on the BF side, and no per-program tape size baked
+/// into the bytecode — the host can dial that knob without recompiling.
+const BF_RUNTIME_CLASS: &str = "env/BFRuntime";
+
 // ── Comparison and branching ───────────────────────────────────────────────
 const IFEQ: u8 = 0x99;      // branch if TOS int == 0
 const IFNE: u8 = 0x9A;      // branch if TOS int != 0
@@ -1955,6 +1978,163 @@ fn lower_function(
             //
             // We look up the callee function in the module to find its descriptor,
             // then add (or find) a Methodref in the constant pool.
+            // ── load_mem (Brainfuck) ─────────────────────────────────────────
+            //
+            // `load_mem  v  ptr  u8`  → read tape[ptr] into `v`.
+            //
+            // The tape is `env/BFRuntime.__tape : [B`, a static byte array
+            // provided by the host class.  JVM `baload` pops [array, index]
+            // and pushes the byte at that index sign-extended to an int.
+            // We mask with `& 0xFF` to match BF's unsigned u8 semantics
+            // (cells are u8 — the high bits of the int must be zero).
+            //
+            // Emitted sequence (5 bytes + 1 = 6):
+            //
+            //   GETSTATIC env/BFRuntime.__tape : [B    ; push array ref
+            //   ILOAD     <ptr_slot>                    ; push index
+            //   BALOAD                                  ; pop[arr,idx], push byte
+            //   SIPUSH    0x00FF                        ; push mask (2 bytes inline)
+            //   IAND                                    ; mask off sign-extended bits
+            //   ISTORE    <dest_slot>                   ; store as u8 value
+            //
+            // We use SIPUSH + IAND rather than i2b because `i2b` re-sign-
+            // extends, which is exactly the opposite of what we want.
+            "load_mem" => {
+                let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                    IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "load_mem must have a dest".to_string(),
+                    }
+                })?;
+                let addr_name = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => s.clone(),
+                    _ => return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "load_mem src[0] must be Operand::Var(addr)".to_string(),
+                    }),
+                };
+                let (addr_slot, _) = lookup_var(&addr_name)?;
+                let (dest_slot, _) = lookup_var(dest_name)?;
+
+                let tape_fieldref = cp.add_fieldref(BF_RUNTIME_CLASS, "__tape", "[B");
+                code.push(GETSTATIC);
+                code.extend_from_slice(&tape_fieldref.to_be_bytes());
+                emit_iload(&mut code, addr_slot);
+                code.push(BALOAD);
+                // Mask sign-extended byte back into u8 (0..=255 int).
+                code.push(SIPUSH);
+                code.extend_from_slice(&0x00FFi16.to_be_bytes());
+                code.push(IAND);
+                emit_istore(&mut code, dest_slot);
+            }
+
+            // ── store_mem (Brainfuck) ────────────────────────────────────────
+            //
+            // `store_mem  ptr  v  u8`  → write low byte of v into tape[ptr].
+            //
+            // JVM `bastore` pops [array, index, value] and stores
+            // `value & 0xFF` at `array[index]`.  Truncation matches BF's u8
+            // tape — overflow / sign of `v` is irrelevant.
+            //
+            // Emitted sequence (4 bytes + 1 = 5):
+            //
+            //   GETSTATIC env/BFRuntime.__tape : [B    ; push array ref
+            //   ILOAD     <ptr_slot>                    ; push index
+            //   ILOAD     <val_slot>                    ; push value
+            //   BASTORE                                 ; pop[arr,idx,val]
+            "store_mem" => {
+                if instr.srcs.len() < 2 {
+                    return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "store_mem requires 2 srcs: [addr, val]".to_string(),
+                    });
+                }
+                let addr_name = match &instr.srcs[0] {
+                    Operand::Var(s) => s.clone(),
+                    _ => return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "store_mem src[0] must be Operand::Var(addr)".to_string(),
+                    }),
+                };
+                let val_name = match &instr.srcs[1] {
+                    Operand::Var(s) => s.clone(),
+                    _ => return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "store_mem src[1] must be Operand::Var(val)".to_string(),
+                    }),
+                };
+                let (addr_slot, _) = lookup_var(&addr_name)?;
+                let (val_slot, _)  = lookup_var(&val_name)?;
+
+                let tape_fieldref = cp.add_fieldref(BF_RUNTIME_CLASS, "__tape", "[B");
+                code.push(GETSTATIC);
+                code.extend_from_slice(&tape_fieldref.to_be_bytes());
+                emit_iload(&mut code, addr_slot);
+                emit_iload(&mut code, val_slot);
+                code.push(BASTORE);
+            }
+
+            // ── call_builtin (Brainfuck putchar / getchar) ───────────────────
+            //
+            // The validator (validate.rs) enforces that `srcs[0]` is in
+            // [`CALL_BUILTIN_SUPPORTED_NAMES`], so the inner match here only
+            // handles whitelisted names.  Falling off the match indicates a
+            // validator/lowerer drift and returns `UnsupportedOp` as a safety
+            // net.
+            //
+            // | Builtin   | Operand layout                          | Bytecode emitted |
+            // |-----------|------------------------------------------|-------------------|
+            // | `putchar` | srcs = [Var("putchar"), Var(val)]; no dest | iload val; invokestatic env/BFRuntime.putchar(I)V |
+            // | `getchar` | srcs = [Var("getchar")]; dest = byte slot  | invokestatic env/BFRuntime.getchar()I; istore dest |
+            "call_builtin" => {
+                let builtin_name = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => s.clone(),
+                    _ => return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "call_builtin: srcs[0] must be the builtin name as Operand::Var".to_string(),
+                    }),
+                };
+                match builtin_name.as_str() {
+                    "putchar" => {
+                        // putchar takes one i32 arg and returns void.
+                        let val_name = match instr.srcs.get(1) {
+                            Some(Operand::Var(s)) => s.clone(),
+                            _ => return Err(IIRJvmError::InvalidOperand {
+                                function: fname.clone(),
+                                detail: "call_builtin \"putchar\" requires srcs[1] = Operand::Var(val)".to_string(),
+                            }),
+                        };
+                        let (val_slot, _) = lookup_var(&val_name)?;
+                        emit_iload(&mut code, val_slot);
+                        let mref = cp.add_methodref(BF_RUNTIME_CLASS, "putchar", "(I)V");
+                        code.push(INVOKESTATIC);
+                        code.extend_from_slice(&mref.to_be_bytes());
+                    }
+                    "getchar" => {
+                        // getchar takes no args, returns i32 (the byte, or -1/0
+                        // for EOF — host convention).
+                        let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                            IIRJvmError::InvalidOperand {
+                                function: fname.clone(),
+                                detail: "call_builtin \"getchar\" requires a dest register".to_string(),
+                            }
+                        })?;
+                        let (dest_slot, _) = lookup_var(dest_name)?;
+                        let mref = cp.add_methodref(BF_RUNTIME_CLASS, "getchar", "()I");
+                        code.push(INVOKESTATIC);
+                        code.extend_from_slice(&mref.to_be_bytes());
+                        emit_istore(&mut code, dest_slot);
+                    }
+                    _ => {
+                        // Validator should have rejected this; defense in depth.
+                        return Err(IIRJvmError::UnsupportedOp {
+                            function: fname.clone(),
+                            op: format!("call_builtin {:?}: not in JVM backend whitelist", builtin_name),
+                        });
+                    }
+                }
+            }
+
             "call" => {
                 // First source is the callee name (as a Var operand).
                 let callee_name = match instr.srcs.first() {

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -62,16 +62,37 @@ use interpreter_ir::{IIRModule, Operand};
 // - `is_null`      — null check via ifnull.
 
 const UNSUPPORTED_OPS: &[&str] = &[
-    "call_builtin",
+    // `call_builtin` is *conditionally* unsupported — handled below.
+    // See [`CALL_BUILTIN_SUPPORTED_NAMES`] for the whitelist.  Whitelisting
+    // specific builtins (today: `putchar`, `getchar`) lets Brainfuck flow
+    // through this backend while still rejecting unknown / unsafe names.
     "io_in",
     "io_out",
     "cast",
-    "load_mem",
-    "store_mem",
+    // `load_mem` / `store_mem` — Brainfuck: now supported (baload/bastore
+    // over a host-provided `env/BFRuntime.__tape : [B` static byte array).
     "box",
     "unbox",
     "safepoint",
 ];
+
+/// Builtin names that the JVM backend can lower via `invokestatic` to a
+/// host-provided helper class.
+///
+/// Each entry maps to a `(class, name, descriptor)` triple resolved at
+/// lowering time.  The standard host class is `env/BFRuntime`:
+///
+/// | Builtin     | JVM call                                 |
+/// |-------------|-------------------------------------------|
+/// | `"putchar"` | `invokestatic env/BFRuntime.putchar(I)V`  |
+/// | `"getchar"` | `invokestatic env/BFRuntime.getchar()I`   |
+///
+/// Adding a new builtin requires:
+///   1. Listing the name here so the validator accepts it.
+///   2. Adding a matching `case` to `lower.rs::lower_function`'s
+///      `call_builtin` branch that emits the right `invokestatic`.
+///   3. Documenting the expected host-class signature.
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar"];
 
 /// Ops that are conditionally supported depending on their `type_hint`.
 ///
@@ -270,12 +291,40 @@ pub fn validate_for_jvm(module: &IIRModule) -> Vec<String> {
             // The JVM backend in this crate implements a focused subset of IIR.
             // Runtime, I/O, heap, and native-bridge operations have no direct
             // JVM-bytecode equivalent here.
+            //
+            // `call_builtin` is conditionally accepted: the builtin name
+            // carried in `srcs[0]` as `Operand::Var` must be in
+            // [`CALL_BUILTIN_SUPPORTED_NAMES`].  This lets Brainfuck's
+            // `putchar` / `getchar` flow through while still rejecting
+            // unknown / unsafe builtins.
             if UNSUPPORTED_OPS.contains(&instr.op.as_str()) {
                 errors.push(format!(
                     "UnsupportedOp: function {:?}, op {:?} is not supported by \
                      the JVM backend; it requires a native method or Java standard-library call",
                     func.name, instr.op
                 ));
+            } else if instr.op == "call_builtin" {
+                // Inspect srcs[0] for the builtin name.
+                let name: Option<&str> = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => Some(s.as_str()),
+                    _ => None,
+                };
+                match name {
+                    Some(n) if CALL_BUILTIN_SUPPORTED_NAMES.contains(&n) => {
+                        // Accepted — lower.rs will emit the corresponding
+                        // invokestatic to `env/BFRuntime.<name>`.
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"call_builtin\" with \
+                             builtin name {:?} is not in the JVM backend's host-class \
+                             whitelist (supported: {:?}); add the builtin to \
+                             CALL_BUILTIN_SUPPORTED_NAMES and the lowering rule in \
+                             lower.rs to extend coverage",
+                            func.name, name, CALL_BUILTIN_SUPPORTED_NAMES
+                        ));
+                    }
+                }
             }
 
             // ── Check 6: Conditionally supported ops ─────────────────────────
@@ -429,13 +478,14 @@ mod tests {
         // These ops are unconditionally unsupported by the JVM backend.
         // Note: alloc/field_load/field_store/is_null are Phase-2 supported ops
         // (via Object[] cons cells) and are NOT in this list.
+        // `load_mem` / `store_mem` were promoted to supported in the BF→JVM PR
+        // (baload/bastore over env/BFRuntime.__tape).  `call_builtin` is
+        // conditionally accepted via CALL_BUILTIN_SUPPORTED_NAMES — see
+        // the call_builtin_*_tests below.
         for op in &[
-            "call_builtin",
             "io_in",
             "io_out",
             "cast",
-            "load_mem",
-            "store_mem",
             "box",
             "unbox",
             "safepoint",
@@ -449,6 +499,104 @@ mod tests {
                 op
             );
         }
+    }
+
+    // ─── BF lowering: load_mem / store_mem now pass ─────────────────────────
+
+    #[test]
+    fn load_mem_accepted_for_bf() {
+        let errs = validate_for_jvm(&single_fn_module(vec![
+            IIRInstr::new(
+                "load_mem",
+                Some("v".into()),
+                vec![Operand::Var("ptr".into())],
+                "u8",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "load_mem should be accepted by JVM validator after BF→JVM PR; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn store_mem_accepted_for_bf() {
+        let errs = validate_for_jvm(&single_fn_module(vec![
+            IIRInstr::new(
+                "store_mem",
+                None,
+                vec![Operand::Var("ptr".into()), Operand::Var("v".into())],
+                "u8",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "store_mem should be accepted by JVM validator; got: {:?}",
+            errs
+        );
+    }
+
+    // ─── BF lowering: call_builtin whitelist (putchar / getchar) ─────────────
+
+    #[test]
+    fn call_builtin_putchar_accepted() {
+        let errs = validate_for_jvm(&single_fn_module(vec![
+            IIRInstr::new(
+                "call_builtin",
+                None,
+                vec![
+                    Operand::Var("putchar".into()),
+                    Operand::Var("v".into()),
+                ],
+                "void",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "call_builtin \"putchar\" should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn call_builtin_getchar_accepted() {
+        let errs = validate_for_jvm(&single_fn_module(vec![
+            IIRInstr::new(
+                "call_builtin",
+                Some("v".into()),
+                vec![Operand::Var("getchar".into())],
+                "u8",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "call_builtin \"getchar\" should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn call_builtin_unknown_name_rejected() {
+        // An arbitrary builtin name not in the whitelist must still fail
+        // validation so unknown / unsafe builtins can't slip through.
+        let errs = validate_for_jvm(&single_fn_module(vec![IIRInstr::new(
+            "call_builtin",
+            None,
+            vec![Operand::Var("system_exec".into())],
+            "void",
+        )]));
+        assert!(
+            errs.iter().any(|e| e.contains("UnsupportedOp")
+                && e.contains("system_exec")),
+            "unknown call_builtin name should be rejected with surfaced \
+             whitelist; got: {:?}",
+            errs
+        );
     }
 
     /// `alloc ref<LispyPair>` is accepted (Phase 2 Object[] cons cells).


### PR DESCRIPTION
## Summary

**Stage 2 of 4** for getting Brainfuck through the universal IIR-to-* backends. Mirrors PR #3921 (BF→WASM) for the JVM target. Adds `load_mem`, `store_mem`, and `call_builtin "putchar"` / `"getchar"` lowering to `iir-to-jvm-class-file`, so Brainfuck's IIR validates and compiles to real \`.class\` bytes through the same backend that Twig, BASIC, Oct, and Nib already use.

After this PR, Brainfuck programs walk the new IIR chain end-to-end:

\`\`\`
BF source → IIRModule
         → iir-to-jvm-class-file validator (accepts)
         → lower_iir_to_jvm
         → serialize_jvm_class_file
         → CAFEBABE… (real .class bytes)
\`\`\`

## Lowering decisions

| BF IIR op                | JVM bytecode emitted                                                                 |
|--------------------------|---------------------------------------------------------------------------------------|
| \`load_mem v ptr u8\`    | \`getstatic env/BFRuntime.__tape : [B; iload addr; baload; sipush 0x00FF; iand; istore dest\` |
| \`store_mem ptr v u8\`   | \`getstatic env/BFRuntime.__tape : [B; iload addr; iload val; bastore\`                  |
| \`call_builtin "putchar"\` | \`iload val; invokestatic env/BFRuntime.putchar(I)V\`                                    |
| \`call_builtin "getchar"\` | \`invokestatic env/BFRuntime.getchar()I; istore dest\`                                   |

The \`sipush 0x00FF; iand\` after \`baload\` masks JVM's sign-extension — BF cells are u8 (0..=255), not signed.

## Host class contract

The Java runtime / launcher must provide \`env/BFRuntime\`:

\`\`\`java
package env;
public class BFRuntime {
    public static byte[] __tape;
    public static void putchar(int b) { System.out.write(b); }
    public static int  getchar()      { return System.in.read(); }
}
\`\`\`

Same shape as WASM's \`env.putchar\` / \`env.getchar\` / linear memory imports — same model, different ABI.

## Why a host class instead of an inline tape?

- **No \`<clinit>\` on the BF side** — the BF-compiled class stays simple.
- **Tape size is host-tunable** — no need to recompile to change tape from 30 KB to 30 MB.
- **Non-BF callers untouched** — Twig/BASIC/Oct/Nib don't emit \`load_mem\` / \`store_mem\`, so feature detection skips the CP injection entirely.

## What's not in this PR

- **Stage 3 (CLR)** — \`byte[]\` + \`System.Console.Read/Write\` lowering
- **Stage 4 (BEAM docs)** — short note explaining why BF→BEAM is intentionally unsupported (immutable substrate → O(N²) tape writes)

## Compatibility

| Crate                   | Tests                                          |
|-------------------------|------------------------------------------------|
| iir-to-jvm-class-file   | 43 lib + 86 integration (all pass)              |
| brainfuck-iir-compiler  | 63 unit + 9 JIT smoke + 4 WASM e2e + **4 JVM e2e** (all pass) |

## Version bumps

- iir-to-jvm-class-file: 0.4.1 → 0.5.0
- brainfuck-iir-compiler: 0.3.1 → 0.3.2 (e2e test only, no API change)

## Test plan

- [x] \`cargo test -p iir-to-jvm-class-file\` (129 pass)
- [x] \`cargo test -p brainfuck-iir-compiler --tests\` (80 pass)
- [x] \`/security-review\` passed (CAFEBABE opcodes, operand stack ordering, CP integrity, two-layer defense all verified)
- [ ] CI green across macOS / Ubuntu / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)