### PR TITLE
feat(twig-ir-compiler): typed if + typed mov (Path A increment 3)

### DIFF
--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog — twig-ir-compiler
 
+## [0.18.0] — 2026-05-22 (Path A — typed `let` / `let*` / `and` / `or`)
+
+### Added — Typed `mov` at the remaining branch-merge sites
+
+Increment 4 of the Twig → IIR-to-* end-to-end story.  Extends the
+`FnCtx::emit_move` helper from increment 3 to the four other
+control-flow sites that previously emitted `call_builtin "_move"`:
+`compile_let`, `compile_let_star`, `compile_and`, `compile_or`.
+
+#### What changed
+
+- `compile_let` — each binding's RHS-to-name copy uses `emit_move`.
+  Type propagates from RHS to binding.
+- `compile_let_star` — same.  Each subsequent RHS sees the previous
+  binding's type, so chains like `(let* ((a 1) (b (+ a 1))) b)` end
+  up fully typed.
+- `compile_and` — both the then-merge and the constant-`#f` else-merge
+  use `emit_move`.  The `#f` literal is emitted with `type_hint "bool"`
+  (matching `Expr::BoolLit`'s increment-1 behaviour).
+- `compile_or` — both the truthy-merge and the falsy-merge use
+  `emit_move`.
+
+`compile_match` (variant arms, binding arms, wildcard arms) still
+uses `call_builtin "_move"` at 7 sites.  Match programs are deferred
+to increment 5+ — the lowering is more complex (variant tag checks,
+field extraction, fallthrough) and needs separate review.
+
+#### What this unlocks
+
+| Program                              | wasm | jvm | clr | beam |
+|--------------------------------------|------|-----|-----|------|
+| `(let ((x 5)) x)`                    | ✅ (was ❌) | ✅ | ✅ | ✅ |
+| `(let* ((a 1) (b (+ a 1))) b)`       | ✅ (was ❌) | ✅ | ✅ | ✅ |
+| `(let ((x 5) (y 10)) (+ x y))`       | ✅ (was ❌) | ✅ | ✅ | ✅ |
+| `(and #t #t)`                        | ✅ (was ❌) | ✅ | ✅ | ✅ |
+| `(or #f 42)`                         | ✅ (was ❌) | ✅ | ✅ | ✅ |
+| `(match x ((Some v) v))`             | ❌ still rejected — match arm `_move`s | ❌ | ❌ | ❌ |
+
+#### Tests
+
+- Existing `let_binds_via_move` test renamed → `let_binds_via_typed_mov`
+  and updated to assert `mov x [i64]`, not `call_builtin "_move"`.
+- 2 new e2e tests in `tests/backend_compat.rs`:
+  - `twig_typed_let_accepted_by_every_backend` — `(let ((x 5)) x)`
+  - `twig_typed_let_star_with_arithmetic` — `(let* ((a 1) (b (+ a 1))) b)`
+- 73 lib + 9 backend e2e tests pass (was 73 + 7).
+
 ## [0.17.0] — 2026-05-22 (Path A — typed `if` + typed `mov`)
 
 ### Added — Typed `mov` for branch-merge sites

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog — twig-ir-compiler
 
+## [0.17.0] — 2026-05-22 (Path A — typed `if` + typed `mov`)
+
+### Added — Typed `mov` for branch-merge sites
+
+Increment 3 of the Twig → IIR-to-* end-to-end story.  Replaces the
+legacy `call_builtin "_move"` emission pattern with the **typed `mov`
+IR opcode** at branch-merge sites in `compile_if`.  When both arms
+of an `(if cond then else)` expression produce a value of the same
+statically-known type, the if's result type is recorded so
+downstream `ret` instructions propagate it cleanly.
+
+#### What changed
+
+- New `FnCtx::emit_move(dst, src, loc)` helper that emits a typed
+  `mov dst = src [type]` instruction.  Type is sourced from
+  `var_types[src]` (or `"any"` when unknown).  When the type is
+  concrete, the destination is also recorded.
+- `compile_if` now uses `emit_move` for both then-branch and
+  else-branch merge sites.  After both arms are emitted, the
+  compiler computes a *consensus type*: if both arms produce the
+  same concrete type, that becomes the if's result type; otherwise
+  the result stays `"any"` (matching the existing dynamic semantics).
+- `compile_if` no longer emits any `call_builtin "_move"` form.
+
+#### What this unlocks
+
+| Program                          | wasm | jvm | clr | beam |
+|----------------------------------|------|-----|-----|------|
+| `(if #t 1 2)`                    | ✅ (was ❌) | ✅ (was ❌) | ✅ (was ❌) | ✅ (was ❌) |
+| `(if (< 1 2) (+ 10 20) (- 10 20))` | ✅ (combined typed cmp+arith+if) | ✅ | ✅ | ✅ |
+| `(if cond 1 "hello")`            | ❌ still rejected — disagreeing arm types (any) | ❌ | ❌ | ❌ |
+
+Programs where both arms produce the same concrete type now flow
+through every backend.  Programs whose if branches return different
+types still hit the dynamic fallback.
+
+#### twig-vm regression fix
+
+Path-A increments 2 (PR #3949) and this PR break twig-vm runtime
+execution by emitting typed CIR mnemonics that twig-vm's dispatch
+table doesn't recognise.  PR #3949 includes the corresponding
+twig-vm patch (`twig-vm` 0.19.0) — typed CIR mnemonics now
+synthesise the equivalent `call_builtin "<runtime_name>"` form and
+delegate to the existing builtin dispatch.
+
+#### Tests
+
+- Existing `if_emits_jmp_if_false_and_two_labels` test renamed
+  and updated to assert two typed `mov` instructions (zero legacy
+  `_move`).
+- 2 new e2e tests in `tests/backend_compat.rs`:
+  - `twig_typed_if_accepted_by_every_backend` — `(if #t 1 2)`
+  - `twig_typed_arithmetic_in_if_accepted_by_every_backend` —
+    `(if (< 1 2) (+ 10 20) (- 10 20))`
+- 73 lib + 7 backend e2e tests pass.
+
+#### Compatibility
+
+- Non-Twig callers unaffected.
+- twig-vm 0.19.0 (this stack, base #3949) handles the typed `mov`
+  natively — no Twig program changes runtime behaviour.
+
 ## [0.16.0] — 2026-05-22 (Path A — typed binary arithmetic + comparison)
 
 ### Added — Typed CIR mnemonics for binary arithmetic / comparison

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG52: let*, and/or special forms.  LANG55: HOF builtins.  LANG56: IIRExport from module_info.  LANG57: match jmpif bug fix + string/symbol conversion builtins.  LANG58: string/char builtins for TW05-E.  LANG72: compile_program_with_externs_and_globals for cross-module strict type checking."
 

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG52: let*, and/or special forms.  LANG55: HOF builtins.  LANG56: IIRExport from module_info.  LANG57: match jmpif bug fix + string/symbol conversion builtins.  LANG58: string/char builtins for TW05-E.  LANG72: compile_program_with_externs_and_globals for cross-module strict type checking."
 

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -312,6 +312,40 @@ impl FnCtx {
     fn type_of(&self, var: &str) -> &str {
         self.var_types.get(var).map(|s| s.as_str()).unwrap_or("any")
     }
+
+    /// Path-A increment 3: emit a typed `mov dst = src` instruction,
+    /// propagating the source's inferred type to the destination.
+    ///
+    /// Replaces the legacy `call_builtin "_move" src` emission pattern
+    /// that the IIR-to-* backend validators all reject (because
+    /// `_move` is not in their `CALL_BUILTIN_SUPPORTED_NAMES` whitelist).
+    /// The typed `mov` IR opcode is accepted by every backend
+    /// (vm-core dispatch fix #3888, iir-to-beam mov lowering #3898,
+    /// and the iir-to-wasm / iir-to-jvm / iir-to-cil backends all
+    /// have native `"mov"` arms in their `lower.rs` match tables).
+    ///
+    /// The `type_hint` carried on the `mov` is the source variable's
+    /// type — `"any"` for dynamically-typed sources, `"i64"` / `"bool"`
+    /// for sources statically inferred by increments 1 and 2.
+    ///
+    /// When the source's type is known, the destination's type is
+    /// recorded so downstream consumers (e.g. the outer `ret` in
+    /// `main`) can propagate further.
+    fn emit_move(&mut self, dst: &str, src: &str, loc: SourceLoc) {
+        let ty = self.type_of(src).to_string();
+        self.emit(
+            IIRInstr::new(
+                "mov",
+                Some(dst.to_string()),
+                vec![Operand::Var(src.to_string())],
+                ty.as_str(),
+            ),
+            loc,
+        );
+        if ty != "any" {
+            self.record_type(dst, ty.as_str());
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -958,15 +992,16 @@ impl Compiler {
             "void",
         ), loc);
 
-        // Then branch — compile and copy into `result` via `_move`.
+        // Then branch — compile and copy into `result` via typed `mov`.
+        // Path-A increment 3: replaces the legacy `call_builtin "_move"`
+        // with a typed `mov` IR opcode.  If both arms produce the same
+        // statically-known type, `result` ends up typed and propagates
+        // through downstream `ret` instructions; programs like
+        // `(if (< x 0) -1 1)` now flow through every IIR-to-* backend.
         let then_v = self.compile_expr(&expr.then_branch, ctx)?;
+        let then_ty = ctx.type_of(&then_v).to_string();
         let then_loc = SourceLoc::new(expr.then_branch.pos().0, expr.then_branch.pos().1);
-        ctx.emit(IIRInstr::new(
-            "call_builtin",
-            Some(result.clone()),
-            vec![Operand::Var("_move".into()), Operand::Var(then_v)],
-            "any",
-        ), then_loc);
+        ctx.emit_move(&result, &then_v, then_loc);
         ctx.emit(IIRInstr::new(
             "jmp",
             None,
@@ -982,13 +1017,32 @@ impl Compiler {
             "void",
         ), loc);
         let else_v = self.compile_expr(&expr.else_branch, ctx)?;
+        let else_ty = ctx.type_of(&else_v).to_string();
         let else_loc = SourceLoc::new(expr.else_branch.pos().0, expr.else_branch.pos().1);
+        // `emit_move` for the else arm would overwrite `result`'s
+        // recorded type from the then-arm's `emit_move`.  Compute the
+        // consensus type up front so the recorded type reflects both
+        // arms' agreement (or `"any"` when they disagree).
         ctx.emit(IIRInstr::new(
-            "call_builtin",
+            "mov",
             Some(result.clone()),
-            vec![Operand::Var("_move".into()), Operand::Var(else_v)],
-            "any",
+            vec![Operand::Var(else_v)],
+            else_ty.as_str(),
         ), else_loc);
+        // Consensus: if both arms agree on a concrete type, that's the
+        // type of the `if` expression.  Otherwise it's `any`.
+        let consensus_ty = if then_ty == else_ty && then_ty != "any" {
+            then_ty
+        } else {
+            "any".to_string()
+        };
+        if consensus_ty != "any" {
+            ctx.record_type(&result, &consensus_ty);
+        } else {
+            // Clear any record from the then-arm's emit_move so
+            // downstream lookups don't return a stale type.
+            ctx.var_types.remove(&result);
+        }
 
         ctx.emit(IIRInstr::new(
             "label",

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -1062,19 +1062,17 @@ impl Compiler {
             binding_values.push((name.clone(), v));
         }
 
-        // Bind each name into `locals_` via a `_move` copy so the
+        // Bind each name into `locals_` via a typed `mov` copy so the
         // binding name exists as a named register in the frame.
+        // Path-A increment 4: typed `mov` propagates the RHS's
+        // inferred type to the binding name, so subsequent expressions
+        // that reference `name` see the concrete type.
         let mut added: Vec<String> = Vec::new();
         for (name, src) in &binding_values {
             if ctx.locals.insert(name.clone()) {
                 added.push(name.clone());
             }
-            ctx.emit(IIRInstr::new(
-                "call_builtin",
-                Some(name.clone()),
-                vec![Operand::Var("_move".into()), Operand::Var(src.clone())],
-                "any",
-            ), loc);
+            ctx.emit_move(name, src, loc);
         }
 
         // Compile body — at least one expression (parser-enforced).
@@ -1116,15 +1114,12 @@ impl Compiler {
             let v = self.compile_expr(rhs, ctx)?;
 
             // Bind the name into locals BEFORE compiling the next binding.
+            // Path-A increment 4: typed `mov` propagates the RHS's
+            // inferred type to the binding name (mirrors compile_let).
             if ctx.locals.insert(name.clone()) {
                 added.push(name.clone());
             }
-            ctx.emit(IIRInstr::new(
-                "call_builtin",
-                Some(name.clone()),
-                vec![Operand::Var("_move".into()), Operand::Var(v)],
-                "any",
-            ), loc);
+            ctx.emit_move(name, &v, loc);
         }
 
         // Compile body — parser-enforced at least one expression.
@@ -1182,18 +1177,23 @@ impl Compiler {
                     vec![Operand::Var(cond), Operand::Var(else_label.clone())],
                     "void"), loc);
 
-                // Then path: compile rest, copy to dest, jump to end.
+                // Then path: compile rest, copy to dest via typed `mov`,
+                // jump to end.  Path-A increment 4.
                 let then_val = self.compile_and(rest, ctx, loc)?;
-                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
-                    vec![Operand::Var("_move".into()), Operand::Var(then_val)], "any"), loc);
+                ctx.emit_move(&dest, &then_val, loc);
                 ctx.emit(IIRInstr::new("jmp", None, vec![Operand::Var(end_label.clone())], "void"), loc);
 
-                // Else path: dest ← #f
+                // Else path: dest ← #f (typed `mov` from a `const_bool`-
+                // typed temporary so the dest carries `"bool"`).
                 ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(else_label)], "void"), loc);
                 let false_tmp = ctx.fresh_var("f");
-                ctx.emit(IIRInstr::new("const", Some(false_tmp.clone()), vec![Operand::Bool(false)], "any"), loc);
-                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
-                    vec![Operand::Var("_move".into()), Operand::Var(false_tmp)], "any"), loc);
+                // The false literal site uses the same typed `const`
+                // shape that `Expr::BoolLit` emits — see compile_expr
+                // path-A increment 1.
+                ctx.emit(IIRInstr::new("const", Some(false_tmp.clone()),
+                    vec![Operand::Bool(false)], "bool"), loc);
+                ctx.record_type(&false_tmp, "bool");
+                ctx.emit_move(&dest, &false_tmp, loc);
 
                 ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(end_label)], "void"), loc);
                 Ok(dest)
