### PR TITLE
feat(forme-doc-demo): end-to-end demo of the DOC00 v0 cluster

### DIFF
--- a/code/programs/typescript/forme-doc-demo/.gitignore
+++ b/code/programs/typescript/forme-doc-demo/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+.tmp-write-*/

--- a/code/programs/typescript/forme-doc-demo/BUILD
+++ b/code/programs/typescript/forme-doc-demo/BUILD
@@ -1,0 +1,16 @@
+cd ../../../packages/typescript/document-ast && npm ci --quiet
+cd ../../../packages/typescript/commonmark-parser && npm ci --quiet
+cd ../../../packages/typescript/document-ast-to-html && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-frontmatter && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-heading-anchors && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-toc-extractor && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-code-block-decorator && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-syntax-highlighter && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-sidebar-builder && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-page-shell && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-search-tokenizer && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-search-index-builder && npm ci --quiet
+cd ../../../packages/typescript/forme-aot-page-bundle-emitter && npm ci --quiet
+cd ../../../packages/typescript/forme-aot-html-doc-emitter && npm ci --quiet
+cd ../../../packages/typescript/forme-doc-site-emitter && npm ci --quiet
+npm install --silent && npx vitest run --coverage

--- a/code/programs/typescript/forme-doc-demo/BUILD
+++ b/code/programs/typescript/forme-doc-demo/BUILD
@@ -1,6 +1,14 @@
+cd ../../../packages/typescript/directed-graph && npm ci --quiet
+cd ../../../packages/typescript/cli-builder && npm ci --quiet
+cd ../../../packages/typescript/grammar-tools && npm ci --quiet
+cd ../../../packages/typescript/lexer && npm ci --quiet
+cd ../../../packages/typescript/state-machine && npm ci --quiet
+cd ../../../packages/typescript/toml-lexer && npm ci --quiet
+cd ../../../packages/typescript/parser && npm ci --quiet
+cd ../../../packages/typescript/toml-parser && npm ci --quiet
 cd ../../../packages/typescript/document-ast && npm ci --quiet
-cd ../../../packages/typescript/commonmark-parser && npm ci --quiet
 cd ../../../packages/typescript/document-ast-to-html && npm ci --quiet
+cd ../../../packages/typescript/commonmark-parser && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-frontmatter && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-heading-anchors && npm ci --quiet
 cd ../../../packages/typescript/forme-doc-toc-extractor && npm ci --quiet

--- a/code/programs/typescript/forme-doc-demo/CHANGELOG.md
+++ b/code/programs/typescript/forme-doc-demo/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog — forme-doc-demo
+
+## 0.1.0 — 2026-05-22
+
+Initial release.  End-to-end demo of the DOC00 v0 cluster —
+the first runnable that exercises all 11 `forme-doc-*` packages
+plus the FM00 page-bundle-emitter against a real markdown
+corpus, producing a browsable static site.
+
+### Added
+
+- Six-page hand-curated markdown corpus (`corpus/`) describing
+  a fictional `@acme/widget` library.
+- `src/build.ts` — pure transform that wires the cluster:
+  per-page parse → AST decoration → HTML render → page-shell
+  wrap; cross-page sidebar + search index build; final
+  composition through `emitSite`.  No I/O.
+- `src/main.ts` — CLI entrypoint and the only file in the
+  program that touches the filesystem.  Reads `corpus/`,
+  writes `dist/`.  Refuses symlinks during corpus walk;
+  validates output directory; `safeJoin` containment check on
+  every write target.
+- `src/plain-text.ts` — small AST walker that extracts plain
+  text from a `DocumentNode` for search-index input (so the
+  index is built over content, not markdown syntax).
+- 46 tests covering the entire pipeline + helpers + disk I/O
+  + path-escape defences.
+
+### Two small in-program helpers
+
+- **`injectHeadingIds`** — after `document-ast-to-html` renders
+  each `<h*>` tag, this walks the HTML and adds the
+  heading-anchors result's `id` attribute (positional match;
+  in-document order).  Necessary because the upstream renderer
+  doesn't read `AnchoredHeadingNode.id`.  ReDoS-free regex
+  (`/<h([1-6])>/g`).
+- **`normaliseSidebarPaths`** — recursively rewrites each
+  sidebar entry's `path` field from a filename
+  (`"guide/setup.md"`) to a URL route (`"/guide/setup"`) so
+  page-shell's `currentPath` highlight works.
+
+Both are unit-tested and clearly scoped; if they grow they
+should be promoted to their own packages.
+
+### Capability declaration
+
+- `fs:read` on `./corpus/**` — read the bundled markdown.
+- `fs:list` on `./corpus/**` — walk the corpus directory.
+- `fs:write` on `./dist/**` — write the rendered site.
+- `fs:create` on `./dist/**` — create output directories.
+
+No net, no proc, no env, no shell.  Capabilities scoped to the
+program's own subdirectories.  Per-write `safeJoin`
+containment check prevents any path-escape attack.
+
+### Security posture
+
+- **Symlinks refused during corpus walk** — defends against
+  traversal-via-symlink to `/etc/passwd` etc.
+- **`safeJoin` containment check** — every write target is
+  resolved and asserted to live under `outDir`; rejects `..`,
+  absolute paths, and prefix-string false matches
+  (`outD` vs `outDir`).
+- **`validateOutDir`** — rejects empty/non-string/system
+  directories (`/`, `/etc`, `/usr`, ...).
+- **No regex on user input** — `injectHeadingIds` uses a fixed
+  6-char character class with no `+` quantifier; `routeFor`
+  uses `String.startsWith`/`endsWith` not regex on the path.
+- **HTML-escape defence-in-depth** — `injectHeadingIds`
+  escapes anchor IDs even though heading-anchors already
+  produces URL-safe slugs.
+- **Pure-transform `build()`** — `build.ts` has zero
+  side-effects; testable in memory, unaffected by environment.
+- **No `eval` / `new Function` / `JSON.parse` with reviver.**
+
+### Build
+
+A 5KB-per-page static site is built in under a second:
+
+```
+[forme-doc-demo] read   = 6 markdown files
+[forme-doc-demo] wrote  = 18 files to ./dist
+```
+
+The 18 files = 6 HTML pages + `sidebar.json` + `search/manifest.json`
++ 10 search shards (one per token-prefix).
+
+### Tests
+
+46 tests in `tests/build.test.ts`:
+
+- `routeFor` (8 cases — every input form)
+- `titleOf` (6 cases — frontmatter precedence + fallback)
+- `injectHeadingIds` (3 cases — ordering, surplus tags, escaping)
+- `normaliseSidebarPaths` (2 cases — file→route, null preserved)
+- `build` end-to-end (12 cases against the bundled corpus)
+- `writeBundle` (4 cases — actual disk output)
+- `safeJoin` (4 cases — including prefix-string false-match)
+- `validateOutDir` (5 cases — non-string, empty, system dirs)
+
+### v0 simplifications
+
+- No watch mode (re-run `npm start` after editing).
+- No multi-locale.
+- No theme system — one inlined CSS stylesheet.
+- No image / asset copying.
+- No search-client JS embedded (manifest + shards emitted;
+  bundling the client is consumer-side per the
+  `forme-doc-search-client-js` README).

--- a/code/programs/typescript/forme-doc-demo/README.md
+++ b/code/programs/typescript/forme-doc-demo/README.md
@@ -1,0 +1,212 @@
+# forme-doc-demo
+
+> End-to-end demo of the DOC00 v0 documentation-site cluster.
+> Reads a small Markdown corpus, runs it through all 11
+> `forme-doc-*` packages plus the FM00 page-bundle-emitter, and
+> writes a fully-functional static site to `dist/`.
+
+The point of this program is to **see the DOC00 v0 cluster
+working** — every package wired together against a real corpus,
+with browsable HTML on the other side.
+
+## Quick start
+
+```bash
+cd code/programs/typescript/forme-doc-demo
+
+# install + build
+npm install
+npm start
+# → reads ./corpus, writes ./dist (6 pages + sidebar + search)
+
+# serve dist/ with anything that speaks static files
+npx serve dist
+# or
+python3 -m http.server --directory dist
+```
+
+Open the printed URL.  The demo includes:
+
+- A two-column page shell (sidebar on the left, content in the
+  middle, in-page TOC on the right).
+- Heading anchors (every `<h*>` gets an `id` so deep-links work).
+- Syntax-highlighted code blocks (bash, typescript, javascript,
+  css).
+- A working sidebar with one group (Guide) and three top-level
+  pages.
+- A pre-built search index (one manifest + ten alphabetised
+  shards under `/search/`).
+
+## What it actually does
+
+```
+corpus/*.md                  (six handwritten markdown pages with
+                              frontmatter)
+   │
+   │  fs:read (walks corpus/)
+   ▼
+┌──────────────── build() pipeline ────────────────────────────┐
+│                                                              │
+│  per page:                                                   │
+│    extractFrontmatter  ── splits YAML/TOML from body         │
+│    parseMarkdown       ── commonmark-parser → DocumentNode   │
+│    generateHeadingAnchors                                    │
+│    decorateCodeBlocks                                        │
+│    highlightCodeBlocks ── TextMate grammars                  │
+│    extractToc          ── for the in-page nav                │
+│    toHtml              ── document-ast-to-html               │
+│    injectHeadingIds    ── small local helper (see below)     │
+│    renderPageShell     ── two-column chrome                  │
+│    generateHtmlDocument── final <!doctype html>...           │
+│                                                              │
+│  cross-page:                                                 │
+│    buildSidebar          ── tree from paths + frontmatter    │
+│    normaliseSidebarPaths ── small local helper (see below)   │
+│    buildSearchIndex      ── Porter-stemmed, prefix-sharded   │
+│                                                              │
+│  composition:                                                │
+│    emitSite              ── PageBundleConfig                 │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+   │
+   │  fs:write (iterates bundle.pages, writes each one)
+   ▼
+dist/
+├── index.html
+├── getting-started/index.html
+├── faq/index.html
+├── guide/installation/index.html
+├── guide/configuration/index.html
+├── api/reference/index.html
+├── sidebar.json
+└── search/
+    ├── manifest.json
+    └── <prefix>.json × N
+```
+
+## Capability discipline
+
+| Package                              | Capability                |
+|--------------------------------------|---------------------------|
+| All 11 `forme-doc-*` libraries       | `[]` (pure transforms)    |
+| `commonmark-parser`, `document-ast-to-html`, `forme-aot-html-doc-emitter`, `forme-aot-page-bundle-emitter` | `[]` |
+| **`forme-doc-demo` (this program)**  | **`fs:read`, `fs:list`, `fs:write`, `fs:create`** |
+
+The I/O capability lives at the leaf — exactly where the DOC00
+spec puts it.  Every library in the chain remains testable in
+memory.
+
+Capability scope: `fs:read` is bounded to `./corpus/**`,
+`fs:write` to `./dist/**` (with a `safeJoin` containment check
+on every write target).  No network, no shell, no env.
+
+## Two small local helpers
+
+This driver does two things itself that don't fit cleanly into
+any existing package, both `<60 lines`:
+
+1. **`injectHeadingIds`** — walks the rendered HTML and injects
+   `id="..."` attributes into each `<h*>` tag from the
+   heading-anchors result.  Necessary because
+   `document-ast-to-html`'s `renderHeading` ignores the
+   `AnchoredHeadingNode.id` field.  Positional match (Nth
+   `<h*>` in HTML order ↔ Nth anchor in document order);
+   trivial ReDoS-free regex (`/<h([1-6])>/g`).
+2. **`normaliseSidebarPaths`** — rewrites each sidebar entry's
+   `path` field from a filename (`"guide/setup.md"`) to a URL
+   route (`"/guide/setup"`).  Necessary because the
+   sidebar-builder emits file paths and page-shell's
+   `currentPath` comparison needs URL routes.
+
+Both are recursive walks over small trees; both are exported
+and unit-tested.
+
+## The corpus
+
+Six handwritten markdown pages:
+
+```
+corpus/
+├── index.md                   (home)
+├── getting-started.md
+├── faq.md
+├── guide/installation.md
+├── guide/configuration.md
+└── api/reference.md
+```
+
+They describe a fictional `@acme/widget` library — the content
+is designed to exercise paragraph rendering, ordered and
+unordered lists, fenced code blocks in multiple languages,
+heading nesting, inline code, and internal cross-page links.
+
+## Running the demo
+
+```bash
+npm start
+# defaults: ./corpus → ./dist
+
+# custom paths
+npx tsx src/main.ts ./my-corpus ./public
+```
+
+## Tests
+
+46 tests in `tests/build.test.ts`:
+
+- **`routeFor`** — every input form (root, nested, `./`, `/`,
+  `.md`, `.mdx`).
+- **`titleOf`** — frontmatter precedence, basename humanising
+  fallback, non-string frontmatter rejection.
+- **`injectHeadingIds`** — in-order injection, extra `<h*>` tag
+  handling, HTML-escape defence-in-depth.
+- **`normaliseSidebarPaths`** — file → route rewrite, null path
+  preservation.
+- **`build` end-to-end** — the cluster correctly emits one route
+  per page + sidebar + search manifest + search shards; the
+  rendered HTML carries the expected fingerprints of every
+  upstream package (heading anchors, sidebar highlight, fenced
+  code blocks, theme CSS, site title).
+- **`writeBundle`** — actual disk output with nested
+  directories and `search/` shards.
+- **`safeJoin`** — rejects `..`, absolute, and prefix-string
+  false-match attacks.
+- **`validateOutDir`** — rejects empty, non-string, and system
+  directories.
+
+Run:
+
+```bash
+npm test
+# or
+npm run test:coverage
+```
+
+## Why this lives in `programs/` not `packages/`
+
+Programs are end-of-line consumers — runnables, not building
+blocks.  They're allowed to own capabilities.  Libraries in
+`packages/` stay pure so consumers can compose them safely.
+
+Putting the demo here means:
+
+- It can own `fs:read` + `fs:write` without leaking those
+  capabilities into the upstream cluster.
+- It can pull in a hand-curated corpus and a default theme
+  without polluting the library packages.
+- Killing or replacing the demo doesn't churn any of the 11
+  shipped library packages.
+
+## v0 simplifications
+
+- No watch mode / live reload (run `npm start` again after
+  editing).
+- No multi-locale support.
+- No custom theme system — one inlined stylesheet.
+- No image / asset copying — corpus is text-only.
+- No search-client JS yet (the demo emits manifest + shards but
+  no `client.js` — building the bundle is the consumer-side
+  concern documented in `forme-doc-search-client-js`).
+
+These belong in v1+; the point of this demo is to prove the
+cluster composes correctly end-to-end.

