### PR TITLE
feat(sql-pipeline): VALUES clause support

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -35,7 +35,24 @@ detach_stmt       = "DETACH" [ "DATABASE" ] NAME ;
 # UNION/EXCEPT.  For the educational subset we treat all three as left-
 # associative equals; ANSI-compliant precedence can be added later.
 
-query_stmt        = [ with_clause ] select_stmt { set_op_clause } ;
+# A query_stmt is either (a) the usual SELECT-plus-set-op-tails form, or
+# (b) a bare VALUES list.  SQLite accepts ``VALUES (1,2), (3,4)`` as a
+# standalone query and inside any context that takes a query_stmt
+# (derived tables, CTE bodies, set-op operands).  We model VALUES as a
+# parallel branch here so it plugs into all those slots without each
+# call site having to special-case the keyword.
+#
+# The two branches are mutually exclusive: a real SELECT always starts
+# with SELECT or WITH, while VALUES starts with the eponymous keyword,
+# so the parser can pick deterministically (no backtracking pain).
+query_stmt        = [ with_clause ] ( values_stmt | select_stmt ) { set_op_clause } ;
+# VALUES list: one or more parenthesised tuples of expressions,
+# comma-separated.  SQLite names the output columns ``column1``,
+# ``column2``, … (1-indexed) when no explicit alias list is given.  The
+# adapter desugars the VALUES into a left-deep UNION-ALL chain of
+# single-row SELECTs so downstream layers (planner, codegen, VM) see
+# only constructs they already handle.
+values_stmt       = "VALUES" row_value { "," row_value } ;
 with_clause       = "WITH" [ "RECURSIVE" ] cte_def { "," cte_def } ;
 # The optional [NOT] MATERIALIZED hint (SQLite 3.35+) tells the planner
 # whether to materialise the CTE result set.  Mini-sqlite has no
@@ -44,7 +61,8 @@ with_clause       = "WITH" [ "RECURSIVE" ] cte_def { "," cte_def } ;
 cte_def           = NAME [ "(" NAME { "," NAME } ")" ] "AS"
                     [ [ "NOT" ] "MATERIALIZED" ]
                     "(" query_stmt ")" ;
