### PR TITLE
feat(cas-summation): Phase 51 — sqrt(polynomial)/polynomial growth-rate recogniser

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 0.9.0 — 2026-05-22
+
+**Phase 51 — Sqrt(polynomial)/polynomial growth-rate recogniser.**
+
+Closes the ``sqrt(k)/k²``-style gap noted as deferred in Phase 50.
+``sqrt(P(k))`` has effective polynomial degree ``deg(P)/2`` for large
+``k`` (assuming positive leading coefficient so the root is
+real-valued).  When the denominator is a polynomial of strictly
+higher degree, the quotient vanishes.
+
+Bumps 0.7.0 → 0.9.0 (skipping 0.8.0 reserved for the in-flight
+Phase 50 PR #3938).
+
+### Added
+
+- **`_sqrt_effective_half_degree(node, k)`** — returns
+  ``Fraction(deg(P), 2)`` for ``node = Sqrt(P(k))`` with ``P``
+  positive-degree and positive leading coefficient; ``None``
+  otherwise.  Conservative: refuses ``Sqrt(negative-polynomial)``
+  shapes whose root isn't real.
+
+### Changed
+
+- ``_g_vanishes_at_infinity`` adds a Phase 51 branch between the
+  Phase 49 bounded check and the Phase 42 degree-aware path.  If the
+  numerator is ``Sqrt(positive-poly)`` and the denominator's
+  polynomial degree exceeds the sqrt's half-degree, the quotient
+  vanishes.
+
+### Added — tests
+
+`tests/test_summation.py::TestEvaluateSumPhase51SqrtOverPolynomial`
+— 5 new cases:
+
+- ``sqrt(k)/k²`` closes (1/2 < 2).
+- ``sqrt(k³)/k²`` closes (3/2 < 2 — tight margin).
+- ``sqrt(k²)/k²`` closes (1 < 2).
+- ``sqrt(k)/k`` closes (1/2 < 1 — also a half-degree edge case).
+- ``sqrt(Mul(-1, k))/k²`` stays unevaluated (regression).
+
+Full suite: **103 passed** (was 98; +5 net new).
+
+### Still deferred
+
+- ``sqrt`` of more exotic shapes (``Sqrt(Exp(k))``, etc.).
+- General transcendental limit-finder.
+
 ## 0.7.0 — 2026-05-22
 
 **Phase 49 — Bounded × vanishing recogniser.**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "0.7.0"
+version = "0.9.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -58,6 +58,7 @@ from symbolic_ir import (
     NEG,
     POW,
     PRODUCT,
+    SQRT,
     SUB,
     SUM,
     IRApply,
@@ -682,6 +683,14 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     # closures under Mul/Add/Neg).
     if _is_bounded_in_k(num, k) and _h_diverges_at_infinity(den, k):
         return True
+    # Phase 51: Sqrt(positive-leading polynomial) numerator + polynomial
+    # denominator with higher degree than the sqrt's half-degree.
+    # ``sqrt(P(k))`` has effective degree ``deg(P)/2`` for large k.
+    sqrt_half_degree = _sqrt_effective_half_degree(num, k)
+    if sqrt_half_degree is not None:
+        den_degree = _polynomial_degree_in_k(den, k)
+        if den_degree is not None and Fraction(den_degree) > sqrt_half_degree:
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -690,6 +699,37 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     if den_degree is None:
         return False
     return num_degree < den_degree
+
+
+def _sqrt_effective_half_degree(node: IRNode, k: IRSymbol) -> Fraction | None:
+    """Return the effective degree of ``sqrt(P(k))`` for large ``k``, as a
+    :class:`Fraction` (so ``sqrt(k³)`` is ``3/2``).
+
+    Recognised shape: ``node = Sqrt(P(k))`` where ``P(k)`` is a
+    positive-degree polynomial in ``k`` with positive leading
+    coefficient (so the square root is real-valued for sufficiently
+    large ``k``).
+
+    Returns ``None`` for any other shape — including bare ``k``,
+    ``Pow(k, n)``, ``Sqrt(negative-polynomial)``, etc.
+
+    Phase 51 — used by :func:`_g_vanishes_at_infinity` to recognise
+    that ``sqrt(k)/k²`` and similar shapes vanish at ∞ (sqrt grows
+    polynomially with degree ``1/2``, slower than any positive-
+    degree polynomial denominator with degree ≥ 1).
+    """
+    if not isinstance(node, IRApply):
+        return None
+    if node.head != SQRT or len(node.args) != 1:
+        return None
+    inner = node.args[0]
+    inner_degree = _polynomial_degree_in_k(inner, k)
+    if inner_degree is None or inner_degree < 1:
+        return None
+    # Need positive leading coefficient so sqrt is real for large k.
+    if _polynomial_leading_coeff_sign_in_k(inner, k) != 1:
+        return None
+    return Fraction(inner_degree, 2)
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1089,3 +1089,106 @@ class TestEvaluateSumPhase49BoundedNumerator:
         # to recognise that.  Stay unevaluated until a transcendental
         # growth-rate recogniser lands.
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+# ---------------------------------------------------------------------------
+# Phase 51 — Sqrt/polynomial growth-rate recogniser.
+#
+# sqrt(P(k)) has effective polynomial degree deg(P)/2.  When the
+# denominator is a polynomial of strictly higher degree, the quotient
+# vanishes.  Closes shapes like sqrt(k)/k², sqrt(k)/k³.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase51SqrtOverPolynomial:
+    def test_sqrt_k_over_k_squared_closes(self):
+        """``∑ [sqrt(k)/k² − sqrt(k+1)/(k+1)²]`` closes.
+
+        Effective degrees: num = 1/2, den = 2; 1/2 < 2 so vanishes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_kp1 = IRApply(SQRT, (IRApply(ADD, (_k, IRInteger(1))),))
+        g_k = IRApply(DIV, (sqrt_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(
+            DIV,
+            (
+                sqrt_kp1,
+                IRApply(POW, (IRApply(ADD, (_k, IRInteger(1))), IRInteger(2))),
+            ),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 51 should close; got {result!r}"
+        )
+
+    def test_sqrt_k_cubed_over_k_squared_refused(self):
+        """``∑ [sqrt(k³)/k² − …]``: sqrt(k³) has effective degree 3/2,
+        denominator has degree 2.  Since 3/2 < 2, this DOES vanish.
+        Edge case worth pinning.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        k_cubed = IRApply(POW, (_k, IRInteger(3)))
+        sqrt_k3 = IRApply(SQRT, (k_cubed,))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        g_k = IRApply(DIV, (sqrt_k3, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (sqrt_kp1_3, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # 3/2 < 2 → vanishes
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_squared_over_k_squared_refused(self):
+        """``∑ [sqrt(k²)/k² − …]``: sqrt(k²) has effective degree 1
+        (= k for positive k), denominator has degree 2.  Since 1 < 2,
+        vanishes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k_sq = IRApply(SQRT, (k_sq,))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_kp1_sq = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(2))),))
+        g_k = IRApply(DIV, (sqrt_k_sq, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (sqrt_kp1_sq, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # 1 < 2 → vanishes
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_over_k_refused_equal_degrees(self):
+        """``∑ [sqrt(k)/k − sqrt(k+1)/(k+1)]``: 1/2 < 1, so it should
+        vanish.  But also a sanity check that the recogniser correctly
+        compares ``Fraction(1, 2)`` against ``Fraction(1)``.
+        """
+        from symbolic_ir import SQRT, SUB
+
+        sqrt_k = IRApply(SQRT, (_k,))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        g_k = IRApply(DIV, (sqrt_k, _k))
+        g_kp1 = IRApply(DIV, (sqrt_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_of_negative_polynomial_refused(self):
+        """Regression: ``sqrt(Mul(-1, k))`` isn't real for positive k.
+        Phase 51 must NOT close this telescope.
+        """
+        from symbolic_ir import MUL, POW, SQRT, SUB
+
+        neg_k = IRApply(MUL, (IRInteger(-1), _k))
+        sqrt_neg_k = IRApply(SQRT, (neg_k,))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_neg_kp1 = IRApply(SQRT, (IRApply(MUL, (IRInteger(-1), kp1)),))
+        g_k = IRApply(DIV, (sqrt_neg_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (sqrt_neg_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Must stay unevaluated — sqrt of negative polynomial.
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.8.0 — 2026-05-22
+
+**Phase 50 — Log/polynomial growth-rate recogniser (Rust port).**
+
+Ports Python ``cas-summation`` 0.8.0.  Extends ``g_vanishes_at_infinity``
+to accept ``Div(Log(diverging), diverging)`` shapes via the squeeze
+argument.
+
+> Bumps 0.6.0 → 0.8.0 (skipping 0.7.0, reserved for the in-flight
+> Phase 49 TS+Rust port PR #3936).
+
+### Added
+
+- **`is_log_of_diverging_in_k(node, k)`** — recognises ``Log(h(k))``
+  with ``h(k) → +∞``.  Sign-aware via ``h_diverges_at_infinity``
+  (refuses ``Log(Mul(-1, k))``-style shapes).
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds the Phase 50 branch between the
+  Phase 41 fast path and the Phase 42 degree-aware path.
+
+### Added — tests
+
+3 new ``phase50_*`` cases:
+- ``phase50_log_over_k_squared_closes``
+- ``phase50_log_of_polynomial_argument_closes``
+- ``phase50_log_of_negative_argument_refused`` (regression)
+
+Full suite: **40 passed** (was 37; +3 net new).
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 40+46 — Add-with-negation telescope normaliser (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "0.6.0"
+version = "0.8.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -910,6 +910,19 @@ fn h_diverges_at_infinity(node: &IRNode, k: &IRNode) -> bool {
     false
 }
 
+/// Phase 50 (Rust port): True when ``node = Log(h(k))`` with
+/// ``h(k) → +∞``.  Sign-aware via ``h_diverges_at_infinity``.
+fn is_log_of_diverging_in_k(node: &IRNode, k: &IRNode) -> bool {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    if !matches!(&apply_node.head, IRNode::Symbol(s) if s == LOG) || apply_node.args.len() != 1 {
+        return false;
+    }
+    h_diverges_at_infinity(node, k)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -924,6 +937,10 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     // (positive-degree polynomial OR exp / b^k transcendental).
     if is_constant_in(num, k) {
         return h_diverges_at_infinity(den, k);
+    }
+    // Phase 50: Log(diverging) numerator + diverging denominator.
+    if is_log_of_diverging_in_k(num, k) && h_diverges_at_infinity(den, k) {
+        return true;
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -789,3 +789,54 @@ fn phase46_both_negative_left_untouched() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 50 (Rust port): Log/polynomial growth-rate recogniser.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase50_log_over_k_squared_closes() {
+    let k = sym("k");
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![log_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase50_log_of_polynomial_argument_closes() {
+    let k = sym("k");
+    let k_sq_plus_1 = apply(sym(ADD), vec![apply(sym(POW), vec![k.clone(), int(2)]), int(1)]);
+    let log_term = apply(sym(LOG), vec![k_sq_plus_1]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let kp1_sq_plus_1 = apply(sym(ADD), vec![apply(sym(POW), vec![kp1.clone(), int(2)]), int(1)]);
+    let log_kp1 = apply(sym(LOG), vec![kp1_sq_plus_1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_term, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![log_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase50_log_of_negative_argument_refused() {
+    // log of negative arg isn't real for odd k — must stay unevaluated.
+    let k = sym("k");
+    let neg_k = apply(sym(MUL), vec![int(-1), k.clone()]);
+    let log_neg_k = apply(sym(LOG), vec![neg_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let neg_kp1 = apply(sym(MUL), vec![int(-1), kp1.clone()]);
+    let log_neg_kp1 = apply(sym(LOG), vec![neg_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![log_neg_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![log_neg_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.8.0 — 2026-05-22
+
+**Phase 50 — Log/polynomial growth-rate recogniser (TypeScript port).**
+
+Ports Python ``cas-summation`` 0.8.0.  Extends ``gVanishesAtInfinity``
+to accept ``Div(Log(diverging), diverging)`` shapes via the squeeze
+argument: ``log(h) → ∞`` at a logarithmic rate, denominator grows
+strictly faster, so the quotient vanishes.
+
+> Note: bumps 0.6.0 → 0.8.0 (skipping 0.7.0, reserved for the
+> in-flight Phase 49 TS+Rust port PR #3936).
+
+### Added
+
+- **`isLogOfDivergingInK(node, k)`** — recognises ``Log(h(k))``
+  with ``h(k) → +∞``.  Sign-aware: delegates to
+  ``hDivergesAtInfinity`` on the full ``Log(...)`` node so
+  Phase 44's Log branch refuses ``Log(Mul(-1, k))``-style negative
+  shapes for free.
+
+### Changed
+
+- ``gVanishesAtInfinity`` now has a Phase 50 branch checking the
+  numerator for ``Log(diverging)`` before the Phase 42 degree-aware
+  path.
+
+### Added — tests
+
+3 new ``summation: Phase 50 log/polynomial growth-rate`` cases:
+- ``log(k)/k²`` closes.
+- ``log(k²+1)/k³`` closes.
+- Regression: ``log(Mul(-1, k))/k²`` stays unevaluated.
+
+Full suite: **40 passed** (was 37; +3 net new).
+
 ## 0.6.0 — 2026-05-22
 
 **Phase 40+46 — Add-with-negation telescope normaliser (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -635,6 +635,22 @@ function hDivergesAtInfinity(node: IRNode, k: IRNode): boolean {
   return false;
 }
 
+/**
+ * Phase 50 (TypeScript port): True when ``node = Log(h(k))`` with
+ * ``h(k) → +∞``.
+ *
+ * The squeeze argument: ``log(h) → ∞`` at a logarithmic rate, while
+ * any positive-degree polynomial / exponential denominator grows
+ * strictly faster.  Sign-aware: delegates to ``hDivergesAtInfinity``
+ * on the full ``Log(...)`` node so Phase 44's Log branch refuses
+ * ``Log(Mul(-1, k))``-style negative-polynomial shapes for free.
+ */
+function isLogOfDivergingInK(node: IRNode, k: IRNode): boolean {
+  if (node.kind !== "apply") return false;
+  if (!equals(node.head, LOG) || node.args.length !== 1) return false;
+  return hDivergesAtInfinity(node, k);
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -644,6 +660,11 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   // (positive-degree polynomial OR exp / b^k transcendental).
   if (isConstantIn(num, k)) {
     return hDivergesAtInfinity(den, k);
+  }
+  // Phase 50: Log(diverging) numerator + diverging denominator.
+  // log/poly → 0 always (log grows slower than any positive power).
+  if (isLogOfDivergingInK(num, k) && hDivergesAtInfinity(den, k)) {
+    return true;
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -566,3 +566,58 @@ describe("summation: Phase 40+46 Add-with-negation normaliser", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 50 (TypeScript port): Log/polynomial growth-rate recogniser.
+//
+// Closes Div(Log(diverging), diverging) telescopes via the squeeze
+// argument: log(h) → ∞ at a logarithmic rate, denominator grows
+// faster polynomially / exponentially, so log/poly → 0.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 50 log/polynomial growth-rate", () => {
+  it("∑_{k=1}^∞ [log(k)/k² − log(k+1)/(k+1)²] closes", () => {
+    const k = sym("k");
+    const logK = app(LOG, [k]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const logKp1 = app(LOG, [kPlus1]);
+    const f = app(SUB, [
+      app(DIV, [logK, app(POW, [k, int(2)])]),
+      app(DIV, [logKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑_{k=1}^∞ [log(k²+1)/k³ − log((k+1)²+1)/(k+1)³] closes", () => {
+    const k = sym("k");
+    const kSqPlus1 = app(ADD, [app(POW, [k, int(2)]), int(1)]);
+    const logK = app(LOG, [kSqPlus1]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const kPlus1SqPlus1 = app(ADD, [app(POW, [kPlus1, int(2)]), int(1)]);
+    const logKp1 = app(LOG, [kPlus1SqPlus1]);
+    const f = app(SUB, [
+      app(DIV, [logK, app(POW, [k, int(3)])]),
+      app(DIV, [logKp1, app(POW, [kPlus1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: log(Mul(-1, k))/k² stays unevaluated", () => {
+    // log of negative argument isn't real-valued for odd k.
+    const k = sym("k");
+    const negK = app(MUL, [int(-1), k]);
+    const logNegK = app(LOG, [negK]);
+    const kPlus1 = app(ADD, [k, int(1)]);
+    const negKp1 = app(MUL, [int(-1), kPlus1]);
+    const logNegKp1 = app(LOG, [negKp1]);
+    const f = app(SUB, [
+      app(DIV, [logNegK, app(POW, [k, int(2)])]),
+      app(DIV, [logNegKp1, app(POW, [kPlus1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // Phase 50 must NOT close this.
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the ``sqrt(k)/k²``-style gap noted as deferred in Phase 50.
``sqrt(P(k))`` has effective polynomial degree ``deg(P)/2`` for large
``k`` (positive leading coefficient required so the root is real-
valued).  When the denominator is a polynomial of strictly higher
degree, the quotient vanishes.

Bumps ``cas-summation`` 0.7.0 → 0.9.0 (skipping 0.8.0 reserved for
the in-flight Phase 50 PR #3938).

### Added

| Function | Returns |
|---|---|
| ``_sqrt_effective_half_degree`` | ``Fraction(deg(P), 2)`` for ``Sqrt(P(k))`` with positive ``P`` |

### Changed

- ``_g_vanishes_at_infinity`` adds a Phase 51 branch between the
  Phase 49 bounded check and the Phase 42 degree-aware path.

### Test plan

- [x] ``pytest tests/ -k phase51`` → 5 passed
- [x] ``pytest tests/`` → 103 passed (was 98; +5)
- [x] No regressions
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Still deferred

- ``Sqrt(Exp(k))``, ``Sqrt(Log(k))`` and other exotic shapes.
- General transcendental limit-finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)