--- a/code/programs/typescript/forme-doc-demo/corpus/api/reference.md
+++ b/code/programs/typescript/forme-doc-demo/corpus/api/reference.md
@@ -1,0 +1,60 @@
+---
+title: API Reference
+sidebar_position: 1
+---
+
+The complete public surface of `@acme/widget`.
+
+## `Widget`
+
+### Constructor
+
+```typescript
+new Widget(options: WidgetOptions): Widget
+```
+
+Throws `TypeError` on invalid options.  See the
+[configuration guide](/guide/configuration) for option
+semantics.
+
+### `widget.render(): string`
+
+Returns the string representation:
+
+```typescript
+const w = new Widget({ label: "hi" });
+w.render();  // → "Widget(hi)"
+```
+
+Pure function.  Idempotent.  Safe to call many times.
+
+### `widget.label: string`
+
+Read-only accessor for the constructor's `label` option.
+
+### `widget.size: "small" | "medium" | "large"`
+
+Read-only accessor for the size.
+
+## Types
+
+```typescript
+export interface WidgetOptions {
+  label: string;
+  size?: "small" | "medium" | "large";
+  rounded?: boolean;
+  className?: string;
+}
+```
+
+## Constants
+
+### `VERSION`
+
+A string of the form `"x.y.z"` matching the package version.
+
+## Errors
+
+The constructor throws `TypeError` with descriptive messages
+for every invalid input.  No silent coercion; no `undefined`
+defaults that hide bugs.

--- a/code/programs/typescript/forme-doc-demo/corpus/faq.md
+++ b/code/programs/typescript/forme-doc-demo/corpus/faq.md
@@ -1,0 +1,40 @@
+---
+title: FAQ
+sidebar_position: 3
+---
+
+## Why is install failing?
+
+The most common cause is a Node.js version below 20.  Run
+`node --version`; if it prints `v18.x.x` or lower, upgrade.
+
+## Does this work in the browser?
+
+Yes.  The package ships an ES module that bundlers (Vite,
+Rollup, esbuild, webpack) accept directly.  No polyfills
+are needed for any modern browser.
+
+## How do I report a bug?
+
+Open an issue on the project's GitHub repository.  Please
+include the version (`Widget.VERSION`), the runtime
+(`node --version` or browser + version), and a minimal
+reproduction.
+
+## Is it tree-shakeable?
+
+The package is published as ES modules and side-effect-free
+(`"sideEffects": false` in `package.json`).  Both Vite and
+Rollup are confirmed to drop unused exports.
+
+## How big is it?
+
+About 8KB minified, 3KB gzipped.  The biggest single chunk
+is the CSS variables; if you don't use theming, your bundler
+should drop them as dead code.
+
+## Where's the source?
+
+See the [API reference](/api/reference) for the surface and
+the [getting started](/getting-started) page for an example.
+The full source lives on GitHub.

--- a/code/programs/typescript/forme-doc-demo/corpus/getting-started.md
+++ b/code/programs/typescript/forme-doc-demo/corpus/getting-started.md
@@ -1,0 +1,44 @@
+---
+title: Getting started with Acme
+sidebar_label: Getting Started
+sidebar_position: 2
+---
+
+Acme is a fictional library used only to give this demo
+documentation site something to talk about.  It does not exist.
+The point of this page is to exercise paragraph rendering,
+ordered lists, inline code, and a code block — all driven by
+the DOC00 pipeline.
+
+## Install
+
+```bash
+npm install @acme/widget
+```
+
+That's it.  No build step.
+
+## Hello, world
+
+A minimal program:
+
+```typescript
+import { Widget } from "@acme/widget";
+
+const w = new Widget({ label: "hello" });
+console.log(w.render());
+// → "Widget(hello)"
+```
+
+The widget exposes one method, `render()`, which returns a
+string description.  See the [API reference](/api/reference) for
+the full surface.
+
+## Next steps
+
+1. Read the [installation guide](/guide/installation) for the
+   long-form version.
+2. Skim the [configuration guide](/guide/configuration) for
+   what's tweakable.
+3. Try the search box in the header — it loads search shards
+   on demand from `/search/`.

--- a/code/programs/typescript/forme-doc-demo/corpus/guide/configuration.md
+++ b/code/programs/typescript/forme-doc-demo/corpus/guide/configuration.md
@@ -1,0 +1,56 @@
+---
+title: Configuration
+sidebar_position: 2
+---
+
+Every knob Acme exposes is passed to the constructor — there
+are no environment variables, no config files, no global
+state to fight with.
+
+## Constructor options
+
+```typescript
+new Widget({
+  label: "hello",     // required
+  size: "medium",     // optional: "small" | "medium" | "large"
+  rounded: false,     // optional: defaults to true
+  className: "x",     // optional: extra CSS class for the wrapper
+});
+```
+
+### `label`
+
+The user-visible string.  Required, non-empty.  Validated at
+construction; an empty or non-string label throws a
+`TypeError`.
+
+### `size`
+
+One of three allowlisted strings.  Maps to a CSS sizing
+class.  Unknown values throw at construction.
+
+### `rounded`
+
+Whether to apply the rounded-corners style.  Boolean only —
+truthy/falsy coercion is intentionally rejected.
+
+### `className`
+
+Extra class name forwarded to the root element.  HTML-escaped
+internally; safe to pass user input.
+
+## Theming
+
+CSS variables on the `.acme-widget` root let you re-skin
+without forking:
+
+```css
+.acme-widget {
+  --acme-bg: #fafafa;
+  --acme-fg: #111;
+  --acme-radius: 6px;
+}
+```
+
+See the [API reference](/api/reference) for the complete
+attribute list.

--- a/code/programs/typescript/forme-doc-demo/corpus/guide/installation.md
+++ b/code/programs/typescript/forme-doc-demo/corpus/guide/installation.md
@@ -1,0 +1,51 @@
+---
+title: Installation
+sidebar_position: 1
+---
+
+Acme runs on any modern JavaScript runtime.  Pick whichever
+you already have.
+
+## Node.js
+
+```bash
+npm install @acme/widget
+# or
+yarn add @acme/widget
+# or
+pnpm add @acme/widget
+```
+
+Node.js 20 or later is required.
+
+## Deno
+
+```typescript
+import { Widget } from "npm:@acme/widget";
+```
+
+Deno's npm-compat layer handles the rest.
+
+## Bun
+
+```bash
+bun add @acme/widget
+```
+
+## Verifying the install
+
+After install, run a one-liner to verify:
+
+```javascript
+console.log(require("@acme/widget").VERSION);
+```
+
+You should see the current version number printed.  If you
+see an error instead, check the [FAQ](/faq) for common
+installation problems.
+
+## What's installed
+
+The package installs a single `.js` bundle (around 8KB
+minified) plus TypeScript type declarations.  No native
+dependencies, no install scripts, no postinstall hooks.

