### PR TITLE
feat(jsdoc): scaffold grammar + lexer + parser (CLOC05 Phase 1)

### DIFF
--- a/code/grammars/jsdoc/jsdoc.grammar
+++ b/code/grammars/jsdoc/jsdoc.grammar
@@ -1,0 +1,163 @@
+# JSDoc — Parser Grammar (minimal, v1)
+# @version 1
+#
+# This grammar parses the interior of a `/** ... */` block comment (with the
+# enclosing markers and the per-line `* ` prefixes stripped — see CLOC05
+# §"jsdoc-comment-extractor") into a tree of tags plus a leading free
+# description. v1 covers @type, @param, @returns/@return; deferred tags
+# (@throws, @template, @typedef, @callback, @property, @deprecated, …) get
+# their own follow-up PR.
+
+# ============================================================================
+# Document
+# ============================================================================
+#
+# A JSDoc document is an optional leading description (free-form prose
+# before any @tag) followed by zero or more tags. Each tag terminates with
+# a NEWLINE; the final tag may or may not have one (handled by the optional
+# trailing NEWLINE).
+
+document = [ description_line ] { tag } ;
+
+# A description line is a single DESCRIPTION_TEXT chunk followed by a
+# NEWLINE. v1 keeps descriptions one-line; multi-line descriptions are a
+# follow-up.
+description_line = DESCRIPTION_TEXT NEWLINE ;
+
+# ============================================================================
+# Tags
+# ============================================================================
+#
+# Every tag starts with an `@tag-name` token. The shape of what follows
+# depends on which tag it is. v1 recognises three tag shapes:
+#
+#   @type {T}                        — type only
+#   @param {T} name [description]    — type + name + optional description
+#   @returns {T} [description]       — type + optional description
+#   @return  {T} [description]       — alias for @returns
+#
+# Tags whose AT_TAG name doesn't match any of those fall through to
+# `unknown_tag`, which captures the raw payload until the next NEWLINE.
+# This is the CLOC05 contract: unknown tags survive and round-trip.
+
+tag = type_tag
+    | param_tag
+    | returns_tag
+    | unknown_tag ;
+
+# @type {T}
+#
+# Just a type expression — no name path, no description.
+type_tag = AT_TAG type_expression NEWLINE ;
+
+# @param {T} name [description]
+#
+# Note: v1 requires the type expression. @param without `{T}` is real
+# JSDoc but lands in a follow-up; for now we treat it as an unknown_tag.
+param_tag = AT_TAG type_expression name_path [ description_line_trailing ] NEWLINE ;
+
+# @returns {T} [description] / @return {T} [description]
+returns_tag = AT_TAG type_expression [ description_line_trailing ] NEWLINE ;
+
+# An unknown tag: AT_TAG plus everything up to the next NEWLINE.
+unknown_tag = AT_TAG { tag_payload_token } NEWLINE ;
+
+# A tag payload is the union of every token that can appear after an
+# @tag besides NEWLINE. The parser groups them into one production so the
+# unknown_tag rule can sweep them all up.
+tag_payload_token = LBRACE
+                  | RBRACE
+                  | LBRACKET
+                  | RBRACKET
+                  | LPAREN
+                  | RPAREN
+                  | ANGLE_OPEN
+                  | ANGLE_CLOSE
+                  | PIPE
+                  | AMP
+                  | COMMA
+                  | COLON
+                  | EQUALS
+                  | ELLIPSIS
+                  | QUESTION
+                  | BANG
+                  | STAR
+                  | ARROW
+                  | DOT
+                  | NAME
+                  | NUMBER
+                  | STRING
+                  | DESCRIPTION_TEXT ;
+
+# A description fragment immediately following a typed/named tag head.
+# Lifted to its own rule so the optional flag composes cleanly.
+description_line_trailing = DESCRIPTION_TEXT ;
+
+# ============================================================================
+# Type expressions
+# ============================================================================
+#
+# v1 type expressions only appear inside `{ ... }`. The full lattice from
+# CLOC05 (object records, type parameters, unions, intersections, function
+# types) is reachable here as `unknown_type_payload` — a catch-all that
+# captures every token between the matching braces and lets the
+# jsdoc-types-extractor (follow-up PR) lower as much as it can.
+
+type_expression = LBRACE type RBRACE ;
+
+# A type is one of the v1 shapes the type-extractor will recognise
+# explicitly, with a fallback to the catch-all unknown type for anything
+# the v1 grammar doesn't model yet.
+type = nullable_type
+     | non_nullable_type
+     | variadic_type
+     | optional_type
+     | primary_type ;
+
+# `?Foo` — nullable wrapper.
+nullable_type = QUESTION primary_type ;
+
+# `!Foo` — non-nullable wrapper.
+non_nullable_type = BANG primary_type ;
+
+# `...Foo` — rest/variadic (only legal inside @param, but parsed
+# everywhere; semantic enforcement is a typechecker concern).
+variadic_type = ELLIPSIS primary_type ;
+
+# `Foo=` — optional (only legal inside @param). Same enforcement note.
+optional_type = primary_type EQUALS ;
+
+# Primary type — anything that can serve as the base of the wrappers
+# above.
+primary_type = array_type
+             | nominal_type
+             | parenthesized_type
+             | wildcard_type ;
+
+# `Foo` or `Foo.Bar.Baz` — a dotted nominal reference.
+nominal_type = NAME { DOT NAME } ;
+
+# `Foo[]` — array of Foo. The `[]` is greedy: `Foo[][]` is parsed as
+# `Array<Array<Foo>>`.
+array_type = nominal_type LBRACKET RBRACKET { LBRACKET RBRACKET } ;
+
+# `(T)` — parenthesised grouping. v1 only allows another type inside;
+# function-arrow syntax `(A, B) => T` is deferred to a follow-up.
+parenthesized_type = LPAREN type RPAREN ;
+
+# `*` — JSDoc's catch-all "any" type.
+wildcard_type = STAR ;
+
+# Name path used by @param: `foo`, `foo.bar`, or `[foo]` / `[foo=default]`
+# for optional bracket-wrapped params.
+name_path = bracket_name | dotted_name ;
+
+dotted_name = NAME { DOT NAME } ;
+
+bracket_name = LBRACKET NAME [ EQUALS default_expr ] RBRACKET ;
+
+# Defaults inside `[foo=DEFAULT]` are restricted to literals plus bare
+# identifiers in v1.
+default_expr = NAME
+             | NUMBER
+             | STRING ;