@@ -1234,16 +1234,15 @@ impl Compiler {
                     vec![Operand::Var(cond.clone()), Operand::Var(falsy_label.clone())],
                     "void"), loc);
 
-                // Truthy path: dest ← cond, jump to end.
-                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
-                    vec![Operand::Var("_move".into()), Operand::Var(cond)], "any"), loc);
+                // Truthy path: dest ← cond via typed `mov`, jump to end.
+                // Path-A increment 4.
+                ctx.emit_move(&dest, &cond, loc);
                 ctx.emit(IIRInstr::new("jmp", None, vec![Operand::Var(end_label.clone())], "void"), loc);
 
-                // Falsy path: evaluate rest.
+                // Falsy path: evaluate rest, copy via typed `mov`.
                 ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(falsy_label)], "void"), loc);
                 let rest_val = self.compile_or(rest, ctx, loc)?;
-                ctx.emit(IIRInstr::new("call_builtin", Some(dest.clone()),
-                    vec![Operand::Var("_move".into()), Operand::Var(rest_val)], "any"), loc);
+                ctx.emit_move(&dest, &rest_val, loc);
 
                 ctx.emit(IIRInstr::new("label", None, vec![Operand::Var(end_label)], "void"), loc);
                 Ok(dest)

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -815,13 +815,23 @@ mod tests {
     }
 
     #[test]
