### PR TITLE
feat(mosaic-pkg-toolkit): v0.1 PR-1 — scaffold + Button + Alert

### DIFF
--- a/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog — mosaic-pkg-toolkit
+
+## [0.1.0] — Unreleased — PR-1 scaffold
+
+### Added
+
+First implementation per `code/specs/mosaic-pkg-toolkit.md`.
+
+- **Package scaffold**: `mosaic-package.toml` (kernel-only,
+  v1-targeting, zero dependencies), `Cargo.toml` (smoke-test
+  harness, opted out of workspace per the userland-package
+  convention), `src/lib.rs` (doc-only), `README.md`, this
+  `CHANGELOG.md`.
+
+- **`Button` component** — the first Tier-1 catalog entry.
+  - `Button.mil` — slots: `label`, `variant`, `size`, `disabled`. Emit: `onClick`.
+  - `Button.mll` — wraps the kernel `HostButton` with `part_name: button`.
+  - `Button.light.msl` + `Button.dark.msl` — base part styling.
+    Variant sub-parts (`button/primary`, `button/danger`, etc.)
+    deferred to the spec §4.1 sub-part syntax decision.
+
+- **`Alert` component** — the second Tier-1 catalog entry.
+  - `Alert.mil` — slots: `message`, `variant`, `dismissible`. Emit: `onClose`.
+  - `Alert.mll` — `Box[alert]` → `Row` → `Text[message]` + `If
+    dismissible HostButton[close-btn]`. Pure kernel composition.
+  - `Alert.light.msl` + `Alert.dark.msl` — base part styling.
+
+- **Smoke test** (`tests/package_compiles.rs`) — asserts the
+  manifest is consistent (correct name/version, exports list
+  matches the per-component compile loop, zero dependencies,
+  kernel v1) and that every exported component's
+  `.mil`/`.mll`/`.{light,dark}.msl` triple round-trips through
+  the three IR compilers. Modeled on `mosaic-pkg-card`'s smoke
+  test.
+
+### Known limitations (deferred to follow-up PRs)
+
+- **Variant styling.** The `variant` slot on `Button` and `Alert`
+  is accepted by the .mil but doesn't currently change the
+  rendered output. The mosstyle sub-part syntax for variants is
+  spec §4.1's open question and lands when the first follow-up PR
+  picks the design.
+- **The full Tier-1 catalog** (13 components from spec §3.1) —
+  Badge, Card, Checkbox, Container, Field, Input, ListGroup,
+  Modal, Radio, Spinner, Toast — lands across follow-up PRs.
+- **Tier 2 / Tier 3 / theming work** per the spec's §7 phasing
+  plan.
+- **Per-backend visual smoke tests.** The current smoke test
+  verifies only IR-level round-trip; backend-specific rendering
+  tests (does Button look right in XAML? in React? in SwiftUI?)
+  belong in each backend's own integration test suite and will
+  land per-component as the catalog grows.

--- a/code/packages/mosaic-pkg-toolkit/Cargo.toml
+++ b/code/packages/mosaic-pkg-toolkit/Cargo.toml
@@ -1,0 +1,38 @@
+# Cargo.toml — smoke-test harness for mosaic-pkg-toolkit.
+#
+# This package's primary deliverables are .mil / .mll / .msl source
+# files (consumed by mosaic-compile and downstream emitters), NOT a
+# Rust crate. The Cargo.toml exists ONLY to host an integration smoke
+# test that runs each source file through its respective compiler crate
+# and asserts the whole package round-trips at the language-frontend
+# layer.
+#
+# `[workspace]` is empty so this Cargo project does NOT join the main
+# code/packages/rust workspace. It lives at
+# code/packages/mosaic-pkg-toolkit (outside the rust/ tree), is
+# conceptually a Mosaic package (not a Rust crate), and runs as a
+# standalone Cargo project via `cargo test`.
+
+[workspace]
+# Intentionally empty: opt out of the parent workspace.
+
+[package]
+name        = "mosaic-pkg-toolkit-smoke"
+version     = "0.1.0"
+edition     = "2021"
+description = "Smoke-test harness for the mosaic-pkg-toolkit component package"
+publish     = false
+
+# The crate has no library code — it exists for the integration test below.
+[lib]
+path = "src/lib.rs"
+
+[dev-dependencies]
+mosmodel-compiler   = { path = "../rust/mosmodel-compiler" }
+moslayout-compiler  = { path = "../rust/moslayout-compiler" }
+mosstyle-compiler   = { path = "../rust/mosstyle-compiler" }
+toml                = "0.8"
+
+[[test]]
+name = "package_compiles"
+path = "tests/package_compiles.rs"

--- a/code/packages/mosaic-pkg-toolkit/README.md
+++ b/code/packages/mosaic-pkg-toolkit/README.md
@@ -1,0 +1,71 @@
+# mosaic-pkg-toolkit
+
+Bootstrap-shaped Mosaic UI component library — ready-made components
+composed purely from UI29 kernel primitives, lowering to every
+backend (React, SwiftUI, Qt, WebComponent, HTML, XAML) with no
+per-backend code.
+
+See [`code/specs/mosaic-pkg-toolkit.md`](../../specs/mosaic-pkg-toolkit.md)
+for the architecture, component catalog, and phasing plan.
+
+## v0.1 — PR-1 (scaffold)
+
+**Exports:**
+
+- **`Button`** — styled push button with `variant` (primary /
+  secondary / success / danger / warning / info / light / dark),
+  `size` (sm / md / lg), and `disabled` slots. Wraps the kernel
+  `HostButton`.
+- **`Alert`** — colored info banner with `variant`, optional inline
+  dismiss button. Composed from `Box` + `Row` + `Text` + `If` +
+  `HostButton`.
+
+Both ship a `.light.msl` and `.dark.msl` theme.
+
+## Roadmap
+
+Per spec §7:
+
+| Phase | Components |
+|---|---|
+| v0.1 PR-1 (this) | Button, Alert |
+| v0.1 PR-2..N | Badge, Card, Checkbox, Container, Field, Input, ListGroup, Modal, Radio, Spinner, Toast — 11 more Tier-1 components |
+| v0.2 | Tier 2 — Nav, Navbar, Pagination, Breadcrumb, InputGroup, ButtonGroup, Tabs, DropdownMenu, Accordion, Select |
+| v0.3 | Bootstrap-aesthetic theme overlay |
+| v0.4 | Tier 3 — Tooltip, Popover, Carousel, Offcanvas (depends on kernel follow-ups) |
+| v0.5 | Responsive grid (depends on mosstyle breakpoints) |
+
+## Using the toolkit (when fully released)
+
+```toml
+# mosaic-package.toml (the host project)
+[dependencies]
+mosaic-pkg-toolkit = "0.1"
+```
+
+```moslayout
+// MyComponent.mll
+layout MyComponent {
+  Column {
+    Alert (variant: "info", message: slot: status-message)
+    Button (variant: "primary", label: "Submit", onClick: emit: onSubmit)
+  }
+}
+```
+
+## Tests
+
+```bash
+cd code/packages/mosaic-pkg-toolkit
+cargo test
+```
+
+Smoke tests assert every exported component's `.mil` / `.mll` /
+`.msl` triple round-trips through the three IR compilers, and that
+the manifest is internally consistent.
+
+## Why kernel-only?
+
+The toolkit composes purely from UI29 kernel primitives — no per-
+backend code anywhere. Adding a new Mosaic backend automatically
+adds the toolkit to it. See spec §1 + §12 for the strategic story.