--- a/code/grammars/jsdoc/jsdoc.tokens
+++ b/code/grammars/jsdoc/jsdoc.tokens
@@ -1,0 +1,126 @@
+# JSDoc — Lexical Grammar (minimal, v1)
+# @version 1
+#
+# This grammar covers the JSDoc lexemes produced when reading the *interior*
+# of a `/** ... */` block comment — the leading `/**` and trailing `*/` are
+# stripped before this lexer runs, by the comment-extractor pipeline stage
+# defined in CLOC05.
+#
+# v1 coverage:
+#   - @type, @param, @returns/@return tags (the three the type-extractor
+#     needs first).
+#   - Type expressions: primitive names (`number`, `string`, `boolean`,
+#     `void`, `null`, `undefined`, `any`, `unknown`, `never`, `bigint`,
+#     `symbol`), generic-style nominal references (`Foo`, `Foo.Bar`),
+#     array-suffix `Foo[]`, optional `Foo=`, variadic `...Foo`, nullable
+#     `?Foo`, non-nullable `!Foo`, function types `function(...): T`, and
+#     grouping with parens.
+#
+# Deferred to follow-up PRs:
+#   - Object record types `{ k: T, l: U }`.
+#   - Type-parameter syntax `<T, U>`.
+#   - Union (`A|B`) and intersection (`A&B`) inside type expressions.
+#   - Template literal types.
+#   - All the remaining JSDoc tags (@throws, @template, @typedef, @callback,
+#     @property, @deprecated, @public/@protected/@private, @override,
+#     @readonly, @const, @nosideeffects, @suppress, @see, @example, etc.).
+#
+# Pattern groups:
+# ---------------
+# JSDoc has two lexing modes:
+#   - DEFAULT (the type/name area right after an @tag, plus type
+#     expressions inside `{...}`)
+#   - DESCRIPTION_MODE (the free-form prose chunk after the name path,
+#     until a NEWLINE)
+# v1 stays in DEFAULT mode only — descriptions ARE lexed but the parser
+# folds them into a generic DESCRIPTION_TEXT token via a single
+# everything-until-newline rule. Group switching can be added in a
+# follow-up once we need to enforce stricter description-vs-type
+# boundaries.
+
+# ============================================================================
+# Tags and structural tokens
+# ============================================================================
+
+AT_TAG = /@[a-zA-Z_$][a-zA-Z0-9_$-]*/
+
+# Type-expression brackets.
+LBRACE      = "{"
+RBRACE      = "}"
+LBRACKET    = "["
+RBRACKET    = "]"
+LPAREN      = "("
+RPAREN      = ")"
+ANGLE_OPEN  = "<"
+ANGLE_CLOSE = ">"
+
+# Type-expression punctuation.
+PIPE     = "|"
+AMP      = "&"
+COMMA    = ","
+COLON    = ":"
+EQUALS   = "="
+ELLIPSIS = "..."
+QUESTION = "?"
+BANG     = "!"
+STAR     = "*"
+ARROW    = "=>"
+DOT      = "."
+
+# Tag boundary — JSDoc tags are line-oriented. The parser uses NEWLINE
+# to know when a tag's payload ends.
+NEWLINE = /\n/
+
+# ============================================================================
+# Literals
+# ============================================================================
+
+# Identifier / nominal type name.
+NAME = /[a-zA-Z_$][a-zA-Z0-9_$]*/
+
+# Numbers (used in literal types like `42`).
+NUMBER = /-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/
+
+# String literals (used in literal types like `"foo"`).
+STRING_DQ = /"([^"\\]|\\.)*"/ -> STRING
+STRING_SQ = /'([^'\\]|\\.)*'/ -> STRING
+
+# Free-form description text — anything between the name path and the next
+# newline that isn't another @tag start. Order matters: this must come
+# AFTER all the more-specific tokens above so they take precedence.
+#
+# v1 captures one line at a time as a single DESCRIPTION_TEXT token. The
+# parser folds these into tag descriptions; further tokenization is a
+# follow-up if/when we need to format embedded markdown.
+#
+# Excludes `@` and `\n` at the start so `@tag` on a fresh line wins, and
+# also excludes the type-expression structural characters so they
+# tokenize separately. This is intentionally narrow — anything inside a
+# type expression `{...}` won't fall into description text.
+DESCRIPTION_TEXT = /[a-zA-Z_$0-9 \t][^\n@{}\[\]()<>|&,:=?!*]*/
+
+# ============================================================================
+# Skipped trivia
+# ============================================================================
+#
+# Inter-token whitespace (but NOT newlines — those are tag boundaries).
+# Tab and space only.
+skip:
+  HSPACE = /[ \t]+/
+
+# A line that's just `* ` after a newline is the JSDoc convention for
+# continuation. We expect the comment-extractor stage to strip these
+# before invoking the lexer (see CLOC05 §"jsdoc-comment-extractor"); the
+# lexer here treats any leading `* ` as plain skipped whitespace as a
+# safety net.
+skip:
+  LEADING_STAR = /\n[ \t]*\*[ \t]?/
+
+# ============================================================================
+# Error tokens
+# ============================================================================
+
+errors:
+  BAD_STRING_DQ = /"[^"\n]*$/
+  BAD_STRING_SQ = /'[^'\n]*$/
+  UNTERMINATED_TYPE = /\{[^}]*$/

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -166,6 +166,8 @@ members = [
     "java-lexer",
     "java-parser",
     "jit-compiler",
+    "jsdoc-lexer",
+    "jsdoc-parser",
     "json-lexer",
     "json-parser",
     "json-serializer",

--- a/code/packages/rust/jsdoc-lexer/BUILD
+++ b/code/packages/rust/jsdoc-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-jsdoc-lexer -- --nocapture

--- a/code/packages/rust/jsdoc-lexer/BUILD_windows
+++ b/code/packages/rust/jsdoc-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-jsdoc-lexer -- --nocapture

--- a/code/packages/rust/jsdoc-lexer/CHANGELOG.md
+++ b/code/packages/rust/jsdoc-lexer/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the `coding-adventures-jsdoc-lexer` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-22
+
+### Added
+- New crate per CLOC05 Phase 1.
+- `create_jsdoc_lexer(source) -> GrammarLexer<'_>` and `tokenize_jsdoc(source) -> Vec<Token>` factory + convenience functions.
+- `_grammar.rs` auto-generated from `code/grammars/jsdoc/jsdoc.tokens` via `grammar-tools compile-tokens`. v1 token set: `AT_TAG`, type-expression brackets (`LBRACE`/`RBRACE`/`LBRACKET`/`RBRACKET`/`LPAREN`/`RPAREN`/`ANGLE_OPEN`/`ANGLE_CLOSE`), type-expression punctuation (`PIPE`/`AMP`/`COMMA`/`COLON`/`EQUALS`/`ELLIPSIS`/`QUESTION`/`BANG`/`STAR`/`ARROW`/`DOT`), `NEWLINE` as tag boundary, `NAME`, `NUMBER`, `STRING` (DQ + SQ both aliased), and `DESCRIPTION_TEXT` for the prose chunk after a tag's name path. Skip patterns for `HSPACE` and leading `* ` continuation. Three error tokens for unterminated strings and types.
+- 8 tests covering: type tag tokenization, AT_TAG value content, dotted nominal types, nullable `?Foo` wrapper, variadic `...Foo` wrapper, `Foo[]` array suffix, whitespace insensitivity, factory path, empty input.
+
+### Notes
+- Callers must strip `/**` and `*/` markers and per-line `* ` continuations before invoking the lexer; the lexer's `LEADING_STAR` skip is a safety net only.
+- Comment-extractor stage (CLOC05 §"jsdoc-comment-extractor") is a follow-up PR.

--- a/code/packages/rust/jsdoc-lexer/Cargo.toml
+++ b/code/packages/rust/jsdoc-lexer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "coding-adventures-jsdoc-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "JSDoc lexer — tokenizes the interior of a /** ... */ block comment using the grammar-driven lexer and the jsdoc.tokens grammar. Per CLOC05."
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/jsdoc-lexer/README.md
+++ b/code/packages/rust/jsdoc-lexer/README.md
@@ -1,0 +1,30 @@
+# coding-adventures-jsdoc-lexer
+
+Grammar-driven lexer for the **interior** of a `/** ... */` JSDoc block
+comment. Per [CLOC05](../../../specs/CLOC05-jsdoc-sub-pipeline.md).
+
+The token grammar lives at
+[`code/grammars/jsdoc/jsdoc.tokens`](../../../grammars/jsdoc/jsdoc.tokens) and
+is compiled to native Rust at build time via
+`grammar-tools compile-tokens`, embedded as `mod _grammar`.
+
+## What's here (v1)
+
+- `create_jsdoc_lexer(source)` → `GrammarLexer<'_>`
+- `tokenize_jsdoc(source)` → `Vec<Token>` (panics on lex error)
+- v1 token set: `AT_TAG`, type-expression brackets and punctuation,
+  `NAME`, `NUMBER`, `STRING`, `NEWLINE`, plus a `DESCRIPTION_TEXT`
+  catch-all for the prose after a tag's name path. See
+  `jsdoc.tokens` for the full list.
+
+## What's coming
+
+- A comment-extractor stage that strips `/** */` markers and per-line
+  `* ` continuation prefixes before invoking this lexer.
+- More token categories as new tags ship (e.g. `@template`, `@typedef`).
+
+## Inputs the lexer assumes are pre-processed
+
+Callers must strip `/**` and `*/` markers and trim per-line `* `
+continuations. The lexer has a `LEADING_STAR` skip as a safety net but
+shouldn't normally see them.

--- a/code/packages/rust/jsdoc-lexer/required_capabilities.json
+++ b/code/packages/rust/jsdoc-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/jsdoc-lexer",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/jsdoc-lexer/src/_grammar.rs
+++ b/code/packages/rust/jsdoc-lexer/src/_grammar.rs
@@ -1,0 +1,250 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: jsdoc.tokens
+// Regenerate with: grammar-tools compile-tokens jsdoc.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{PatternGroup, TokenDefinition, TokenGrammar};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"AT_TAG"#.to_string(),
+                pattern: r#"@[a-zA-Z_$][a-zA-Z0-9_$-]*"#.to_string(),
+                is_regex: true,
+                line_number: 45,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACE"#.to_string(),
+                pattern: r#"{"#.to_string(),
+                is_regex: false,
+                line_number: 48,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACE"#.to_string(),
+                pattern: r#"}"#.to_string(),
+                is_regex: false,
+                line_number: 49,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACKET"#.to_string(),
+                pattern: r#"["#.to_string(),
+                is_regex: false,
+                line_number: 50,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACKET"#.to_string(),
+                pattern: r#"]"#.to_string(),
+                is_regex: false,
+                line_number: 51,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 52,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 53,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ANGLE_OPEN"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 54,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ANGLE_CLOSE"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 55,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PIPE"#.to_string(),
+                pattern: r#"|"#.to_string(),
+                is_regex: false,
+                line_number: 58,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"AMP"#.to_string(),
+                pattern: r#"&"#.to_string(),
+                is_regex: false,
+                line_number: 59,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 60,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COLON"#.to_string(),
+                pattern: r#":"#.to_string(),
+                is_regex: false,
+                line_number: 61,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQUALS"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 62,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ELLIPSIS"#.to_string(),
+                pattern: r#"..."#.to_string(),
+                is_regex: false,
+                line_number: 63,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"QUESTION"#.to_string(),
+                pattern: r#"?"#.to_string(),
+                is_regex: false,
+                line_number: 64,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"BANG"#.to_string(),
+                pattern: r#"!"#.to_string(),
+                is_regex: false,
+                line_number: 65,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STAR"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 66,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ARROW"#.to_string(),
+                pattern: r#"=>"#.to_string(),
+                is_regex: false,
+                line_number: 67,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DOT"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: false,
+                line_number: 68,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEWLINE"#.to_string(),
+                pattern: r#"\n"#.to_string(),
+                is_regex: true,
+                line_number: 72,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z_$][a-zA-Z0-9_$]*"#.to_string(),
+                is_regex: true,
+                line_number: 79,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 82,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STRING_DQ"#.to_string(),
+                pattern: r#""([^"\\]|\\.)*""#.to_string(),
+                is_regex: true,
+                line_number: 85,
+                alias: Some(r#"STRING"#.to_string()),
+            },
+            TokenDefinition {
+                name: r#"STRING_SQ"#.to_string(),
+                pattern: r#"'([^'\\]|\\.)*'"#.to_string(),
+                is_regex: true,
+                line_number: 86,
+                alias: Some(r#"STRING"#.to_string()),
+            },
+            TokenDefinition {
+                name: r#"DESCRIPTION_TEXT"#.to_string(),
+                pattern: r#"[a-zA-Z_$0-9 \t][^\n@{}\[\]()<>|&,:=?!*]*"#.to_string(),
+                is_regex: true,
+                line_number: 100,
+                alias: None,
+            },
+        ],
+        keywords: vec![],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"HSPACE"#.to_string(),
+                pattern: r#"[ \t]+"#.to_string(),
+                is_regex: true,
+                line_number: 109,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LEADING_STAR"#.to_string(),
+                pattern: r#"\n[ \t]*\*[ \t]?"#.to_string(),
+                is_regex: true,
+                line_number: 117,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: None,
+        error_definitions: vec![
+            TokenDefinition {
+                name: r#"BAD_STRING_DQ"#.to_string(),
+                pattern: r#""[^"\n]*$"#.to_string(),
+                is_regex: true,
+                line_number: 124,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"BAD_STRING_SQ"#.to_string(),
+                pattern: r#"'[^'\n]*$"#.to_string(),
+                is_regex: true,
+                line_number: 125,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"UNTERMINATED_TYPE"#.to_string(),
+                pattern: r#"\{[^}]*$"#.to_string(),
+                is_regex: true,
+                line_number: 126,
+                alias: None,
+            },
+        ],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+    }
+}

