### PR TITLE
feat(iir-to-cil-bytecode): BF tape + I/O via env.BFRuntime (Stages 3+4 — closes BF→backend story)

### DIFF
--- a/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/brainfuck-iir-compiler/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog — brainfuck-iir-compiler
 
+## [0.3.3] — 2026-05-22 (BF → CLR end-to-end + BEAM rejection doc)
+
+### Added — `tests/clr_e2e.rs`
+
+Stage 3 of 4 for the BF→{wasm,jvm,clr,beam} story.  Walks the new
+IIR-based chain through the CLR backend:
+
+```text
+BF source → IIRModule → iir-to-cil-bytecode validator → lower_iir_to_cil
+          → CILProgramArtifact (with reserved env.BFRuntime tokens)
+```
+
+Before iir-to-cil-bytecode 0.5.0, the validator rejected `load_mem` /
+`store_mem` and any `call_builtin`.  With 0.5.0 those are accepted,
+and this e2e test locks the path in for Brainfuck with byte-exact
+sequence assertions:
+
+- `brainfuck_three_increments_lowers_to_cil` — `+++.` lowers; the
+  main method's CIL body contains `[0x28, 0x03, 0x00, 0x00, 0x0A]`
+  (call BF_PUTCHAR_TOKEN at MemberRef row 3).
+- `brainfuck_loop_lowers_to_cil` — `++[-]` lowers; the body contains
+  `[0x7E, 0x01, 0x00, 0x00, 0x04]` (ldsfld BF_TAPE_TOKEN, FieldRef row 1).
+- `brainfuck_input_emits_getchar_call` — `,.` emits both
+  `call BF_GETCHAR_TOKEN` and `call BF_PUTCHAR_TOKEN`.
+- `brainfuck_empty_program_emits_minimal_cil` — the empty BF program
+  contains **none** of the BF runtime token sequences.
+
+### Added — README "Cross-backend compilation status" section
+
+Documents that BF flows through wasm/jvm/clr but **not** BEAM, with
+a full rationale:
+
+> BEAM's substrate is purely functional.  Brainfuck's tape is mutable
+> bytes in random-access addressing.  Compiled to vanilla BEAM
+> bytecode, every `store_mem` would copy the whole 30 KB tape — O(N²·M)
+> on a `,[.,]` cat over a non-trivial input.  Alternatives (ETS,
+> process dictionary, NIF) exist but each one abandons the "compile to
+> vanilla bytecode" promise.  Documented rejection is the right call.
+
+(Closes Stage 4 of the BF→{wasm,jvm,clr,beam} story.)
+
 ## [0.3.2] — 2026-05-22 (BF → JVM end-to-end test)
 
 ### Added — `tests/jvm_e2e.rs`
@@ -31,9 +72,6 @@ the path in for Brainfuck:
 
 No source-code changes in this crate — the test runs against the
 existing `compile_source`.  Only the JVM e2e test file is new.
-
-Stages 3 (CLR) and the BEAM-rejection doc are queued as follow-on
-work items.
 
 ## [0.3.1] — 2026-05-22 (BF → WASM end-to-end test)
 

--- a/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
+++ b/code/packages/rust/brainfuck-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brainfuck-iir-compiler"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "BF04/BF05 — Brainfuck → InterpreterIR compiler, vm-core wrapper, jit-core JIT chain, and real CIR-bytecode JIT backend"
 license = "MIT"
@@ -16,5 +16,6 @@ lexer          = { path = "../lexer" }
 [dev-dependencies]
 iir-to-wasm           = { path = "../iir-to-wasm" }
 iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
+iir-to-cil-bytecode   = { path = "../iir-to-cil-bytecode" }
 wasm-module-encoder   = { path = "../wasm-module-encoder" }
 wasm-types            = { path = "../wasm-types" }

--- a/code/packages/rust/brainfuck-iir-compiler/README.md
+++ b/code/packages/rust/brainfuck-iir-compiler/README.md
@@ -133,6 +133,49 @@ assert!(bytecode_len.unwrap() >= 15);   // ~30-40 bytes for `+++.`
 (pure interpreter), once with `jit=true` (CIR-bytecode JIT) — and
 asserts byte-identical output.  If they ever diverge, the JIT is wrong.
 
