### PR TITLE
feat(cas-summation): Phase 49 — bounded × vanishing recogniser

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 0.7.0 — 2026-05-22
+
+**Phase 49 — Bounded × vanishing recogniser.**
+
+Extends ``_g_vanishes_at_infinity`` to accept
+``Div(bounded, diverging)`` shapes where the numerator is uniformly
+bounded.  Closes telescopes like ``∑ [sin(k)/k² − sin(k+1)/(k+1)²]
+ = sin(1)`` that the previous Phase 42 degree-aware path refused
+(``sin(k)`` isn't a polynomial, so its degree-in-k was ``None``).
+
+### Added
+
+- **`_is_bounded_in_k(node, k)`** — recogniser for uniformly
+  bounded shapes:
+  1.  constant in ``k``                                  → True
+  2.  ``Sin(...)`` or ``Cos(...)`` (any inner argument)  → True
+  3.  ``Mul(bounded, bounded)``                          → True
+  4.  ``Add(bounded, bounded)``                          → True
+  5.  ``Neg(bounded)``                                   → True
+  6.  anything else (bare ``k``, ``Log(k)``, ``Exp(k)``, …) → False
+
+  Conservative — when in doubt, returns False so the caller falls
+  through to the unevaluated ``Sum(...)`` form.
+
+### Changed
+
+- ``_g_vanishes_at_infinity`` now consults ``_is_bounded_in_k`` on
+  the numerator (before falling through to the Phase 42 degree-
+  aware path).  If the numerator is bounded AND the denominator
+  diverges (via the existing ``_h_diverges_at_infinity``), the
+  quotient vanishes at infinity.
+
+### Added — tests
+
+`tests/test_summation.py::TestEvaluateSumPhase49BoundedNumerator`
+— 5 new cases:
+
+- ``test_sin_over_k_squared_closes`` —
+  ``∑ [sin(k)/k² − sin(k+1)/(k+1)²]`` closes to ``sin(1)``.
+- ``test_cos_over_k_cube_closes`` — analogous with ``cos`` / ``k³``.
+- ``test_sin_cos_product_over_diverging`` — product of bounded
+  factors is bounded (closure under ``Mul``).
+- ``test_unbounded_numerator_still_refused`` — regression for
+  Phase 42 path on ``k/k³`` (deg-difference catches it, not
+  Phase 49).
+- ``test_log_numerator_still_refused`` — regression: ``log(k)/k²``
+  stays unevaluated.  The math limit IS 0 by squeeze, but
+  ``Log(k)`` isn't bounded — the recogniser refuses correctly.
+
+### Renamed
+
+- ``test_transcendental_numerator_falls_through`` →
+  ``test_transcendental_numerator_closes_via_phase49`` (assertion
+  flipped from "stays unevaluated" to "now closes").
+
+Full suite: **98 passed** (was 92 + 1 stale assertion that
+required updating; +5 net new + 1 flipped).
+
+### Still deferred
+
+- Transcendental growth-rate recogniser for shapes like
+  ``log(k)/k`` or ``log(k)/k²`` — these vanish by squeeze too,
+  but require comparing growth rates (``log`` < any polynomial),
+  not just boundedness.  Future phase.
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 44 — Log divergence in vanishing-at-infinity recogniser.**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "0.6.0"
+version = "0.7.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -578,6 +578,58 @@ def _h_diverges_at_infinity(node: IRNode, k: IRSymbol) -> bool:
     return False
 
 
+_SIN = IRSymbol("Sin")
+_COS = IRSymbol("Cos")
+
+
+def _is_bounded_in_k(node: IRNode, k: IRSymbol) -> bool:
+    """Return True when ``node`` is *provably* uniformly bounded in ``k``.
+
+    Phase 49 — used by :func:`_g_vanishes_at_infinity` to recognise
+    shapes like ``sin(k)/k²`` where the numerator is bounded
+    (``|sin(k)| ≤ 1``) and the denominator diverges, hence the
+    quotient vanishes.
+
+    +-----------------------------+----------------------------+
+    | ``node`` shape              | Provably bounded?          |
+    +=============================+============================+
+    | constant in ``k``           | yes (trivially)            |
+    | ``Sin(h(k))`` / ``Cos(...)``| yes (``|sin|, |cos| ≤ 1``) |
+    | ``Mul(bounded, bounded)``   | yes (recursive)            |
+    | ``Add(bounded, bounded)``   | yes (recursive)            |
+    | ``Neg(bounded)``            | yes (sign flip preserves)  |
+    | ``k`` / ``k²``              | no (diverges)              |
+    | ``Exp(k)``                  | no (diverges)              |
+    | ``Log(k)``                  | no (diverges)              |
+    +-----------------------------+----------------------------+
+
+    Conservative — when in doubt, returns False so the caller falls
+    through to the unevaluated ``Sum(...)`` form.
+    """
+    # Trivial case: nothing depending on k is bounded by being
+    # constant in k.
+    if _is_constant_in(node, k):
+        return True
+    if not isinstance(node, IRApply):
+        # Bare ``k`` is *not* bounded; it diverges.
+        return False
+    # Sin / Cos with any inner argument are bounded by 1 in modulus.
+    # The inner argument can depend on k freely — ``sin(k²)`` is still
+    # bounded by 1.
+    if node.head == _SIN and len(node.args) == 1:
+        return True
+    if node.head == _COS and len(node.args) == 1:
+        return True
+    # Closure under Mul / Add / Neg.
+    if node.head == MUL:
+        return all(_is_bounded_in_k(a, k) for a in node.args)
+    if node.head == ADD:
+        return all(_is_bounded_in_k(a, k) for a in node.args)
+    if node.head == NEG and len(node.args) == 1:
+        return _is_bounded_in_k(node.args[0], k)
+    return False
+
+
 def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     """Return True when ``g(k)`` provably tends to 0 as ``k → ∞``.
 
@@ -624,6 +676,12 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     # (positive-degree polynomial OR exp / b^k transcendental).
     if _is_constant_in(num, k):
         return _h_diverges_at_infinity(den, k)
+    # Phase 49: bounded numerator + diverging denominator.  Covers
+    # shapes like ``sin(k)/k²`` and ``cos(k)·sin(k)/k³`` where the
+    # numerator is uniformly bounded (``|sin|, |cos| ≤ 1`` and
+    # closures under Mul/Add/Neg).
+    if _is_bounded_in_k(num, k) and _h_diverges_at_infinity(den, k):
+        return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -578,11 +578,15 @@ class TestEvaluateSumPhase42DegreeAware:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
 
-    def test_transcendental_numerator_falls_through(self):
-        """``g(k) = sin(k)/k²``: numerator is not a polynomial, so the
-        degree-aware path refuses.  (The limit IS 0 by squeeze, but
-        decidably proving so needs a transcendental limit-finder we
-        don't have yet.)
+    def test_transcendental_numerator_closes_via_phase49(self):
+        """``g(k) = sin(k)/k²``: previously refused by the
+        degree-aware path because ``sin(k)`` isn't a polynomial.
+        Phase 49 (bounded-numerator widening) recognises that
+        ``|sin(k)| ≤ 1`` and the denominator ``k²`` diverges, so the
+        quotient vanishes at ∞.
+
+        The antisymmetric telescope ``g(k) − g(k+1)`` from k=1 to ∞
+        closes to ``g(1) = sin(1)/1 = sin(1)``.
         """
         from symbolic_ir import POW, SIN, SUB
 
@@ -598,8 +602,13 @@ class TestEvaluateSumPhase42DegreeAware:
         )
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
-        # Conservative: refuse since num is not a polynomial.
-        assert isinstance(result, IRApply) and result.head == SUM
+        # Phase 49 closure: g(1) = sin(1)/1² = sin(1).  Either:
+        #   - the result is exactly the Sin apply (``Sin(1)``)
+        #   - or it's the Div shape that vm-eval folded to ``Sin(1)/1``
+        # Pin the new behaviour: result is no longer the unevaluated Sum.
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 49 should close this telescope; got {result!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -952,4 +961,131 @@ class TestEvaluateSumPhase44LogDivergence:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         # Phase 44 must refuse — `log((-2)^k)` is complex / undefined
         # for odd k, so the sum doesn't have a real closed form.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+# ---------------------------------------------------------------------------
+# Phase 49 — Bounded × vanishing recogniser.
+#
+# Extends `_g_vanishes_at_infinity` to accept ``Div(bounded, diverging)``
+# shapes where the numerator is uniformly bounded (``Sin``, ``Cos``, or
+# constants — closed under Mul/Add/Neg) and the denominator diverges.
+# Closes telescopes like ``∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1)``.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase49BoundedNumerator:
+    def test_sin_over_k_squared_closes(self):
+        """``∑_{k=1}^∞ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1)``.
+
+        Phase 49: ``sin(k)`` is bounded, ``k²`` diverges, so the
+        quotient vanishes.  Antisymmetric telescope closes to
+        ``g(1) = sin(1)/1²``.
+        """
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sin_kp1 = IRApply(SIN, (IRApply(ADD, (_k, IRInteger(1))),))
+        g_k = IRApply(DIV, (sin_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                sin_kp1,
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(2))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Must close — not the unevaluated Sum form.
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 49 should close; got {result!r}"
+        )
+
+    def test_cos_over_k_cube_closes(self):
+        """``∑_{k=1}^∞ [cos(k)/k³ − cos(k+1)/(k+1)³] = cos(1)``.
+
+        Phase 49: ``cos(k)`` is bounded; ``k³`` diverges.
+        """
+        from symbolic_ir import COS, POW, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        cos_kp1 = IRApply(COS, (IRApply(ADD, (_k, IRInteger(1))),))
+        g_k = IRApply(DIV, (cos_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                cos_kp1,
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(3))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_cos_product_over_diverging(self):
+        """``sin(k)·cos(k)`` is bounded (product of two bounded functions),
+        so ``sin(k)·cos(k)/k²`` vanishes at ∞.
+        """
+        from symbolic_ir import COS, MUL, POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        cos_k = IRApply(COS, (_k,))
+        num_k = IRApply(MUL, (sin_k, cos_k))
+        sin_kp1 = IRApply(SIN, (IRApply(ADD, (_k, IRInteger(1))),))
+        cos_kp1 = IRApply(COS, (IRApply(ADD, (_k, IRInteger(1))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, cos_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                num_kp1,
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(2))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_unbounded_numerator_still_refused(self):
+        """Regression: ``g(k) = k/k³`` looks like ``unbounded/diverging``
+        on the surface (Phase 49 doesn't apply), but Phase 42 catches
+        it via deg-difference (deg 1 < deg 3).  This pins the right
+        recogniser fires — not Phase 49 — and the sum still closes.
+        """
+        from symbolic_ir import POW, SUB
+
+        g_k = IRApply(DIV, (_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                IRApply(ADD, (_k, IRInteger(1))),
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(3))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_numerator_still_refused(self):
+        """Regression: ``g(k) = log(k)/k²``.  ``log(k)`` is NOT bounded
+        (diverges to ∞ slowly).  Phase 49 must NOT incorrectly accept
+        it.  The sum stays unevaluated.
+        """
+        from symbolic_ir import LOG, POW, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        log_kp1 = IRApply(LOG, (IRApply(ADD, (_k, IRInteger(1))),))
+        g_k = IRApply(DIV, (log_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                log_kp1,
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(2))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Math: limit of log(k)/k² IS 0, but Phase 49 isn't smart enough
+        # to recognise that.  Stay unevaluated until a transcendental
+        # growth-rate recogniser lands.
         assert isinstance(result, IRApply) and result.head == SUM


### PR DESCRIPTION
## Summary

Extends ``_g_vanishes_at_infinity`` to accept ``Div(bounded, diverging)``
shapes where the numerator is uniformly bounded.  Closes telescopes
like ``∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1)`` that the previous
Phase 42 degree-aware path refused (``sin(k)`` isn't a polynomial,
so its degree-in-k was ``None``).

Bumps ``cas-summation`` 0.6.0 → 0.7.0.

### Why this is a meaningful extension

Phase 42's degree-aware path only fires when both numerator and
denominator are polynomials in ``k``.  Many real-world telescope
summands have a *transcendental* (but bounded) numerator like
``sin(k)``, ``cos(k)``, or products thereof.  Phase 49 covers
exactly that family via the squeeze argument: ``|num| ≤ M`` and
``|den| → ∞`` implies ``num/den → 0``.

### Added

| Function | Returns True when ``node`` matches |
|---|---|
| ``_is_bounded_in_k(node, k)`` | constant-in-``k``; ``Sin(any)``; ``Cos(any)``; ``Mul/Add`` of bounded terms; ``Neg(bounded)`` |

### Changed

- ``_g_vanishes_at_infinity`` now consults ``_is_bounded_in_k`` on
  the numerator (between the Phase 41 constant-numerator fast path
  and the Phase 42 degree-aware path).  If the numerator is
  bounded AND the denominator diverges via ``_h_diverges_at_infinity``,
  the quotient vanishes.

### Test plan

- [x] ``pytest tests/test_summation.py -k phase49`` → 5 passed
- [x] ``pytest tests/`` → 98 passed (was 92; +5 new + 1 flipped from
      previously stale assertion)
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Still deferred

- Transcendental growth-rate recogniser for ``log(k)/k``,
  ``sqrt(k)/k²``, etc.  These vanish by squeeze too, but require
  comparing growth rates (``log(k)`` < any positive-degree
  polynomial), not just boundedness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)