### PR TITLE
feat(cas-summation): Phase 49 — bounded × vanishing recogniser (TS+Rust port)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.7.0 — 2026-05-22
+
+**Phase 49 — Bounded × vanishing recogniser (Rust port).**
+
+Ports Python ``cas-summation`` 0.7.0.  Extends ``g_vanishes_at_infinity``
+to accept ``Div(bounded, diverging)`` shapes where the numerator is
+uniformly bounded.  Closes telescopes like
+``∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1)`` that the Phase 42
+degree-aware path refused.
+
+### Added
+
+- **`is_bounded_in_k(node, k)`** — recogniser for uniformly bounded
+  shapes: constants in ``k``, ``Sin(...)``, ``Cos(...)``, closures
+  under ``Mul``/``Add``/``Neg``.  Conservative — returns false for
+  anything else.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` now consults ``is_bounded_in_k`` on
+  the numerator between the Phase 41 fast-path and the Phase 42
+  degree-aware path.
+
+### Added — tests
+
+`tests/tests.rs` — 4 new ``phase49_*`` cases plus the renamed
+``phase42_transcendental_numerator_closes_via_phase49`` (assertion
+flipped from "stays unevaluated" to "now closes"):
+
+- ``phase49_sin_over_k_squared_closes``
+- ``phase49_cos_over_k_cube_closes``
+- ``phase49_sin_cos_product_over_diverging``
+- ``phase49_log_numerator_still_refused`` (regression)
+
+Full suite: **41 passed** (was 37; +4 net new).
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 40+46 — Add-with-negation telescope normaliser (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -910,6 +910,50 @@ fn h_diverges_at_infinity(node: &IRNode, k: &IRNode) -> bool {
     false
 }
 
+/// Phase 49 (Rust port): True when ``node`` is *provably* uniformly
+/// bounded in ``k``.  Used by ``g_vanishes_at_infinity`` to recognise
+/// shapes like ``sin(k)/k²``.
+///
+///   node shape                   | Provably bounded?
+///   -----------------------------|----------------------------
+///   constant in k                | yes (trivially)
+///   Sin(any) / Cos(any)          | yes (|sin|, |cos| ≤ 1)
+///   Mul(bounded, bounded)        | yes (recursive)
+///   Add(bounded, bounded)        | yes (recursive)
+///   Neg(bounded)                 | yes
+///   anything else                | no (conservative)
+fn is_bounded_in_k(node: &IRNode, k: &IRNode) -> bool {
+    if is_constant_in(node, k) {
+        return true;
+    }
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    let head_name = match &apply_node.head {
+        IRNode::Symbol(s) => s.as_str(),
+        _ => return false,
+    };
+    // Sin / Cos bounded by 1 in modulus.
+    if head_name == "Sin" && apply_node.args.len() == 1 {
+        return true;
+    }
+    if head_name == "Cos" && apply_node.args.len() == 1 {
+        return true;
+    }
+    // Closure under Mul / Add / Neg.
+    if head_name == MUL {
+        return apply_node.args.iter().all(|a| is_bounded_in_k(a, k));
+    }
+    if head_name == ADD {
+        return apply_node.args.iter().all(|a| is_bounded_in_k(a, k));
+    }
+    if head_name == NEG && apply_node.args.len() == 1 {
+        return is_bounded_in_k(&apply_node.args[0], k);
+    }
+    false
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -924,6 +968,11 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     // (positive-degree polynomial OR exp / b^k transcendental).
     if is_constant_in(num, k) {
         return h_diverges_at_infinity(den, k);
+    }
+    // Phase 49: bounded numerator + diverging denominator.  Covers
+    // shapes like sin(k)/k² and cos(k)·sin(k)/k³.
+    if is_bounded_in_k(num, k) && h_diverges_at_infinity(den, k) {
+        return true;
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -442,8 +442,9 @@ fn phase42_improper_rational_falls_through() {
 }
 
 #[test]
-fn phase42_transcendental_numerator_falls_through() {
-    // sin(k)/k² is non-polynomial; conservative refuse.
+fn phase42_transcendental_numerator_closes_via_phase49() {
+    // Phase 49 closes this: |sin(k)| ≤ 1 + k² → ∞.  Antisymmetric
+    // telescope reduces to g(1) = sin(1)/1² = sin(1).
     let k = sym("k");
     let sin_k = apply(sym("Sin"), vec![k.clone()]);
     let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
@@ -462,7 +463,8 @@ fn phase42_transcendental_numerator_falls_through() {
         ],
     );
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
-    assert!(matches!(out, IRNode::Apply(node) if node.head == sym(SUM)));
+    // Must NOT be the unevaluated Sum form.
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
 
 // ---------------------------------------------------------------------------
@@ -786,6 +788,76 @@ fn phase46_both_negative_left_untouched() {
             apply(sym(NEG), vec![apply(sym(DIV), vec![int(1), apply(sym(ADD), vec![k.clone(), int(1)])])]),
         ],
     );
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 49 (Rust port): Bounded × vanishing recogniser.
+//
+// Extends g_vanishes_at_infinity to accept Div(bounded, diverging)
+// shapes where the numerator is uniformly bounded (Sin/Cos, closed
+// under Mul/Add/Neg, constants in k).  Closes telescopes like
+// ∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase49_sin_over_k_squared_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![sin_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![sin_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase49_cos_over_k_cube_closes() {
+    let k = sym("k");
+    let cos_k = apply(sym("Cos"), vec![k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let cos_kp1 = apply(sym("Cos"), vec![kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![cos_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![cos_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase49_sin_cos_product_over_diverging() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let cos_k = apply(sym("Cos"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, cos_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let cos_kp1 = apply(sym("Cos"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, cos_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase49_log_numerator_still_refused() {
+    // log(k) is NOT bounded — Phase 49 must refuse to close the sum.
+    let k = sym("k");
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![log_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.7.0 — 2026-05-22
+
+**Phase 49 — Bounded × vanishing recogniser (TypeScript port).**
+
+Ports Python ``cas-summation`` 0.7.0.  Extends ``gVanishesAtInfinity``
+to accept ``Div(bounded, diverging)`` shapes where the numerator is
+uniformly bounded — covers telescopes like
+``∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1)`` that the Phase 42
+degree-aware path refused (``sin`` isn't a polynomial).
+
+### Added
+
+- **`isBoundedInK(node, k)`** — recogniser for uniformly bounded
+  shapes: constants in ``k``, ``Sin(...)``, ``Cos(...)``, closures
+  under ``Mul``/``Add``/``Neg``.
+
+### Changed
+
+- ``gVanishesAtInfinity`` now consults ``isBoundedInK`` on the
+  numerator between the Phase 41 fast-path and the Phase 42
+  degree-aware path.  If the numerator is bounded AND the
+  denominator diverges, the quotient vanishes.
+
+### Added — tests
+
+`tests/cas-summation.test.ts` — new
+``summation: Phase 49 bounded × vanishing`` block with 4 cases:
+
+- ``∑ [sin(k)/k² − sin(k+1)/(k+1)²]`` closes.
+- ``∑ [cos(k)/k³ − cos(k+1)/(k+1)³]`` closes.
+- ``sin(k)·cos(k)/k²`` closes (Mul closure of bounded factors).
+- Regression: ``log(k)/k²`` stays unevaluated (``Log`` isn't
+  bounded).
+
+Plus renamed
+``transcendental numerator … falls through`` →
+``transcendental numerator … closes via Phase 49`` (assertion
+flipped).
+
+Full suite: **41 passed** (was 37; +4 net new).
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 40+46 — Add-with-negation telescope normaliser (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -635,6 +635,45 @@ function hDivergesAtInfinity(node: IRNode, k: IRNode): boolean {
   return false;
 }
 
+const _SIN_HEAD = sym("Sin");
+const _COS_HEAD = sym("Cos");
+
+/**
+ * Phase 49: True when ``node`` is *provably* uniformly bounded in ``k``.
+ *
+ * Used by :func:`gVanishesAtInfinity` to recognise shapes like
+ * ``sin(k)/k²`` where the numerator is bounded (``|sin(k)| ≤ 1``) and
+ * the denominator diverges, hence the quotient vanishes.
+ *
+ *   node shape                   | Provably bounded?
+ *   -----------------------------|----------------------------
+ *   constant in ``k``            | yes (trivially)
+ *   ``Sin(h(k))`` / ``Cos(...)`` | yes (``|sin|, |cos| ≤ 1``)
+ *   ``Mul(bounded, bounded)``    | yes (recursive)
+ *   ``Add(bounded, bounded)``    | yes (recursive)
+ *   ``Neg(bounded)``             | yes
+ *   ``k`` / ``k²``               | no (diverges)
+ *   ``Exp(k)`` / ``Log(k)``      | no (diverges)
+ *
+ * Conservative — when in doubt, returns false.
+ */
+function isBoundedInK(node: IRNode, k: IRNode): boolean {
+  if (isConstantIn(node, k)) return true;
+  if (node.kind !== "apply") return false;
+  if (equals(node.head, _SIN_HEAD) && node.args.length === 1) return true;
+  if (equals(node.head, _COS_HEAD) && node.args.length === 1) return true;
+  if (equals(node.head, MUL)) {
+    return node.args.every((a) => isBoundedInK(a, k));
+  }
+  if (equals(node.head, ADD)) {
+    return node.args.every((a) => isBoundedInK(a, k));
+  }
+  if (equals(node.head, NEG) && node.args.length === 1) {
+    return isBoundedInK(node.args[0], k);
+  }
+  return false;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -644,6 +683,11 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   // (positive-degree polynomial OR exp / b^k transcendental).
   if (isConstantIn(num, k)) {
     return hDivergesAtInfinity(den, k);
+  }
+  // Phase 49: bounded numerator + diverging denominator.  Covers
+  // shapes like ``sin(k)/k²`` and ``cos(k)·sin(k)/k³``.
+  if (isBoundedInK(num, k) && hDivergesAtInfinity(den, k)) {
+    return true;
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -326,8 +326,10 @@ describe("summation: Phase 41+42 limit-aware infinite telescope", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 
-  it("transcendental numerator ∑_{k=1}^∞ [sin(k)/k² − sin(k+1)/(k+1)²] falls through", () => {
-    // sin(k)/k² is non-polynomial; conservative refuse.
+  it("transcendental numerator ∑_{k=1}^∞ [sin(k)/k² − sin(k+1)/(k+1)²] closes via Phase 49", () => {
+    // Phase 49 (bounded-numerator widening) recognises |sin(k)| ≤ 1 +
+    // k² → ∞, so the quotient vanishes and the antisymmetric telescope
+    // closes to g(1) = sin(1)/1² = sin(1).
     const k = sym("k");
     const sinK = app(sym("Sin"), [k]);
     const kPlus1 = app(ADD, [k, int(1)]);
@@ -337,7 +339,7 @@ describe("summation: Phase 41+42 limit-aware infinite telescope", () => {
       app(DIV, [sinKp1, app(POW, [kPlus1, int(2)])]),
     ]);
     const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
-    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
   });
 });
 
@@ -563,6 +565,76 @@ describe("summation: Phase 40+46 Add-with-negation normaliser", () => {
     // the closed-form integer 1 or -1.  It either evaluates numerically
     // (for finite hi) or stays as an unevaluated Sum (for ∞).
     const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 49 (TypeScript port): Bounded × vanishing recogniser.
+//
+// Extends gVanishesAtInfinity to accept Div(bounded, diverging) shapes
+// where the numerator is uniformly bounded (Sin/Cos, closed under
+// Mul/Add/Neg, constants in k).  Closes telescopes like
+// ∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1) that the Phase 42 degree-
+// aware path refused (sin isn't a polynomial).
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 49 bounded × vanishing", () => {
+  it("∑_{k=1}^∞ [sin(k)/k² − sin(k+1)/(k+1)²] closes", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kPlus1]);
+    const f = app(SUB, [
+      app(DIV, [sinK, app(POW, [k, int(2)])]),
+      app(DIV, [sinKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // Not the unevaluated Sum form.
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑_{k=1}^∞ [cos(k)/k³ − cos(k+1)/(k+1)³] closes", () => {
+    const k = sym("k");
+    const cosK = app(sym("Cos"), [k]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const cosKp1 = app(sym("Cos"), [kPlus1]);
+    const f = app(SUB, [
+      app(DIV, [cosK, app(POW, [k, int(3)])]),
+      app(DIV, [cosKp1, app(POW, [kPlus1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("sin(k)·cos(k)/k² (Mul of bounded factors) closes", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const cosK = app(sym("Cos"), [k]);
+    const numK = app(MUL, [sinK, cosK]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kPlus1]);
+    const cosKp1 = app(sym("Cos"), [kPlus1]);
+    const numKp1 = app(MUL, [sinKp1, cosKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: log(k)/k² stays unevaluated (Log isn't bounded)", () => {
+    const k = sym("k");
+    const logK = app(LOG, [k]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const logKp1 = app(LOG, [kPlus1]);
+    const f = app(SUB, [
+      app(DIV, [logK, app(POW, [k, int(2)])]),
+      app(DIV, [logKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // Phase 49 must NOT close this — log(k) is unbounded.
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });


### PR DESCRIPTION
## Summary

Ports the Python Phase 49 fix (PR #3933) to TypeScript and Rust
``cas-summation``.  Extends ``gVanishesAtInfinity`` /
``g_vanishes_at_infinity`` to accept ``Div(bounded, diverging)``
shapes where the numerator is uniformly bounded.  Closes telescopes
like ``∑ [sin(k)/k² − sin(k+1)/(k+1)²] = sin(1)`` that the Phase 42
degree-aware path refused (``sin`` isn't a polynomial).

Bumps:
- ``@coding-adventures/cas-summation``  0.6.0 → 0.7.0
- ``cas-summation`` (Rust)              0.6.0 → 0.7.0

### Added (both languages)

| Function | Recognises |
|---|---|
| ``isBoundedInK`` / ``is_bounded_in_k`` | constants in ``k``; ``Sin(any)``; ``Cos(any)``; ``Mul``/``Add`` of bounded; ``Neg(bounded)`` |

Conservative — false for anything else (in particular ``k``, ``k²``,
``Exp(k)``, ``Log(k)``).

### Wiring

```typescript
// Between the Phase 41 fast path and the Phase 42 degree-aware path:
if (isBoundedInK(num, k) && hDivergesAtInfinity(den, k)) return true;
```

### Test plan

- [x] TS: ``npm test`` → 41 passed (was 37; +4 new)
- [x] Rust: ``cargo test`` → 41 passed (was 37; +4 new)
- [x] No regressions; renamed two stale "falls through" tests to
      "closes via Phase 49"
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Closes the alternation

Phase 49 Python landed in PR #3933 (in flight).  This PR keeps the
three-language pipeline in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)