+## Cross-backend compilation status
+
+Brainfuck flows through every universal IIR-to-* backend except BEAM:
+
+| Target  | Status | Lowering                                                                  | Test |
+|---------|--------|---------------------------------------------------------------------------|------|
+| WASM    | ✅     | `i32.load8_u` / `i32.store8` + `env.putchar` / `env.getchar` host imports | `tests/wasm_e2e.rs` |
+| JVM     | ✅     | `baload` / `bastore` + `invokestatic env/BFRuntime.{put,get}char`         | `tests/jvm_e2e.rs`  |
+| CLR     | ✅     | `ldelem.u1` / `stelem.i1` + `call env.BFRuntime::{put,get}char`           | `tests/clr_e2e.rs`  |
+| BEAM    | ❌     | *intentionally not supported — see below*                                 | —    |
+
+### Why no BEAM target?
+
+BEAM's substrate is **purely functional**.  Tuples, binaries, and process
+dictionary entries are all immutable — every write produces a fresh copy
+of the surrounding container.  Brainfuck's tape is the opposite shape:
+mutable byte cells in random-access addressing, with one write per cell
+per iteration of the program's main loop.
+
+Compiled to vanilla BEAM bytecode, every `store_mem` would have to
+allocate a fresh copy of the entire 30,000-byte tape with the one byte
+changed.  That's O(N) per cell write × N cells × M loop iterations =
+O(N²·M).  A `,[.,]` `cat` over a 30 KB input would copy a 30 KB tape on
+every loop iteration — wall-clock seconds for a program that runs in
+microseconds on every other target.
+
+Alternative shapes do exist:
+
+- **ETS** (Erlang Term Storage): mutable side-store, but every read/write
+  is a function call with microsecond latency.  Defeats the point of a
+  compiled target.
+- **Process dictionary**: same shape; same problem.
+- **NIF** (Native Implemented Function): write the tape ops in C, link
+  the `.so` at load time.  This is C code wearing a BEAM costume —
+  you're not "compiling BF to BEAM bytecode" anymore.
+
+Each of those would technically work, but none honor the LANG VM
+promise of "any frontend compiles to vanilla code on any backend."
+Brainfuck's mutable byte cells are anti-BEAM, and the right call is a
+**documented rejection** — readers reach this section instead of
+silence, and future work that wants to revisit this has a clear starting
+point.
+
 ## Running tests
 
 ```bash

--- a/code/packages/rust/brainfuck-iir-compiler/tests/clr_e2e.rs
+++ b/code/packages/rust/brainfuck-iir-compiler/tests/clr_e2e.rs
@@ -1,0 +1,151 @@
+//! Brainfuck → CLR (CIL) end-to-end test.
+//!
+//! Walks the new IIR-based chain through the CLR backend:
+//!
+//! ```text
+//! BF source
+//!   │ brainfuck-iir-compiler::compile_source
+//! IIRModule (FullyTyped)
+//!   │ iir_to_cil_bytecode::validate_iir_for_clr   ← must report no errors
+//!   │ iir_to_cil_bytecode::lower_iir_to_cil
+//! CILProgramArtifact
+//! ```
+//!
+//! Before this PR (Stage 3 of BF→{wasm,jvm,clr,beam}), the CLR validator
+//! rejected `load_mem` / `store_mem` and any `call_builtin`.  After this
+//! PR, the validator accepts them (memory ops + the
+//! `CALL_BUILTIN_SUPPORTED_NAMES` whitelist of `putchar` / `getchar`)
+//! and the lowering emits real CIL bytecode (`ldsfld
+//! env.BFRuntime::__tape; ldelem.u1` for load_mem, `stelem.i1` for
+//! store_mem, `call <token>` to `env.BFRuntime::putchar/getchar`).
+//!
+//! Tokens used: `BF_TAPE_TOKEN = 0x04000001` (FieldRef row 1),
+//! `BF_PUTCHAR_TOKEN = 0x0A000003`, `BF_GETCHAR_TOKEN = 0x0A000004`
+//! (MemberRef rows 3 and 4 — after Console.WriteLine which is row 2).
+
+use brainfuck_iir_compiler::compile_source;
+use iir_to_cil_bytecode::{validate_iir_for_clr, lower_iir_to_cil, IIRClrConfig};
+
+#[test]
+fn brainfuck_three_increments_lowers_to_cil() {
+    let module = compile_source("+++.", "clr_e2e")
+        .expect("BF source must compile to IIR");
+
+    let errs = validate_iir_for_clr(&module);
+    assert!(
+        errs.is_empty(),
+        "CLR validator should accept BF IIR after the BF→CLR PR; got: {errs:?}",
+    );
+
+    let cfg = IIRClrConfig::new("BrainfuckProgram");
+    let prog = lower_iir_to_cil(&module, &cfg)
+        .expect("IIR → CIL lowering must succeed");
+
+    // The lowered program must have at least the `main` method.
+    assert!(!prog.methods.is_empty(),
+        "expected at least the `main` method; got 0");
+    assert!(
+        prog.methods.iter().any(|m| m.name == "main"),
+        "expected `main` method; got: {:?}",
+        prog.methods.iter().map(|m| &m.name).collect::<Vec<_>>(),
+    );
+
+    // The CIL body of `main` must contain at least one byte sequence that
+    // looks like a `call <BF_PUTCHAR_TOKEN>`.  `call` is 0x28 followed by
+    // 4 little-endian bytes of the token (0x0A000003).  We look for the
+    // 5-byte signature `[0x28, 0x03, 0x00, 0x00, 0x0A]`.
+    let main_method = prog.methods.iter().find(|m| m.name == "main").unwrap();
+    let putchar_call_sig = [0x28u8, 0x03, 0x00, 0x00, 0x0A];
+    assert!(
+        main_method.body.windows(5).any(|w| w == putchar_call_sig),
+        "main body should contain a `call <BF_PUTCHAR_TOKEN>` sequence; body: {:02X?}",
+        main_method.body,
+    );
+}
+
+#[test]
+fn brainfuck_loop_lowers_to_cil() {
+    let module = compile_source("++[-]", "clr_loop")
+        .expect("BF loop must compile to IIR");
+    let errs = validate_iir_for_clr(&module);
+    assert!(errs.is_empty(),
+        "CLR validator rejected loop IIR: {errs:?}");
+
+    let prog = lower_iir_to_cil(&module, &IIRClrConfig::new("LoopProgram"))
+        .expect("lowering must succeed");
+    assert!(!prog.methods.is_empty());
+
+    // The body must contain `ldsfld <BF_TAPE_TOKEN>` (0x7E + 4 LE bytes
+    // of 0x04000001) for the load_mem / store_mem ops.
+    let main_method = prog.methods.iter().find(|m| m.name == "main").unwrap();
+    let ldsfld_tape_sig = [0x7Eu8, 0x01, 0x00, 0x00, 0x04];
+    assert!(
+        main_method.body.windows(5).any(|w| w == ldsfld_tape_sig),
+        "main body should contain a `ldsfld <BF_TAPE_TOKEN>` sequence; body: {:02X?}",
+        main_method.body,
+    );
+}
+
+#[test]
+fn brainfuck_input_emits_getchar_call() {
+    let module = compile_source(",.", "clr_input")
+        .expect("BF input/output program must compile to IIR");
+    let errs = validate_iir_for_clr(&module);
+    assert!(errs.is_empty(),
+        "CLR validator rejected `,.` IIR: {errs:?}");
+
+    let prog = lower_iir_to_cil(&module, &IIRClrConfig::new("InputProgram"))
+        .expect("lowering must succeed");
+
+    let main_method = prog.methods.iter().find(|m| m.name == "main").unwrap();
+
+    // Both `call <BF_GETCHAR_TOKEN>` and `call <BF_PUTCHAR_TOKEN>` must
+    // appear in the body.
+    let getchar_call = [0x28u8, 0x04, 0x00, 0x00, 0x0A];
+    let putchar_call = [0x28u8, 0x03, 0x00, 0x00, 0x0A];
+    assert!(
+        main_method.body.windows(5).any(|w| w == getchar_call),
+        "expected `call <BF_GETCHAR_TOKEN>` in body; body: {:02X?}",
+        main_method.body,
+    );
+    assert!(
+        main_method.body.windows(5).any(|w| w == putchar_call),
+        "expected `call <BF_PUTCHAR_TOKEN>` in body; body: {:02X?}",
+        main_method.body,
+    );
+}
+
+#[test]
+fn brainfuck_empty_program_emits_minimal_cil() {
+    let module = compile_source("", "clr_empty")
+        .expect("empty BF must compile to IIR");
+    let errs = validate_iir_for_clr(&module);
+    assert!(errs.is_empty(), "validator rejected empty BF: {errs:?}");
+
+    let prog = lower_iir_to_cil(&module, &IIRClrConfig::new("EmptyProgram"))
+        .expect("lowering must succeed");
+
+    // The empty BF program must NOT reference any BF runtime tokens —
+    // proving the CIL emission is "pay for what you use".  We assert that
+    // neither the tape fieldref nor the putchar/getchar memberrefs appear
+    // in the main body.
+    let main_method = prog.methods.iter().find(|m| m.name == "main").unwrap();
+    let ldsfld_tape = [0x7Eu8, 0x01, 0x00, 0x00, 0x04];
+    let putchar_call = [0x28u8, 0x03, 0x00, 0x00, 0x0A];
+    let getchar_call = [0x28u8, 0x04, 0x00, 0x00, 0x0A];
+    assert!(
+        !main_method.body.windows(5).any(|w| w == ldsfld_tape),
+        "empty BF should not reference BF_TAPE_TOKEN; body: {:02X?}",
+        main_method.body,
+    );
+    assert!(
+        !main_method.body.windows(5).any(|w| w == putchar_call),
+        "empty BF should not reference BF_PUTCHAR_TOKEN; body: {:02X?}",
+        main_method.body,
+    );
+    assert!(
+        !main_method.body.windows(5).any(|w| w == getchar_call),
+        "empty BF should not reference BF_GETCHAR_TOKEN; body: {:02X?}",
+        main_method.body,
+    );
+}