--- a/code/packages/rust/jsdoc-lexer/src/lib.rs
+++ b/code/packages/rust/jsdoc-lexer/src/lib.rs
@@ -1,0 +1,167 @@
+//! JSDoc lexer.
+//!
+//! Tokenizes the **interior** of a `/** ... */` block comment per CLOC05
+//! §"`jsdoc-tokens` outline." The enclosing `/**` and `*/` markers and the
+//! per-line `* ` continuation prefixes are expected to be stripped by an
+//! upstream comment-extractor stage (deferred follow-up); this lexer is
+//! tolerant of leftover `* ` line-starts via a skip pattern as a safety
+//! net.
+//!
+//! The lexer is grammar-driven: the actual token definitions live in
+//! [`code/grammars/jsdoc/jsdoc.tokens`](../../../grammars/jsdoc/jsdoc.tokens),
+//! compiled to native Rust at build time via `grammar-tools compile-tokens`
+//! and embedded as `mod _grammar`.
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+/// Construct a JSDoc [`GrammarLexer`] over `source`. The caller is
+/// responsible for stripping the surrounding `/** */` markers; see the
+/// crate-level docs.
+pub fn create_jsdoc_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+/// Convenience: tokenize `source` and return the produced tokens. Panics
+/// on lexer error (use [`create_jsdoc_lexer`] + `tokenize()` for callers
+/// that need to handle errors explicitly).
+pub fn tokenize_jsdoc(source: &str) -> Vec<Token> {
+    let mut lexer = create_jsdoc_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("JSDoc tokenization failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    /// Helper: collect owned `(type_name, value)` pairs minus the
+    /// trailing EOF.
+    ///
+    /// Token names favor `type_name` when set (the grammar-driven name
+    /// from `.tokens`), falling back to a mapping from the built-in
+    /// `TokenType` enum for the well-known single-character tokens
+    /// (`LBRACE`, `RBRACE`, `LBRACKET`, …). This lets tests assert
+    /// against the SCREAMING_SNAKE_CASE names declared in `jsdoc.tokens`
+    /// uniformly, without caring whether the lexer used a built-in or a
+    /// custom token type.
+    fn pairs(tokens: &[Token]) -> Vec<(String, String)> {
+        tokens
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| {
+                let name = t.type_name.clone().unwrap_or_else(|| match t.type_ {
+                    TokenType::LBrace => "LBRACE".into(),
+                    TokenType::RBrace => "RBRACE".into(),
+                    TokenType::LBracket => "LBRACKET".into(),
+                    TokenType::RBracket => "RBRACKET".into(),
+                    TokenType::LParen => "LPAREN".into(),
+                    TokenType::RParen => "RPAREN".into(),
+                    TokenType::Comma => "COMMA".into(),
+                    TokenType::Colon => "COLON".into(),
+                    TokenType::Dot => "DOT".into(),
+                    TokenType::Bang => "BANG".into(),
+                    TokenType::Star => "STAR".into(),
+                    TokenType::Equals => "EQUALS".into(),
+                    TokenType::Newline => "NEWLINE".into(),
+                    TokenType::Name => "NAME".into(),
+                    TokenType::Number => "NUMBER".into(),
+                    TokenType::String => "STRING".into(),
+                    TokenType::Keyword => "KEYWORD".into(),
+                    other => format!("{:?}", other),
+                });
+                (name, t.value.clone())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn tokenizes_type_tag() {
+        // `@type {number}` is the simplest JSDoc tag — one tag, one
+        // type expression with one primitive.
+        let tokens = tokenize_jsdoc("@type {number}\n");
+        let names: Vec<String> = pairs(&tokens).into_iter().map(|(n, _)| n).collect();
+        assert!(names.contains(&"AT_TAG".to_string()));
+        assert!(names.contains(&"LBRACE".to_string()));
+        assert!(names.contains(&"NAME".to_string()));
+        assert!(names.contains(&"RBRACE".to_string()));
+        assert!(names.contains(&"NEWLINE".to_string()));
+    }
+
+    #[test]
+    fn at_tag_value_includes_at_sign() {
+        let tokens = tokenize_jsdoc("@param {string} name\n");
+        let at = tokens.iter().find(|t| t.type_name.as_deref() == Some("AT_TAG"));
+        assert!(at.is_some());
+        assert_eq!(at.unwrap().value, "@param");
+    }
+
+    #[test]
+    fn nominal_type_with_dots() {
+        // `Foo.Bar` should produce NAME DOT NAME — three tokens.
+        let tokens = tokenize_jsdoc("@type {Foo.Bar}\n");
+        let name_dot_name: Vec<String> = pairs(&tokens)
+            .into_iter()
+            .filter(|(n, _)| n == "NAME" || n == "DOT")
+            .map(|(n, _)| n)
+            .collect();
+        assert_eq!(name_dot_name, vec!["NAME", "DOT", "NAME"]);
+    }
+
+    #[test]
+    fn nullable_wrapper() {
+        // `?Foo` → QUESTION NAME.
+        let tokens = tokenize_jsdoc("@type {?Foo}\n");
+        let p = pairs(&tokens);
+        assert!(p.iter().any(|(n, _)| n == "QUESTION"));
+        assert!(p.iter().any(|(n, v)| n == "NAME" && v == "Foo"));
+    }
+
+    #[test]
+    fn variadic_wrapper() {
+        let tokens = tokenize_jsdoc("@param {...string} args\n");
+        assert!(pairs(&tokens).iter().any(|(n, _)| n == "ELLIPSIS"));
+    }
+
+    #[test]
+    fn array_suffix() {
+        // `string[]` → NAME LBRACKET RBRACKET.
+        let tokens = tokenize_jsdoc("@type {string[]}\n");
+        let p = pairs(&tokens);
+        assert!(p.iter().any(|(n, v)| n == "NAME" && v == "string"));
+        assert!(p.iter().any(|(n, _)| n == "LBRACKET"));
+        assert!(p.iter().any(|(n, _)| n == "RBRACKET"));
+    }
+
+    #[test]
+    fn whitespace_skipped_between_tokens() {
+        let compact_tokens = tokenize_jsdoc("@type{number}\n");
+        let spaced_tokens = tokenize_jsdoc("@type   {  number  }\n");
+        let compact = pairs(&compact_tokens);
+        let spaced = pairs(&spaced_tokens);
+        // Same logical sequence, different whitespace.
+        let names_compact: Vec<&String> = compact.iter().map(|(n, _)| n).collect();
+        let names_spaced: Vec<&String> = spaced.iter().map(|(n, _)| n).collect();
+        assert_eq!(names_compact, names_spaced);
+    }
+
+    #[test]
+    fn create_jsdoc_lexer_returns_working_lexer() {
+        // Factory path produces a lexer that can drive tokenize() itself.
+        let mut lexer = create_jsdoc_lexer("@type {number}\n");
+        let tokens = lexer.tokenize().expect("tokenize should succeed");
+        assert!(tokens.last().unwrap().type_ == TokenType::Eof);
+    }
+
+    #[test]
+    fn empty_input_is_eof_only() {
+        let tokens = tokenize_jsdoc("");
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].type_, TokenType::Eof);
+    }
+}

--- a/code/packages/rust/jsdoc-parser/BUILD
+++ b/code/packages/rust/jsdoc-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-jsdoc-parser -- --nocapture

--- a/code/packages/rust/jsdoc-parser/BUILD_windows
+++ b/code/packages/rust/jsdoc-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-jsdoc-parser -- --nocapture

--- a/code/packages/rust/jsdoc-parser/CHANGELOG.md
+++ b/code/packages/rust/jsdoc-parser/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the `coding-adventures-jsdoc-parser` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-22
+
+### Added
+- New crate per CLOC05 Phase 1.
+- `create_jsdoc_parser(source) -> GrammarParser` and `parse_jsdoc(source) -> Result<GrammarASTNode, String>` factory + convenience functions. Output rule: `document`.
+- `_grammar.rs` auto-generated from `code/grammars/jsdoc/jsdoc.grammar` via `grammar-tools compile-grammar`. v1 grammar covers `@type`, `@param`, `@returns`/`@return` as named tags; every other `@xxx` tag falls through to an `unknown_tag` rule that round-trips the payload tokens until the next `NEWLINE`.
+- Type-expression rules: nominal types with dotted paths (`Foo.Bar`), array suffix (`Foo[]`), nullable (`?Foo`), non-nullable (`!Foo`), variadic (`...Foo`), optional (`Foo=`), parenthesised grouping, and the wildcard `*`.
+- 10 tests covering: empty document, type tag, returns tag, param tag with name, multi-tag documents, nullable type, array type, dotted nominal type, unknown tag tolerance, factory path.
+
+### Notes
+- Output is the generic `GrammarASTNode` tree. A typed `jsdoc-ast` crate per CLOC05 is a follow-up.
+- Deferred grammar features: object records, generic args, union/intersection inside type expressions, template literal types, and the long tail of named JSDoc tags.

--- a/code/packages/rust/jsdoc-parser/Cargo.toml
+++ b/code/packages/rust/jsdoc-parser/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding-adventures-jsdoc-parser"
+version = "0.1.0"
+edition = "2021"
+description = "JSDoc parser — parses the interior of a /** ... */ block comment into a tag tree using the grammar-driven parser. Per CLOC05."
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-jsdoc-lexer = { path = "../jsdoc-lexer" }

--- a/code/packages/rust/jsdoc-parser/README.md
+++ b/code/packages/rust/jsdoc-parser/README.md
@@ -1,0 +1,39 @@
+# coding-adventures-jsdoc-parser
+
+Grammar-driven parser for the **interior** of a `/** ... */` JSDoc block
+comment. Per [CLOC05](../../../specs/CLOC05-jsdoc-sub-pipeline.md).
+
+The parser grammar lives at
+[`code/grammars/jsdoc/jsdoc.grammar`](../../../grammars/jsdoc/jsdoc.grammar)
+and is compiled to native Rust at build time via
+`grammar-tools compile-grammar`, embedded as `mod _grammar`.
+
+## What's here (v1)
+
+- `create_jsdoc_parser(source)` → `GrammarParser`
+- `parse_jsdoc(source)` → `Result<GrammarASTNode, String>`
+- v1 recognises `@type`, `@param`, `@returns` (and `@return`) explicitly,
+  with a fallback `unknown_tag` rule for everything else (so `@throws`,
+  `@template`, etc. parse without errors and round-trip).
+- Type-expression coverage: nominal references with dotted paths, array
+  suffix `Foo[]`, nullable `?Foo`, non-nullable `!Foo`, variadic `...Foo`,
+  optional `Foo=`, parens, wildcard `*`.
+
+## What's coming (follow-up PRs)
+
+Per CLOC05:
+- Object record types `{ k: T, l: U }`.
+- Generic type arguments `<T, U>`.
+- Union (`A|B`) / intersection (`A&B`) inside type expressions.
+- Template literal types.
+- Named-tag rules for the rest of the JSDoc tag set (`@template`,
+  `@typedef`, `@callback`, `@property`, `@implements`, `@extends`,
+  `@constructor`, `@enum`, `@deprecated`, `@public`/`@private`,
+  `@override`, `@readonly`, `@const`, `@pure`/`@nosideeffects`,
+  `@suppress`, etc.).
+- `jsdoc-ast` typed AST crate (the current output is the generic
+  `GrammarASTNode`).
+- `jsdoc-comment-extractor` (pulls comment ranges from a
+  `javascript-ast::Program`).
+- `jsdoc-types-extractor` (walks the JSDoc AST → emits
+  `type-sidecar::Sidecar` records per CLOC04).

--- a/code/packages/rust/jsdoc-parser/required_capabilities.json
+++ b/code/packages/rust/jsdoc-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/jsdoc-parser",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/jsdoc-parser/src/_grammar.rs
+++ b/code/packages/rust/jsdoc-parser/src/_grammar.rs
@@ -1,0 +1,256 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: jsdoc.grammar
+// Regenerate with: grammar-tools compile-grammar jsdoc.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"document"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"description_line"#.to_string() }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"tag"#.to_string() }) },
+            ] },
+            line_number: 20,
+        },
+        GrammarRule {
+            name: r#"description_line"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"DESCRIPTION_TEXT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 25,
+        },
+        GrammarRule {
+            name: r#"tag"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"type_tag"#.to_string() },
+                GrammarElement::RuleReference { name: r#"param_tag"#.to_string() },
+                GrammarElement::RuleReference { name: r#"returns_tag"#.to_string() },
+                GrammarElement::RuleReference { name: r#"unknown_tag"#.to_string() },
+            ] },
+            line_number: 43,
+        },
+        GrammarRule {
+            name: r#"type_tag"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"AT_TAG"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expression"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 51,
+        },
+        GrammarRule {
+            name: r#"param_tag"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"AT_TAG"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expression"#.to_string() },
+                GrammarElement::RuleReference { name: r#"name_path"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"description_line_trailing"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 57,
+        },
+        GrammarRule {
+            name: r#"returns_tag"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"AT_TAG"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expression"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"description_line_trailing"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 60,
+        },
+        GrammarRule {
+            name: r#"unknown_tag"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"AT_TAG"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"tag_payload_token"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 63,
+        },
+        GrammarRule {
+            name: r#"tag_payload_token"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ANGLE_OPEN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ANGLE_CLOSE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"PIPE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"AMP"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ELLIPSIS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"BANG"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ARROW"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DESCRIPTION_TEXT"#.to_string() },
+            ] },
+            line_number: 68,
+        },
+        GrammarRule {
+            name: r#"description_line_trailing"#.to_string(),
+            body: GrammarElement::TokenReference { name: r#"DESCRIPTION_TEXT"#.to_string() },
+            line_number: 94,
+        },
+        GrammarRule {
+            name: r#"type_expression"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 106,
+        },
+        GrammarRule {
+            name: r#"type"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"nullable_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"non_nullable_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"variadic_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"optional_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"primary_type"#.to_string() },
+            ] },
+            line_number: 111,
+        },
+        GrammarRule {
+            name: r#"nullable_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
+                GrammarElement::RuleReference { name: r#"primary_type"#.to_string() },
+            ] },
+            line_number: 118,
+        },
+        GrammarRule {
+            name: r#"non_nullable_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"BANG"#.to_string() },
+                GrammarElement::RuleReference { name: r#"primary_type"#.to_string() },
+            ] },
+            line_number: 121,
+        },
+        GrammarRule {
+            name: r#"variadic_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"ELLIPSIS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"primary_type"#.to_string() },
+            ] },
+            line_number: 125,
+        },
+        GrammarRule {
+            name: r#"optional_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"primary_type"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+            ] },
+            line_number: 128,
+        },
+        GrammarRule {
+            name: r#"primary_type"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"array_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"nominal_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"parenthesized_type"#.to_string() },
+                GrammarElement::RuleReference { name: r#"wildcard_type"#.to_string() },
+            ] },
+            line_number: 132,
+        },
+        GrammarRule {
+            name: r#"nominal_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 138,
+        },
+        GrammarRule {
+            name: r#"array_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"nominal_type"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 142,
+        },
+        GrammarRule {
+            name: r#"parenthesized_type"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 146,
+        },
+        GrammarRule {
+            name: r#"wildcard_type"#.to_string(),
+            body: GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+            line_number: 149,
+        },
+        GrammarRule {
+            name: r#"name_path"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"bracket_name"#.to_string() },
+                GrammarElement::RuleReference { name: r#"dotted_name"#.to_string() },
+            ] },
+            line_number: 153,
+        },
+        GrammarRule {
+            name: r#"dotted_name"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 155,
+        },
+        GrammarRule {
+            name: r#"bracket_name"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"default_expr"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 157,
+        },
+        GrammarRule {
+            name: r#"default_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 161,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/jsdoc-parser/src/lib.rs
+++ b/code/packages/rust/jsdoc-parser/src/lib.rs
@@ -1,0 +1,114 @@
+//! JSDoc parser.
+//!
+//! Parses the **interior** of a `/** ... */` block comment into a tree of
+//! tags and type expressions per CLOC05 §"`jsdoc.grammar` outline." The
+//! enclosing markers are expected to be stripped by an upstream
+//! comment-extractor stage (deferred follow-up).
+//!
+//! The parser is grammar-driven: the actual rules live in
+//! [`code/grammars/jsdoc/jsdoc.grammar`](../../../grammars/jsdoc/jsdoc.grammar),
+//! compiled to native Rust at build time via `grammar-tools compile-grammar`
+//! and embedded as `mod _grammar`.
+
+use coding_adventures_jsdoc_lexer::tokenize_jsdoc;
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+mod _grammar;
+
+/// Construct a JSDoc [`GrammarParser`] over `source`. The caller is
+/// responsible for stripping the surrounding `/** */` markers; see the
+/// crate-level docs.
+pub fn create_jsdoc_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_jsdoc(source);
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar)
+}
+
+/// Parse `source` into a [`GrammarASTNode`] rooted at the `document`
+/// rule. Returns `Err` on parse failure.
+pub fn parse_jsdoc(source: &str) -> Result<GrammarASTNode, String> {
+    let mut parser = create_jsdoc_parser(source);
+    parser
+        .parse()
+        .map_err(|e| format!("JSDoc parse failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_document() {
+        let ast = parse_jsdoc("").unwrap();
+        assert_eq!(ast.rule_name, "document");
+    }
+
+    #[test]
+    fn parses_type_tag() {
+        let ast = parse_jsdoc("@type {number}\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+        // The tree should mention the AT_TAG token's text somewhere.
+        let dumped = format!("{:?}", ast);
+        assert!(dumped.contains("@type"));
+    }
+
+    #[test]
+    fn parses_returns_tag() {
+        let ast = parse_jsdoc("@returns {string}\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+    }
+
+    #[test]
+    fn parses_param_tag_with_name() {
+        let ast = parse_jsdoc("@param {string} name\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+        let dumped = format!("{:?}", ast);
+        assert!(dumped.contains("@param"));
+        assert!(dumped.contains("name"));
+    }
+
+    #[test]
+    fn parses_multiple_tags() {
+        let src = "@param {string} name\n@returns {boolean}\n";
+        let ast = parse_jsdoc(src).unwrap();
+        assert_eq!(ast.rule_name, "document");
+        let dumped = format!("{:?}", ast);
+        assert!(dumped.contains("@param"));
+        assert!(dumped.contains("@returns"));
+    }
+
+    #[test]
+    fn parses_nullable_type() {
+        let ast = parse_jsdoc("@type {?Foo}\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+    }
+
+    #[test]
+    fn parses_array_type() {
+        let ast = parse_jsdoc("@type {string[]}\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+    }
+
+    #[test]
+    fn parses_dotted_nominal_type() {
+        let ast = parse_jsdoc("@type {Foo.Bar.Baz}\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+    }
+
+    #[test]
+    fn unknown_tag_is_tolerated() {
+        // @throws isn't in the v1 named-tag list, but the unknown_tag
+        // rule should sweep it up so the parse still succeeds.
+        let ast = parse_jsdoc("@throws {Error} when bad\n").unwrap();
+        assert_eq!(ast.rule_name, "document");
+        let dumped = format!("{:?}", ast);
+        assert!(dumped.contains("@throws"));
+    }
+
+    #[test]
+    fn create_jsdoc_parser_returns_working_parser() {
+        let mut parser = create_jsdoc_parser("@type {string}\n");
+        let ast = parser.parse().expect("parse should succeed");
+        assert_eq!(ast.rule_name, "document");
+    }
+}


### PR DESCRIPTION
## Summary

Third Stage-2 PR. Establishes the JSDoc sub-pipeline foundation per
[CLOC05](../../code/specs/CLOC05-jsdoc-sub-pipeline.md): a JSDoc grammar
under `code/grammars/jsdoc/` and two new Rust crates wrapping the
grammar-driven lexer/parser, mirroring the `javascript-lexer/parser`
pattern.

### Grammar files (`code/grammars/jsdoc/`)

- **`jsdoc.tokens`** — 26 token definitions: `AT_TAG`, type-expression
  brackets and punctuation, `NEWLINE` as tag boundary, `NAME`, `NUMBER`,
  `STRING` (DQ + SQ aliased), `DESCRIPTION_TEXT` catch-all. Skip patterns
  for `HSPACE` and a `LEADING_STAR` safety net. 3 error tokens.
- **`jsdoc.grammar`** — `document = [ description_line ] { tag } ;`
  with three named tags (`@type`, `@param`, `@returns`/`@return`) plus
  an `unknown_tag` fallback that round-trips every other `@xxx`. Type
  expressions cover nullable `?Foo`, non-nullable `!Foo`, variadic
  `...Foo`, optional `Foo=`, dotted nominal `Foo.Bar`, array `Foo[]`,
  parens, and wildcard `*`.
- Both files validate cleanly via `grammar-tools validate`.

### Crates

- **`coding-adventures-jsdoc-lexer`** `v0.1.0` — `create_jsdoc_lexer` +
  `tokenize_jsdoc`. `_grammar.rs` auto-generated by
  `grammar-tools compile-tokens`. 9 tests.
- **`coding-adventures-jsdoc-parser`** `v0.1.0` — `create_jsdoc_parser`
  + `parse_jsdoc`. `_grammar.rs` auto-generated by
  `grammar-tools compile-grammar`. 10 tests.

### What's deferred

- `jsdoc-ast` (typed AST over `GrammarASTNode`).
- `jsdoc-comment-extractor` (strips `/** */` markers + per-line `* `).
- `jsdoc-types-extractor` (JSDoc AST → `type-sidecar::Sidecar` per
  CLOC05's tag-to-sidecar mapping table).
- Grammar features: object record types, generic args `<T,U>`,
  union/intersection inside types, template literal types, and the
  long tail of named JSDoc tags. v1's `unknown_tag` rule keeps them
  parseable.

## Test plan

- [x] `grammar-tools validate code/grammars/jsdoc/{jsdoc.tokens,jsdoc.grammar}`
      passes — 26 tokens / 2 skip / 3 error; 24 rules.
- [x] `cargo test -p coding-adventures-jsdoc-lexer -p coding-adventures-jsdoc-parser`
      — **19/19 pass** (9 lexer + 10 parser).
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      error unrelated).
- [ ] CI matrix (Linux/macOS/Windows).

## What's next

Stage 2 continues with:
1. **`jsdoc-comment-extractor`** — pulls comment ranges from a
   `javascript-ast::Program`, strips markers/prefixes.
2. **`jsdoc-types-extractor`** — walks the JSDoc AST and emits
   `type-sidecar::Sidecar` records per CLOC05.

Then Stage 3 (`closure-typechecker` + `closure-pass-*` family) and
Stage 4 (emitter, source-map, CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)