-    fn let_binds_via_move() {
+    fn let_binds_via_typed_mov() {
+        // Path-A increment 4: let-bindings now use typed `mov` instead
+        // of `call_builtin "_move"`.  The type of the RHS (`1` → `i64`)
+        // propagates to the binding name `x`.
         let i = main_instrs("(let ((x 1)) x)");
-        // Should have a _move into a register named "x".
-        let mv = i.iter().find(|x| x.op == "call_builtin"
-            && matches!(&x.srcs[0], Operand::Var(s) if s == "_move")
-            && x.dest.as_deref() == Some("x"));
-        assert!(mv.is_some(), "expected (let ((x 1)) ...) to _move into x");
+        let mv = i.iter().find(|x| x.op == "mov"
+            && x.dest.as_deref() == Some("x")).expect(
+            "expected (let ((x 1)) ...) to emit `mov x = <rhs>`",
+        );
+        assert_eq!(mv.type_hint, "i64",
+            "typed mov must carry the RHS's inferred type");
+        // The legacy `call_builtin "_move"` shape must NOT appear.
+        assert!(
+            !i.iter().any(|x| x.op == "call_builtin"
+                && matches!(&x.srcs[0], Operand::Var(s) if s == "_move")),
+            "compile_let must not emit legacy call_builtin \"_move\"",
+        );
     }
 
     #[test]

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -794,16 +794,24 @@ mod tests {
     fn if_emits_jmp_if_false_and_two_labels() {
         let i = main_instrs("(if #t 1 2)");
         let ops = op_names(&i);
-        // jmp_if_false ... call_builtin _move ... jmp ... label ... call_builtin _move ... label ... ret
+        // jmp_if_false ... mov ... jmp ... label ... mov ... label ... ret
         assert!(ops.contains(&"jmp_if_false"));
         assert!(ops.contains(&"jmp"));
         assert_eq!(ops.iter().filter(|&&o| o == "label").count(), 2);
-        // Both arms use _move (preserves type, doesn't coerce booleans).
-        let moves: Vec<_> = i.iter().filter(|x| {
-            x.op == "call_builtin"
-                && matches!(&x.srcs[0], Operand::Var(s) if s == "_move")
-        }).collect();
-        assert_eq!(moves.len(), 2);
+        // Path-A increment 3: both arms use typed `mov` (not the legacy
+        // `call_builtin "_move"`).  This is what makes the if's result
+        // flow through the IIR-to-* backend validators — they all
+        // accept `mov` but reject unknown `call_builtin` names.
+        let moves: Vec<_> = i.iter().filter(|x| x.op == "mov").collect();
+        assert_eq!(moves.len(), 2,
+            "compile_if should emit two typed `mov` instructions \
+             (one per branch); got ops: {ops:?}");
+        // The legacy `_move` shape must NOT appear anywhere.
+        assert!(
+            !i.iter().any(|x| x.op == "call_builtin"
+                && matches!(&x.srcs[0], Operand::Var(s) if s == "_move")),
+            "compile_if must not emit the legacy call_builtin \"_move\" form",
+        );
     }
 
     #[test]

--- a/code/packages/rust/twig-ir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/twig-ir-compiler/tests/backend_compat.rs
@@ -12,6 +12,7 @@
 //! instructions and remain rejected by the IIR-to-* validators.
 //! Subsequent path-A increments will narrow that gap.
 
+use interpreter_ir::Operand;
 use twig_ir_compiler::compile_source;
 
 /// `42` — the smallest Twig program — must now reach every backend's
@@ -114,6 +115,68 @@ fn twig_typed_comparison_accepted_by_every_backend() {
     ] {
         assert!(errs.is_empty(),
             "[{name}] validator should accept Twig `(< 1 2)`; got {errs:?}",
+            errs = errs);
+    }
+}
+
+/// Path-A increment 3: `(if cond then else)` over typed branches now
+/// lowers to typed `mov` (not `call_builtin "_move"`).  The if's
+/// result type is the consensus of the two arms; if both agree,
+/// downstream `ret` propagates the same type to the function's
+/// return.
+#[test]
+fn twig_typed_if_accepted_by_every_backend() {
+    let m = compile_source("(if #t 1 2)", "compat")
+        .expect("Twig must compile");
+    let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+
+    // Both arms are i64 literals; consensus i64 should propagate to ret.
+    assert_eq!(main.return_type, "i64",
+        "main return_type should be inferred as i64 when both `if` \
+         arms produce i64");
+
+    // The IR must contain two `mov` instructions (one per arm) and
+    // zero `call_builtin "_move"` instructions.
+    let movs = main.instructions.iter().filter(|i| i.op == "mov")
+        .collect::<Vec<_>>();
+    assert_eq!(movs.len(), 2,
+        "expected two typed mov instructions; got: {movs:?}");
+    assert!(
+        !main.instructions.iter().any(|i| i.op == "call_builtin"
+            && matches!(&i.srcs[0], Operand::Var(s) if s == "_move")),
+        "typed if must not emit legacy call_builtin \"_move\"",
+    );
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] validator should accept Twig `(if #t 1 2)` after \
+             path-A increment 3; got {} error(s): {errs:?}",
+            errs.len());
+    }
+}
+
+/// A combined arithmetic + if program: `(if (< 1 2) (+ 10 20) (- 10 20))`.
+/// Exercises typed cmp_lt + typed add + typed sub + typed if all together.
+#[test]
+fn twig_typed_arithmetic_in_if_accepted_by_every_backend() {
+    let m = compile_source("(if (< 1 2) (+ 10 20) (- 10 20))", "compat")
+        .expect("Twig must compile");
+    let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.return_type, "i64");
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] should accept combined arith+if; got {errs:?}",
             errs = errs);
     }
 }