--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 All notable changes to this crate are documented here.
 
+## [0.5.0] — 2026-05-22 (Brainfuck — `byte[]` tape + I/O via env.BFRuntime)
+
+### Added — Brainfuck `load_mem` / `store_mem` / `call_builtin` lowering
+
+Stage 3 of 4 for the BF→{wasm,jvm,clr,beam} story.  Mirrors PR #3921
+(iir-to-wasm 0.4.0) and PR #3928 (iir-to-jvm-class-file 0.5.0) for the
+CLR target.  Lets BF's IIR — including `load_mem`, `store_mem`, and
+`call_builtin "putchar"`/`"getchar"` — flow through the same universal
+`iir-to-cil-bytecode` backend that Twig, BASIC, Oct, and Nib already
+use.
+
+#### Validator changes
+
+- `load_mem` and `store_mem` removed from `UNSUPPORTED_OPS` (previously
+  hard-rejected).  Both lower to CIL `ldelem.u1` / `stelem.i1` over a
+  host-provided byte array.
+- `call_builtin` is now **conditionally** accepted via a new
+  `CALL_BUILTIN_SUPPORTED_NAMES` whitelist (currently
+  `["putchar", "getchar"]`).  Unknown builtin names still produce a
+  clear `UnsupportedOp` error that includes the rejected name and the
+  whitelist.
+
+#### Lowering changes
+
+- Three new reserved metadata tokens referencing the simulated
+  `env.BFRuntime` host class:
+  - `BF_TAPE_TOKEN   = 0x0400_0001` — FieldRef row 1, the static `byte[] __tape`.
+  - `BF_PUTCHAR_TOKEN = 0x0A00_0003` — MemberRef row 3 (Console.WriteLine is row 2),
+    `void env.BFRuntime::putchar(int32)`.
+  - `BF_GETCHAR_TOKEN = 0x0A00_0004` — MemberRef row 4,
+    `int32 env.BFRuntime::getchar()`.
+- New `emit_instr` arms:
+  - `load_mem v ptr` → `ldsfld BF_TAPE_TOKEN; ldloc ptr; ldelem.u1;
+    stloc dest`.  `ldelem.u1` zero-extends the byte to int32 — matching
+    BF's u8 cell semantics without the sign-extension surgery the JVM
+    target requires after `baload`.
+  - `store_mem ptr v` → `ldsfld BF_TAPE_TOKEN; ldloc ptr; ldloc v;
+    stelem.i1`.  `stelem.i1` truncates the int32 to a byte, matching
+    BF's u8 wraparound.
+  - `call_builtin "putchar" v` → `ldloc v; call BF_PUTCHAR_TOKEN`.
+  - `call_builtin "getchar" -> v` → `call BF_GETCHAR_TOKEN; stloc v`.
+- Defense in depth: hand-crafted IIR that slips an unknown builtin
+  past the validator still hits a `UnsupportedOp` in `lower.rs`.
+
+#### Host class contract
+
+The CLR runtime / launcher (or PE packager) must provide `env.BFRuntime`:
+
+| Symbol                                       | Metadata token reserved | Notes                          |
+|----------------------------------------------|--------------------------|--------------------------------|
+| `public static byte[] __tape`                | FieldRef row 1           | typically 30 KB BF tape         |
+| `public static void putchar(int32)`          | MemberRef row 3          | write one byte to stdout        |
+| `public static int32 getchar()`              | MemberRef row 4          | read one byte; -1 / 0 on EOF     |
+
+This is the CLR analog of the WASM backend's `env` import namespace
+and the JVM backend's `env/BFRuntime` class — same model, different ABI.
+
+### Tests
+
+- 5 new validator unit tests (`load_mem_accepted_for_bf`,
+  `store_mem_accepted_for_bf`, `call_builtin_putchar_accepted`,
+  `call_builtin_getchar_accepted`,
+  `call_builtin_unknown_name_rejected`).
+- 33 lib + 83 integration tests pass.
+- 4 new BF→CLR e2e tests in
+  `brainfuck-iir-compiler/tests/clr_e2e.rs` assert exact byte
+  sequences for `call BF_PUTCHAR_TOKEN`, `ldsfld BF_TAPE_TOKEN`,
+  and `call BF_GETCHAR_TOKEN`.
+
+### Compatibility
+
+- Non-BF frontends (Twig, BASIC, Oct, Nib) unchanged.  Modules without
+  BF features get no `env.BFRuntime` token references, preserving CIL
+  byte-equivalence with pre-0.5.0 output.
+
 ## [0.4.1] — 2026-05-13
 
 ### Fixed (Multi-backend demo — fib(10)=55)

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact without compiler-ir"
+description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact (now with Brainfuck tape + I/O via env.BFRuntime)"
 
 [lib]
 name = "iir_to_cil_bytecode"