--- a/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
@@ -1,0 +1,29 @@
+# mosaic-package.toml — manifest for mosaic-pkg-toolkit.
+#
+# A Bootstrap-shaped Mosaic UI component library. Composed purely from
+# UI29 kernel primitives — every component lowers to every backend
+# (React, SwiftUI, Qt, WebComponent, HTML, XAML) with no per-backend
+# code.
+#
+# See `code/specs/mosaic-pkg-toolkit.md` for the design.
+#
+# Phase: v0.1 (PR-1) — scaffold + Button + Alert.
+# The full v0.1 catalog (13 components) lands across follow-up PRs.
+
+[package]
+name        = "mosaic-pkg-toolkit"
+version     = "0.1.0"
+description = "Bootstrap-shaped Mosaic UI component library — ready-made components composed purely from UI29 kernel primitives"
+license     = "MIT OR Apache-2.0"
+
+[components]
+# v0.1 PR-1 exports. The full Tier-1 catalog (13 components) lands in
+# follow-up PRs; the exports list grows with each.
+exports = ["Button", "Alert"]
+
+[dependencies]
+# No other userland packages — toolkit components compose purely from
+# UI29 kernel primitives. Stays empty across the full v0.1 catalog.
+
+[kernel]
+version = "1"

--- a/code/packages/mosaic-pkg-toolkit/src/Alert.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Alert.dark.msl
@@ -1,0 +1,23 @@
+// Alert.dark.msl — dark-theme styling for Alert.
+
+style Alert {
+  part alert {
+    padding       : 12 ;
+    border-radius : 4 ;
+    background    : "#055160" ;
+    color         : "#cff4fc" ;
+    border-width  : 1 ;
+    border-color  : "#087990" ;
+  }
+  part alert-row {
+    padding : 0 ;
+  }
+  part message {
+  }
+  part close-btn {
+    padding : 4 ;
+    background : "transparent" ;
+    border-width : 0 ;
+    color : "#cff4fc" ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Alert.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Alert.light.msl
@@ -1,0 +1,27 @@
+// Alert.light.msl — default light-theme styling for Alert.
+//
+// Same caveat as Button.light.msl: variant sub-parts (alert/info,
+// alert/danger, etc.) defer to the spec §4.1 syntax decision. v0.1
+// PR-1 uses the info-variant colors as the base.
+
+style Alert {
+  part alert {
+    padding       : 12 ;
+    border-radius : 4 ;
+    background    : "#cff4fc" ;
+    color         : "#055160" ;
+    border-width  : 1 ;
+    border-color  : "#b6effb" ;
+  }
+  part alert-row {
+    padding : 0 ;
+  }
+  part message {
+  }
+  part close-btn {
+    padding : 4 ;
+    background : "transparent" ;
+    border-width : 0 ;
+    color : "#055160" ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Alert.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Alert.mil
@@ -1,0 +1,25 @@
+// Alert.mil — interface for the toolkit's Alert component.
+//
+// A colored info banner. Bootstrap's `<div class="alert alert-info">`
+// equivalent. One message string, an optional variant, an optional
+// dismissible flag. When dismissible, an inline close button fires
+// `onClose`.
+
+component Alert {
+  // The alert's message text. Required.
+  slot message : text ;
+
+  // Variant keyword. One of: primary, secondary, success, danger,
+  // warning, info, light, dark. Default: info.
+  // Drives the part-level styling via `part alert/<variant>`.
+  slot variant : text ;
+
+  // When true, an inline close button appears at the trailing edge
+  // and clicking it fires onClose. When false (default), no close
+  // button is rendered.
+  slot dismissible : bool ;
+
+  // Fired when the user clicks the dismiss button. Only fireable
+  // when dismissible: true.
+  emit onClose ;
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Alert.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Alert.mll
@@ -1,0 +1,30 @@
+// Alert.mll — layout for the Alert component.
+//
+// Box[alert] wraps a horizontal Row with the message Text on the
+// leading edge and (when dismissible) a HostButton on the trailing
+// edge. Pure kernel-primitive composition:
+//
+//   Box [alert]
+//     Row
+//       Text [message]
+//       If (dismissible) HostButton [close-btn]
+//
+// The variant slot doesn't appear in the .mll — it routes through
+// the part-level styling in Alert.{theme}.msl. Same convention as
+// Button.mll (see Button.mll's commentary).
+
+layout Alert {
+  Box [ alert ] {
+    Row [ alert-row ] {
+      Text [ message ] (
+        content : slot: message
+      )
+      If ( when: slot: dismissible ) {
+        HostButton [ close-btn ] (
+          label : "x" ,
+          onClick : emit: onClose
+        )
+      }
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Button.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Button.dark.msl
@@ -1,0 +1,15 @@
+// Button.dark.msl — dark-theme styling for Button.
+//
+// Same shape, darker palette tuned for dark backgrounds.
+
+style Button {
+  part button {
+    padding       : 8 ;
+    border-radius : 4 ;
+    font-weight   : 500 ;
+    background    : "#3b82f6" ;
+    color         : "#0f172a" ;
+    border-width  : 1 ;
+    border-color  : "#1e40af" ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Button.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Button.light.msl
@@ -1,0 +1,26 @@
+// Button.light.msl — default light-theme styling for Button.
+//
+// The base `part button` defines the shape (padding, border-radius,
+// font weight) that applies regardless of variant. Variant- and size-
+// specific styling is intentionally NOT in this file for v0.1 — the
+// spec §4.1 leaves the variant sub-part syntax as an open question.
+// Once the syntax lands (sub-parts via `part X/Y { ... }` or
+// equivalent), this file grows to define `part button/primary`,
+// `part button/danger`, etc.
+//
+// Today (v0.1 PR-1): the variant slot is accepted by the .mil and
+// stays unused at the styling layer — every variant renders with the
+// base style. That's intentional: it lets us land the API surface
+// without blocking on the mosstyle sub-part design.
+
+style Button {
+  part button {
+    padding       : 8 ;
+    border-radius : 4 ;
+    font-weight   : 500 ;
+    background    : "#0d6efd" ;
+    color         : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#0d6efd" ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Button.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Button.mil
@@ -1,0 +1,27 @@
+// Button.mil — interface for the toolkit's Button component.
+//
+// Wraps the kernel `HostButton` with a Bootstrap-shaped variant system
+// (primary / secondary / success / danger / warning / info / light /
+// dark) and size system (sm / md / lg). The actual variant colors live
+// in Button.{theme}.msl part definitions; this .mil just declares the
+// surface.
+
+component Button {
+  // Visible label text. Required.
+  slot label : text ;
+
+  // Variant keyword. One of: primary, secondary, success, danger,
+  // warning, info, light, dark. Default: primary.
+  // Hosts that pass an unknown variant get the primary styling.
+  slot variant : text ;
+
+  // Size keyword. One of: sm, md, lg. Default: md.
+  slot size : text ;
+
+  // Disabled state. When true, the button paints disabled and stops
+  // firing onClick.
+  slot disabled : bool ;
+
+  // Click event. Forwarded from the underlying HostButton.
+  emit onClick ;
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Button.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Button.mll
@@ -1,0 +1,26 @@
+// Button.mll — layout for the toolkit Button.
+//
+// Single-element wrapping the kernel `HostButton`. The Mosaic
+// composition is intentionally minimal — every visual difference
+// between variants lives in Button.{theme}.msl, not here. That keeps
+// the .mll variant-agnostic and the styling backend-portable.
+//
+// Why not lower variants in the .mll via If/Else?
+// -----------------------------------------------
+// Could write:
+//   If (when: slot: variant == "primary") {
+//     HostButton [primary] (...)
+//   } Else If ... { ... }
+//
+// That would produce per-variant XAML/JSX trees, which any backend
+// would then de-duplicate via styling anyway. Driving variants
+// through part_name + .msl is the conventional mosstyle pattern
+// (see mosaic-pkg-grid's parts) and is what mosstyle is designed for.
+
+layout Button {
+  HostButton [ button ] (
+    label : slot: label ,
+    disabled : slot: disabled ,
+    onClick : emit: onClick
+  )
+}

--- a/code/packages/mosaic-pkg-toolkit/src/lib.rs
+++ b/code/packages/mosaic-pkg-toolkit/src/lib.rs
@@ -1,0 +1,27 @@
+//! mosaic-pkg-toolkit — Bootstrap-shaped Mosaic UI component library.
+//!
+//! This crate is intentionally empty. The package's real deliverables
+//! are the `.mil` / `.mll` / `.msl` source files under `src/` and the
+//! `mosaic-package.toml` manifest at the package root. Authors consume
+//! the package by declaring it in their own `mosaic-package.toml`
+//! dependencies and referencing its exported components from `.mll`
+//! source.
+//!
+//! See `code/specs/mosaic-pkg-toolkit.md` for the architecture.
+//!
+//! The Rust crate exists only so the integration smoke test in
+//! `tests/package_compiles.rs` can run each component's three source
+//! files through the mosmodel / moslayout / mosstyle compilers and
+//! assert the whole package round-trips at the language-frontend
+//! layer.
+//!
+//! ## v0.1 PR-1 exports
+//!
+//! - **Button** — styled push button, slot-driven variant + size,
+//!   wraps the kernel `HostButton`.
+//! - **Alert** — colored info banner, slot-driven variant, optional
+//!   inline dismiss button, composed from Box + Row + Text + If +
+//!   HostButton.
+//!
+//! The full Tier-1 catalog (13 components) lands across follow-up
+//! PRs. See `code/specs/mosaic-pkg-toolkit.md` §3.1.

--- a/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -1,0 +1,194 @@
+//! package_compiles — smoke test for the mosaic-pkg-toolkit package.
+//!
+//! Asserts that every exported component (`Button`, `Alert` in v0.1
+//! PR-1) compiles through the three IR compilers (mosmodel /
+//! moslayout / mosstyle) and that the manifest is internally
+//! consistent.
+//!
+//! What this test verifies:
+//!
+//!   1. The manifest parses, names the package correctly, declares
+//!      every exported component in `[components].exports`, lists no
+//!      runtime dependencies (the toolkit is kernel-only), and
+//!      targets kernel v1.
+//!   2. For each exported component:
+//!      a. `<Component>.mil` compiles via `mosmodel_compiler::compile`.
+//!      b. `<Component>.mll` compiles via `moslayout_compiler::compile`,
+//!         validated against the matching `.mil` interface.
+//!      c. `<Component>.light.msl` and `<Component>.dark.msl` each
+//!         compile via `mosstyle_compiler::compile`, validated
+//!         against the matching `.mll` part map.
+//!
+//! Backend-specific lowering (does each component produce valid
+//! React/SwiftUI/Qt/XAML/etc.?) is NOT in scope here — that lives in
+//! per-backend integration tests (`mosaic-emit-xaml/tests/`,
+//! `mosaic-emit-react/tests/`, …) and lands as each backend gets
+//! per-toolkit-component coverage.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// The list of exported components in PR-1. Drives the per-component
+/// compile loop. Grows as each Tier-1 component lands.
+const COMPONENTS: &[&str] = &["Button", "Alert"];
+
+/// Themes shipped per component. Both must compile.
+const THEMES: &[&str] = &["light", "dark"];
+
+fn package_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn src_path(name: &str) -> PathBuf {
+    package_root().join("src").join(name)
+}
+
+fn read_source(name: &str) -> String {
+    let path = src_path(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Manifest
+// ---------------------------------------------------------------------------
+
+#[test]
+fn manifest_declares_expected_exports() {
+    let manifest_src = fs::read_to_string(package_root().join("mosaic-package.toml"))
+        .expect("manifest mosaic-package.toml must exist at the package root");
+
+    let value: toml::Value = toml::from_str(&manifest_src)
+        .expect("mosaic-package.toml must parse as valid TOML");
+
+    let name = value
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .expect("[package].name must be set");
+    assert_eq!(name, "mosaic-pkg-toolkit", "[package].name mismatch");
+
+    let version = value
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[package].version must be set");
+    assert_eq!(
+        version, "0.1.0",
+        "[package].version must be 0.1.0 for the v0.1 PR-1 release"
+    );
+
+    let exports = value
+        .get("components")
+        .and_then(|c| c.get("exports"))
+        .and_then(|e| e.as_array())
+        .expect("[components].exports must be an array");
+    let export_names: Vec<&str> = exports.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        export_names,
+        COMPONENTS,
+        "[components].exports must match the compile-loop's list"
+    );
+
+    let kernel_version = value
+        .get("kernel")
+        .and_then(|k| k.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("[kernel].version must be set");
+    assert_eq!(
+        kernel_version, "1",
+        "[kernel].version must target UI29 kernel v1"
+    );
+
+    assert!(
+        value.get("dependencies").is_some(),
+        "[dependencies] table must be present (may be empty)"
+    );
+    let deps = value
+        .get("dependencies")
+        .and_then(|d| d.as_table())
+        .expect("[dependencies] must be a TOML table");
+    assert!(
+        deps.is_empty(),
+        "[dependencies] must be empty — toolkit is built only from UI29 kernel primitives; got {:?}",
+        deps
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Per-component round-trip
+// ---------------------------------------------------------------------------
+
+/// Compile one component's .mil + .mll + each .msl. Asserts everything
+/// round-trips and the .mll's name matches the .mil's.
+fn compile_component(name: &str) {
+    // .mil
+    let mil_src = read_source(&format!("{name}.mil"));
+    let mil_out = mosmodel_compiler::compile(&mil_src).unwrap_or_else(|e| {
+        panic!("{name}.mil failed to compile:\n{:#?}", e)
+    });
+    assert_eq!(
+        mil_out.component.component, name,
+        "{name}.mil must declare component named {name:?}, got {:?}",
+        mil_out.component.component
+    );
+
+    // .mll, validated against the .mil's descriptor.
+    let mll_src = read_source(&format!("{name}.mll"));
+    let mll_out =
+        moslayout_compiler::compile(&mll_src, Some(&mil_out.descriptor_json))
+            .unwrap_or_else(|e| panic!("{name}.mll failed to compile:\n{:#?}", e));
+    assert_eq!(
+        mll_out.def.component_name, name,
+        "{name}.mll must declare layout for {name:?}"
+    );
+
+    // Both .msl files, validated against the .mll's part map.
+    for theme in THEMES {
+        let msl_filename = format!("{name}.{theme}.msl");
+        let msl_src = read_source(&msl_filename);
+        mosstyle_compiler::compile(&msl_src, Some(&mll_out.part_map_json))
+            .unwrap_or_else(|e| {
+                panic!("{msl_filename} failed to compile:\n{:#?}", e)
+            });
+    }
+}
+
+#[test]
+fn every_exported_component_round_trips() {
+    for name in COMPONENTS {
+        compile_component(name);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Per-component sanity checks — light bound on the surface
+// ---------------------------------------------------------------------------
+
+/// Button must have the documented slot/emit surface.
+#[test]
+fn button_interface_matches_spec() {
+    let mil_src = read_source("Button.mil");
+    let out = mosmodel_compiler::compile(&mil_src).unwrap();
+    let c = &out.component;
+
+    let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(slot_names, vec!["label", "variant", "size", "disabled"]);
+
+    let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(emit_names, vec!["onClick"]);
+}
+
+/// Alert must have the documented slot/emit surface.
+#[test]
+fn alert_interface_matches_spec() {
+    let mil_src = read_source("Alert.mil");
+    let out = mosmodel_compiler::compile(&mil_src).unwrap();
+    let c = &out.component;
+
+    let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(slot_names, vec!["message", "variant", "dismissible"]);
+
+    let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(emit_names, vec!["onClose"]);
+}

--- a/code/specs/mosaic-pkg-toolkit.md
+++ b/code/specs/mosaic-pkg-toolkit.md
@@ -1,0 +1,533 @@
+# mosaic-pkg-toolkit — Bootstrap-shaped Mosaic component library
+
+**Status:** Specification (draft)
+**Layer:** UI / userland component package
+**Depends on:** UI29 (primitive kernel), UI29-1 (HostDialog), UI24
+(emit→dispatch). Implements against the kernel only — no backend
+dependencies.
+**Sibling packages:** `mosaic-pkg-grid` (data grid), `mosaic-pkg-card`
+(minimal card), `mosaic-pkg-dialog` (modal helper). The toolkit
+re-exports a richer Card on top of those primitives where it makes
+sense.
+
+---
+
+## 1. Vision
+
+Twitter Bootstrap proved a thesis: ship a small, opinionated set of
+ready-made UI components and the average web app's UI cost drops by an
+order of magnitude. Authors stop writing buttons; they pick a button.
+
+Mosaic's UI29 kernel is the right *foundation* for that thesis — 16
+primitives that lower to native widgets on every backend — but the
+kernel deliberately stops at primitives. A `<HostButton>` says
+"button," not "primary danger button with a leading icon and a
+loading spinner."
+
+`mosaic-pkg-toolkit` is the **Mosaic answer to Bootstrap**: a
+single userland package composed *purely from UI29 kernel primitives*,
+publishing a catalog of ready-made components that any host —
+React/SwiftUI/Qt/HTML/WebComp/XAML — can drop in. One package, one
+import, every backend.
+
+The key architectural property: **the toolkit has no backend code**.
+Every component is `.mil` + `.mll` + `.msl` triples that compile
+through every existing Mosaic emitter unchanged. Adding a new backend
+to Mosaic automatically adds the toolkit to it. No per-backend forks.
+
+### What's "Bootstrap-shaped" mean
+
+Bootstrap's value isn't its visual style — that gets re-themed
+constantly. The value is the catalog + the API consistency:
+
+- A predictable set of components every web dev knows (Alert, Badge,
+  Button, Card, Modal, Nav, Pagination, Spinner, …).
+- A predictable variant system (`-primary`, `-secondary`, `-success`,
+  `-danger`, `-warning`, `-info`, `-light`, `-dark`).
+- Predictable spacing/sizing utilities.
+- A grid system for layout (Container/Row/Col — though this
+  collides with kernel `Row`; see §6.1).
+- Form controls with consistent labelling/validation patterns.
+- Default styling that gets out of the way.
+
+The toolkit copies the *catalog* and the *API consistency*; the
+default styling is a Mosaic-native look that re-themes via
+`.msl` overrides (§7).
+
+---
+
+## 2. Naming + package layout
+
+### 2.1 Package name
+
+Open question — see §10. Working name: **`mosaic-pkg-toolkit`**.
+
+Alternatives considered:
+- `mosaic-pkg-bootstrap` — trademark + brand confusion.
+- `mosaic-pkg-ui` — too generic.
+- `mosaic-pkg-mortar` — cute (mortar holds mosaic tiles), but
+  unsearchable.
+- `mosaic-pkg-kit` — generic but short.
+- `mosaic-pkg-widgets` — accurate, dated feel.
+
+Going with `mosaic-pkg-toolkit` until a better name surfaces.
+
+### 2.2 Layout
+
+Standard userland package shape per UI29 §4.1:
+
+```
+code/packages/mosaic-pkg-toolkit/
+├── mosaic-package.toml             # manifest — lists every export
+├── Cargo.toml                      # smoke-test harness only
+├── README.md
+├── CHANGELOG.md
+├── src/
+│   ├── lib.rs                      # empty (doc only)
+│   ├── Alert.mil / .mll / .light.msl / .dark.msl
+│   ├── Badge.mil / .mll / .light.msl / .dark.msl
+│   ├── Button.mil / .mll / .light.msl / .dark.msl
+│   ├── Card.mil / .mll / .light.msl / .dark.msl
+│   ├── Checkbox.mil / .mll / .light.msl / .dark.msl
+│   ├── Container.mil / .mll / .light.msl / .dark.msl
+│   ├── Field.mil / .mll / .light.msl / .dark.msl
+│   ├── Input.mil / .mll / .light.msl / .dark.msl
+│   ├── ListGroup.mil / .mll / .light.msl / .dark.msl
+│   ├── Modal.mil / .mll / .light.msl / .dark.msl
+│   ├── Nav.mil / .mll / .light.msl / .dark.msl
+│   ├── Pagination.mil / .mll / .light.msl / .dark.msl
+│   ├── Radio.mil / .mll / .light.msl / .dark.msl
+│   ├── Select.mil / .mll / .light.msl / .dark.msl
+│   ├── Spinner.mil / .mll / .light.msl / .dark.msl
+│   ├── Toast.mil / .mll / .light.msl / .dark.msl
+│   └── ...
+└── tests/
+    └── package_compiles.rs          # asserts every triple round-trips
+```
+
+One package, many components. Authors `import` one thing.
+
+### 2.3 Why one package, not many small ones
+
+Bootstrap is one library, not seventeen. The cost of one big package
+is paid once at install time; the cost of seventeen tiny packages is
+paid every time you need a new component.
+
+When (not if) the toolkit grows large enough that tree-shaking
+matters, a follow-up spec can split it — but that's a real cost only
+the JS backends pay, and only when the bundle is shipped to a browser.
+For SwiftUI/Qt/XAML, "tree-shaking" is just "don't reference the
+component" — the compiler drops it.
+
+---
+
+## 3. Component inventory — v0.1 catalog
+
+Three tiers, by implementation complexity. **v0.1 ships tier 1 only.**
+Tier 2 + 3 are follow-up specs.
+
+### 3.1 Tier 1 — kernel-only, no novel mechanisms
+
+These compose from existing kernel primitives only (`Box`, `Row`,
+`Column`, `Stack`, `Text`, `Icon`, `HostButton`, `HostInput`,
+`HostDialog`, `If`, `For`). Each is a single `.mil`/`.mll`/`.msl`
+triple.
+
+| Component   | What it is                       | Kernel composition |
+|-------------|----------------------------------|--------------------|
+| `Alert`     | colored info banner              | `Box[alert] { Row { Icon, Text } }` |
+| `Badge`     | small pill label                 | `Box[badge] { Text }` |
+| `Button`    | styled button + variants         | `HostButton (variant: prop)` |
+| `Card`      | content container, header/body/footer | `Box[card] { Column { Box[header], Box[body], Box[footer] } }` |
+| `Checkbox`  | binary input + label             | `Row { HostButton[checkbox] (toggle), Text[label] }` (treated as toggle) |
+| `Container` | width-constrained layout box     | `Box[container] { children }` |
+| `Field`     | label + control + help text + error | `Column { Text[label], <slot>, Text[help], If error Text[error] }` |
+| `Input`     | text input + label/help wrapper  | uses `Field` + `HostInput` |
+| `ListGroup` | vertical list of selectable rows | `Column { For (each: items, as: item) { Box[item] { Text } } }` |
+| `Modal`     | titled modal dialog              | `HostDialog (title: slot:t, modal: true) { Column { children } }` |
+| `Radio`     | radio button + label             | similar to Checkbox |
+| `Spinner`   | indeterminate loading indicator  | `Stack { Icon[spinner-glyph] }` — animation is host's job |
+| `Toast`     | dismissible bottom-anchored note | `Stack { Box[toast] { Row { Icon, Text, HostButton[close] } } }` |
+
+13 components for v0.1.
+
+### 3.2 Tier 2 — adds composition complexity
+
+These compose multiple Tier-1 components. Shipped after v0.1 proves
+the model.
+
+| Component      | Composition |
+|----------------|-------------|
+| `Nav`          | `Row { For (links) { HostButton[nav-link] } }` |
+| `Navbar`       | `Box[navbar] { Row { Container { ... } } }` |
+| `Pagination`   | `Row { HostButton[prev], For (pages) { HostButton[page] }, HostButton[next] }` |
+| `Breadcrumb`   | `Row { For (crumbs) { HostButton[crumb], Text[separator] } }` |
+| `InputGroup`   | `Row { Text[addon], HostInput, Text[addon] }` |
+| `ButtonGroup`  | `Row { For (buttons) { HostButton } }` |
+| `Tabs`         | `Column { Row[tab-bar] { For (tabs) { HostButton[tab] } }, Box[tab-panel] { ... } }` |
+| `DropdownMenu` | `Stack { HostButton[trigger], If open { Box[menu] { For (items) { HostButton } } } }` |
+| `Accordion`    | `Column { For (sections) { Box[section] { HostButton[header], If open { Box[body] } } } }` |
+| `Select`       | uses `DropdownMenu` |
+
+### 3.3 Tier 3 — needs new infrastructure
+
+Each item flags a kernel feature not yet present.
+
+| Component   | Blocker |
+|-------------|---------|
+| `Tooltip`   | needs hover state + portal positioning (UI29 doesn't have either) |
+| `Popover`   | same as Tooltip |
+| `Modal` with focus trap | needs first-class focus mgmt across backends |
+| `Offcanvas` | needs slide-in animation primitive |
+| `Carousel`  | needs animated transitions |
+| `ProgressBar` (determinate) | tier 1 if just a styled Box; tier 3 if smooth animation |
+
+Tier 3 unblocks as the kernel grows.
+
+---
+
+## 4. The variant system
+
+Bootstrap's variants (`-primary`, `-secondary`, `-success`,
+`-danger`, `-warning`, `-info`, `-light`, `-dark`) are the central
+API consistency Mosaic has to copy.
+
+### 4.1 Variant as a keyword slot
+
+Every toolkit component that has variants declares:
+
+```moslayout
+component Alert {
+  slot variant : text ;  // one of: primary, secondary, success, danger, warning, info, light, dark
+  slot message : text ;
+}
+```
+
+The `.mll` is variant-agnostic — it just attaches `part_name: "alert"`
+to the outer Box. The `.msl` defines the variant-specific colors:
+
+```mosstyle
+part alert {
+  padding : 12 ;
+  border-radius : 4 ;
+}
+part alert/primary {  // sub-part for the variant
+  background : "#cfe2ff" ;
+  color : "#084298" ;
+}
+part alert/danger {
+  background : "#f8d7da" ;
+  color : "#842029" ;
+}
+// ... etc.
+```
+
+The XAML / React / SwiftUI / Qt emitters lower the sub-part
+references to whatever styling mechanism they support (CSS class,
+SwiftUI modifier, QML state).
+
+**Open question** (§10): the `part/variant` sub-part syntax. Existing
+mosstyle has `part X { state Y { ... } }` for hover/focus states.
+Variants are conceptually similar — a sub-key into the same part.
+Either reuse `state` semantically, add a new `variant` block, or
+treat variants as straight conditional styling via `If` blocks in the
+.mll. Pick when implementing the first variant'd component.
+
+### 4.2 Sizes
+
+Bootstrap has `-sm`, `-md`, `-lg`. Same mechanism — a `size` slot.
+
+### 4.3 Why slot-driven, not class-driven
+
+Bootstrap's `class="btn btn-primary btn-lg"` works because HTML is
+the host language. Mosaic targets multiple host languages; an
+HTML-class-based variant system would force every backend to
+implement CSS-class semantics. Slot-driven is the kernel-native form
+and lets every backend lower it idiomatically.
+
+---
+
+## 5. Theming
+
+### 5.1 Light / dark / custom
+
+Each component ships at least `<Component>.light.msl` and
+`<Component>.dark.msl`. The host project picks one at compile time
+(currently the file extension is the selection mechanism).
+
+Hosts that want to brand-override use the UI29 §8 open-question 6
+proposal: ship their own `.msl` ResourceDictionary (XAML) /
+modifier-table (SwiftUI/Qt) / class-overrides (React) that loads
+*after* the package's defaults. Host's setters win on collision.
+
+### 5.2 Default visual style
+
+The toolkit's default theme is a **Mosaic-native, modern-flat**
+aesthetic — neutral colors, generous spacing, rounded corners,
+no shadows by default. Deliberately distinct from Bootstrap's
+factory aesthetic so designers immediately recognise "Mosaic" not
+"Bootstrap." The semantics are Bootstrap; the look isn't.
+
+Mockups belong in a follow-up spec (`mosaic-pkg-toolkit-design.md`).
+
+### 5.3 Tokens
+
+A small `<Component>.tokens.msl` per component declares named
+color/spacing tokens; the variant `.msl` files reference them. This
+makes the entire theme re-theme-able from a single tokens file the
+host can override.
+
+---
+
+## 6. Cross-cutting design questions
+
+### 6.1 The `Row` / `Container` / `Col` naming collision
+
+Bootstrap's grid system is `Container > Row > Col`. Kernel `Row` is
+already a flex-row primitive. Mosaic's `Container` toolkit component
+will resolve to something like:
+
+```moslayout
+component Container {
+  slot children : node ;
+}
+layout Container {
+  Box [container] {
+    children
+  }
+}
+```
+
+…and the toolkit doesn't redefine `Row` — it just *uses* the kernel
+`Row` directly. Authors write:
+
+```moslayout
+Container {
+  Row {
+    Col [span-6] { ... }
+    Col [span-6] { ... }
+  }
+}
+```
+
+`Col` becomes a toolkit component because it has the span/offset
+props the kernel doesn't.
+
+### 6.2 Responsive breakpoints
+
+**The big one.** Bootstrap's grid is fundamentally responsive:
+`col-md-6 col-lg-4` means "6 cols on medium screens, 4 on large."
+Mosaic's kernel has no notion of viewport / breakpoint.
+
+Three options:
+
+| Option | Description | Verdict |
+|---|---|---|
+| **A** | Defer responsive — Col takes a single numeric `span` prop; host picks the value at render time | Recommended for v0.1 |
+| **B** | Add breakpoints to mosstyle | A bigger spec (mosstyle §X) |
+| **C** | Slot-driven breakpoint props (`span-md: number`) where host watches viewport and updates the slot | Workable interim; awkward for the host |
+
+**v0.1 ships Option A.** Open follow-up: extend mosstyle with
+breakpoint-aware `@media`-like syntax (Option B). Until then, hosts
+calculate the responsive `span` themselves.
+
+### 6.3 Icon system
+
+Bootstrap ships Bootstrap Icons as a separate library. The kernel
+has `Icon` but it just renders a glyph from whatever font the
+backend's default icon stack uses. The toolkit doesn't ship its own
+icon set in v0.1; each component's `Icon` slot takes a glyph name
+the host's icon stack understands.
+
+A future `mosaic-pkg-toolkit-icons` could ship a curated 200-icon
+set as SVG bundles that each backend lowers natively.
+
+### 6.4 Validation states
+
+Bootstrap inputs have `is-valid` / `is-invalid` classes. The toolkit
+`Field` component declares a `state` slot (`valid` / `invalid` /
+`neutral`) that maps to part-state styling.
+
+### 6.5 Accessibility
+
+Every toolkit component is built on kernel `Host*` primitives where
+possible (Modal → HostDialog, Input → HostInput, Button →
+HostButton). The kernel's a11y story is what each backend's native
+widget provides; the toolkit doesn't add anything beyond ARIA
+labels exposed as slots on each component (`aria-label: text`).
+
+---
+
+## 7. Implementation phasing
+
+### 7.1 v0.1 — Tier-1 catalog (this spec)
+
+13 components from §3.1. Single package. Light + dark themes. Smoke
+test that every triple compiles through every backend's `from_pipeline`
+without error (modelled on `mosaic-pkg-grid/tests/package_compiles.rs`).
+
+### 7.2 v0.2 — Tier 2
+
+10 more components from §3.2. Adds the component-references-component
+pattern (e.g. `Pagination` references `Button`). This will exercise
+PR-5's `ComponentRegistry` resolver on every backend.
+
+### 7.3 v0.3 — Bootstrap-aesthetic theme
+
+A `mosaic-pkg-toolkit/themes/bootstrap.msl` overlay that ships the
+classic Bootstrap visual style. Hosts that want "looks like
+Bootstrap" load this overlay; everyone else gets the default
+Mosaic-native theme.
+
+### 7.4 v0.4 — Tier 3
+
+Tooltips, popovers, focus trap. Each will likely require a kernel
+follow-up first (UI29-2 spec for hover/positioning primitives, etc.).
+
+### 7.5 v0.5 — Responsive grid
+
+Either Option B (mosstyle breakpoints) or a richer slot-driven
+breakpoint model. Decided after the kernel-level work for B is scoped.
+
+---
+
+## 8. Per-backend rendering matrix
+
+Spot-check that v0.1 components round-trip through each existing
+emitter. Cells are illustrative — they're what the emitter produces,
+not what the toolkit author writes.
+
+| Component | React (JSX)                          | SwiftUI                | Qt/QML            | XAML                | Web Component       | HTML                |
+|-----------|--------------------------------------|------------------------|-------------------|---------------------|---------------------|---------------------|
+| `Alert`   | `<div class="alert"><div class="row"><i/><span/></div></div>` | `Group { HStack { Image, Text } }` | `Item { RowLayout { Image, Text } }` | `<Border><StackPanel Orientation="Horizontal"><FontIcon/><TextBlock/></StackPanel></Border>` | `<div>...</div>` shadow DOM | `<div>...</div>` static |
+| `Button`  | `<button ...>` | `Button { ... }` | `Button { ... }` | `<Button .../>` | `<button>` | `<button>` |
+| `Modal`   | `<dialog>` | `.sheet` | `Popup` | `<ContentDialog>` | `<dialog>` | `<dialog>` |
+| `Card`    | nested `<div>`s | `VStack` of `Group` | `ColumnLayout` of `Item` | nested `<Border>`s | nested `<div>`s shadow | nested `<div>`s |
+
+All backends already implement every primitive used — the toolkit
+adds no new primitive dependency.
+
+---
+
+## 9. Public consumer experience
+
+A host project consuming the toolkit looks like:
+
+```toml
+# mosaic-package.toml (the host's package)
+[dependencies]
+mosaic-pkg-toolkit = "0.1"
+```
+
+And in their `.mll`:
+
+```moslayout
+component LoginScreen {
+  slot username : text ;
+  slot password : text ;
+  slot is-submitting : bool ;
+  slot error : text ;
+
+  emit onLogin (u: text, p: text) ;
+}
+
+layout LoginScreen {
+  Container {
+    Card {
+      Text [title] (content: "Sign in")
+
+      Field (label: "Username") {
+        Input (value: slot: username)
+      }
+      Field (label: "Password", help: "8 characters minimum") {
+        Input (value: slot: password, type: "password")
+      }
+
+      If (when: slot: error) {
+        Alert (variant: "danger", message: slot: error)
+      }
+
+      Button (
+        variant: "primary",
+        label: "Sign in",
+        disabled: slot: is-submitting,
+        onClick: emit: onLogin
+      )
+
+      If (when: slot: is-submitting) {
+        Spinner ()
+      }
+    }
+  }
+}
+```
+
+That's the entire LoginScreen. No CSS files, no `.tsx` per
+component, no SwiftUI views to hand-write. The toolkit composes from
+the kernel and lowers through every backend.
+
+---
+
+## 10. Open questions
+
+1. **Package name** — `mosaic-pkg-toolkit`, `-kit`, `-ui`, or
+   something else? Picked at v0.1 commit time.
+2. **Variant syntax in mosstyle** — `part/variant` sub-part, a new
+   `variant` block, or `If`-driven? Picked when the first
+   variant'd component lands.
+3. **Responsive grid** — slot-driven (Option A), mosstyle
+   breakpoints (Option B), or both? v0.1 ships A; B is a kernel-spec
+   follow-up.
+4. **Default theme aesthetic** — does the package ship the
+   Bootstrap-classic look or a fresh Mosaic look as the default? The
+   spec recommends fresh-Mosaic default + bootstrap-classic as an
+   overlay. Lock that decision at design-mockup time.
+5. **Icon system** — curated set in `mosaic-pkg-toolkit-icons`, or
+   defer entirely? Recommend defer for v0.1.
+6. **Component-references-component** — at what point does a
+   toolkit component reference another? `Pagination → Button` is the
+   first natural one. Defer to Tier 2 / v0.2.
+7. **Test strategy** — `package_compiles.rs` (frontend round-trip)
+   for v0.1; visual regression tests (per-backend rendering
+   screenshots) for v0.3+ when there's something visual to compare.
+
+---
+
+## 11. Out of scope for v0.1
+
+- **Hover / focus / positioning** primitives (Tooltip, Popover).
+- **Animation** primitives (Carousel, Offcanvas slide-in,
+  Accordion slide-down).
+- **Responsive breakpoints** beyond slot-driven.
+- **Form validation framework** — `Field` ships with a slot for
+  error text; how the host computes "valid" is its problem.
+- **Internationalisation** — strings are passed as slots; no
+  i18n framework in the toolkit.
+- **Icon library** — see §10.5.
+- **A bespoke design language** — the default look is utilitarian.
+  Brand-specific overlays live in host projects, not the toolkit.
+
+---
+
+## 12. Why this fits Mosaic's strategic story
+
+Three reasons:
+
+1. **It proves UI29's thesis.** A 13-component library written
+   purely against the kernel, lowering to every backend with no
+   per-backend code, is exactly the validation UI29 §1 promised.
+   The current `mosaic-pkg-grid` and `mosaic-pkg-dialog` packages
+   each prove one component; the toolkit proves the *catalog*.
+
+2. **It removes the "ok but what do you build with this?" wall.**
+   Today a Mosaic adopter sees the kernel primitives and has to
+   compose every component themselves. With the toolkit, the next
+   adopter writes their LoginScreen in 25 lines of `.mll` (§9) and
+   that compiles to React + SwiftUI + Qt + XAML + HTML +
+   WebComponent simultaneously.
+
+3. **It clarifies the kernel's frozen contract.** The toolkit can
+   only do what the kernel supports. The Tier-3 list (§3.3) is
+   exactly the set of kernel features still needed for a
+   "complete" Bootstrap-level catalog. That's a roadmap, not a
+   wishlist.


### PR DESCRIPTION
## Summary

First implementation PR for \`mosaic-pkg-toolkit\` — the scaffold + the first two Tier-1 components (Button, Alert) from the spec's §3.1 catalog.

**Stacks on the spec PR #3932** — review the spec first; this implementation reflects it. The base branch is \`claude/mosaic-toolkit-spec\`, so once #3932 merges, GitHub will auto-rebase this onto main.

## Package scaffold

- \`mosaic-package.toml\` — kernel-only, v1-targeting, zero dependencies
- \`Cargo.toml\` — smoke-test harness, opted out of workspace per the userland-package convention modelled on \`mosaic-pkg-card\`
- \`src/lib.rs\` — doc-only
- \`README.md\` + \`CHANGELOG.md\`

## Components

**Button** — wraps the kernel \`HostButton\` with the Bootstrap-shaped variant + size system.
- Slots: \`label\`, \`variant\`, \`size\`, \`disabled\`
- Emits: \`onClick\`
- Composition: single \`HostButton [button]\`
- Themes: \`Button.light.msl\` + \`Button.dark.msl\`

**Alert** — colored info banner. Composition + dismiss-button via \`If\`.
- Slots: \`message\`, \`variant\`, \`dismissible\`
- Emits: \`onClose\`
- Composition: \`Box [alert] { Row { Text, If dismissible HostButton } }\`
- Themes: \`Alert.light.msl\` + \`Alert.dark.msl\`

## Variant styling — intentionally deferred

Both .mil files accept a \`variant\` slot but the current .msl files only define the base part style (no variant-specific sub-parts). Variant sub-part syntax is **spec §10 open question #2** — it gets designed when the first PR to land variant'd styling makes the call. The slot is on the API today so the surface is stable before the styling story is finalized.

## Smoke test

\`tests/package_compiles.rs\` covers:
- Manifest consistency (name, version, exports, zero deps, kernel v1)
- Every component's \`.mil\`/\`.mll\`/\`.light.msl\`/\`.dark.msl\` round-trip through the three IR compilers
- Per-component interface surface (slots + emits match spec)

**4 tests pass.**

## End-to-end through XAML

Compiled both components via \`mosaic-compile --backend xaml\` to verify the toolkit composition lowers correctly. Alert's \`If dismissible\` block auto-emits the \`BoolToVisibilityConverter.cs\` sidecar (Fix A5 from \`demo/hello-dialog-xaml/ISSUES.md\`), proving the entire A1-A5/B1-B3 fixed XAML pipeline runs cleanly against userland toolkit components.

**Alert.xaml excerpt** (proves the kernel composition produces correct XAML):

\`\`\`xml
<UserControl ...>
    <UserControl.Resources>
        <local:BoolToVisibilityConverter x:Key=\"BoolToVisibilityConverter\"/>
    </UserControl.Resources>
    <Border Padding=\"12\" BorderRadius=\"4\" Background=\"#cff4fc\" ...>
        <StackPanel Orientation=\"Horizontal\" Padding=\"0\">
            <TextBlock Text=\"{x:Bind Message}\"/>
            <ContentControl Visibility=\"{x:Bind Dismissible, Converter=...}\">
                <Button x:Name=\"CloseBtn\" Content=\"x\" Click=\"CloseBtn_Click\".../>
            </ContentControl>
        </StackPanel>
    </Border>
</UserControl>
\`\`\`

## What's next

After this PR lands, the remaining v0.1 Tier-1 components (Badge, Card, Checkbox, Container, Field, Input, ListGroup, Modal, Radio, Spinner, Toast — 11 more) land in follow-up PRs. Each is a separate small PR, batched 2-3 at a time depending on dependency graph (Field references Input, etc.).

## Test plan

- [x] 4 smoke tests pass (\`cargo test\` in the package dir)
- [x] Both components compile cleanly through the XAML backend
- [x] Alert exercises the auto-emitted BoolToVisibilityConverter (Fix A5)
- [ ] CI green
- [ ] #3932 (spec) lands first

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)