--- a/code/packages/rust/twig-ir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/twig-ir-compiler/tests/backend_compat.rs
@@ -181,6 +181,64 @@ fn twig_typed_arithmetic_in_if_accepted_by_every_backend() {
     }
 }
 
+/// Path-A increment 4: `let` bindings now use typed `mov`.
+#[test]
+fn twig_typed_let_accepted_by_every_backend() {
+    let m = compile_source("(let ((x 5)) x)", "compat")
+        .expect("Twig must compile");
+    let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.return_type, "i64",
+        "main return_type should be inferred as i64 for `(let ((x 5)) x)`");
+    assert!(
+        main.instructions.iter().any(|i| i.op == "mov"
+            && i.dest.as_deref() == Some("x")
+            && i.type_hint == "i64"),
+        "let-binding should emit typed `mov x` with i64 type",
+    );
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] should accept `(let ((x 5)) x)`; got {errs:?}",
+            errs = errs);
+    }
+}
+
+/// `let*` builds up typed bindings sequentially.  `(let* ((a 1) (b (+ a 1))) b)`
+/// types `a` as i64, then `(+ a 1)` lowers to typed `add`, then `b`
+/// inherits i64 too.
+#[test]
+fn twig_typed_let_star_with_arithmetic() {
+    let m = compile_source("(let* ((a 1) (b (+ a 1))) b)", "compat")
+        .expect("Twig must compile");
+    let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.return_type, "i64");
+    let a_mov = main.instructions.iter().find(|i| i.op == "mov"
+        && i.dest.as_deref() == Some("a"))
+        .expect("expected `mov a`");
+    assert_eq!(a_mov.type_hint, "i64");
+    let b_mov = main.instructions.iter().find(|i| i.op == "mov"
+        && i.dest.as_deref() == Some("b"))
+        .expect("expected `mov b`");
+    assert_eq!(b_mov.type_hint, "i64",
+        "binding `b` should inherit i64 from the typed-add RHS");
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] should accept `(let* ((a 1) (b (+ a 1))) b)`; got {errs:?}",
+            errs = errs);
+    }
+}
+
 /// Pin the *current* boundary: arithmetic where at least one operand
 /// has a dynamic type (comes from a `call_builtin` like `car`) still
 /// emits `call_builtin "+"` and gets rejected by every backend.  When