--- a/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
@@ -70,6 +70,32 @@ use ir_to_cil_bytecode::{OBJECT_ARRAY_TYPE_TOKEN, INT32_ARRAY_TYPE_TOKEN};
 /// which by convention we reserve for `Console.WriteLine(int64)`.
 const CONSOLE_WRITELINE_I64_TOKEN: u32 = 0x0A00_0002;
 
+// ─── Brainfuck host-class metadata tokens ─────────────────────────────────────
+//
+// These sentinel tokens reference symbols on the simulated `env.BFRuntime`
+// host class.  In a real CLR PE file these would be resolved metadata tokens
+// (`FieldRef` table 0x04 for the tape, `MemberRef` table 0x0A for methods);
+// for simulation, backends that parse the token bytes emit the appropriate
+// `ldsfld` / `call` sequences.
+//
+// The numbering is contiguous starting from row 1 in their respective tables
+// to keep the simulated metadata small and deterministic.  Console.WriteLine
+// already occupies MemberRef row 2 — putchar / getchar take rows 3 and 4.
+//
+// Host contract: the CLR runtime / launcher (or PE packager) must provide
+// `env.BFRuntime` with:
+//
+//   * `public static byte[] __tape`                  ← the BF tape buffer
+//   * `public static void putchar(int32)`            ← write one byte to stdout
+//   * `public static int32 getchar()`                ← read one byte; -1/0 on EOF
+//
+// Same shape as the WASM (`env.putchar` / `env.getchar` + linear memory) and
+// JVM (`env/BFRuntime.__tape`, `putchar(I)V`, `getchar()I`) backends — same
+// model, different ABI surface.
+const BF_TAPE_TOKEN: u32     = 0x0400_0001; // FieldRef row 1
+const BF_PUTCHAR_TOKEN: u32  = 0x0A00_0003; // MemberRef row 3 (after WriteLine @ row 2)
+const BF_GETCHAR_TOKEN: u32  = 0x0A00_0004; // MemberRef row 4
+
 use crate::validate::validate_iir_for_clr;
 
 // ===========================================================================