--- a/code/programs/typescript/forme-doc-demo/corpus/index.md
+++ b/code/programs/typescript/forme-doc-demo/corpus/index.md
@@ -1,0 +1,40 @@
+---
+title: Welcome to Acme Docs
+sidebar_label: Home
+sidebar_position: 1
+---
+
+This is a **demo documentation site** built end-to-end by the DOC00
+v0 package cluster.  Every byte of this site — the markdown
+parsing, heading anchors, table of contents, code blocks, syntax
+highlighting, sidebar, page shell, search index, search client
+JS — comes from eleven small composable packages that you can
+audit independently.
+
+## What this demo shows
+
+- Markdown is parsed by `commonmark-parser` into a `DocumentNode`
+  AST.
+- The AST flows through the **content pipeline**:
+  `forme-doc-frontmatter` → `forme-doc-heading-anchors` →
+  `forme-doc-toc-extractor` → `forme-doc-code-block-decorator`
+  → `forme-doc-syntax-highlighter`.
+- The decorated AST is rendered to HTML by
+  `document-ast-to-html`, then wrapped in chrome by
+  `forme-doc-page-shell`.
+- The sidebar is built by `forme-doc-sidebar-builder`.
+- The search index is built by `forme-doc-search-tokenizer`
+  plus `forme-doc-search-index-builder`.
+- The whole site is composed by `forme-doc-site-emitter` into a
+  `PageBundleConfig` and written to `dist/` by this driver.
+
+Browse the sidebar on the left.  Try the navigation; every
+internal link below resolves to a real page you can read.
+
+## Where to go next
+
+- [Getting started](/getting-started) — install and run.
+- [Installation guide](/guide/installation) — detailed setup.
+- [Configuration guide](/guide/configuration) — knobs and dials.
+- [API reference](/api/reference) — the public surface.
+- [FAQ](/faq) — common questions answered.

--- a/code/programs/typescript/forme-doc-demo/package-lock.json
+++ b/code/programs/typescript/forme-doc-demo/package-lock.json
@@ -1,0 +1,3029 @@
+{
+  "name": "forme-doc-demo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "forme-doc-demo",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/commonmark-parser": "file:../../../packages/typescript/commonmark-parser",
+        "@coding-adventures/document-ast": "file:../../../packages/typescript/document-ast",
+        "@coding-adventures/document-ast-to-html": "file:../../../packages/typescript/document-ast-to-html",
+        "@coding-adventures/forme-aot-html-doc-emitter": "file:../../../packages/typescript/forme-aot-html-doc-emitter",
+        "@coding-adventures/forme-aot-page-bundle-emitter": "file:../../../packages/typescript/forme-aot-page-bundle-emitter",
+        "@coding-adventures/forme-doc-code-block-decorator": "file:../../../packages/typescript/forme-doc-code-block-decorator",
+        "@coding-adventures/forme-doc-frontmatter": "file:../../../packages/typescript/forme-doc-frontmatter",
+        "@coding-adventures/forme-doc-heading-anchors": "file:../../../packages/typescript/forme-doc-heading-anchors",
+        "@coding-adventures/forme-doc-page-shell": "file:../../../packages/typescript/forme-doc-page-shell",
+        "@coding-adventures/forme-doc-search-index-builder": "file:../../../packages/typescript/forme-doc-search-index-builder",
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../../../packages/typescript/forme-doc-search-tokenizer",
+        "@coding-adventures/forme-doc-sidebar-builder": "file:../../../packages/typescript/forme-doc-sidebar-builder",
+        "@coding-adventures/forme-doc-site-emitter": "file:../../../packages/typescript/forme-doc-site-emitter",
+        "@coding-adventures/forme-doc-syntax-highlighter": "file:../../../packages/typescript/forme-doc-syntax-highlighter",
+        "@coding-adventures/forme-doc-toc-extractor": "file:../../../packages/typescript/forme-doc-toc-extractor"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/commonmark-parser": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/document-ast": "file:../document-ast",
+        "@coding-adventures/document-ast-to-html": "file:../document-ast-to-html",
+        "@coding-adventures/state-machine": "file:../state-machine"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/document-ast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/document-ast-to-html": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-aot-html-doc-emitter": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-aot-page-bundle-emitter": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-code-block-decorator": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-frontmatter": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cli-builder": "file:../cli-builder",
+        "@coding-adventures/directed-graph": "file:../directed-graph",
+        "@coding-adventures/grammar-tools": "file:../grammar-tools",
+        "@coding-adventures/lexer": "file:../lexer",
+        "@coding-adventures/parser": "file:../parser",
+        "@coding-adventures/state-machine": "file:../state-machine",
+        "@coding-adventures/toml-lexer": "file:../toml-lexer",
+        "@coding-adventures/toml-parser": "file:../toml-parser"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-heading-anchors": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-page-shell": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-search-index-builder": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-doc-search-tokenizer": "file:../forme-doc-search-tokenizer"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-search-tokenizer": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-sidebar-builder": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-site-emitter": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/forme-aot-page-bundle-emitter": "file:../forme-aot-page-bundle-emitter",
+        "@coding-adventures/forme-doc-search-index-builder": "file:../forme-doc-search-index-builder",
+        "@coding-adventures/forme-doc-sidebar-builder": "file:../forme-doc-sidebar-builder"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-syntax-highlighter": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../../../packages/typescript/forme-doc-toc-extractor": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/document-ast": "file:../document-ast",
+        "@coding-adventures/forme-doc-heading-anchors": "file:../forme-doc-heading-anchors"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/commonmark-parser": {
+      "resolved": "../../../packages/typescript/commonmark-parser",
+      "link": true
+    },
+    "node_modules/@coding-adventures/document-ast": {
+      "resolved": "../../../packages/typescript/document-ast",
+      "link": true
+    },
+    "node_modules/@coding-adventures/document-ast-to-html": {
+      "resolved": "../../../packages/typescript/document-ast-to-html",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-aot-html-doc-emitter": {
+      "resolved": "../../../packages/typescript/forme-aot-html-doc-emitter",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-aot-page-bundle-emitter": {
+      "resolved": "../../../packages/typescript/forme-aot-page-bundle-emitter",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-code-block-decorator": {
+      "resolved": "../../../packages/typescript/forme-doc-code-block-decorator",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-frontmatter": {
+      "resolved": "../../../packages/typescript/forme-doc-frontmatter",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-heading-anchors": {
+      "resolved": "../../../packages/typescript/forme-doc-heading-anchors",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-page-shell": {
+      "resolved": "../../../packages/typescript/forme-doc-page-shell",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-search-index-builder": {
+      "resolved": "../../../packages/typescript/forme-doc-search-index-builder",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-search-tokenizer": {
+      "resolved": "../../../packages/typescript/forme-doc-search-tokenizer",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-sidebar-builder": {
+      "resolved": "../../../packages/typescript/forme-doc-sidebar-builder",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-site-emitter": {
+      "resolved": "../../../packages/typescript/forme-doc-site-emitter",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-syntax-highlighter": {
+      "resolved": "../../../packages/typescript/forme-doc-syntax-highlighter",
+      "link": true
+    },
+    "node_modules/@coding-adventures/forme-doc-toc-extractor": {
+      "resolved": "../../../packages/typescript/forme-doc-toc-extractor",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/programs/typescript/forme-doc-demo/package.json
+++ b/code/programs/typescript/forme-doc-demo/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "forme-doc-demo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "End-to-end demo of the DOC00 v0 documentation-site cluster: reads a small Markdown corpus, runs it through all 11 forme-doc-* packages plus the FM00 page-bundle-emitter, writes a static site to dist/.  Run with `npm start`, then serve dist/ with any static HTTP server.",
+  "type": "module",
+  "main": "src/main.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "tsx src/main.ts corpus dist",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/commonmark-parser": "file:../../../packages/typescript/commonmark-parser",
+    "@coding-adventures/document-ast": "file:../../../packages/typescript/document-ast",
+    "@coding-adventures/document-ast-to-html": "file:../../../packages/typescript/document-ast-to-html",
+    "@coding-adventures/forme-doc-frontmatter": "file:../../../packages/typescript/forme-doc-frontmatter",
+    "@coding-adventures/forme-doc-heading-anchors": "file:../../../packages/typescript/forme-doc-heading-anchors",
+    "@coding-adventures/forme-doc-toc-extractor": "file:../../../packages/typescript/forme-doc-toc-extractor",
+    "@coding-adventures/forme-doc-code-block-decorator": "file:../../../packages/typescript/forme-doc-code-block-decorator",
+    "@coding-adventures/forme-doc-syntax-highlighter": "file:../../../packages/typescript/forme-doc-syntax-highlighter",
+    "@coding-adventures/forme-doc-sidebar-builder": "file:../../../packages/typescript/forme-doc-sidebar-builder",
+    "@coding-adventures/forme-doc-page-shell": "file:../../../packages/typescript/forme-doc-page-shell",
+    "@coding-adventures/forme-doc-search-tokenizer": "file:../../../packages/typescript/forme-doc-search-tokenizer",
+    "@coding-adventures/forme-doc-search-index-builder": "file:../../../packages/typescript/forme-doc-search-index-builder",
+    "@coding-adventures/forme-doc-site-emitter": "file:../../../packages/typescript/forme-doc-site-emitter",
+    "@coding-adventures/forme-aot-html-doc-emitter": "file:../../../packages/typescript/forme-aot-html-doc-emitter",
+    "@coding-adventures/forme-aot-page-bundle-emitter": "file:../../../packages/typescript/forme-aot-page-bundle-emitter"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "tsx": "^4.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/programs/typescript/forme-doc-demo/required_capabilities.json
+++ b/code/programs/typescript/forme-doc-demo/required_capabilities.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/forme-doc-demo",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "./corpus/**/*.md",
+      "justification": "Read the bundled Markdown corpus that the DOC00 pipeline transforms.  Scoped to the program's own corpus subdirectory (relative path); never reads anything outside its working directory."
+    },
+    {
+      "category": "fs",
+      "action": "list",
+      "target": "./corpus/**",
+      "justification": "Walk the corpus directory to discover .md pages.  Same scope as read above."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "./dist/**",
+      "justification": "Write the rendered static site (HTML pages, sidebar.json, search/manifest.json, search/<key>.json) to a dist/ directory.  Output path is the second CLI arg, defaulting to ./dist; the writer rejects absolute targets and paths containing .. segments before opening any file handle."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "./dist/**",
+      "justification": "Create the dist/ output directory and any nested subdirectories (search/, guide/, api/) the route layout requires."
+    }
+  ],
+  "justification": "Demo driver program — the ONE end-to-end runnable in the DOC00 v0 cluster.  Reads a small Markdown corpus, runs it through the eleven forme-doc-* packages plus the FM00 page-bundle-emitter, writes a static site to dist/.  Every forme-doc-* package this driver depends on remains capabilities []; the I/O capability is owned here, at the leaf, exactly as the DOC00 spec intends.  Capabilities are tightly scoped: corpus reads are bounded to ./corpus/**; writes are bounded to ./dist/**; no net, no proc, no env, no shell."
+}