### PR DESCRIPTION
## Summary

**Stacked on PR #3949** (typed arithmetic + twig-vm regression fix).

Increment 3 replaces the legacy \`call_builtin \"_move\"\` emission pattern with the **typed \`mov\` IR opcode** at branch-merge sites in \`compile_if\`.  When both arms of an \`(if cond then else)\` expression produce the same statically-known type, the if's result type is recorded so downstream \`ret\` instructions propagate it cleanly.

## What this unlocks

| Program                          | wasm | jvm | clr | beam |
|----------------------------------|------|-----|-----|------|
| \`(if #t 1 2)\`                  | ✅ (was ❌) | ✅ (was ❌) | ✅ (was ❌) | ✅ (was ❌) |
| \`(if (< 1 2) (+ 10 20) (- 10 20))\` | ✅ (combined typed cmp+arith+if) | ✅ | ✅ | ✅ |
| \`(if cond 1 \"hello\")\`        | ❌ still rejected — disagreeing arm types | ❌ | ❌ | ❌ |

Programs where both arms produce the same concrete type now flow through every backend.  Programs whose if branches return different types still hit the dynamic fallback.

## What's in this PR

### \`FnCtx::emit_move(dst, src, loc)\`

New helper that emits \`mov dst = src [type]\`.  Type sourced from \`var_types[src]\` (or \`\"any\"\` when unknown).  When concrete, dest is recorded for downstream propagation.

### \`compile_if\` rewritten

- Both then-branch and else-branch merge sites use \`emit_move\` instead of \`call_builtin \"_move\"\`.
- Computes a *consensus type* from the two arms: if both produce the same concrete type, that becomes the if's result type; otherwise \`\"any\"\`.

### Tests

- Existing \`if_emits_jmp_if_false_and_two_labels\` updated to assert two typed \`mov\` (zero legacy \`_move\`).
- 2 new e2e tests in \`tests/backend_compat.rs\`.
- 73 lib + 7 backend e2e tests pass.
- 179 twig-vm tests pass (the typed-mov runtime is handled by twig-vm 0.19.0 in the base PR #3949).

## Compatibility

- Non-Twig callers unaffected.
- twig-vm regression fix lives in the base PR #3949 — without that, this PR would break runtime execution.

## Version bump

twig-ir-compiler: 0.16.0 → 0.17.0

## Test plan

- [x] \`cargo test -p twig-ir-compiler\` (80 pass)
- [x] \`cargo test -p twig-vm\` (179 pass)
- [x] /security-review passed
- [ ] CI green
- [ ] Will rebase onto \`main\` after #3949 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)