@@ -1576,6 +1602,141 @@ pub fn lower_iir_to_cil(
                         }
                     })?.clone();
                     emit_store(&mut builder, &dest_info, fn_name)?;
+                }
+
+                // ── load_mem (Brainfuck) → ldsfld __tape; ldelem.u1 ─────────
+                //
+                // `load_mem v ptr u8`  → push tape[ptr] (zero-extended u8 → int32)
+                // into local `v`.
+                //
+                // CIL sequence emitted:
+                //
+                //   ldsfld     uint8[] env.BFRuntime::__tape   ; push array ref
+                //   ldloc      <ptr_slot>                       ; push index
+                //   ldelem.u1                                   ; pop[arr,idx], push byte
+                //   stloc      <dest_slot>                       ; store into v
+                //
+                // `ldelem.u1` (0x91) zero-extends the byte to int32 — exactly
+                // matching Brainfuck's u8 cell semantics (no sign-extension
+                // surgery needed, unlike JVM's `baload` which we have to mask
+                // with `& 0xFF`).
+                "load_mem" => {
+                    let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                        IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "load_mem must have a dest".to_string(),
+                        }
+                    })?;
+                    let addr_name = match instr.srcs.first() {
+                        Some(Operand::Var(v)) => v.clone(),
+                        _ => return Err(IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "load_mem src[0] must be Operand::Var(addr)".to_string(),
+                        }),
+                    };
+                    let addr_info = reg_info!(addr_name).clone();
+                    let dest_info = reg_info!(dest_name).clone();
+                    // Push tape ref + index, do the load, store.
+                    builder.emit_ldsfld(BF_TAPE_TOKEN);
+                    emit_load(&mut builder, &addr_info, fn_name)?;
+                    builder.emit_opcode(CILOpcode::LdElemU1);
+                    emit_store(&mut builder, &dest_info, fn_name)?;
+                }
+
+                // ── store_mem (Brainfuck) → ldsfld __tape; stelem.i1 ────────
+                //
+                // `store_mem ptr v u8`  → tape[ptr] = (byte) v.
+                //
+                // CIL sequence emitted:
+                //
+                //   ldsfld     uint8[] env.BFRuntime::__tape   ; push array ref
+                //   ldloc      <ptr_slot>                       ; push index
+                //   ldloc      <val_slot>                       ; push value (int32)
+                //   stelem.i1                                   ; pop[arr,idx,val]
+                //
+                // `stelem.i1` (0x9C) truncates the int32 to a byte automatically —
+                // matching BF's u8 wraparound (no explicit mask needed).
+                "store_mem" => {
+                    if instr.srcs.len() < 2 {
+                        return Err(IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "store_mem requires 2 srcs: [addr, val]".to_string(),
+                        });
+                    }
+                    let addr_name = match &instr.srcs[0] {
+                        Operand::Var(v) => v.clone(),
+                        _ => return Err(IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "store_mem src[0] must be Operand::Var(addr)".to_string(),
+                        }),
+                    };
+                    let val_name = match &instr.srcs[1] {
+                        Operand::Var(v) => v.clone(),
+                        _ => return Err(IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "store_mem src[1] must be Operand::Var(val)".to_string(),
+                        }),
+                    };
+                    let addr_info = reg_info!(addr_name).clone();
+                    let val_info  = reg_info!(val_name).clone();
+                    builder.emit_ldsfld(BF_TAPE_TOKEN);
+                    emit_load(&mut builder, &addr_info, fn_name)?;
+                    emit_load(&mut builder, &val_info, fn_name)?;
+                    builder.emit_opcode(CILOpcode::StElemI1);
+                }
+
+                // ── call_builtin (Brainfuck putchar / getchar) ──────────────
+                //
+                // The validator (validate.rs) enforces that `srcs[0]` is in
+                // [`CALL_BUILTIN_SUPPORTED_NAMES`], so the inner match here
+                // only handles whitelisted names.  Falling off the match
+                // indicates a validator/lowerer drift and returns
+                // `UnsupportedOp` as a safety net.
+                //
+                // | Builtin   | Operand layout                        | CIL emitted                                                  |
+                // |-----------|----------------------------------------|---------------------------------------------------------------|
+                // | `putchar` | srcs = [Var("putchar"), Var(val)]; no dest | `ldloc val; call <BF_PUTCHAR_TOKEN>`                          |
+                // | `getchar` | srcs = [Var("getchar")]; dest = byte slot  | `call <BF_GETCHAR_TOKEN>; stloc dest`                         |
+                "call_builtin" => {
+                    let builtin_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => return Err(IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "call_builtin: srcs[0] must be the builtin name as Operand::Var".to_string(),
+                        }),
+                    };
+                    match builtin_name.as_str() {
+                        "putchar" => {
+                            let val_name = match instr.srcs.get(1) {
+                                Some(Operand::Var(v)) => v.clone(),
+                                _ => return Err(IIRClrError::InvalidOperand {
+                                    function: fn_name.clone(),
+                                    detail: "call_builtin \"putchar\" requires srcs[1] = Operand::Var(val)".to_string(),
+                                }),
+                            };
+                            let val_info = reg_info!(val_name).clone();
+                            emit_load(&mut builder, &val_info, fn_name)?;
+                            builder.emit_call(BF_PUTCHAR_TOKEN);
+                        }
+                        "getchar" => {
+                            let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                                IIRClrError::InvalidOperand {
+                                    function: fn_name.clone(),
+                                    detail: "call_builtin \"getchar\" requires a dest register".to_string(),
+                                }
+                            })?;
+                            let dest_info = reg_info!(dest_name).clone();
+                            builder.emit_call(BF_GETCHAR_TOKEN);
+                            emit_store(&mut builder, &dest_info, fn_name)?;
+                        }
+                        _ => {
+                            // Validator should have rejected this; defense in depth.
+                            return Err(IIRClrError::UnsupportedOp {
+                                function: fn_name.clone(),
+                                op: format!("call_builtin {:?}: not in CLR backend whitelist", builtin_name),
+                            });
+                        }
+                    }
                 }
 
                 // ── io_out → Console.WriteLine(int64) ───────────────────────

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -85,14 +85,17 @@ use interpreter_ir::{IIRModule, Operand};
 //   Exception: i64/u64/f32/f64 captures produce a ClosureOpcode error.
 
 const UNSUPPORTED_OPS: &[&str] = &[
-    "call_builtin",
+    // `call_builtin` is *conditionally* unsupported — handled below.
+    // See [`CALL_BUILTIN_SUPPORTED_NAMES`] for the whitelist.  Whitelisting
+    // specific builtins (today: `putchar`, `getchar`) lets Brainfuck flow
+    // through this backend while still rejecting unknown / unsafe names.
     "io_in",
     // "io_out"       — LANG32: now supported (Console.WriteLine).
     // "global_store" — returns UnsupportedOp from lower.rs, not rejected by validator.
     // "global_load"  — returns UnsupportedOp from lower.rs, not rejected by validator.
     "cast",
-    "load_mem",
-    "store_mem",
+    // "load_mem"   — Brainfuck: now supported (ldelem.u1 over env.BFRuntime::__tape).
+    // "store_mem"  — Brainfuck: now supported (stelem.i1 over env.BFRuntime::__tape).
     // "alloc"      — promoted in Phase 2 (ref<LispyPair> only)
     "box",
     "unbox",
@@ -101,6 +104,25 @@ const UNSUPPORTED_OPS: &[&str] = &[
     // "is_null"    — promoted in Phase 2
     "safepoint",
 ];
+
+/// Builtin names that the CLR backend can lower via `call` to a
+/// host-provided helper class.
+///
+/// Each entry maps to a `(class, name, signature)` triple resolved at
+/// lowering time via reserved metadata tokens (MemberRef table rows on
+/// the simulated `env.BFRuntime` class):
+///
+/// | Builtin     | CIL call                                            |
+/// |-------------|------------------------------------------------------|
+/// | `"putchar"` | `call void env.BFRuntime::putchar(int32)`            |
+/// | `"getchar"` | `call int32 env.BFRuntime::getchar()`                |
+///
+/// Adding a new builtin requires:
+///   1. Listing the name here so the validator accepts it.
+///   2. Reserving a new metadata-token constant in `lower.rs`.
+///   3. Adding a matching `case` to lower.rs's `call_builtin` arm
+///      that emits the right `call <token>` sequence.
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar"];
 
 // ---------------------------------------------------------------------------
 // Heap ops that need special validation (type-restricted)
@@ -387,12 +409,42 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
             // (they were removed in Phase 2); they are handled by the lowerer.
             // `alloc` is also removed — it is accepted for ref<LispyPair> and
             // the type-check above handles unsupported alloc types.
+            //
+            // `call_builtin` is conditionally accepted: the builtin name
+            // carried in `srcs[0]` as `Operand::Var` must be in
+            // [`CALL_BUILTIN_SUPPORTED_NAMES`].  This lets Brainfuck's
+            // `putchar` / `getchar` flow through while still rejecting
+            // unknown / unsafe builtins.
             if UNSUPPORTED_OPS.contains(&instr.op.as_str()) {
                 errors.push(format!(
                     "UnsupportedOp: function {:?}, op {:?} is not supported by \
                      the CLR backend; it requires a P/Invoke or .NET BCL call",
                     func.name, instr.op
                 ));
+            } else if instr.op == "call_builtin" {
+                // Inspect srcs[0] for the builtin name.  IIR carries it as
+                // `Operand::Var(name)` (Rust's IIR has no separate string
+                // operand kind for builtin lookup — names share the Var variant).
+                let name: Option<&str> = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => Some(s.as_str()),
+                    _ => None,
+                };
+                match name {
+                    Some(n) if CALL_BUILTIN_SUPPORTED_NAMES.contains(&n) => {
+                        // Accepted — lower.rs emits the corresponding
+                        // `call <token>` to env.BFRuntime::<name>.
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"call_builtin\" with \
+                             builtin name {:?} is not in the CLR backend's host-class \
+                             whitelist (supported: {:?}); add the builtin to \
+                             CALL_BUILTIN_SUPPORTED_NAMES and the lowering rule in \
+                             lower.rs to extend coverage",
+                            func.name, name, CALL_BUILTIN_SUPPORTED_NAMES
+                        ));
+                    }
+                }
             }
         }
     }
