### PR TITLE
Flatten drain last-checkpoint summary flag

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this package will be documented in this file.
   summaries.
 - Flattened last-checkpoint timestamp and call-id fields in supervisor drain
   run summaries.
+- Flattened last-checkpoint presence flags in supervisor drain run summaries.
 - Flattened planned and replayed follow-up row counts in supervisor drain run
   summaries.
 - Follow-up pressure drift flags in supervisor drain run reports and summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -62,6 +62,8 @@ The crate keeps the boundary narrow:
   for timestamp and call-id host logs
 - supervisor drain run summaries flatten last-checkpoint timestamp and call-id
   fields for payload-free checkpoint logging
+- supervisor drain run summaries flatten last-checkpoint presence flags beside
+  timestamp and call-id checkpoint fields
 - supervisor drain run summaries flatten planned and replayed follow-up row
   counts for host routing decisions
 - supervisor drain run summaries flag when planned and replayed follow-up

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1255,6 +1255,7 @@ impl ToolAuditSupervisorDrainRunReport {
             requires_follow_up: self.requires_follow_up(),
             advanced_checkpoint: self.advanced_checkpoint(),
             last_checkpoint: self.last_checkpoint().cloned(),
+            has_last_checkpoint: self.has_last_checkpoint(),
             last_checkpoint_timestamp_ms: self.last_checkpoint_timestamp_ms(),
             last_checkpoint_call_id: self.last_checkpoint_call_id().map(str::to_owned),
         }
@@ -1520,6 +1521,8 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub advanced_checkpoint: bool,
     /// Last replay checkpoint observed by the actual run.
     pub last_checkpoint: Option<ToolAuditReadCheckpoint>,
+    /// Whether the actual run observed a replay checkpoint.
+    pub has_last_checkpoint: bool,
     /// Timestamp for the last replay checkpoint observed by the actual run.
     pub last_checkpoint_timestamp_ms: Option<u64>,
     /// Call id for the last replay checkpoint observed by the actual run.
@@ -1809,7 +1812,7 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return whether the actual run observed a replay checkpoint.
     pub fn has_last_checkpoint(&self) -> bool {
-        self.last_checkpoint().is_some()
+        self.has_last_checkpoint
     }
 
     /// Return the timestamp for the last replay checkpoint observed by the actual run.
@@ -4500,6 +4503,7 @@ mod tests {
         assert!(summary.advanced_checkpoint());
         assert_eq!(summary.last_checkpoint, report.last_checkpoint().cloned());
         assert_eq!(summary.last_checkpoint(), report.last_checkpoint());
+        assert!(summary.has_last_checkpoint);
         assert_eq!(summary.last_checkpoint_timestamp_ms, Some(120));
         assert_eq!(summary.last_checkpoint_call_id.as_deref(), Some("call_2"));
         assert!(summary.has_last_checkpoint());


### PR DESCRIPTION
Summary:
- Flatten has_last_checkpoint onto ToolAuditSupervisorDrainRunSummary beside the existing checkpoint scalar fields
- Wire the summary accessor to the flattened field and cover the raw field in host summary tests
- Document the new flattened last-checkpoint presence flag in README/CHANGELOG

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-last-checkpoint-summary-flag/mise.toml cargo test -p chief-of-staff-tool-audit-store
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-last-checkpoint-summary-flag/mise.toml sh BUILD