-set_op_clause     = ( "UNION" | "INTERSECT" | "EXCEPT" ) [ "ALL" ] select_stmt ;
+set_op_clause     = ( "UNION" | "INTERSECT" | "EXCEPT" ) [ "ALL" ]
+                    ( values_stmt | select_stmt ) ;
 
 # ── SELECT ───────────────────────────────────────────────────────────────────
 

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.81.0] - 2026-05-22
+
+### Added
+
+- **VALUES clause** support, end-to-end and byte-identical with
+  stdlib `sqlite3`.  ``VALUES (a, b), (c, d), …`` now works anywhere
+  a SELECT does:
+  - **Standalone**: ``VALUES (1, 'a'), (2, 'b')`` is a top-level
+    statement that returns a rowset.
+  - **Derived table**: ``SELECT * FROM (VALUES (1), (2))``.
+  - **CTE body** (with or without column alias list):
+    ``WITH t(n) AS (VALUES (1), (2)) SELECT n FROM t``.
+  - **Set-op operand**, either side: ``SELECT 1 UNION ALL VALUES (2)``
+    and the symmetric ``VALUES (1) UNION SELECT 2``.
+- Default column names are ``column1``, ``column2``, … (1-indexed)
+  when no explicit alias list is given — matching SQLite.
+- 21 oracle tests in ``tests/test_tier3_values_clause.py``.
+
+### Changed
+
+- Adapter desugars VALUES into a left-deep ``UNION ALL`` chain of
+  single-row SELECTs, so the planner, codegen, and VM see only
+  constructs they already handle.
+- ``_set_op_clause`` now returns a 4-tuple ``(op, all_flag, body_node,
+  body_rule)`` so callers can dispatch on whether the operand is a
+  SELECT or a VALUES list.  Recursive-CTE callers reject VALUES as
+  the recursive step with a clear error (the standard requires the
+  step to be a SELECT referencing the CTE's working set).
+
 ## [1.80.0] - 2026-05-22
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.80.0"
+version = "1.81.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -282,9 +282,19 @@ def _query_stmt(
                 union_all = True
                 rec_stmt: SelectStmt | None = None
                 for sop in set_op_nodes:
-                    op, all_flag, right_sel_node = _set_op_clause(sop)
+                    op, all_flag, right_sel_node, right_rule = _set_op_clause(sop)
                     if op == "UNION":
                         union_all = all_flag
+                        # The recursive step is required to be a SELECT
+                        # (the grammar doesn't accept ``UNION ALL VALUES
+                        # (n+1) FROM cte`` because VALUES can't reference
+                        # row columns).  Reject the VALUES form with the
+                        # same error SQLite would.
+                        if right_rule == "values_stmt":
+                            raise ProgrammingError(
+                                f"RECURSIVE CTE '{cte_name}' recursive step "
+                                f"cannot be a VALUES expression"
+                            )
                         rec_stmt = _select(right_sel_node, ctes=ctes_without_self)
                 if rec_stmt is None:
                     raise ProgrammingError(
@@ -309,12 +319,23 @@ def _query_stmt(
                 # Make this CTE visible to subsequent CTEs and the main query.
                 active_ctes[cte_name] = inner_stmt
 
-    select_node = _child_node(node, "select_stmt")
-    left: Statement = _select(select_node, ctes=active_ctes, view_defs=view_defs)
+    # query_stmt branches: ( values_stmt | select_stmt ) { set_op_clause }
+    # Either branch produces a left-hand Statement; set_op_clauses chain
+    # additional SELECTs onto the right via UNION/INTERSECT/EXCEPT.
+    values_node = _maybe_child(node, "values_stmt")
+    left: Statement
+    if values_node is not None:
+        left = _values_stmt(values_node)
+    else:
+        select_node = _child_node(node, "select_stmt")
+        left = _select(select_node, ctes=active_ctes, view_defs=view_defs)
     set_ops = _child_nodes(node, "set_op_clause")
     for op_node in set_ops:
-        op, all_flag, right_select_node = _set_op_clause(op_node)
-        right_stmt = _select(right_select_node, ctes=active_ctes, view_defs=view_defs)
+        op, all_flag, right_node, right_rule = _set_op_clause(op_node)
+        if right_rule == "values_stmt":
+            right_stmt = _values_stmt(right_node)
+        else:
+            right_stmt = _select(right_node, ctes=active_ctes, view_defs=view_defs)
         # Build a left-associative tree: after the first iteration ``left``
         # will already be a UnionStmt/IntersectStmt/ExceptStmt.  The AST
         # types accept any set-op stmt on the left side, and the planner
@@ -329,11 +350,17 @@ def _query_stmt(
     return left
 
 
-def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode]:
-    """Extract (operator_name, all_flag, select_stmt_node) from a set_op_clause."""
+def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode, str]:
+    """Extract (operator_name, all_flag, body_node, body_rule) from a set_op_clause.
+
+    The body may be a ``select_stmt`` (the usual case) or a
+    ``values_stmt`` (``UNION ALL VALUES (1)``).  The caller dispatches
+    on ``body_rule`` to call the right translator.
+    """
     op: str | None = None
     all_flag = False
-    select_node: ASTNode | None = None
+    body_node: ASTNode | None = None
+    body_rule: str | None = None
     for c in node.children:
         if isinstance(c, Token) and _token_type(c) == "KEYWORD":
             kw = c.value.upper()
@@ -341,11 +368,80 @@ def _set_op_clause(node: ASTNode) -> tuple[str, bool, ASTNode]:
                 op = kw
             elif kw == "ALL":
                 all_flag = True
-        elif isinstance(c, ASTNode) and c.rule_name == "select_stmt":
-            select_node = c
-    if op is None or select_node is None:
+        elif isinstance(c, ASTNode) and c.rule_name in ("select_stmt", "values_stmt"):
+            body_node = c
+            body_rule = c.rule_name
+    if op is None or body_node is None or body_rule is None:
         raise ProgrammingError("malformed set_op_clause")
-    return op, all_flag, select_node
+    return op, all_flag, body_node, body_rule
+
+
+# --------------------------------------------------------------------------
+# VALUES — desugars a standalone ``VALUES (a,b),(c,d),…`` query into a
+# left-deep UNION-ALL chain of single-row SELECTs.  This lets downstream
+# layers see only constructs they already handle.
+# --------------------------------------------------------------------------
+
+
+def _values_stmt(node: ASTNode) -> Statement:
+    """Translate ``values_stmt = "VALUES" row_value { "," row_value }`` to a Statement.
+
+    SQLite's behaviour, which we match byte-for-byte:
+
+    * Output columns are named ``column1``, ``column2``, …
+      (1-indexed) when no explicit alias list is given.  Callers that
+      *do* give aliases — e.g. ``WITH x(a, b) AS (VALUES (1, 2))`` —
+      get the aliases applied by ``_apply_cte_col_aliases`` because
+      that helper already walks down the left spine of a set-op tree
+      to find the leftmost SELECT.  We only need to lay down the
+      default names here.
+    * UNION ALL (not plain UNION) so duplicate rows survive — matches
+      SQLite's ``VALUES (1),(1)`` returning two rows.
+    * Empty VALUES is rejected by the parser (the grammar requires at
+      least one ``row_value``), so we don't need to handle that case.
+
+    Implementation detail: we build a left-deep tree
+    ``UNION ALL(UNION ALL(SELECT row0, SELECT row1), SELECT row2)`` so
+    that the existing set-op tree machinery (column derivation, alias
+    application, planner descent) sees exactly the shape it already
+    handles.
+    """
+    row_nodes = _child_nodes(node, "row_value")
+    if not row_nodes:
+        raise ProgrammingError("VALUES list cannot be empty")
+
+    # Fresh placeholder counter — matches the convention every other
+    # top-level translator (_select, _insert, _update, _delete) uses:
+    # each statement-shaped node starts its own ``?`` indexing.  A
+    # nested VALUES inside a larger SELECT therefore can't share a
+    # counter with the surrounding statement; that's a pre-existing
+    # adapter-wide limitation, not specific to VALUES.
+    state = _PlaceholderCounter()
+
+    def _build_row(row_node: ASTNode) -> SelectStmt:
+        # row_value = "(" expr { "," expr } ")"
+        exprs = [
+            _expr(c, state)
+            for c in row_node.children
+            if isinstance(c, ASTNode) and c.rule_name == "expr"
+        ]
+        if not exprs:
+            raise ProgrammingError("VALUES row cannot be empty")
+        # Name columns column1, column2, ... 1-indexed, matching SQLite.
+        items = tuple(
+            SelectItem(expr=e, alias=f"column{i + 1}")
+            for i, e in enumerate(exprs)
+        )
+        return SelectStmt(items=items)
+
+    selects = [_build_row(r) for r in row_nodes]
+    if len(selects) == 1:
+        return selects[0]
+    # Fold left: ((s0 UNION ALL s1) UNION ALL s2) ...
+    left: Statement = selects[0]
+    for right in selects[1:]:
+        left = UnionStmt(left=left, right=right, all=True)  # type: ignore[arg-type]
+    return left
 
 
 # --------------------------------------------------------------------------

--- a/code/packages/python/mini-sqlite/tests/test_tier3_values_clause.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_values_clause.py
@@ -1,0 +1,140 @@
+"""``VALUES (a,b),(c,d)`` — standalone query, table source, CTE body.
+
+SQLite (and the SQL standard) accepts ``VALUES`` as a first-class
+query expression anywhere a SELECT can appear:
+
+* **Standalone**: ``VALUES (1, 'a'), (2, 'b')`` is a top-level
+  statement that returns a rowset.
+* **Table source**: ``SELECT * FROM (VALUES (1), (2))`` — a derived
+  table whose rows are the VALUES tuples.
+* **CTE body**: ``WITH t(n) AS (VALUES (1), (2)) SELECT n FROM t`` —
+  every place a CTE accepts a ``query_stmt``.
+* **Set-op operand**: ``SELECT 1 UNION ALL VALUES (2)`` and the
+  symmetric ``VALUES (1) UNION SELECT 2``.
+
+Mini-sqlite desugars VALUES into a left-deep UNION-ALL chain of
+single-row SELECTs, so downstream layers (planner, codegen, VM) see
+only constructs they already handle.  Output columns are named
+``column1``, ``column2``, … (1-indexed) when no explicit alias list
+is given — this matches SQLite.
+
+These oracle tests pin byte-identical results against stdlib
+``sqlite3``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check(query: str) -> None:
+    m = list(mini_sqlite.connect(":memory:").execute(query))
+    r = list(sqlite3.connect(":memory:").execute(query))
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# Top-level VALUES statement.
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelValues:
+    def test_single_row_single_column(self) -> None:
+        _check("VALUES (1)")
+
+    def test_single_row_two_columns(self) -> None:
+        _check("VALUES (1, 2)")
+
+    def test_multi_row(self) -> None:
+        _check("VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+    def test_duplicate_rows_preserved(self) -> None:
+        # UNION ALL (not UNION) semantics — duplicates survive.
+        _check("VALUES (1), (1), (1)")
+
+    def test_null_in_tuple(self) -> None:
+        _check("VALUES (1, NULL), (NULL, 2)")
+
+    def test_expressions_in_tuple(self) -> None:
+        _check("VALUES (1+2, 3*4)")
+
+    def test_string_concat_in_tuple(self) -> None:
+        _check("VALUES ('foo' || 'bar')")
+
+
+# ---------------------------------------------------------------------------
+# VALUES as table source — synthetic ``column1``, ``column2`` names.
+# ---------------------------------------------------------------------------
+
+
+class TestValuesAsTableSource:
+    def test_basic(self) -> None:
+        _check("SELECT * FROM (VALUES (1, 'a'), (2, 'b'))")
+
+    def test_with_alias(self) -> None:
+        _check("SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS v")
+
+    def test_column1_default_name(self) -> None:
+        # SQLite names columns column1, column2, … when no alias list
+        # is given; the WHERE below relies on that name.
+        _check("SELECT column1 FROM (VALUES (1+1)) WHERE column1 > 1")
+
+    def test_column1_plus_column2(self) -> None:
+        _check("SELECT column1 + column2 FROM (VALUES (1, 2), (3, 4))")
+
+    def test_select_star_includes_all_columns(self) -> None:
+        _check("SELECT column1, column2 FROM (VALUES (1, NULL), (2, 'b'))")
+
+
+# ---------------------------------------------------------------------------
+# VALUES inside CTE bodies — both with and without explicit column
+# aliases.  The alias case exercises ``_apply_cte_col_aliases`` walking
+# down the left spine of the UNION-ALL chain to find the leftmost
+# SelectStmt.
+# ---------------------------------------------------------------------------
+
+
+class TestValuesInCTE:
+    def test_unaliased(self) -> None:
+        _check("WITH x AS (VALUES (1), (2)) SELECT * FROM x")
+
+    def test_explicit_column_alias(self) -> None:
+        _check("WITH x(n) AS (VALUES (10), (20)) SELECT n FROM x ORDER BY n")
+
+    def test_two_column_alias_list(self) -> None:
+        _check(
+            "WITH x(a, b) AS (VALUES (1, 'x'), (2, 'y')) "
+            "SELECT a, b FROM x ORDER BY a"
+        )
+
+    def test_chained_ctes(self) -> None:
+        _check(
+            "WITH a(x) AS (VALUES (1), (2), (3)), "
+            "     b AS (SELECT x*10 AS y FROM a) "
+            "SELECT y FROM b ORDER BY y"
+        )
+
+
+# ---------------------------------------------------------------------------
+# VALUES as a set-op operand — symmetric in either position.
+# ---------------------------------------------------------------------------
+
+
+class TestValuesInSetOp:
+    def test_select_union_all_values(self) -> None:
+        _check("SELECT 1 UNION ALL VALUES (2)")
+
+    def test_values_union_select(self) -> None:
+        _check("VALUES (1) UNION SELECT 2")
+
+    def test_values_union_values(self) -> None:
+        # Two VALUES queries set-op'd together.
+        _check("VALUES (1) UNION VALUES (2)")
+
+    def test_values_intersect_select(self) -> None:
+        _check("VALUES (1), (2), (3) INTERSECT SELECT 2")
+
+    def test_values_except_select(self) -> None:
+        _check("VALUES (1), (2), (3) EXCEPT SELECT 2")

--- a/code/packages/python/sql-parser/CHANGELOG.md
+++ b/code/packages/python/sql-parser/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the SQL parser package will be documented in this file.
 
+## [0.33.0] - 2026-05-22
+
+### Added
+
+- New `values_stmt` production handling SQLite's ``VALUES (a,b),(c,d),…``
+  expression:
+
+      values_stmt = "VALUES" row_value { "," row_value } ;
+
+  `query_stmt` now accepts `values_stmt` as an alternative to
+  `select_stmt`, and `set_op_clause` accepts it as a right operand —
+  so VALUES works anywhere a SELECT does (top-level, derived table,
+  CTE body, set-op operand).
+- Regenerated `_grammar.py` to embed the new production.
+
 ## [0.32.0] - 2026-05-21
 
 ### Added

--- a/code/packages/python/sql-parser/pyproject.toml
+++ b/code/packages/python/sql-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-parser"
-version = "0.32.0"
+version = "0.33.0"
 description = "Parses SQL text into ASTs using the grammar-driven parser — a thin wrapper that loads sql.grammar"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-parser/src/sql_parser/_grammar.py
+++ b/code/packages/python/sql-parser/src/sql_parser/_grammar.py
@@ -107,12 +107,32 @@ PARSER_GRAMMAR = ParserGrammar(
                 Optional(element=
                     RuleReference(name='with_clause', is_token=False),
                 ),
-                RuleReference(name='select_stmt', is_token=False),
+                Group(element=
+                    Alternation(choices=[
+                        RuleReference(name='values_stmt', is_token=False),
+                        RuleReference(name='select_stmt', is_token=False),
+                    ]),
+                ),
                 Repetition(element=
                     RuleReference(name='set_op_clause', is_token=False),
                 ),
             ]),
-            line_number=38,
+            line_number=48,
+        ),
+        GrammarRule(
+            name='values_stmt',
+            body=
+            Sequence(elements=[
+                Literal(value='VALUES'),
+                RuleReference(name='row_value', is_token=False),
+                Repetition(element=
+                    Sequence(elements=[
+                        Literal(value=','),
+                        RuleReference(name='row_value', is_token=False),
+                    ]),
+                ),
+            ]),
+            line_number=55,
         ),
         GrammarRule(
             name='with_clause',
@@ -130,7 +150,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=39,
+            line_number=56,
         ),
         GrammarRule(
             name='cte_def',
@@ -163,7 +183,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='query_stmt', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=44,
+            line_number=61,
         ),
         GrammarRule(
             name='set_op_clause',
@@ -179,9 +199,14 @@ PARSER_GRAMMAR = ParserGrammar(
                 Optional(element=
                     Literal(value='ALL'),
                 ),
-                RuleReference(name='select_stmt', is_token=False),
+                Group(element=
+                    Alternation(choices=[
+                        RuleReference(name='values_stmt', is_token=False),
+                        RuleReference(name='select_stmt', is_token=False),
+                    ]),
+                ),
             ]),
-            line_number=47,
+            line_number=64,
         ),
         GrammarRule(
             name='select_stmt',
@@ -220,7 +245,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='limit_clause', is_token=False),
                 ),
             ]),
-            line_number=51,
+            line_number=69,
         ),
         GrammarRule(
             name='select_list',
@@ -237,7 +262,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ),
                 ]),
             ]),
-            line_number=56,
+            line_number=74,
         ),
         GrammarRule(
             name='select_item',
@@ -251,7 +276,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=57,
+            line_number=75,
         ),
         GrammarRule(
             name='table_ref',
@@ -283,7 +308,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ),
                 ]),
             ]),
-            line_number=67,
+            line_number=85,
         ),
         GrammarRule(
             name='table_name',
@@ -297,7 +322,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=68,
+            line_number=86,
         ),
         GrammarRule(
             name='join_clause',
@@ -339,7 +364,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=76,
+            line_number=94,
         ),
         GrammarRule(
             name='join_type',
@@ -373,7 +398,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=78,
+            line_number=96,
         ),
         GrammarRule(
             name='where_clause',
@@ -382,7 +407,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='WHERE'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=82,
+            line_number=100,
         ),
         GrammarRule(
             name='group_clause',
@@ -398,7 +423,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=83,
+            line_number=101,
         ),
         GrammarRule(
             name='having_clause',
@@ -407,7 +432,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='HAVING'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=84,
+            line_number=102,
         ),
         GrammarRule(
             name='order_clause',
@@ -423,7 +448,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=85,
+            line_number=103,
         ),
         GrammarRule(
             name='order_item',
@@ -443,7 +468,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=96,
+            line_number=114,
         ),
         GrammarRule(
             name='limit_clause',
@@ -458,7 +483,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=98,
+            line_number=116,
         ),
         GrammarRule(
             name='conflict_clause',
@@ -475,7 +500,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=120,
+            line_number=138,
         ),
         GrammarRule(
             name='insert_stmt',
@@ -508,7 +533,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=122,
+            line_number=140,
         ),
         GrammarRule(
             name='upsert_clause',
@@ -553,7 +578,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=139,
+            line_number=157,
         ),
         GrammarRule(
             name='upsert_assignment',
@@ -563,7 +588,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='='),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=145,
+            line_number=163,
         ),
         GrammarRule(
             name='replace_stmt',
@@ -590,7 +615,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=146,
+            line_number=164,
         ),
         GrammarRule(
             name='insert_body',
@@ -608,7 +633,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=150,
+            line_number=168,
         ),
         GrammarRule(
             name='row_value',
@@ -624,7 +649,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value=')'),
             ]),
-            line_number=151,
+            line_number=169,
         ),
         GrammarRule(
             name='update_stmt',
@@ -647,7 +672,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=153,
+            line_number=171,
         ),
         GrammarRule(
             name='assignment',
@@ -657,7 +682,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='='),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=155,
+            line_number=173,
         ),
         GrammarRule(
             name='delete_stmt',
@@ -673,7 +698,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=157,
+            line_number=175,
         ),
         GrammarRule(
             name='returning_clause',
@@ -688,7 +713,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=159,
+            line_number=177,
         ),
         GrammarRule(
             name='create_table_stmt',
@@ -717,7 +742,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='table_options', is_token=False),
                 ),
             ]),
-            line_number=163,
+            line_number=181,
         ),
         GrammarRule(
             name='table_options',
@@ -731,7 +756,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=172,
+            line_number=190,
         ),
         GrammarRule(
             name='table_option',
@@ -743,7 +768,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='NAME', is_token=True),
                 ]),
             ]),
-            line_number=173,
+            line_number=191,
         ),
         GrammarRule(
             name='col_def',
@@ -755,7 +780,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='col_constraint', is_token=False),
                 ),
             ]),
-            line_number=178,
+            line_number=196,
         ),
         GrammarRule(
             name='col_type',
@@ -776,7 +801,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=182,
+            line_number=200,
         ),
         GrammarRule(
             name='col_constraint',
@@ -824,7 +849,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=183,
+            line_number=201,
         ),
         GrammarRule(
             name='drop_table_stmt',
@@ -840,7 +865,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=188,
+            line_number=206,
         ),
         GrammarRule(
             name='alter_table_stmt',
@@ -855,7 +880,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='col_def', is_token=False),
             ]),
-            line_number=192,
+            line_number=210,
         ),
         GrammarRule(
             name='create_index_stmt',
@@ -889,7 +914,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='where_clause', is_token=False),
                 ),
             ]),
-            line_number=201,
+            line_number=219,
         ),
         GrammarRule(
             name='index_col',
@@ -909,7 +934,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=218,
+            line_number=236,
         ),
         GrammarRule(
             name='drop_index_stmt',
@@ -925,7 +950,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=220,
+            line_number=238,
         ),
         GrammarRule(
             name='create_view_stmt',
@@ -944,7 +969,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='AS'),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=228,
+            line_number=246,
         ),
         GrammarRule(
             name='drop_view_stmt',
@@ -960,7 +985,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=230,
+            line_number=248,
         ),
         GrammarRule(
             name='begin_stmt',
@@ -971,7 +996,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=236,
+            line_number=254,
         ),
         GrammarRule(
             name='commit_stmt',
@@ -982,7 +1007,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=237,
+            line_number=255,
         ),
         GrammarRule(
             name='rollback_stmt',
@@ -993,7 +1018,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=238,
+            line_number=256,
         ),
         GrammarRule(
             name='savepoint_stmt',
@@ -1002,7 +1027,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='SAVEPOINT'),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=254,
+            line_number=272,
         ),
         GrammarRule(
             name='release_stmt',
@@ -1014,7 +1039,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=255,
+            line_number=273,
         ),
         GrammarRule(
             name='rollback_to_stmt',
@@ -1027,13 +1052,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=256,
+            line_number=274,
         ),
         GrammarRule(
             name='expr',
             body=
             RuleReference(name='or_expr', is_token=False),
-            line_number=260,
+            line_number=278,
         ),
         GrammarRule(
             name='or_expr',
@@ -1047,7 +1072,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=261,
+            line_number=279,
         ),
         GrammarRule(
             name='and_expr',
@@ -1061,7 +1086,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=262,
+            line_number=280,
         ),
         GrammarRule(
             name='not_expr',
@@ -1073,7 +1098,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='comparison', is_token=False),
             ]),
-            line_number=263,
+            line_number=281,
         ),
         GrammarRule(
             name='comparison',
@@ -1171,7 +1196,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=264,
+            line_number=282,
         ),
         GrammarRule(
             name='in_expr',
@@ -1180,7 +1205,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='query_stmt', is_token=False),
                 RuleReference(name='value_list', is_token=False),
             ]),
-            line_number=280,
+            line_number=298,
         ),
         GrammarRule(
             name='cmp_op',
@@ -1193,7 +1218,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='<='),
                 Literal(value='>='),
             ]),
-            line_number=282,
+            line_number=300,
         ),
         GrammarRule(
             name='bitwise',
@@ -1214,7 +1239,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=296,
+            line_number=314,
         ),
         GrammarRule(
             name='additive',
@@ -1236,7 +1261,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=297,
+            line_number=315,
         ),
         GrammarRule(
             name='multiplicative',
@@ -1256,7 +1281,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=298,
+            line_number=316,
         ),
         GrammarRule(
             name='unary',
@@ -1273,7 +1298,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='primary', is_token=False),
             ]),
-            line_number=299,
+            line_number=317,
         ),
         GrammarRule(
             name='primary',
@@ -1307,7 +1332,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value=')'),
                 ]),
             ]),
-            line_number=319,
+            line_number=337,
         ),
         GrammarRule(
             name='column_ref',
@@ -1321,7 +1346,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=329,
+            line_number=347,
         ),
         GrammarRule(
             name='function_call',
@@ -1351,7 +1376,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='filter_clause', is_token=False),
                 ),
             ]),
-            line_number=343,
+            line_number=361,
         ),
         GrammarRule(
             name='filter_clause',
@@ -1363,7 +1388,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='expr', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=347,
+            line_number=365,
         ),
         GrammarRule(
             name='cast_expr',
@@ -1376,7 +1401,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='NAME', is_token=True),
                 Literal(value=')'),
             ]),
-            line_number=353,
+            line_number=371,
         ),
         GrammarRule(
             name='window_func_call',
@@ -1398,7 +1423,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='window_spec', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=382,
+            line_number=400,
         ),
         GrammarRule(
             name='window_spec',
@@ -1414,7 +1439,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_clause', is_token=False),
                 ),
             ]),
-            line_number=383,
+            line_number=401,
         ),
         GrammarRule(
             name='partition_clause',
@@ -1430,7 +1455,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=384,
+            line_number=402,
         ),
         GrammarRule(
             name='value_list',
@@ -1444,7 +1469,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=385,
+            line_number=403,
         ),
         GrammarRule(
             name='frame_clause',
@@ -1462,7 +1487,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_bound', is_token=False),
                 ]),
             ]),
-            line_number=407,
+            line_number=425,
         ),
         GrammarRule(
             name='frame_unit',
@@ -1472,7 +1497,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='RANGE'),
                 Literal(value='GROUPS'),
             ]),
-            line_number=409,
+            line_number=427,
         ),
         GrammarRule(
             name='frame_bound',
@@ -1499,7 +1524,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='FOLLOWING'),
                 ]),
             ]),
-            line_number=410,
+            line_number=428,
         ),
         GrammarRule(
             name='create_trigger_stmt',
@@ -1537,7 +1562,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=436,
+            line_number=454,
         ),
         GrammarRule(
             name='trigger_body_stmt',
@@ -1549,7 +1574,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='delete_stmt', is_token=False),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=441,
+            line_number=459,
         ),
         GrammarRule(
             name='drop_trigger_stmt',
@@ -1565,7 +1590,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=443,
+            line_number=461,
         ),
         GrammarRule(
             name='case_expr',
@@ -1587,13 +1612,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=458,
+            line_number=476,
         ),
         GrammarRule(
             name='case_operand',
             body=
             RuleReference(name='expr', is_token=False),
-            line_number=459,
+            line_number=477,
         ),
         GrammarRule(
             name='case_when',
@@ -1604,7 +1629,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='THEN'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=460,
+            line_number=478,
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Adds full SQLite-style `VALUES (a, b), (c, d), …` support — works
anywhere a SELECT can appear, byte-identical with stdlib sqlite3.

| Context | Example |
|---|---|
| Top-level | `VALUES (1, 'a'), (2, 'b')` |
| Derived table | `SELECT * FROM (VALUES (1), (2))` |
| CTE body | `WITH t(n) AS (VALUES (1), (2)) SELECT n FROM t` |
| Set-op rhs | `SELECT 1 UNION ALL VALUES (2)` |
| Set-op lhs | `VALUES (1) UNION SELECT 2` |

Default output columns are named `column1`, `column2`, … (1-indexed),
matching SQLite.  Explicit CTE column aliases (`WITH t(a, b) AS …`)
override the defaults; the adapter walks down the left spine of the
UNION-ALL chain to rewrite the leftmost SELECT's items.

## Pipeline changes

| Package | Change |
|---|---|
| sql-parser 0.32 → 0.33 | New `values_stmt` production |
| mini-sqlite 1.80 → 1.81 | Adapter desugars VALUES → UNION ALL chain; `_set_op_clause` returns body_rule for dispatch; recursive-CTE step rejects VALUES |

## Test plan

- [x] 21 oracle tests in `test_tier3_values_clause.py` covering all five contexts, expressions in tuples, NULL, duplicates, chained CTEs
- [x] All 1987 mini-sqlite tests pass at 91.72% coverage
- [x] All 91 sql-parser tests pass
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)