--- a/code/programs/typescript/forme-doc-demo/src/build.ts
+++ b/code/programs/typescript/forme-doc-demo/src/build.ts
@@ -1,0 +1,426 @@
+/**
+ * build.ts — pure transform that wires the DOC00 v0 cluster
+ * end-to-end.
+ *
+ * Input:  an in-memory list of `{ path, source }` markdown files.
+ * Output: a `PageBundleConfig` ready for either `generatePageBundle`
+ *         (for hashing) or direct disk-write iteration.
+ *
+ * Capability `[]`.  Lives in `src/` not `bin/` because we want to
+ * unit-test the pipeline without touching the filesystem.  All
+ * fs I/O lives in `main.ts`.
+ *
+ * # Pipeline (per page)
+ *
+ * ```
+ *   raw markdown
+ *       ▼ forme-doc-frontmatter.extractFrontmatter
+ *   { body, frontmatter }
+ *       ▼ commonmark-parser.parse
+ *   DocumentNode
+ *       ▼ forme-doc-heading-anchors.generateHeadingAnchors
+ *   { document, anchors }                       (anchors not used yet)
+ *       ▼ forme-doc-code-block-decorator.decorateCodeBlocks
+ *   DocumentNode'
+ *       ▼ forme-doc-syntax-highlighter.highlightCodeBlocks
+ *   DocumentNode''
+ *       ▼ forme-doc-toc-extractor.extractToc
+ *   { document, toc, entries }
+ *       ▼ document-ast-to-html.toHtml          (uses the final AST)
+ *   bodyHtml                                   (the <main> contents)
+ *       ▼ forme-doc-page-shell.renderPageShell  (+ sidebar)
+ *   { head, body }
+ *       ▼ forme-aot-html-doc-emitter.generateHtmlDocument
+ *   full HTML document string
+ * ```
+ *
+ * # Sidebar (built once, cross-page)
+ *
+ * Each page contributes `{ path, frontmatter }` to
+ * `forme-doc-sidebar-builder.buildSidebar`, which produces the
+ * tree we pass into every page-shell render call.
+ *
+ * # Search (built once, cross-page)
+ *
+ * Each page contributes `{ id, title, body }` (body = plain text
+ * from the final AST, via `plainText`) to
+ * `forme-doc-search-index-builder.buildSearchIndex`, which
+ * produces a `{ manifest, shards }` pair.  The whole bundle is
+ * then composed by `forme-doc-site-emitter.emitSite`.
+ */
+
+import { extractFrontmatter } from "@coding-adventures/forme-doc-frontmatter";
+import { parse as parseMarkdown } from "@coding-adventures/commonmark-parser";
+import { generateHeadingAnchors } from "@coding-adventures/forme-doc-heading-anchors";
+import { decorateCodeBlocks } from "@coding-adventures/forme-doc-code-block-decorator";
+import { highlightCodeBlocks } from "@coding-adventures/forme-doc-syntax-highlighter";
+import { extractToc } from "@coding-adventures/forme-doc-toc-extractor";
+import { toHtml } from "@coding-adventures/document-ast-to-html";
+import { renderPageShell } from "@coding-adventures/forme-doc-page-shell";
+import { generateHtmlDocument } from "@coding-adventures/forme-aot-html-doc-emitter";
+import { buildSidebar } from "@coding-adventures/forme-doc-sidebar-builder";
+import { buildSearchIndex } from "@coding-adventures/forme-doc-search-index-builder";
+import { emitSite } from "@coding-adventures/forme-doc-site-emitter";
+import type { PageBundleConfig } from "@coding-adventures/forme-doc-site-emitter";
+
+import { plainText } from "./plain-text.js";
+
+/**
+ * One markdown source file the caller has read from disk.
+ *
+ *   - `path`   — relative path under the corpus root, e.g.
+ *                `"guide/installation.md"`.  Drives both the
+ *                output route and the sidebar position.
+ *   - `source` — raw markdown including frontmatter.
+ */
+export interface MarkdownFile {
+  readonly path: string;
+  readonly source: string;
+}
+
+export interface BuildOptions {
+  readonly siteTitle: string;
+  readonly githubUrl?: string;
+  readonly copyright?: string;
+  /** Embedded JS for the search client; emitted as /search/client.js if provided. */
+  readonly searchClientJs?: string;
+  /** Embedded CSS injected into every page's <head>.  Optional. */
+  readonly themeCss?: string;
+}
+
+/**
+ * Compose the entire site.  Pure function; deterministic; no I/O.
+ */
+export function build(files: readonly MarkdownFile[], options: BuildOptions): PageBundleConfig {
+  // -- Step 1: parse every file (frontmatter + AST) -------------
+  const parsed = files.map(parseOne);
+
+  // -- Step 2: build the cross-page sidebar ---------------------
+  //
+  // The sidebar-builder receives file paths ("guide/setup.md") and
+  // emits entries whose `path` field is the same file path.  Page-
+  // shell, however, compares `currentPath` against each entry's
+  // `path` to render the `aria-current="page"` highlight.  We want
+  // that comparison to work against URL routes ("/guide/setup"),
+  // not file paths — so we normalise every entry's path through
+  // `routeFor` before handing the tree to page-shell.
+  const rawSidebar = buildSidebar(parsed.map((p) => ({
+    path: p.file.path,
+    frontmatter: p.frontmatter,
+  })));
+  const sidebar = normaliseSidebarPaths(rawSidebar);
+
+  // -- Step 3: render every page's HTML -------------------------
+  const themeCss = options.themeCss ?? DEFAULT_THEME_CSS;
+  const headExtra = `<style>${themeCss}</style>`;
+  const pages = parsed.map((p) => renderPage(p, sidebar, options, headExtra));
+
+  // -- Step 4: build the search index ---------------------------
+  const searchInputs = parsed.map((p) => ({
+    id: routeFor(p.file.path),
+    title: titleOf(p.frontmatter, p.file.path),
+    body: plainText(p.decoratedAst),
+  }));
+  const { manifest, shards } = buildSearchIndex(searchInputs);
+
+  // -- Step 5: compose the PageBundleConfig --------------------
+  return emitSite({
+    pages: pages.map((page) => ({ route: page.route, html: page.html })),
+    sidebar,
+    search: {
+      manifest,
+      shards,
+      clientJs: options.searchClientJs,
+    },
+  });
+}
+
+// =====================================================================
+// Per-page pipeline
+// =====================================================================
+
+interface ParsedPage {
+  readonly file: MarkdownFile;
+  readonly frontmatter: Record<string, unknown>;
+  readonly decoratedAst: unknown;  // DocumentNode after the full pipeline
+  readonly anchors: ReturnType<typeof generateHeadingAnchors>["anchors"];
+  readonly toc: ReturnType<typeof extractToc>;
+}
+
+function parseOne(file: MarkdownFile): ParsedPage {
+  const { body, frontmatter } = extractFrontmatter(file.source);
+  const ast0 = parseMarkdown(body);
+
+  // The heading-anchors walker computes slug IDs for every
+  // heading; we'll need these later to inject into the rendered
+  // HTML (since `document-ast-to-html`'s `renderHeading` ignores
+  // the `id` field on `AnchoredHeadingNode`).
+  const { document: ast1, anchors } = generateHeadingAnchors(ast0);
+  const ast2 = decorateCodeBlocks(ast1);
+  const ast3 = highlightCodeBlocks(ast2);
+  // toc-extractor walks the AST and returns a tree (it also runs
+  // heading-anchors internally, which is idempotent on already-
+  // anchored headings).
+  const toc = extractToc(ast3);
+
+  return {
+    file,
+    frontmatter: frontmatter ?? {},
+    decoratedAst: ast3,
+    anchors,
+    toc,
+  };
+}
+
+interface RenderedPage {
+  readonly route: string;
+  readonly html: string;
+}
+
+function renderPage(
+  parsed: ParsedPage,
+  sidebar: ReturnType<typeof buildSidebar>,
+  options: BuildOptions,
+  headExtra: string,
+): RenderedPage {
+  const route = routeFor(parsed.file.path);
+  const title = titleOf(parsed.frontmatter, parsed.file.path);
+
+  // The <main> body — the markdown rendered to HTML, with anchor
+  // IDs injected into each `<h*>` tag in document order.
+  const rawBody = toHtml(parsed.decoratedAst as Parameters<typeof toHtml>[0]);
+  const bodyHtml = injectHeadingIds(rawBody, parsed.anchors);
+
+  const shell = renderPageShell({
+    site: {
+      title: options.siteTitle,
+      homeUrl: "/",
+      githubUrl: options.githubUrl,
+      copyright: options.copyright,
+    },
+    page: {
+      title,
+      body: bodyHtml,
+      toc: parsed.toc.entries,
+    },
+    sidebar,
+    options: {
+      currentPath: route,
+      headExtra,
+      searchPlaceholder: "Search docs…",
+    },
+  });
+
+  const html = generateHtmlDocument({
+    head: shell.head,
+    body: shell.body,
+    lang: "en",
+  });
+
+  return { route, html };
+}
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+/**
+ * Turn a corpus file path into a clean URL route:
+ *
+ *   "index.md"                     → "/"
+ *   "getting-started.md"           → "/getting-started"
+ *   "guide/installation.md"        → "/guide/installation"
+ *   "guide/index.md"               → "/guide"
+ *
+ * Normalisation rules:
+ *   - Strip leading `./` and leading `/`.
+ *   - Strip `.md` / `.mdx` suffix.
+ *   - Collapse trailing `/index` to `""` (so `guide/index.md`
+ *     becomes `/guide`, not `/guide/index`).
+ *   - Empty result becomes `/`.
+ *
+ * SECURITY NOTE: this is a *normalisation* helper, NOT a
+ * sanitiser.  It does not strip `..` segments — input like
+ * `"../etc/passwd.md"` produces `"/../etc/passwd"`.  We rely
+ * on TWO facts to keep that benign:
+ *   1. Corpus paths come from `readCorpus`, which walks a known
+ *      root using `fs.readdir` — `readdir` entry names can never
+ *      contain `/` or `..`, so a malicious `..` path cannot
+ *      arise from any filesystem source.
+ *   2. The downstream `forme-doc-site-emitter.emitSite`
+ *      validates every route for `..`/`\`/`//` and throws
+ *      before any disk write; `safeJoin` in `main.ts` adds a
+ *      containment check on top.
+ * Callers who hand `routeFor` arbitrary user-controlled strings
+ * outside the read-from-disk path MUST validate the result.
+ */
+export function routeFor(path: string): string {
+  let p = path;
+  if (p.startsWith("./")) p = p.slice(2);
+  if (p.startsWith("/")) p = p.slice(1);
+  // Strip extension (only .md / .mdx — anything else preserved).
+  if (p.endsWith(".mdx")) p = p.slice(0, -".mdx".length);
+  else if (p.endsWith(".md")) p = p.slice(0, -".md".length);
+  // Collapse trailing /index → "" so guide/index.md → guide.
+  if (p === "index") p = "";
+  else if (p.endsWith("/index")) p = p.slice(0, -"/index".length);
+  return p === "" ? "/" : `/${p}`;
+}
+
+/**
+ * Resolve a page's display title:
+ *   1. `frontmatter.title` if it's a non-empty string.
+ *   2. Otherwise humanise the basename of the file path.
+ */
+export function titleOf(frontmatter: Record<string, unknown>, path: string): string {
+  const t = frontmatter["title"];
+  if (typeof t === "string" && t.length > 0) return t;
+  // Fallback: humanise the basename.
+  const slash = path.lastIndexOf("/");
+  const base = slash === -1 ? path : path.slice(slash + 1);
+  const noExt = base.replace(/\.(md|mdx)$/u, "");
+  // dashed-or-underscored → spaced + Title Case (simple impl;
+  // sidebar-builder's `humanise` would also work but pulling it
+  // in for a fallback only is more wiring than it's worth).
+  return noExt
+    .split(/[-_]/u)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Inject `id="..."` attributes into rendered heading tags using
+ * the in-document-order list of anchors from
+ * `forme-doc-heading-anchors`.
+ *
+ * Why this exists: `document-ast-to-html` doesn't read the
+ * `AnchoredHeadingNode.id` field (it only knows about plain
+ * `HeadingNode`).  Rather than patch the upstream renderer (out
+ * of scope), we walk the rendered HTML and inject the IDs here.
+ *
+ * The match is positional — N-th `<hL>` in HTML order maps to
+ * the N-th anchor in document order.  This is safe because the
+ * AST-to-HTML renderer emits headings in the same order as the
+ * AST visits them, and `<h*>` tags only appear from heading
+ * nodes (code-blocks render as `<pre><code>`, so no false
+ * matches there).
+ *
+ * The regex is `/<h([1-6])>/g` (no `+` quantifier, fixed
+ * 6-char character class) — trivially ReDoS-free.
+ */
+export function injectHeadingIds(
+  html: string,
+  anchors: ReadonlyArray<{ readonly id: string }>,
+): string {
+  let i = 0;
+  return html.replace(/<h([1-6])>/g, (_match, level: string) => {
+    if (i >= anchors.length) return _match;
+    const id = anchors[i]!.id;
+    i++;
+    return `<h${level} id="${escapeAttr(id)}">`;
+  });
+}
+
+/**
+ * Escape a slug for safe insertion into an HTML attribute value.
+ * Slugs from heading-anchors are already URL-safe (alphanumerics
+ * + dashes), but defence-in-depth: still escape the five
+ * HTML-special chars to make the helper safe for any string.
+ */
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Recursively walk the sidebar tree and replace every entry's
+ * `path` field (a relative file path like `"guide/setup.md"`)
+ * with its URL route equivalent (`"/guide/setup"`) so that
+ * page-shell's `currentPath` comparison works.
+ *
+ * The input tree is treated as immutable; we return new entries.
+ */
+export function normaliseSidebarPaths<
+  T extends { readonly path: string | null; readonly children?: readonly T[] }
+>(tree: readonly T[]): T[] {
+  return tree.map((entry) => normaliseOne(entry));
+}
+
+function normaliseOne<
+  T extends { readonly path: string | null; readonly children?: readonly T[] }
+>(entry: T): T {
+  const out: { path: string | null; children?: T[] } & Record<string, unknown> = { ...entry };
+  if (typeof entry.path === "string" && entry.path.length > 0) {
+    out.path = routeFor(entry.path);
+  }
+  if (Array.isArray(entry.children)) {
+    out.children = entry.children.map((c) => normaliseOne(c));
+  }
+  return out as T;
+}
+
+/**
+ * A minimal stylesheet — just enough to make the demo look
+ * presentable.  Two-column layout, lightly-styled sidebar,
+ * monospace for code.  Inlined into every page's <head>.
+ *
+ * Intentionally NOT loaded as an external <link> — keeps the
+ * demo single-file-portable (any page is fully self-contained
+ * apart from its search shard fetches).
+ */
+const DEFAULT_THEME_CSS = `
+:root { --fg:#222; --bg:#fff; --muted:#666; --link:#0366d6; --accent:#0366d6;
+        --sidebar-bg:#fafafa; --border:#e5e5e5; --code-bg:#f6f8fa; }
+* { box-sizing: border-box; }
+body { font: 15px/1.55 system-ui, -apple-system, sans-serif; color: var(--fg);
+       margin: 0; background: var(--bg); }
+a { color: var(--link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+header { display: flex; align-items: center; gap: 1rem; padding: .8rem 1.5rem;
+         border-bottom: 1px solid var(--border); position: sticky; top: 0;
+         background: var(--bg); z-index: 10; }
+header .site-title { font-weight: 600; font-size: 1.05rem; color: var(--fg); }
+header .search input { padding: .35rem .6rem; border: 1px solid var(--border);
+                       border-radius: 4px; min-width: 240px; }
+header .github-link { margin-left: auto; }
+.layout { display: grid; grid-template-columns: 240px minmax(0,1fr) 200px;
+          gap: 0; min-height: calc(100vh - 56px); }
+nav.sidebar { background: var(--sidebar-bg); border-right: 1px solid var(--border);
+              padding: 1rem .8rem; overflow-y: auto; }
+nav.sidebar ul { list-style: none; padding: 0 0 0 .8rem; margin: 0; }
+nav.sidebar > ul { padding-left: 0; }
+nav.sidebar li { margin: .25rem 0; }
+nav.sidebar a { color: var(--fg); display: block; padding: .15rem .4rem;
+                border-radius: 3px; }
+nav.sidebar a[aria-current=page] { background: var(--accent); color: white; }
+nav.sidebar .sidebar-group > .sidebar-group-label { font-weight: 600;
+              color: var(--muted); font-size: .85rem;
+              text-transform: uppercase; letter-spacing: .03em;
+              padding: .5rem .4rem .15rem; }
+main { padding: 2rem 2.5rem; max-width: 820px; min-width: 0; }
+main h1 { margin-top: 0; font-size: 2rem; }
+main h2 { margin-top: 2rem; padding-bottom: .3rem; border-bottom: 1px solid var(--border); }
+main p, main ul, main ol, main pre { margin: .8rem 0; }
+main code { background: var(--code-bg); padding: .1em .35em; border-radius: 3px;
+            font-size: .92em; }
+main pre { background: var(--code-bg); padding: 1rem; border-radius: 6px;
+           overflow-x: auto; }
+main pre code { background: none; padding: 0; font-size: .9rem; }
+aside.toc { padding: 1rem; border-left: 1px solid var(--border);
+            font-size: .9rem; color: var(--muted); }
+aside.toc ul { list-style: none; padding: 0; }
+aside.toc li { margin: .25rem 0; }
+aside.toc a { color: var(--muted); }
+aside.toc a:hover { color: var(--fg); }
+footer { padding: 1rem 1.5rem; border-top: 1px solid var(--border);
+         color: var(--muted); font-size: .85rem; text-align: center; }
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  nav.sidebar, aside.toc { display: none; }
+}
+`;

--- a/code/programs/typescript/forme-doc-demo/src/main.ts
+++ b/code/programs/typescript/forme-doc-demo/src/main.ts
@@ -1,0 +1,265 @@
+/**
+ * main.ts — CLI entrypoint for the DOC00 v0 demo driver.
+ *
+ * This is the ONLY file in the program that touches the
+ * filesystem.  Everything else (`build.ts`, `plain-text.ts`)
+ * is a pure transform.
+ *
+ *   Usage:
+ *     tsx src/main.ts [<corpus-dir>] [<out-dir>]
+ *     tsx src/main.ts                          → corpus → dist
+ *     tsx src/main.ts ./my-md ./build/site
+ *
+ * Capabilities: `fs:read`, `fs:list`, `fs:write`, `fs:create`
+ * (declared in `required_capabilities.json`).  No network, no
+ * shell, no env access.
+ *
+ * Safety:
+ *   - Output directory is validated against absolute paths and
+ *     `..` segments BEFORE any directory is created.  An attacker
+ *     setting `OUT=/etc` doesn't get to write into /etc.
+ *   - Corpus reads are scoped to a single directory walk; the
+ *     walker rejects symlinks (no traversal escape via symlink
+ *     to /etc/passwd or similar).
+ *   - Write paths derived from the bundle's routes have already
+ *     been validated by the site-emitter (no `..`, no `\`,
+ *     leading `/` required) — we still re-confirm before
+ *     opening files, as defence in depth.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as url from "node:url";
+import { routeToOutputPath } from "@coding-adventures/forme-aot-page-bundle-emitter";
+
+import { build, type MarkdownFile } from "./build.js";
+
+// ─────────────────────────────────────────────────────────────────────
+// CLI entry
+// ─────────────────────────────────────────────────────────────────────
+
+async function cli(): Promise<void> {
+  const [, , corpusArg, outArg] = process.argv;
+  const corpusDir = path.resolve(process.cwd(), corpusArg ?? "corpus");
+  const outDir = path.resolve(process.cwd(), outArg ?? "dist");
+
+  validateOutDir(outDir, process.cwd());
+  await warnIfOverwritingFiles(outDir);
+
+  console.log(`[forme-doc-demo] corpus = ${corpusDir}`);
+  console.log(`[forme-doc-demo] out    = ${outDir}`);
+
+  const files = await readCorpus(corpusDir);
+  console.log(`[forme-doc-demo] read   = ${files.length} markdown files`);
+
+  const bundle = build(files, {
+    siteTitle: "Acme Docs",
+    githubUrl: "https://github.com/example/acme",
+    copyright: `© ${new Date().getFullYear()} Acme`,
+  });
+
+  await writeBundle(bundle, outDir);
+  console.log(`[forme-doc-demo] wrote  = ${bundle.pages.length} files to ${outDir}`);
+  console.log("");
+  console.log("Done.  Serve it with any static HTTP server, e.g.:");
+  console.log(`    npx serve ${path.relative(process.cwd(), outDir) || "."}`);
+  console.log(`    python3 -m http.server --directory ${path.relative(process.cwd(), outDir) || "."}`);
+}
+
+// Only invoke the CLI when this module is the entry point, NOT
+// when a test imports its helpers.  We compare this module's URL
+// against the entry-script URL using `url.pathToFileURL` — that
+// handles Windows drive letters and URL-encoding correctly,
+// avoiding the basename-suffix fallback's spoofability /
+// false-positive risk (a test runner whose entry script happens
+// to be named `main.ts` would otherwise auto-execute the CLI).
+const isCliEntry =
+  process.argv[1] !== undefined &&
+  import.meta.url === url.pathToFileURL(process.argv[1]).href;
+
+if (isCliEntry) {
+  cli().catch((err: unknown) => {
+    console.error("[forme-doc-demo] FAILED:", err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Filesystem helpers — these are the entire I/O surface.
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate the user-supplied output directory.
+ *
+ * The most important guarantee is downstream: every per-file
+ * write goes through `safeJoin(outDir, relPath)` which
+ * re-validates containment.  This function's job is to catch
+ * obviously-dangerous `outDir` *values* before any directory
+ * is created.
+ *
+ * Rules:
+ *   - Reject empty / non-string.
+ *   - Reject explicit Unix system roots (`/`, `/etc`, ...) and
+ *     Windows system roots (`C:\Windows`, `C:\Program Files`, ...).
+ *   - Require the output dir to live *inside* the current
+ *     working directory.  This is the single most effective
+ *     guard — a `npm start corpus ~/Documents` typo otherwise
+ *     happily overwrites files in the user's Documents folder.
+ *
+ *     Callers running the CLI from a project root (the typical
+ *     case) get sensible behaviour: `./dist`, `./build`,
+ *     `./out`, `./public` all work.  A path *outside* CWD is
+ *     refused with an explicit error pointing at the override.
+ */
+export function validateOutDir(outDir: string, cwd: string): void {
+  if (typeof outDir !== "string" || outDir.length === 0) {
+    throw new Error("validateOutDir: outDir must be a non-empty string");
+  }
+  // System-directory blocklist — defence in depth even though
+  // the cwd-containment check below would catch most of these
+  // (a CLI run from `/etc` is unusual but not impossible).
+  //
+  // Unix system roots.
+  const bannedUnix = ["/", "/bin", "/boot", "/dev", "/etc", "/home",
+                      "/lib", "/opt", "/proc", "/root", "/sbin",
+                      "/sys", "/usr", "/var"];
+  // Windows system paths — match case-insensitively so the user
+  // can't sidestep by passing "c:\\WINDOWS" or similar.
+  const bannedWin = ["C:\\", "C:\\Windows", "C:\\Program Files",
+                     "C:\\Program Files (x86)", "C:\\Users",
+                     "C:\\ProgramData"];
+  // Strip trailing separators from BOTH sides so `c:\` matches
+  // `C:\` matches `C:` — avoids accidentally allowing through a
+  // trailing-separator variant of a banned path.
+  const stripTrailing = (s: string): string => s.replace(/[\\\/]+$/u, "");
+  const norm = stripTrailing(outDir);
+  for (const b of bannedUnix) {
+    if (norm === stripTrailing(b) || outDir === b) {
+      throw new Error(`validateOutDir: refusing to write to system directory ${outDir}`);
+    }
+  }
+  for (const b of bannedWin) {
+    if (norm.toLowerCase() === stripTrailing(b).toLowerCase()) {
+      throw new Error(`validateOutDir: refusing to write to system directory ${outDir}`);
+    }
+  }
+  // Containment check: outDir must be cwd or a descendant of it.
+  // `path.resolve` normalises both sides; we append `path.sep`
+  // to defeat prefix-string false matches (the same trick as
+  // `safeJoin`).
+  const cwdResolved = path.resolve(cwd);
+  const outResolved = path.resolve(outDir);
+  const cwdWithSep = cwdResolved.endsWith(path.sep)
+    ? cwdResolved
+    : cwdResolved + path.sep;
+  if (!(outResolved === cwdResolved || outResolved.startsWith(cwdWithSep))) {
+    throw new Error(
+      `validateOutDir: outDir must live inside the working directory (got ${outDir}, cwd ${cwd})`,
+    );
+  }
+}
+
+/**
+ * If `outDir` already exists and contains files that don't look
+ * like a previous demo build's output, log a prominent warning.
+ *
+ * We don't BLOCK overwrite — the typical run case is re-running
+ * the demo against the previous `dist/` — but we do want a user
+ * who accidentally points the demo at their actual website to
+ * see the warning before everything is silently overwritten.
+ *
+ * Heuristic: a "previous demo build" has either no files at all,
+ * or `index.html` + `sidebar.json` + `search/manifest.json` at
+ * the top level.  Anything else triggers the warning.
+ */
+async function warnIfOverwritingFiles(outDir: string): Promise<void> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(outDir, { withFileTypes: true });
+  } catch {
+    return; // Doesn't exist yet → nothing to warn about.
+  }
+  if (entries.length === 0) return;
+  // Look for the demo-build fingerprint.
+  const names = new Set(entries.map((e) => e.name));
+  const looksLikeDemoBuild =
+    names.has("index.html") && names.has("sidebar.json") && names.has("search");
+  if (looksLikeDemoBuild) return;
+  console.warn(
+    `[forme-doc-demo] WARNING: ${outDir} contains files that don't look ` +
+    `like a previous demo build (${entries.length} entries: ` +
+    `${entries.slice(0, 5).map((e) => e.name).join(", ")}${entries.length > 5 ? ", ..." : ""}). ` +
+    `Existing files at conflicting paths WILL be overwritten.`,
+  );
+}
+
+/**
+ * Walk a corpus directory and return every `.md` file under it.
+ * Refuses symlinks (defence against escape-via-symlink).  Result
+ * paths are relative to `root` and use forward slashes (so the
+ * downstream `routeFor` works identically on Windows).
+ */
+export async function readCorpus(root: string): Promise<MarkdownFile[]> {
+  const files: MarkdownFile[] = [];
+  await walk(root, "", files);
+  // Stable order: sort by path so build output is deterministic
+  // regardless of `readdir`'s OS-specific iteration order.
+  files.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return files;
+}
+
+async function walk(root: string, rel: string, out: MarkdownFile[]): Promise<void> {
+  const absDir = path.join(root, rel);
+  const entries = await fs.readdir(absDir, { withFileTypes: true });
+  for (const e of entries) {
+    if (e.isSymbolicLink()) continue;        // skip symlinks unconditionally
+    const childRel = rel === "" ? e.name : `${rel}/${e.name}`;
+    if (e.isDirectory()) {
+      await walk(root, childRel, out);
+    } else if (e.isFile() && e.name.endsWith(".md")) {
+      const source = await fs.readFile(path.join(root, childRel), "utf8");
+      out.push({ path: childRel, source });
+    }
+  }
+}
+
+/**
+ * Write a `PageBundleConfig` to disk.  Each PageEntry's body is
+ * written to `outDir/<routeToOutputPath(route)>`; intermediate
+ * directories are created on demand.
+ *
+ * Containment check: every resolved write target must start with
+ * `outDir + path.sep`.  If a malicious route ever slipped past
+ * the site-emitter's validation, this catches it before opening
+ * any handle.
+ */
+export async function writeBundle(
+  bundle: { pages: ReadonlyArray<{ route: string; html: string }> },
+  outDir: string,
+): Promise<void> {
+  await fs.mkdir(outDir, { recursive: true });
+  for (const page of bundle.pages) {
+    const relPath = routeToOutputPath(page.route);
+    const target = safeJoin(outDir, relPath);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, page.html, "utf8");
+  }
+}
+
+/**
+ * Join `base` and `rel`, then assert the result stays within
+ * `base`.  Defends against any rel-path that — after normalisation
+ * — escapes upward.  Throws on escape, otherwise returns the
+ * joined absolute path.
+ */
+export function safeJoin(base: string, rel: string): string {
+  const target = path.resolve(base, rel);
+  // Containment check using the resolved-prefix comparison.
+  // Append `path.sep` to `base` so that `outDir/foo` doesn't
+  // accept an outDir of `outD` (prefix-string false match).
+  const baseWithSep = base.endsWith(path.sep) ? base : base + path.sep;
+  if (!(target === base || target.startsWith(baseWithSep))) {
+    throw new Error(`safeJoin: ${rel} escapes ${base} (resolved to ${target})`);
+  }
+  return target;
+}

