### PR TITLE
feat(ml-framework-core): MX10 Phase 4-back-gelu — Rust fast path for GELUFunction.backward

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,83 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 4-back-gelu: optional Rust fast path for `GELUFunction.backward` via an 18-op composed graph
+
+Closes the fourth activation backward.  Pairs with Phase 4c's
+forward GELU dispatch.  Together with Phase 4-back (Tanh + Sigmoid)
+and Phase 4-back-softmax, this means **four of the five classic
+activation backwards now have Rust fast paths**.  Only ReLU
+backward remains, which needs an upstream matrix-cpu primitive
+(`Greater` or similar comparison op) that the matrix-ir-json IR
+doesn't expose as a single op today.
+
+#### Why 18 ops
+
+GELU backward uses the closed-form chain-rule derivative of the
+tanh-approximation form:
+
+```
+inner    = sqrt(2/π) * x * (1 + 0.044715 * x²)
+tanh_v   = tanh(inner)
+sech²    = 1 - tanh_v²
+d_inner  = sqrt(2/π) * (1 + 3 * 0.044715 * x²)
+grad_in  = grad * (0.5 * (1 + tanh_v) + 0.5 * x * sech² * d_inner)
+```
+
+That's two parallel sub-graphs (one for `inner`/`tanh_v`/`1+tanh_v`,
+one for `d_inner`/`sech²`) that combine in the final
+`term1 + term2 → multiply by grad` step.  Forward used 9 ops; the
+backward adds the `sech²` derivative chain and the term combination,
+landing at 18.
+
+All 18 ops still ship in **one** FFI envelope.  Five constants are
+materialised at full target shape (`0.044715`, `3 * 0.044715 =
+0.134145`, `sqrt(2/π)`, `1.0`, `0.5`) because matrix-cpu's
+elementwise ops don't broadcast scalars.  The pre-multiplied
+`3 * 0.044715` constant saves one in-graph `Mul` vs computing it
+from `c_coeff` at runtime.
+
+#### Implementation
+
+- **`_rust_backend.py`** — adds `gelu_backward_via_rust(grad_data,
+  input_data, target_shape, device)` (~165 LOC).  Reuses the
+  module-level `_GELU_SQRT_2_PI` and `_GELU_COEFF` constants from
+  Phase 4c's forward helper.  Inner `_const_bytes(value)` helper
+  packs each constant tensor.
+- **`functions.py`** — `GELUFunction.backward` gains a 9-line
+  dispatch block before the existing per-cell loop.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `numel ≥ 100_000` | **Rust** (18-op composed graph in one FFI call) |
+| Extension installed, `numel < 100_000` | Pure-Python per-cell loop |
+| Extension NOT installed | Pure-Python per-cell loop |
+
+#### Tests (86 total MX10 tests, was 84)
+
+- **`ActivationParityTests.test_gelu_backward_parity`** (1 case,
+  skip if extension missing): builds a `(500, 200)` requires_grad
+  input in `[-3, 3]`, runs `GELU` forward + backward via Rust,
+  then via pure-Python, compares gradients at `rtol=1e-3,
+  atol=1e-4`.  Range `[-3, 3]` covers both the linear and
+  saturating regions of GELU.
+- **`GELUFallbackTests.test_gelu_backward_via_rust_raises_when_unavailable`**
+  (1 case, always run): defence-in-depth `RuntimeError`.
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**375 passed + 33 skipped (parity tests that need the extension)**;
+the pre-existing `test_device.py` failure on main is unrelated.
+
+### What's NOT in Phase 4-back-gelu
+
+- ReLU backward (`g * (x > 0)`).  Needs a `Greater` / `Step` /
+  `Where` op in matrix-cpu that's not exposed in matrix-ir-json
+  today.  Workarounds using `Max(x, 0) / x * g` hit div-by-zero on
+  the negative half.  **Deferred until matrix-cpu adds a comparison
+  primitive.**
+
 ### Added — MX10 Phase 4-back-softmax: optional Rust fast path for `SoftmaxFunction.backward` via a 5-op composed graph
 
 Closes the third activation backward.  After Phase 4-back's

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -1795,3 +1795,149 @@ def softmax_backward_via_rust(
         )
     out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
     return _Tensor(out_floats, target_shape, device=device)
