### PR TITLE
feat(mosaic-pkg-toolkit): v0.1 PR-5 — Field (form group)

### DIFF
--- a/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog — mosaic-pkg-toolkit
 
+## [Unreleased] — v0.1 PR-5 — Field (form group)
+
+### Added
+
+**`Field`** — Bootstrap's "form group" pattern. Labelled text input
+with optional help text below (or error text in red when validation
+fails). Composition: `Column[field]` containing label `Text`, the
+`HostInput[field-input]`, and an `If error / Else help` pair of
+muted-vs-danger texts. Slots: `label`, `value`, `placeholder`,
+`help`, `error`, `disabled`. Emits: `onChange(value: text)`,
+`onCommit`.
+
+### Why HostInput inline, not Input via component reference
+
+Field would naturally reference the toolkit's `Input` component
+since both wrap HostInput similarly. But UI29 §4.4 routes
+component-reference resolution through the manifest's
+`[dependencies]` table — and a package can't depend on itself,
+so Field can't reference Input from the same package today.
+
+Inlining HostInput in Field.mll is the path of least resistance. A
+small follow-up can add self-reference support to the resolver
+(auto-register the active package's own `[components].exports`);
+until then the duplication is acceptable.
+
+### Tests
+
+`tests/package_compiles.rs` grew to 13 (was 12). All pass.
+
+**11 of 13 Tier-1 components shipped.** Remaining: Card, Container
+— both still blocked on the UI29-2 children pass-through spec
+(#3947).
+
 ## [Unreleased] — v0.1 PR-4 — ListGroup / Modal
 
 ### Added — 2 more Tier-1 components

--- a/code/packages/mosaic-pkg-toolkit/README.md
+++ b/code/packages/mosaic-pkg-toolkit/README.md
@@ -10,7 +10,7 @@ for the architecture, component catalog, and phasing plan.
 
 ## v0.1 — exports so far
 
-**10 of 13 Tier-1 components shipped:**
+**11 of 13 Tier-1 components shipped:**
 
 - **`Alert`** — colored info banner with `variant`, optional inline
   dismiss button. Composed from `Box` + `Row` + `Text` + `If` +
@@ -22,6 +22,10 @@ for the architecture, component catalog, and phasing plan.
 - **`Checkbox`** — labeled checkbox. `Row { If checked HostButton[✓]
   Else HostButton[], Text }`. Slots: `label`, `checked`,
   `disabled`. Emit: `onChange`. Host owns the state.
+- **`Field`** — labelled text input + help/error pattern.
+  Bootstrap's "form group". Slots: `label`, `value`,
+  `placeholder`, `help`, `error`, `disabled`. Emits:
+  `onChange(value: text)`, `onCommit`.
 - **`Input`** — styled single-line text input. Wraps the kernel
   `HostInput`. Slots: `value`, `placeholder`, `disabled`, `size`.
   Emits: `onChange(value: text)`, `onCommit`.
@@ -54,8 +58,9 @@ Per spec §7:
 | v0.1 PR-1 | Button, Alert |
 | v0.1 PR-2 | Badge, Spinner, Toast |
 | v0.1 PR-3 | Input, Checkbox, Radio |
-| v0.1 PR-4 (this) | ListGroup, Modal |
-| v0.1 PR-5+ | Card, Container, Field — depend on the children-pass-through UI29 follow-up spec |
+| v0.1 PR-4 | ListGroup, Modal |
+| v0.1 PR-5 (this) | Field |
+| v0.1 PR-6 | Card, Container — depend on UI29-2 children pass-through |
 | v0.2 | Tier 2 — Nav, Navbar, Pagination, Breadcrumb, InputGroup, ButtonGroup, Tabs, DropdownMenu, Accordion, Select |
 | v0.3 | Bootstrap-aesthetic theme overlay |
 | v0.4 | Tier 3 — Tooltip, Popover, Carousel, Offcanvas (depends on kernel follow-ups) |

--- a/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
@@ -21,9 +21,11 @@ license     = "MIT OR Apache-2.0"
 # v0.1 PR-2: Badge, Spinner, Toast.
 # v0.1 PR-3: Checkbox, Input, Radio (form controls).
 # v0.1 PR-4: ListGroup, Modal.
-# Remaining Tier-1 (Card, Container, Field) lands across follow-up PRs.
+# v0.1 PR-5: Field (label + HostInput + help/error).
+# Remaining Tier-1 (Card, Container) blocked on UI29-2 children
+# pass-through spec; ship when that lands.
 exports = [
-  "Alert", "Badge", "Button", "Checkbox", "Input",
+  "Alert", "Badge", "Button", "Checkbox", "Field", "Input",
   "ListGroup", "Modal", "Radio", "Spinner", "Toast",
 ]
 

--- a/code/packages/mosaic-pkg-toolkit/src/Field.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Field.dark.msl
@@ -1,0 +1,32 @@
+// Field.dark.msl — dark-theme styling.
+
+style Field {
+  part field {
+    padding : 8 ;
+  }
+  part field-label {
+    color       : "#f1f5f9" ;
+    font-size   : 14 ;
+    font-weight : 500 ;
+    padding     : 0 ;
+  }
+  part field-input {
+    padding       : 8 ;
+    border-radius : 4 ;
+    background    : "#1e293b" ;
+    color         : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#475569" ;
+    font-size     : 14 ;
+  }
+  part field-help {
+    color     : "#94a3b8" ;
+    font-size : 12 ;
+    padding   : 0 ;
+  }
+  part field-error {
+    color     : "#f87171" ;
+    font-size : 12 ;
+    padding   : 0 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Field.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Field.light.msl
@@ -1,0 +1,32 @@
+// Field.light.msl — default light-theme styling.
+
+style Field {
+  part field {
+    padding : 8 ;
+  }
+  part field-label {
+    color       : "#212529" ;
+    font-size   : 14 ;
+    font-weight : 500 ;
+    padding     : 0 ;
+  }
+  part field-input {
+    padding       : 8 ;
+    border-radius : 4 ;
+    background    : "#ffffff" ;
+    color         : "#212529" ;
+    border-width  : 1 ;
+    border-color  : "#ced4da" ;
+    font-size     : 14 ;
+  }
+  part field-help {
+    color     : "#6c757d" ;
+    font-size : 12 ;
+    padding   : 0 ;
+  }
+  part field-error {
+    color     : "#dc3545" ;
+    font-size : 12 ;
+    padding   : 0 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Field.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Field.mil
@@ -1,0 +1,44 @@
+// Field.mil — interface for the toolkit's Field.
+//
+// Bootstrap's "form group" — a labelled text input with optional
+// help text below (or error text in red when validation fails).
+// The classic pattern:
+//
+//   Label
+//   [_____________ ]
+//   help / error
+//
+// v0.1 ships a text-input-only Field. A future PR (after UI29-2
+// children pass-through lands) can let Field wrap arbitrary content
+// (a Select, a Checkbox group, etc.) via a `children: node` slot.
+// For now the inner input is a HostInput inlined directly in
+// Field.mll — there's no inter-toolkit-component reference because
+// the kernel doesn't yet support self-package references in the
+// resolver.
+
+component Field {
+  // The label text shown above the input.
+  slot label : text ;
+
+  // The current value of the inner input. Required.
+  slot value : text ;
+
+  // Placeholder shown when the input is empty.
+  slot placeholder : text ;
+
+  // Help text shown below the input when there's no error.
+  slot help : text ;
+
+  // Error text shown below the input when validation fails. When
+  // set (non-empty), this REPLACES the help text and the field
+  // paints in the danger state. When empty, the help text shows.
+  slot error : text ;
+
+  // Disabled flag — propagates to the inner input.
+  slot disabled : bool ;
+
+  // Fired on each character change with the new text value.
+  emit onChange ( value : text ) ;
+  // Fired on Enter / commit.
+  emit onCommit ;
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Field.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Field.mll
@@ -1,0 +1,47 @@
+// Field.mll — layout for the Field component.
+//
+//   Column [ field ]
+//     Text [ field-label ] ( content: slot: label )
+//     HostInput [ field-input ] (
+//       value: slot: value ,
+//       placeholder: slot: placeholder ,
+//       read-only: slot: disabled ,
+//       onChange: emit: onChange ,
+//       onCommit: emit: onCommit ,
+//     )
+//     If ( when: slot: error ) {
+//       Text [ field-error ] ( content: slot: error )
+//     } Else {
+//       Text [ field-help ] ( content: slot: help )
+//     }
+//
+// Both the help and error texts share the bottom slot via If/Else.
+// When `error: slot: e` evaluates truthy (non-empty per UI29 expr
+// truthiness), the error renders; otherwise the help renders. The
+// .msl styles the two differently — field-error gets the danger
+// color, field-help gets the neutral muted color.
+
+layout Field {
+  Column [ field ] {
+    Text [ field-label ] (
+      content : slot: label
+    )
+    HostInput [ field-input ] (
+      value : slot: value ,
+      placeholder : slot: placeholder ,
+      read-only : slot: disabled ,
+      onChange : emit: onChange ,
+      onCommit : emit: onCommit
+    )
+    If ( when: slot: error ) {
+      Text [ field-error ] (
+        content : slot: error
+      )
+    }
+    Else {
+      Text [ field-help ] (
+        content : slot: help
+      )
+    }
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -35,7 +35,7 @@ use std::path::PathBuf;
 /// Alphabetical order matches the manifest's `[components].exports`
 /// list. Reorder both together if it ever changes.
 const COMPONENTS: &[&str] = &[
-    "Alert", "Badge", "Button", "Checkbox", "Input",
+    "Alert", "Badge", "Button", "Checkbox", "Field", "Input",
     "ListGroup", "Modal", "Radio", "Spinner", "Toast",
 ];
 
@@ -294,4 +294,20 @@ fn modal_interface_matches_spec() {
     assert_eq!(slot_names, vec!["title", "message", "open", "close-label"]);
     let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
     assert_eq!(emit_names, vec!["onClose"]);
+}
+
+/// Field — label + HostInput + help/error. The label/help/error
+/// slots are text; value/placeholder are text; disabled is bool.
+#[test]
+fn field_interface_matches_spec() {
+    let mil_src = read_source("Field.mil");
+    let out = mosmodel_compiler::compile(&mil_src).unwrap();
+    let c = &out.component;
+    let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        slot_names,
+        vec!["label", "value", "placeholder", "help", "error", "disabled"]
+    );
+    let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(emit_names, vec!["onChange", "onCommit"]);
 }


### PR DESCRIPTION
Bootstrap's "form group" pattern. Stacks on #3945.

`Column[field]` containing label `Text`, `HostInput[field-input]`, and an `If error / Else help` pair. Slots: `label`, `value`, `placeholder`, `help`, `error`, `disabled`. Emits: `onChange(value: text)`, `onCommit`.

## Why HostInput inline, not Input via component reference

UI29 §4.4 routes component-ref resolution through `[dependencies]` — a package can't depend on itself, so Field can't reference Input from the same toolkit package. Inlining HostInput is the path of least resistance. A small follow-up could add self-reference support to the resolver (auto-register the active package's own `[components].exports`); until then, the duplication is acceptable.

## Tests

13 pass (was 12). Field's interface verified.

**11 of 13 Tier-1 components shipped.** Remaining: Card, Container — both still blocked on UI29-2 children pass-through (#3947).

🤖 Generated with Claude Code