@@ -573,5 +625,81 @@ mod tests {
             IIRInstr::new("ret_void", None, vec![], "void"),
         ]));
         assert!(errs.is_empty(), "const nil ref<LispyPair> should pass: {:?}", errs);
+    }
+
+    // ─── BF lowering: load_mem / store_mem now pass ─────────────────────────
+
+    #[test]
+    fn load_mem_accepted_for_bf() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new("load_mem", Some("v".into()),
+                vec![Operand::Var("ptr".into())], "u8"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "load_mem should be accepted by CLR validator after BF→CLR PR; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn store_mem_accepted_for_bf() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new("store_mem", None::<String>,
+                vec![Operand::Var("ptr".into()), Operand::Var("v".into())], "u8"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "store_mem should be accepted by CLR validator; got: {:?}",
+            errs
+        );
+    }
+
+    // ─── BF lowering: call_builtin whitelist (putchar / getchar) ─────────────
+
+    #[test]
+    fn call_builtin_putchar_accepted() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new("call_builtin", None::<String>,
+                vec![Operand::Var("putchar".into()), Operand::Var("v".into())],
+                "void"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "call_builtin \"putchar\" should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn call_builtin_getchar_accepted() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new("call_builtin", Some("v".into()),
+                vec![Operand::Var("getchar".into())], "u8"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ]));
+        assert!(
+            errs.iter().all(|e| !e.contains("UnsupportedOp")),
+            "call_builtin \"getchar\" should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn call_builtin_unknown_name_rejected() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new("call_builtin", None::<String>,
+                vec![Operand::Var("system_exec".into())], "void"),
+        ]));
+        assert!(
+            errs.iter().any(|e| e.contains("UnsupportedOp")
+                && e.contains("system_exec")),
+            "unknown call_builtin name should be rejected with surfaced \
+             whitelist; got: {:?}",
+            errs
+        );
     }
 }