--- a/code/programs/typescript/forme-doc-demo/src/main.ts
+++ b/code/programs/typescript/forme-doc-demo/src/main.ts
@@ -131,7 +131,25 @@ export function validateOutDir(outDir: string, cwd: string): void {
   // Strip trailing separators from BOTH sides so `c:\` matches
   // `C:\` matches `C:` — avoids accidentally allowing through a
   // trailing-separator variant of a banned path.
-  const stripTrailing = (s: string): string => s.replace(/[\\\/]+$/u, "");
+  //
+  // Explicit charCodeAt loop (no regex) to satisfy CodeQL's
+  // `js/polynomial-redos` rule, which flags `+`-quantified
+  // regexes on user input regardless of actual polynomial
+  // behaviour.  Matches the project-wide convention established
+  // by sidebar-builder/page-shell after the same rule fired
+  // there.
+  const stripTrailing = (s: string): string => {
+    let end = s.length;
+    while (end > 0) {
+      const c = s.charCodeAt(end - 1);
+      if (c === 0x2f /* "/" */ || c === 0x5c /* "\" */) {
+        end--;
+      } else {
+        break;
+      }
+    }
+    return end === s.length ? s : s.slice(0, end);
+  };
   const norm = stripTrailing(outDir);
   for (const b of bannedUnix) {
     if (norm === stripTrailing(b) || outDir === b) {

--- a/code/programs/typescript/forme-doc-demo/src/plain-text.ts
+++ b/code/programs/typescript/forme-doc-demo/src/plain-text.ts
@@ -1,0 +1,66 @@
+/**
+ * plain-text.ts — extract plain-text content from a DocumentNode
+ * AST, so the search-index-builder can index page bodies without
+ * indexing markdown syntax noise.
+ *
+ * Why a tiny dedicated walker instead of regex-stripping the
+ * markdown source?
+ *
+ *   - The AST is already parsed and trusted; walking it costs
+ *     nothing.
+ *   - Regex-stripping fenced code blocks, link syntax, image
+ *     refs, etc. is the kind of "looks easy, becomes a
+ *     rats-nest" job we explicitly avoid in this repo.
+ *   - Walking matches what the index actually wants — paragraph
+ *     text, heading text, list-item text, alt-text on images,
+ *     etc. — and naturally skips structural nodes that aren't
+ *     content.
+ *
+ * Capability `[]`.  Pure data walk.
+ */
+
+/**
+ * Maximum recursion depth.  Markdown documents in practice nest
+ * at most a handful of levels (a blockquote containing a list
+ * containing nested lists is already extreme); 1024 is two
+ * orders of magnitude past that.  The cap protects against a
+ * pathological or malformed AST with cyclic `children`
+ * references which would otherwise stack-overflow Node's
+ * default call stack (~10k frames).
+ */
+const MAX_DEPTH = 1024;
+
+/**
+ * Recursively pull every `text` field out of an AST node and
+ * its descendants, joined by spaces.  Plain conservative walk;
+ * we treat unknown node shapes as opaque containers and
+ * recurse into `children` if present.
+ *
+ * Bounded by `MAX_DEPTH` — defends against malformed ASTs with
+ * cyclic `children` references.  Today's input source
+ * (`commonmark-parser`) cannot produce cycles, so the cap is
+ * defence-in-depth only.
+ */
+export function plainText(node: unknown): string {
+  const buf: string[] = [];
+  walk(node, buf, 0);
+  return buf.join(" ").replace(/\s+/g, " ").trim();
+}
+
+function walk(node: unknown, buf: string[], depth: number): void {
+  if (depth > MAX_DEPTH) return;
+  if (node === null || node === undefined) return;
+  if (typeof node !== "object") return;
+  const n = node as { type?: unknown; text?: unknown; children?: unknown };
+  if (typeof n.text === "string") {
+    buf.push(n.text);
+  }
+  // Recurse into children if the node has any.  Most DocumentNode
+  // variants use `children: Node[]`; some inline nodes (TextNode,
+  // CodeSpanNode) have no children — `walk` is a no-op on those.
+  if (Array.isArray(n.children)) {
+    for (let i = 0; i < n.children.length; i++) {
+      walk(n.children[i], buf, depth + 1);
+    }
+  }
+}

--- a/code/programs/typescript/forme-doc-demo/tests/build.test.ts
+++ b/code/programs/typescript/forme-doc-demo/tests/build.test.ts
@@ -1,0 +1,410 @@
+/**
+ * build.test.ts — smoke + integration tests for the demo driver.
+ *
+ * Strategy: rather than re-test every upstream package's contract
+ * (those have their own >95% suites), we assert that this driver
+ * actually composes them end-to-end correctly:
+ *
+ *   - Reading the bundled corpus produces the expected page
+ *     count and stable order.
+ *   - Building the bundle produces a route per page + sidebar +
+ *     search manifest + search shards.
+ *   - The rendered HTML for at least one page contains the
+ *     expected fingerprint of every upstream package's output
+ *     (heading anchors, code-block decoration, sidebar
+ *     highlight, etc.).
+ *   - Writing the bundle creates a real `dist/` directory
+ *     with `index.html`, nested routes, and search files.
+ *   - Round-trips through `generatePageBundle` (the FM00
+ *     downstream consumer) cleanly.
+ *   - safeJoin rejects path-escape attacks.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { generatePageBundle } from "@coding-adventures/forme-aot-page-bundle-emitter";
+
+import { build, routeFor, titleOf, injectHeadingIds, normaliseSidebarPaths, type MarkdownFile } from "../src/build.js";
+import { readCorpus, writeBundle, safeJoin, validateOutDir } from "../src/main.js";
+import { plainText } from "../src/plain-text.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const CORPUS = path.join(REPO_ROOT, "corpus");
+
+// ─────────────────────────────────────────────────────────────────────
+// routeFor
+// ─────────────────────────────────────────────────────────────────────
+
+describe("routeFor", () => {
+  it("turns index.md into /", () => expect(routeFor("index.md")).toBe("/"));
+  it("turns getting-started.md into /getting-started", () =>
+    expect(routeFor("getting-started.md")).toBe("/getting-started"));
+  it("turns guide/installation.md into /guide/installation", () =>
+    expect(routeFor("guide/installation.md")).toBe("/guide/installation"));
+  it("turns guide/index.md into /guide", () =>
+    expect(routeFor("guide/index.md")).toBe("/guide"));
+  it("strips leading ./", () =>
+    expect(routeFor("./api/reference.md")).toBe("/api/reference"));
+  it("strips leading /", () =>
+    expect(routeFor("/api/reference.md")).toBe("/api/reference"));
+  it("strips .mdx extension", () =>
+    expect(routeFor("page.mdx")).toBe("/page"));
+  it("preserves non-.md extensions", () =>
+    expect(routeFor("file.json")).toBe("/file.json"));
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// titleOf
+// ─────────────────────────────────────────────────────────────────────
+
+describe("titleOf", () => {
+  it("prefers frontmatter.title when present", () =>
+    expect(titleOf({ title: "Hello" }, "any.md")).toBe("Hello"));
+  it("humanises basename when frontmatter has no title", () =>
+    expect(titleOf({}, "getting-started.md")).toBe("Getting Started"));
+  it("falls back when title is empty string", () =>
+    expect(titleOf({ title: "" }, "x.md")).toBe("X"));
+  it("falls back when title is non-string", () =>
+    expect(titleOf({ title: 5 as unknown as string }, "x.md")).toBe("X"));
+  it("handles nested paths", () =>
+    expect(titleOf({}, "guide/installation.md")).toBe("Installation"));
+  it("handles underscored names", () =>
+    expect(titleOf({}, "advanced_topics.md")).toBe("Advanced Topics"));
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// injectHeadingIds
+// ─────────────────────────────────────────────────────────────────────
+
+describe("injectHeadingIds", () => {
+  it("injects ids in document order", () => {
+    const html = "<h1>A</h1>\n<p>x</p>\n<h2>B</h2>\n<h3>C</h3>\n";
+    const anchors = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(injectHeadingIds(html, anchors)).toBe(
+      `<h1 id="a">A</h1>\n<p>x</p>\n<h2 id="b">B</h2>\n<h3 id="c">C</h3>\n`,
+    );
+  });
+
+  it("leaves extra <h*> tags untouched when anchors run out", () => {
+    const html = "<h1>A</h1>\n<h2>B</h2>\n";
+    const anchors = [{ id: "only" }];
+    expect(injectHeadingIds(html, anchors)).toBe(
+      `<h1 id="only">A</h1>\n<h2>B</h2>\n`,
+    );
+  });
+
+  it("escapes HTML-special chars in id values (defence-in-depth)", () => {
+    const html = "<h1>A</h1>\n";
+    const anchors = [{ id: `a"&<>` }];
+    expect(injectHeadingIds(html, anchors)).toBe(
+      `<h1 id="a&quot;&amp;&lt;&gt;">A</h1>\n`,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// normaliseSidebarPaths
+// ─────────────────────────────────────────────────────────────────────
+
+describe("normaliseSidebarPaths", () => {
+  it("rewrites file-path entries to URL routes", () => {
+    const input = [
+      { kind: "page" as const, label: "Intro", path: "intro.md" },
+      { kind: "group" as const, label: "Guide", path: "guide/index.md", children: [
+        { kind: "page" as const, label: "Setup", path: "guide/setup.md" },
+      ] },
+    ];
+    const out = normaliseSidebarPaths(input);
+    expect(out[0]!.path).toBe("/intro");
+    expect(out[1]!.path).toBe("/guide");
+    expect(out[1]!.children![0]!.path).toBe("/guide/setup");
+  });
+
+  it("preserves null paths (groups without an index page)", () => {
+    const input = [{ kind: "group" as const, label: "Misc", path: null, children: [] }];
+    const out = normaliseSidebarPaths(input);
+    expect(out[0]!.path).toBe(null);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// build — pipeline integration
+// ─────────────────────────────────────────────────────────────────────
+
+describe("build — full pipeline", () => {
+  let files: readonly MarkdownFile[];
+  let bundle: ReturnType<typeof build>;
+
+  beforeAll(async () => {
+    files = await readCorpus(CORPUS);
+    bundle = build(files, {
+      siteTitle: "Acme Docs",
+      githubUrl: "https://github.com/example/acme",
+      copyright: "© 2026 Acme",
+    });
+  });
+
+  it("reads exactly the 6 corpus pages", () => {
+    expect(files.length).toBe(6);
+  });
+
+  it("reads pages in stable sorted order", () => {
+    expect(files.map((f) => f.path)).toEqual([
+      "api/reference.md",
+      "faq.md",
+      "getting-started.md",
+      "guide/configuration.md",
+      "guide/installation.md",
+      "index.md",
+    ]);
+  });
+
+  it("produces one route per page", () => {
+    const pageRoutes = bundle.pages
+      .map((p) => p.route)
+      .filter((r) => !r.startsWith("/search/") && r !== "/sidebar.json");
+    expect(pageRoutes.sort()).toEqual([
+      "/",
+      "/api/reference",
+      "/faq",
+      "/getting-started",
+      "/guide/configuration",
+      "/guide/installation",
+    ]);
+  });
+
+  it("emits a sidebar.json with the right top-level entries", () => {
+    // sidebar-builder treats the root index.md as the implicit root of
+    // the tree (its frontmatter `sidebar_label` is therefore NOT a
+    // top-level entry — the home page is reached via the brand link in
+    // the header).  Top-level entries are: non-index root pages +
+    // every subdirectory group.
+    const sidebar = bundle.pages.find((p) => p.route === "/sidebar.json");
+    expect(sidebar).toBeDefined();
+    const parsed = JSON.parse(sidebar!.html) as Array<{ label: string; kind: "page" | "group" }>;
+    const labels = parsed.map((e) => e.label);
+    expect(labels).toContain("Getting Started");
+    expect(labels).toContain("FAQ");
+    expect(labels).toContain("Guide");
+    expect(labels).toContain("API");
+  });
+
+  it("normalises sidebar paths to URL routes (so aria-current matches)", () => {
+    const sidebar = bundle.pages.find((p) => p.route === "/sidebar.json")!;
+    const parsed = JSON.parse(sidebar.html) as Array<{ path: string | null; children?: Array<{ path: string | null }> }>;
+    // Every leaf page's path should be a URL route, not a .md file path.
+    for (const entry of parsed) {
+      if (entry.path !== null) {
+        expect(entry.path.startsWith("/")).toBe(true);
+        expect(entry.path.endsWith(".md")).toBe(false);
+      }
+      if (entry.children) {
+        for (const child of entry.children) {
+          if (child.path !== null) {
+            expect(child.path.startsWith("/")).toBe(true);
+            expect(child.path.endsWith(".md")).toBe(false);
+          }
+        }
+      }
+    }
+  });
+
+  it("emits a search manifest listing every page", () => {
+    const manifestEntry = bundle.pages.find((p) => p.route === "/search/manifest.json");
+    expect(manifestEntry).toBeDefined();
+    const m = JSON.parse(manifestEntry!.html) as { pages: string[]; shardKeys: string[] };
+    expect(m.pages).toContain("/");
+    expect(m.pages).toContain("/getting-started");
+    expect(m.pages).toContain("/guide/installation");
+    expect(m.shardKeys.length).toBeGreaterThan(0);
+  });
+
+  it("emits one search shard per shardKey in the manifest", () => {
+    const manifestEntry = bundle.pages.find((p) => p.route === "/search/manifest.json")!;
+    const m = JSON.parse(manifestEntry.html) as { shardKeys: string[] };
+    for (const key of m.shardKeys) {
+      const shardEntry = bundle.pages.find((p) => p.route === `/search/${key}.json`);
+      expect(shardEntry, `shard /search/${key}.json missing`).toBeDefined();
+    }
+  });
+
+  it("contains a heading anchor in a page's HTML (heading-anchors pipeline)", () => {
+    const home = bundle.pages.find((p) => p.route === "/")!;
+    // heading-anchors emits id="..." on every <h*>
+    expect(home.html).toMatch(/<h[1-6][^>]*id="[^"]+"/);
+  });
+
+  it("contains the page-shell chrome (header, sidebar, footer)", () => {
+    const home = bundle.pages.find((p) => p.route === "/")!;
+    expect(home.html).toMatch(/<header[\s>]/);
+    expect(home.html).toMatch(/<nav[^>]+class="[^"]*sidebar/);
+    expect(home.html).toMatch(/<footer[\s>]/);
+  });
+
+  it("highlights the current page in the sidebar via aria-current", () => {
+    // `/` itself isn't in the sidebar (root index.md is the implicit
+    // root, not a sidebar entry — see the test above).  A page that
+    // IS in the sidebar — like /getting-started — should be highlighted
+    // when it's the current page.
+    const gs = bundle.pages.find((p) => p.route === "/getting-started")!;
+    expect(gs.html).toMatch(/aria-current="page"/);
+  });
+
+  it("renders a fenced code block as <pre><code>", () => {
+    const gs = bundle.pages.find((p) => p.route === "/getting-started")!;
+    expect(gs.html).toMatch(/<pre><code/);
+  });
+
+  it("injects the theme CSS into <head>", () => {
+    const home = bundle.pages.find((p) => p.route === "/")!;
+    expect(home.html).toMatch(/<style>[^<]*\.sidebar/);
+  });
+
+  it("uses the site title in <title> and the brand", () => {
+    const home = bundle.pages.find((p) => p.route === "/")!;
+    expect(home.html).toContain("Acme Docs");
+  });
+
+  it("feeds cleanly into generatePageBundle (round-trip)", () => {
+    const manifestJson = generatePageBundle(bundle);
+    const manifest = JSON.parse(manifestJson) as { version: 1; routes: Record<string, unknown> };
+    expect(manifest.version).toBe(1);
+    // Every emitted PageEntry should be in the routes table.
+    for (const p of bundle.pages) {
+      expect(manifest.routes[p.route]).toBeDefined();
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// writeBundle — disk output
+// ─────────────────────────────────────────────────────────────────────
+
+describe("writeBundle", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(REPO_ROOT, ".tmp-write-"));
+    const files = await readCorpus(CORPUS);
+    const bundle = build(files, {
+      siteTitle: "Acme Docs",
+      copyright: "© 2026 Acme",
+    });
+    await writeBundle(bundle, tmpDir);
+  });
+
+  it("writes index.html at the output root", async () => {
+    const stat = await fs.stat(path.join(tmpDir, "index.html"));
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it("writes nested route output at <route>/index.html", async () => {
+    const stat = await fs.stat(path.join(tmpDir, "guide/installation/index.html"));
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it("writes search/manifest.json", async () => {
+    const body = await fs.readFile(path.join(tmpDir, "search/manifest.json"), "utf8");
+    const parsed = JSON.parse(body) as { pages: string[] };
+    expect(parsed.pages.length).toBeGreaterThan(0);
+  });
+
+  it("writes sidebar.json", async () => {
+    const stat = await fs.stat(path.join(tmpDir, "sidebar.json"));
+    expect(stat.isFile()).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// plainText
+// ─────────────────────────────────────────────────────────────────────
+
+describe("plainText", () => {
+  it("extracts text from a flat node", () => {
+    expect(plainText({ type: "text", text: "hello" })).toBe("hello");
+  });
+
+  it("recurses into children and joins with spaces", () => {
+    const ast = {
+      type: "doc",
+      children: [
+        { type: "p", children: [{ type: "text", text: "hello" }, { type: "text", text: "world" }] },
+      ],
+    };
+    expect(plainText(ast)).toBe("hello world");
+  });
+
+  it("returns empty string for null / undefined / non-object", () => {
+    expect(plainText(null)).toBe("");
+    expect(plainText(undefined)).toBe("");
+    expect(plainText(5)).toBe("");
+    expect(plainText("string")).toBe("");  // text field, not the node itself
+  });
+
+  it("respects MAX_DEPTH on a cyclic AST without stack overflow", () => {
+    // Build a cyclic node: parent.children = [parent] forever.
+    const cyclic: { type: string; text: string; children?: unknown[] } = {
+      type: "p",
+      text: "loop",
+    };
+    cyclic.children = [cyclic];
+    // Should not throw — the depth cap protects us.
+    expect(() => plainText(cyclic)).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// safeJoin + validateOutDir
+// ─────────────────────────────────────────────────────────────────────
+
+describe("safeJoin", () => {
+  it("joins a normal relative path under the base", () => {
+    expect(safeJoin("/tmp/site", "page/index.html")).toBe(path.join("/tmp/site", "page/index.html"));
+  });
+  it("rejects ../ escape", () => {
+    expect(() => safeJoin("/tmp/site", "../etc/passwd")).toThrow(/escapes/);
+  });
+  it("rejects absolute paths that resolve outside", () => {
+    expect(() => safeJoin("/tmp/site", "/etc/passwd")).toThrow(/escapes/);
+  });
+  it("rejects prefix-string false-match (outD vs outDir)", () => {
+    expect(() => safeJoin("/tmp/outD", "../outDir/file")).toThrow(/escapes/);
+  });
+});
+
+describe("validateOutDir", () => {
+  it("accepts a normal dist directory inside cwd", () => {
+    expect(() => validateOutDir("/tmp/site/dist", "/tmp/site")).not.toThrow();
+  });
+  it("accepts cwd itself (edge case but legal)", () => {
+    expect(() => validateOutDir("/tmp/site", "/tmp/site")).not.toThrow();
+  });
+  it("rejects empty string", () => {
+    expect(() => validateOutDir("", "/tmp")).toThrow();
+  });
+  it("rejects non-string", () => {
+    expect(() => validateOutDir(5 as unknown as string, "/tmp")).toThrow();
+  });
+  it("rejects /etc", () => {
+    expect(() => validateOutDir("/etc", "/etc")).toThrow(/system directory/);
+  });
+  it("rejects / (root)", () => {
+    expect(() => validateOutDir("/", "/")).toThrow(/system directory/);
+  });
+  it("rejects paths outside cwd", () => {
+    expect(() => validateOutDir("/tmp/site/dist", "/home/user/proj")).toThrow(/inside the working directory/);
+  });
+  it("rejects parent-of-cwd output dir", () => {
+    expect(() => validateOutDir("/tmp", "/tmp/site")).toThrow(/inside the working directory/);
+  });
+  it("rejects Windows C:\\ root (case-insensitive)", () => {
+    expect(() => validateOutDir("c:\\", "/tmp")).toThrow(/system directory/);
+  });
+  it("rejects C:\\Windows (case-insensitive)", () => {
+    expect(() => validateOutDir("C:\\WINDOWS", "/tmp")).toThrow(/system directory/);
+  });
+  it("rejects prefix-string false-match (cwd /tmp/outD vs out /tmp/outDir)", () => {
+    expect(() => validateOutDir("/tmp/outDir/dist", "/tmp/outD")).toThrow(/inside the working directory/);
+  });
+});

--- a/code/programs/typescript/forme-doc-demo/tsconfig.json
+++ b/code/programs/typescript/forme-doc-demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist-ts",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/code/programs/typescript/forme-doc-demo/vitest.config.ts
+++ b/code/programs/typescript/forme-doc-demo/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

First runnable that exercises **all 11 `forme-doc-*` packages plus the FM00 page-bundle-emitter** against a real markdown corpus, producing a browsable static site. Reads `./corpus`, writes `./dist` (6 HTML pages + sidebar.json + search/manifest.json + search shards).

You asked: *"Do we have a test site that I can see?"* — this is that test site. `npm install && npm start && npx serve dist`.

## Why this lives in `programs/` not `packages/`

Programs are end-of-line consumers — runnables, not building blocks. They're allowed to own capabilities at the leaf. This program declares:

- `fs:read` / `fs:list` on `./corpus/**`
- `fs:write` / `fs:create` on `./dist/**`

**Every `forme-doc-*` library this program depends on remains `capabilities: []`.** No library was modified to enable this demo.

## Components

- **`corpus/`** — six handwritten markdown pages describing a fictional `@acme/widget` library, designed to exercise paragraphs, lists, fenced code in multiple languages, heading nesting, inline code, and internal cross-page links.
- **`src/build.ts`** — pure transform (no I/O, capability `[]`) that composes the cluster: per-page `extractFrontmatter → parseMarkdown → generateHeadingAnchors → decorateCodeBlocks → highlightCodeBlocks → extractToc → toHtml → injectHeadingIds → renderPageShell → generateHtmlDocument`; cross-page `buildSidebar (+ normaliseSidebarPaths) + buildSearchIndex`; final `emitSite` composition.
- **`src/main.ts`** — CLI entrypoint and the ONLY file in the program that touches the filesystem. Walks corpus (rejecting symlinks), validates output dir, `safeJoin` containment on every write.
- **`src/plain-text.ts`** — small AST text-extraction walker for search-index input. Depth-capped at 1024.

## Two small in-program helpers (each <60 lines, exported & unit-tested)

- **`injectHeadingIds`** — injects `id="..."` attributes into rendered `<h*>` tags from the heading-anchors result, because `document-ast-to-html`'s `renderHeading` doesn't read `AnchoredHeadingNode.id`. ReDoS-free regex (`/<h([1-6])>/g`).
- **`normaliseSidebarPaths`** — rewrites each sidebar entry's `path` field from `"foo.md"` to `"/foo"` so page-shell's `currentPath` can highlight the active page.

## Security posture (two-pass `/security-review`)

Initial review found 2 MEDIUMs + 4 LOWs; **all six addressed in this PR**; re-review confirms clean.

- **`validateOutDir(outDir, cwd)`** — rejects empty/non-string; Unix system roots (`/`, `/etc`, ...); Windows system paths (`C:\`, `C:\Windows`, ..., case-insensitive); **requires `outDir` to live inside `cwd`** (typo-defence against `npm start corpus ~/Documents` overwriting user files).
- **`warnIfOverwritingFiles`** — heuristic detects when `outDir` contains files that don't look like a previous demo build; logs prominent warning before clobber.
- **`safeJoin` containment** on every write target (`path.resolve` + `path.sep`-suffix prefix-string check).
- **Symlinks refused** during corpus walk.
- **`isCliEntry`** uses `url.pathToFileURL(argv[1]).href` — no basename-suffix fallback (defends against test-runner false-positives + Windows / URL-encoding edge cases).
- **`plainText`** depth cap of 1024.
- **`escapeAttr`** handles all five HTML-special chars in correct order.
- **`routeFor`** documented as a normaliser, not a sanitiser, with the two upstream invariants that keep callers safe.

## Tests

**56 tests** in `tests/build.test.ts`:

- `routeFor` (8), `titleOf` (6), `injectHeadingIds` (3), `normaliseSidebarPaths` (2)
- `plainText` (4 — including cyclic-AST stack-overflow defence)
- `build` end-to-end (12 against the bundled corpus — heading anchors, sidebar highlight, fenced code blocks, theme CSS, site title, search shards, sidebar.json content, round-trip through `generatePageBundle`)
- `writeBundle` (4 — actual disk output with nested dirs)
- `safeJoin` (4 — including prefix-string false-match)
- `validateOutDir` (11 — including Windows paths + cwd-containment)

**Coverage**: 84.4% line / 91.86% branch / 89.47% function across `src/`. (Programs target >80%; libraries target >95%.) Uncovered code is the CLI bootstrap (lines 81–85, 153, 175–194 of `main.ts`), exercised implicitly by `npm start`.

## What you get

```bash
cd code/programs/typescript/forme-doc-demo
npm install
npm start
# → [forme-doc-demo] wrote = 18 files to ./dist
npx serve dist
```

The resulting site has heading anchors, sidebar navigation with current-page highlighting, syntax-highlighted code blocks, in-page TOC on the right, and a pre-built search index ready to wire up to `forme-doc-search-client-js`.

## DOC00 v0 cluster status

- ✅ 11 library packages (all `capabilities: []`)
- ✅ 1 runnable demo (this PR — `capabilities: [fs:read, fs:write, fs:list, fs:create]`)

## Test plan

- [x] `npx vitest run --coverage` — 56/56 pass; 84.4% line / 91.86% branch
- [x] `npm start` — produces 18 files in `./dist`
- [x] `python3 -m http.server --directory dist` — site browses correctly
- [x] `/security-review` (pass 1) — 2 MEDIUMs + 4 LOWs found
- [x] All findings addressed in this PR
- [x] `/security-review` (pass 2) — clean, no regressions
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)