### PR TITLE
[codex] Add Board VM input callback dispatch planning

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -107,6 +107,10 @@ event-queue decision in Rust too. Frontends still own queue storage and runtime
 scheduling, but Rust decides whether a callback invocation is enqueued, drops
 the incoming event, drops the oldest queued event first, and whether cooperative
 dispatch should be woken.
+`input_callback_dispatch_plan_for_queue_plan` then turns an admitted queue item
+into the callback execution handoff: callback program id, instruction budget,
+event identity, queue action, and cooperative dispatch reason stay in Rust,
+while language adapters only schedule the native callback runner.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -104,6 +104,7 @@ pub const LANGUAGE_INPUT_CALLBACK_DEFAULT_DEBOUNCE_MS: u16 = 25;
 pub const LANGUAGE_INPUT_CALLBACK_DEFAULT_QUEUE_CAPACITY: u8 = 8;
 pub const LANGUAGE_INPUT_CALLBACK_DISPATCH_MODEL: &str = "cooperative_event_queue";
 pub const LANGUAGE_INPUT_CALLBACK_EVENT_KIND: &str = "digital_input_change";
+pub const LANGUAGE_INPUT_CALLBACK_DISPATCH_REASON: &str = "queued_input_event";
 pub const ARDUINO_CLI_NATIVE_USB_BOOTLOADER_TOUCH_BAUD: u32 = 1_200;
 pub const ARDUINO_CLI_UPLOAD_PORT_PLACEHOLDER: &str = "<port>";
 pub const ARDUINO_CLI_UPLOAD_INPUT_FILE_PLACEHOLDER: &str = "<firmware-image>";
@@ -744,6 +745,24 @@ pub struct LanguageInputCallbackQueuePlan {
     pub dropped_existing_event: bool,
     pub dropped_incoming_event: bool,
     pub dispatch_required: bool,
+    pub interrupt_backed: bool,
+    pub dispatch_model: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackDispatchPlan {
+    pub board_id: String,
+    pub pin: u8,
+    pub label: String,
+    pub event_kind: String,
+    pub dispatch_reason: String,
+    pub callback_program_id: u16,
+    pub callback_instruction_budget: u32,
+    pub sequence: u32,
+    pub timestamp_ms: u64,
+    pub queue_depth_after: u8,
+    pub queue_action: LanguageInputCallbackQueueAction,
+    pub dropped_existing_event: bool,
     pub interrupt_backed: bool,
     pub dispatch_model: String,
 }
@@ -1998,6 +2017,31 @@ pub fn input_callback_queue_plan_for_invocation(
         dispatch_required: queued,
         interrupt_backed: invocation.interrupt_backed,
         dispatch_model: invocation.dispatch_model.clone(),
+    })
+}
+
+pub fn input_callback_dispatch_plan_for_queue_plan(
+    queue_plan: &LanguageInputCallbackQueuePlan,
+) -> Option<LanguageInputCallbackDispatchPlan> {
+    if !queue_plan.dispatch_required {
+        return None;
+    }
+
+    Some(LanguageInputCallbackDispatchPlan {
+        board_id: queue_plan.board_id.clone(),
+        pin: queue_plan.pin,
+        label: queue_plan.label.clone(),
+        event_kind: queue_plan.event_kind.clone(),
+        dispatch_reason: LANGUAGE_INPUT_CALLBACK_DISPATCH_REASON.to_owned(),
+        callback_program_id: queue_plan.callback_program_id,
+        callback_instruction_budget: queue_plan.callback_instruction_budget,
+        sequence: queue_plan.sequence,
+        timestamp_ms: queue_plan.timestamp_ms,
+        queue_depth_after: queue_plan.queue_depth_after,
+        queue_action: queue_plan.action,
+        dropped_existing_event: queue_plan.dropped_existing_event,
+        interrupt_backed: queue_plan.interrupt_backed,
+        dispatch_model: queue_plan.dispatch_model.clone(),
     })
 }
 
@@ -6551,6 +6595,74 @@ mod tests {
             error.kind,
             LanguageInputCallbackQueuePlanErrorKind::EmptyQueue
         );
+    }
+
+    #[test]
+    fn input_callback_dispatch_plans_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let dispatch = input_callback_dispatch_plan_for_queue_plan(&queue_plan).unwrap();
+        assert_eq!(dispatch.board_id, "arduino-uno-r4-wifi");
+        assert_eq!(dispatch.pin, 3);
+        assert_eq!(dispatch.label, "D3");
+        assert_eq!(dispatch.event_kind, LANGUAGE_INPUT_CALLBACK_EVENT_KIND);
+        assert_eq!(
+            dispatch.dispatch_reason,
+            LANGUAGE_INPUT_CALLBACK_DISPATCH_REASON
+        );
+        assert_eq!(dispatch.callback_program_id, 7);
+        assert_eq!(dispatch.callback_instruction_budget, 64);
+        assert_eq!(dispatch.sequence, 42);
+        assert_eq!(dispatch.timestamp_ms, 9001);
+        assert_eq!(dispatch.queue_depth_after, 3);
+        assert_eq!(
+            dispatch.queue_action,
+            LanguageInputCallbackQueueAction::Enqueue
+        );
+        assert!(!dispatch.dropped_existing_event);
+        assert!(dispatch.interrupt_backed);
+        assert_eq!(
+            dispatch.dispatch_model,
+            LANGUAGE_INPUT_CALLBACK_DISPATCH_MODEL
+        );
+
+        let full_queue =
+            input_callback_queue_plan_for_invocation(&invocation, invocation.queue_capacity)
+                .unwrap();
+        let dispatch = input_callback_dispatch_plan_for_queue_plan(&full_queue).unwrap();
+        assert_eq!(
+            dispatch.queue_action,
+            LanguageInputCallbackQueueAction::DropOldestThenEnqueue
+        );
+        assert_eq!(
+            dispatch.queue_depth_after,
+            LANGUAGE_INPUT_CALLBACK_DEFAULT_QUEUE_CAPACITY
+        );
+        assert!(dispatch.dropped_existing_event);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        assert!(input_callback_dispatch_plan_for_queue_plan(&newest_drop).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned input callback dispatch handoff metadata for admitted queue items
- expose callback program id, instruction budget, event identity, queue action, and cooperative dispatch reason
- return no dispatch plan when the queue policy drops the incoming event

## Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-dispatch-plan cargo test -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-dispatch-plan cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

## Notes
- The external target-detect build-tool path from earlier monitors was unavailable in this workspace: /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool no longer exists.