+
+
+def gelu_backward_via_rust(
+    grad_data: list[float],
+    input_data: list[float],
+    target_shape: tuple[int, ...],
+    *,
+    device: str | None = None,
+) -> Tensor:
+    """GELU backward via the tanh-approximation chain rule, as an 18-op
+    composed graph.
+
+    Formula (matches ``GELUFunction.backward``'s pure-Python kernel)::
+
+        inner    = sqrt(2/π) * x * (1 + 0.044715 * x²)        # forward inner term
+        tanh_v   = tanh(inner)
+        sech²    = 1 - tanh_v²
+        d_inner  = sqrt(2/π) * (1 + 3 * 0.044715 * x²)        # d/dx of inner
+        grad_in  = grad * (0.5 * (1 + tanh_v) + 0.5 * x * sech² * d_inner)
+
+    GELU's backward is the heaviest activation backward by op count (18
+    ops vs 3 for Sigmoid/Tanh, 5 for Softmax) because the closed-form
+    derivative has two terms (the leading ``0.5 * (1 + tanh)`` from
+    differentiating ``x * sigmoid_like(x)`` plus the chain-rule
+    contribution from ``inner(x)``).  All 18 ops still ship in **one**
+    FFI envelope so per-call overhead is paid once.
+
+    Five constants (``0.044715``, ``3 * 0.044715 = 0.134145``,
+    ``sqrt(2/π)``, ``1.0``, ``0.5``) are each materialised at full
+    target_shape because matrix-cpu Mul/Add/Sub don't broadcast scalars.
+    The pre-multiplied ``3 * 0.044715`` constant avoids one in-graph
+    Mul vs computing it from ``c_coeff`` at runtime.
+
+    Caller saves ``a`` (the input tensor) in ``self.saved_tensors`` —
+    backward calls this helper with ``input_data = a.data``.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "gelu_backward_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_activation() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(grad_data)
+    if len(input_data) != numel:
+        raise RuntimeError(
+            f"gelu_backward_via_rust: grad has {numel} cells but input "
+            f"has {len(input_data)} cells — must match"
+        )
+
+    target_shape_list = list(target_shape)
+
+    grad_bytes = struct.pack(f"<{numel}f", *grad_data)
+    x_bytes = struct.pack(f"<{numel}f", *input_data)
+
+    def _const_bytes(value: float) -> str:
+        return struct.pack(f"<{numel}f", *([value] * numel)).hex()
+
+    coeff_hex = _const_bytes(_GELU_COEFF)                    # 0.044715
+    three_coeff_hex = _const_bytes(3.0 * _GELU_COEFF)         # 0.134145
+    sqrt_2pi_hex = _const_bytes(_GELU_SQRT_2_PI)
+    ones_hex = _const_bytes(1.0)
+    half_hex = _const_bytes(0.5)
+
+    # Tensor ID layout (25 tensors total).
+    # Inputs:  0=g, 1=x
+    # Constants: 3=c_coeff, 5=c_1, 8=c_sqrt_2π, 12=c_half, 16=c_3coeff
+    # Intermediates and output: see ops list below for the data-flow.
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    {"id": 0, "dtype": "f32", "shape": target_shape_list},   # g
+                    {"id": 1, "dtype": "f32", "shape": target_shape_list},   # x
+                    {"id": 2, "dtype": "f32", "shape": target_shape_list},   # x²
+                    {"id": 3, "dtype": "f32", "shape": target_shape_list},   # c_coeff
+                    {"id": 4, "dtype": "f32", "shape": target_shape_list},   # 0.044715 · x²
+                    {"id": 5, "dtype": "f32", "shape": target_shape_list},   # c_1
+                    {"id": 6, "dtype": "f32", "shape": target_shape_list},   # 1 + 0.044715·x²
+                    {"id": 7, "dtype": "f32", "shape": target_shape_list},   # x · (1 + 0.044715·x²)
+                    {"id": 8, "dtype": "f32", "shape": target_shape_list},   # c_sqrt_2π
+                    {"id": 9, "dtype": "f32", "shape": target_shape_list},   # inner = sqrt(2/π) · x · (1 + 0.044715·x²)
+                    {"id": 10, "dtype": "f32", "shape": target_shape_list},  # tanh(inner)
+                    {"id": 11, "dtype": "f32", "shape": target_shape_list},  # 1 + tanh(inner)
+                    {"id": 12, "dtype": "f32", "shape": target_shape_list},  # c_half
+                    {"id": 13, "dtype": "f32", "shape": target_shape_list},  # term1 = 0.5 · (1 + tanh(inner))
+                    {"id": 14, "dtype": "f32", "shape": target_shape_list},  # tanh²
+                    {"id": 15, "dtype": "f32", "shape": target_shape_list},  # sech² = 1 - tanh²
+                    {"id": 16, "dtype": "f32", "shape": target_shape_list},  # c_3coeff = 0.134145
+                    {"id": 17, "dtype": "f32", "shape": target_shape_list},  # 0.134145 · x²
+                    {"id": 18, "dtype": "f32", "shape": target_shape_list},  # 1 + 0.134145·x²
+                    {"id": 19, "dtype": "f32", "shape": target_shape_list},  # d_inner = sqrt(2/π) · (1 + 0.134145·x²)
+                    {"id": 20, "dtype": "f32", "shape": target_shape_list},  # sech² · d_inner
+                    {"id": 21, "dtype": "f32", "shape": target_shape_list},  # x · sech² · d_inner
+                    {"id": 22, "dtype": "f32", "shape": target_shape_list},  # term2 = 0.5 · x · sech² · d_inner
+                    {"id": 23, "dtype": "f32", "shape": target_shape_list},  # term1 + term2
+                    {"id": 24, "dtype": "f32", "shape": target_shape_list},  # output = g · (term1 + term2)
+                ],
+                "inputs": [0, 1],
+                "outputs": [24],
+                "ops": [
+                    {"kind": "Mul", "lhs": 1, "rhs": 1, "output": 2},        # x²
+                    {"kind": "Mul", "lhs": 2, "rhs": 3, "output": 4},        # 0.044715·x²
+                    {"kind": "Add", "lhs": 4, "rhs": 5, "output": 6},        # 1 + 0.044715·x²
+                    {"kind": "Mul", "lhs": 1, "rhs": 6, "output": 7},        # x · (1 + 0.044715·x²)
+                    {"kind": "Mul", "lhs": 7, "rhs": 8, "output": 9},        # inner
+                    {"kind": "Tanh", "input": 9, "output": 10},              # tanh(inner)
+                    {"kind": "Add", "lhs": 10, "rhs": 5, "output": 11},      # 1 + tanh(inner)
+                    {"kind": "Mul", "lhs": 11, "rhs": 12, "output": 13},     # term1
+                    {"kind": "Mul", "lhs": 10, "rhs": 10, "output": 14},     # tanh²
+                    {"kind": "Sub", "lhs": 5, "rhs": 14, "output": 15},      # sech² = 1 - tanh²
+                    {"kind": "Mul", "lhs": 2, "rhs": 16, "output": 17},      # 0.134145·x²
+                    {"kind": "Add", "lhs": 17, "rhs": 5, "output": 18},      # 1 + 0.134145·x²
+                    {"kind": "Mul", "lhs": 18, "rhs": 8, "output": 19},      # d_inner
+                    {"kind": "Mul", "lhs": 15, "rhs": 19, "output": 20},     # sech² · d_inner
+                    {"kind": "Mul", "lhs": 1, "rhs": 20, "output": 21},      # x · sech² · d_inner
+                    {"kind": "Mul", "lhs": 21, "rhs": 12, "output": 22},     # term2 = 0.5 · x · sech² · d_inner
+                    {"kind": "Add", "lhs": 13, "rhs": 22, "output": 23},     # term1 + term2
+                    {"kind": "Mul", "lhs": 0, "rhs": 23, "output": 24},      # g · (term1 + term2)
+                ],
+                "constants": [
+                    {"tensor_id": 3, "dtype": "f32", "shape": target_shape_list, "bytes_hex": coeff_hex},
+                    {"tensor_id": 5, "dtype": "f32", "shape": target_shape_list, "bytes_hex": ones_hex},
+                    {"tensor_id": 8, "dtype": "f32", "shape": target_shape_list, "bytes_hex": sqrt_2pi_hex},
+                    {"tensor_id": 12, "dtype": "f32", "shape": target_shape_list, "bytes_hex": half_hex},
+                    {"tensor_id": 16, "dtype": "f32", "shape": target_shape_list, "bytes_hex": three_coeff_hex},
+                ],
+            },
+            "inputs": [grad_bytes.hex(), x_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_bytes = bytes.fromhex(result["outputs"][0])
+
+    expected_bytes = numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"gelu_backward_via_rust: expected {expected_bytes} output bytes "
+            f"({numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
+    return _Tensor(out_floats, target_shape, device=device)

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -47,6 +47,7 @@ from ._rust_backend import (
     abs_via_rust,
     add_via_rust,
     div_via_rust,
+    gelu_backward_via_rust,
     gelu_via_rust,
     matmul_via_rust,
     mean_axis_via_rust,
@@ -944,6 +945,21 @@ class GELUFunction(Function):
 
     def backward(self, grad_output: Tensor) -> tuple[Tensor | None, ...]:
         (a,) = self.saved_tensors
+        # MX10 Phase 4-back-gelu — optional Rust fast path.  GELU
+        # backward = ``g * (0.5 * (1 + tanh_v) + 0.5 * x * sech² * d_inner)``
+        # with ``tanh_v = tanh(inner)``, ``sech² = 1 - tanh_v²``, and
+        # ``d_inner = sqrt(2/π) * (1 + 3 * 0.044715 * x²)``.  Composed
+        # as an 18-op graph (the heaviest activation backward by op
+        # count) with 5 full-shape constants; same threshold as forward.
+        if should_use_rust_for_activation(len(a.data)):
+            return (
+                gelu_backward_via_rust(
+                    grad_output.data,
+                    a.data,
+                    a.shape,
+                    device=a.device,
+                ),
+            )
         grad_data = []
         for x, g in zip(a.data, grad_output.data, strict=False):
             inner = self._SQRT_2_PI * (x + self._COEFF * x * x * x)

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -809,6 +809,14 @@ class GELUFallbackTests(unittest.TestCase):
             expected = 0.5 * x * (1.0 + math.tanh(inner))
             self.assertAlmostEqual(result.data[i], expected, places=12)
 
+    def test_gelu_backward_via_rust_raises_when_unavailable(self) -> None:
+        """``gelu_backward_via_rust`` must raise (defence-in-depth)."""
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.gelu_backward_via_rust(
+                [1.0, 1.0, 1.0], [0.0, 1.0, -1.0], (3,)
+            )
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
     def test_gelu_backward_via_fallback(self) -> None:
         """GELU's backward formula recomputes ``inner`` and
         ``tanh(inner)`` from the saved input (no metadata handshake

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -845,6 +845,41 @@ class ActivationParityTests(unittest.TestCase):
         # default rtol=1e-3 anyway for consistency.
         self._assert_close(rust_result.data, python_result.data)
 
+    def test_gelu_backward_parity(self) -> None:
+        """``GELUFunction.backward`` Rust matches pure-Python.
+
+        Phase 4-back-gelu — backward is the 18-op chain-rule
+        expansion of the tanh-approximation form: ``g * (0.5 * (1 +
+        tanh_v) + 0.5 * x * sech² * d_inner)``.  All 18 ops + 5
+        full-shape constants ship in a single FFI envelope.
+
+        Numerical drift across 18 f32 ops is bounded but non-trivial,
+        so we use the standard ``rtol=1e-3, atol=1e-4`` budget; the
+        random ``[-3, 3]`` input range covers both the saturating
+        and linear regions of GELU.
+        """
+        from ml_framework_core import GELUFunction, Tensor, _rust_backend
+
+        a = self._make_tensor(seed=222)
+        a.requires_grad = True
+        y = GELUFunction.apply(a)
+        grad_data = [1.0] * (500 * 200)
+        y.backward(Tensor(list(grad_data), self.SHAPE))
+        rust_grad = a.grad
+        self.assertIsNotNone(rust_grad)
+        self.assertEqual(rust_grad.shape, self.SHAPE)
+
+        a2 = Tensor(list(a.data), self.SHAPE, requires_grad=True)
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            y2 = GELUFunction.apply(a2)
+            y2.backward(Tensor(list(grad_data), self.SHAPE))
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_grad.data, a2.grad.data)
+
     def test_softmax_dim1_backward_parity(self) -> None:
         """``SoftmaxFunction.backward`` (dim=1) Rust matches pure-Python.
 


### PR DESCRIPTION
## Summary

- Closes the fourth activation backward (after Tanh/Sigmoid/Softmax). GELU backward = `g * (0.5*(1+tanh_v) + 0.5*x*sech²*d_inner)` via the tanh-approximation chain rule, composed as an **18-op graph** in a single FFI envelope.
- Heaviest activation backward by op count (18 vs 3 for Sigmoid/Tanh, 5 for Softmax) — closed-form derivative has two parallel sub-chains (`inner/tanh_v` and `d_inner/sech²`) combined in a final term1+term2 → multiply-by-grad step.
- Five constants materialised at full target shape (0.044715, 0.134145 = 3·0.044715, sqrt(2/π), 1.0, 0.5). Pre-multiplied 3·coeff saves one in-graph Mul.
- Reuses `_GELU_SQRT_2_PI` / `_GELU_COEFF` from Phase 4c's forward.
- +2 tests (1 parity, 1 fallback). Full suite: **375 passed + 33 skipped + 1 pre-existing unrelated failure**.
- Security review: PASSED.
- **Four of five activation backwards now have Rust fast paths**; only ReLU backward remains (needs upstream matrix-cpu Greater/Step/Where op).

## Test plan

- [x] `python3 -m pytest tests/` passes (375/376)
- [x] New `test_gelu_backward_parity` (1 case) skips without the C extension
- [x] New `test_gelu_backward_via_rust_raises_when_unavailable` (1 case) always runs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)