### PR DESCRIPTION
## Summary

**Closes the BF→backend story** with **Stage 3 (CLR)** + **Stage 4 (BEAM rejection doc)**:

| Target | Status | Lowering                                                                  |
|--------|--------|---------------------------------------------------------------------------|
| WASM   | ✅ (#3921)  | \`i32.load8_u\` / \`i32.store8\` + \`env.putchar\` / \`env.getchar\` imports |
| JVM    | ✅ (#3928)  | \`baload\` / \`bastore\` + \`invokestatic env/BFRuntime.{put,get}char\`     |
| CLR    | ✅ **(this PR)** | \`ldelem.u1\` / \`stelem.i1\` + \`call env.BFRuntime::{put,get}char\` |
| BEAM   | ❌ **(this PR, documented)** | intentionally not supported — immutable substrate ⇒ O(N²) tape writes |

## What's in this PR

### Stage 3: CLR lowering

- **Validator** (\`iir-to-cil-bytecode/src/validate.rs\`): \`load_mem\` / \`store_mem\` removed from \`UNSUPPORTED_OPS\`; new \`CALL_BUILTIN_SUPPORTED_NAMES\` whitelist for \`putchar\` / \`getchar\`. Unknown names still rejected.
- **Lowering** (\`lower.rs\`): three new reserved metadata tokens (\`BF_TAPE_TOKEN = 0x04000001\`, \`BF_PUTCHAR_TOKEN = 0x0A000003\`, \`BF_GETCHAR_TOKEN = 0x0A000004\`); new emit arms for \`load_mem\` / \`store_mem\` / \`call_builtin\`. Row 2 of MemberRef is taken by Console.WriteLine (LANG32), so BF starts at row 3.
- **End-to-end test** (\`brainfuck-iir-compiler/tests/clr_e2e.rs\`): 4 tests, including **byte-exact CIL sequence assertions** (\`[0x28, 0x03, 0x00, 0x00, 0x0A]\` for \`call BF_PUTCHAR_TOKEN\`, etc.) and an empty-program test that confirms feature detection is conditional.

### Stage 4: BEAM rejection doc

- **README** (\`brainfuck-iir-compiler/README.md\`): adds a "Cross-backend compilation status" section laying out the full success matrix and the BEAM-specific rationale.

> BEAM's substrate is **purely functional**.  Brainfuck's tape is mutable bytes.  Every \`store_mem\` would copy the whole 30 KB tape — O(N²·M) on a \`,[.,]\` cat over a non-trivial input.  ETS / process dictionary / NIF alternatives exist but each one abandons the "compile to vanilla bytecode" promise.

## Why \`env.BFRuntime\` (and not a static class field)?

Mirrors the pattern from WASM (\`env\` import namespace) and JVM (\`env/BFRuntime\`).  Picking a fixed host class keeps the BF-compiled output self-contained: no class initializer required, no per-program tape size baked into bytecode, and the host can dial the tape size without recompiling.

## Compatibility

| Crate                   | Tests                                              |
|-------------------------|----------------------------------------------------|
| iir-to-cil-bytecode     | 33 lib + 83 integration (all pass)                  |
| brainfuck-iir-compiler  | 63 unit + 9 JIT smoke + 4 WASM e2e + **4 CLR e2e** (all pass) |

(JVM e2e tests live on the unmerged \`feat/bf-to-jvm\` branch — they'll rejoin on merge.)

## Version bumps

- iir-to-cil-bytecode: 0.4.1 → 0.5.0
- brainfuck-iir-compiler: 0.3.1 → 0.3.3 (skipping 0.3.2 which is on the JVM branch)

## Test plan

- [x] \`cargo test -p iir-to-cil-bytecode\` (116 pass)
- [x] \`cargo test -p brainfuck-iir-compiler --tests\` (80 pass)
- [x] \`/security-review\` passed (CIL opcodes, operand stack ordering, token collision check, two-layer defense all verified)
- [ ] CI green across macOS / Ubuntu / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)