### PR TITLE
feat(cas-summation): Phase 50 — log/polynomial growth-rate (TS+Rust port)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.8.0 — 2026-05-22
+
+**Phase 50 — Log/polynomial growth-rate recogniser (Rust port).**
+
+Ports Python ``cas-summation`` 0.8.0.  Extends ``g_vanishes_at_infinity``
+to accept ``Div(Log(diverging), diverging)`` shapes via the squeeze
+argument.
+
+> Bumps 0.6.0 → 0.8.0 (skipping 0.7.0, reserved for the in-flight
+> Phase 49 TS+Rust port PR #3936).
+
+### Added
+
+- **`is_log_of_diverging_in_k(node, k)`** — recognises ``Log(h(k))``
+  with ``h(k) → +∞``.  Sign-aware via ``h_diverges_at_infinity``
+  (refuses ``Log(Mul(-1, k))``-style shapes).
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds the Phase 50 branch between the
+  Phase 41 fast path and the Phase 42 degree-aware path.
+
+### Added — tests
+
+3 new ``phase50_*`` cases:
+- ``phase50_log_over_k_squared_closes``
+- ``phase50_log_of_polynomial_argument_closes``
+- ``phase50_log_of_negative_argument_refused`` (regression)
+
+Full suite: **40 passed** (was 37; +3 net new).
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 40+46 — Add-with-negation telescope normaliser (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.6.0"
+version = "0.8.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -910,6 +910,19 @@ fn h_diverges_at_infinity(node: &IRNode, k: &IRNode) -> bool {
     false
 }
 
+/// Phase 50 (Rust port): True when ``node = Log(h(k))`` with
+/// ``h(k) → +∞``.  Sign-aware via ``h_diverges_at_infinity``.
+fn is_log_of_diverging_in_k(node: &IRNode, k: &IRNode) -> bool {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    if !matches!(&apply_node.head, IRNode::Symbol(s) if s == LOG) || apply_node.args.len() != 1 {
+        return false;
+    }
+    h_diverges_at_infinity(node, k)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -924,6 +937,10 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     // (positive-degree polynomial OR exp / b^k transcendental).
     if is_constant_in(num, k) {
         return h_diverges_at_infinity(den, k);
+    }
+    // Phase 50: Log(diverging) numerator + diverging denominator.
+    if is_log_of_diverging_in_k(num, k) && h_diverges_at_infinity(den, k) {
+        return true;
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -789,3 +789,54 @@ fn phase46_both_negative_left_untouched() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 50 (Rust port): Log/polynomial growth-rate recogniser.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase50_log_over_k_squared_closes() {
+    let k = sym("k");
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![log_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase50_log_of_polynomial_argument_closes() {
+    let k = sym("k");
+    let k_sq_plus_1 = apply(sym(ADD), vec![apply(sym(POW), vec![k.clone(), int(2)]), int(1)]);
+    let log_term = apply(sym(LOG), vec![k_sq_plus_1]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let kp1_sq_plus_1 = apply(sym(ADD), vec![apply(sym(POW), vec![kp1.clone(), int(2)]), int(1)]);
+    let log_kp1 = apply(sym(LOG), vec![kp1_sq_plus_1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_term, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![log_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase50_log_of_negative_argument_refused() {
+    // log of negative arg isn't real for odd k — must stay unevaluated.
+    let k = sym("k");
+    let neg_k = apply(sym(MUL), vec![int(-1), k.clone()]);
+    let log_neg_k = apply(sym(LOG), vec![neg_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let neg_kp1 = apply(sym(MUL), vec![int(-1), kp1.clone()]);
+    let log_neg_kp1 = apply(sym(LOG), vec![neg_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_neg_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![log_neg_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.8.0 — 2026-05-22
+
+**Phase 50 — Log/polynomial growth-rate recogniser (TypeScript port).**
+
+Ports Python ``cas-summation`` 0.8.0.  Extends ``gVanishesAtInfinity``
+to accept ``Div(Log(diverging), diverging)`` shapes via the squeeze
+argument: ``log(h) → ∞`` at a logarithmic rate, denominator grows
+strictly faster, so the quotient vanishes.
+
+> Note: bumps 0.6.0 → 0.8.0 (skipping 0.7.0, reserved for the
+> in-flight Phase 49 TS+Rust port PR #3936).
+
+### Added
+
+- **`isLogOfDivergingInK(node, k)`** — recognises ``Log(h(k))``
+  with ``h(k) → +∞``.  Sign-aware: delegates to
+  ``hDivergesAtInfinity`` on the full ``Log(...)`` node so
+  Phase 44's Log branch refuses ``Log(Mul(-1, k))``-style negative
+  shapes for free.
+
+### Changed
+
+- ``gVanishesAtInfinity`` now has a Phase 50 branch checking the
+  numerator for ``Log(diverging)`` before the Phase 42 degree-aware
+  path.
+
+### Added — tests
+
+3 new ``summation: Phase 50 log/polynomial growth-rate`` cases:
+- ``log(k)/k²`` closes.
+- ``log(k²+1)/k³`` closes.
+- Regression: ``log(Mul(-1, k))/k²`` stays unevaluated.
+
+Full suite: **40 passed** (was 37; +3 net new).
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 40+46 — Add-with-negation telescope normaliser (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -635,6 +635,22 @@ function hDivergesAtInfinity(node: IRNode, k: IRNode): boolean {
   return false;
 }
 
+/**
+ * Phase 50 (TypeScript port): True when ``node = Log(h(k))`` with
+ * ``h(k) → +∞``.
+ *
+ * The squeeze argument: ``log(h) → ∞`` at a logarithmic rate, while
+ * any positive-degree polynomial / exponential denominator grows
+ * strictly faster.  Sign-aware: delegates to ``hDivergesAtInfinity``
+ * on the full ``Log(...)`` node so Phase 44's Log branch refuses
+ * ``Log(Mul(-1, k))``-style negative-polynomial shapes for free.
+ */
+function isLogOfDivergingInK(node: IRNode, k: IRNode): boolean {
+  if (node.kind !== "apply") return false;
+  if (!equals(node.head, LOG) || node.args.length !== 1) return false;
+  return hDivergesAtInfinity(node, k);
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -644,6 +660,11 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   // (positive-degree polynomial OR exp / b^k transcendental).
   if (isConstantIn(num, k)) {
     return hDivergesAtInfinity(den, k);
+  }
+  // Phase 50: Log(diverging) numerator + diverging denominator.
+  // log/poly → 0 always (log grows slower than any positive power).
+  if (isLogOfDivergingInK(num, k) && hDivergesAtInfinity(den, k)) {
+    return true;
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -566,3 +566,58 @@ describe("summation: Phase 40+46 Add-with-negation normaliser", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 50 (TypeScript port): Log/polynomial growth-rate recogniser.
+//
+// Closes Div(Log(diverging), diverging) telescopes via the squeeze
+// argument: log(h) → ∞ at a logarithmic rate, denominator grows
+// faster polynomially / exponentially, so log/poly → 0.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 50 log/polynomial growth-rate", () => {
+  it("∑_{k=1}^∞ [log(k)/k² − log(k+1)/(k+1)²] closes", () => {
+    const k = sym("k");
+    const logK = app(LOG, [k]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const logKp1 = app(LOG, [kPlus1]);
+    const f = app(SUB, [
+      app(DIV, [logK, app(POW, [k, int(2)])]),
+      app(DIV, [logKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑_{k=1}^∞ [log(k²+1)/k³ − log((k+1)²+1)/(k+1)³] closes", () => {
+    const k = sym("k");
+    const kSqPlus1 = app(ADD, [app(POW, [k, int(2)]), int(1)]);
+    const logK = app(LOG, [kSqPlus1]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const kPlus1SqPlus1 = app(ADD, [app(POW, [kPlus1, int(2)]), int(1)]);
+    const logKp1 = app(LOG, [kPlus1SqPlus1]);
+    const f = app(SUB, [
+      app(DIV, [logK, app(POW, [k, int(3)])]),
+      app(DIV, [logKp1, app(POW, [kPlus1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: log(Mul(-1, k))/k² stays unevaluated", () => {
+    // log of negative argument isn't real-valued for odd k.
+    const k = sym("k");
+    const negK = app(MUL, [int(-1), k]);
+    const logNegK = app(LOG, [negK]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const negKp1 = app(MUL, [int(-1), kPlus1]);
+    const logNegKp1 = app(LOG, [negKp1]);
+    const f = app(SUB, [
+      app(DIV, [logNegK, app(POW, [k, int(2)])]),
+      app(DIV, [logNegKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // Phase 50 must NOT close this.
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Phase 50 fix (PR #3938) to TypeScript and Rust
``cas-summation``.  Extends ``gVanishesAtInfinity`` /
``g_vanishes_at_infinity`` to accept ``Div(Log(diverging), diverging)``
shapes via the squeeze argument: ``log(h) → ∞`` at a logarithmic
rate, denominator grows strictly faster, so ``log/poly → 0``.

Bumps:
- ``@coding-adventures/cas-summation``  0.6.0 → 0.8.0
- ``cas-summation`` (Rust)              0.6.0 → 0.8.0

(Skipping 0.7.0 — reserved for the in-flight Phase 49 TS+Rust port
PR #3936.)

### Added (both languages)

| Function | Recognises |
|---|---|
| ``isLogOfDivergingInK`` / ``is_log_of_diverging_in_k`` | ``Log(h(k))`` with ``h(k) → +∞`` |

Sign-aware: delegates to ``hDivergesAtInfinity`` on the full
``Log(...)`` node so Phase 44's Log branch refuses
``Log(Mul(-1, k))``-style negative shapes for free.

### Test plan

- [x] TS: ``npm test`` → 40 passed (was 37; +3 new)
- [x] Rust: ``cargo test`` → 40 passed (was 37; +3 new)
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Closes the alternation

Phase 50 Python landed in PR #3938.  This PR keeps the three-language
pipeline in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)