### PR TITLE
Flatten drain match alias summary flags

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -58,6 +58,8 @@ All notable changes to this package will be documented in this file.
   summaries.
 - Status aliases for supervisor drain run reports.
 - Row-count match helpers for supervisor drain run reports and summaries.
+- Flattened row-count and follow-up-pressure match alias flags for supervisor
+  drain run summaries.
 - Planned-count match and drift flag accessors for supervisor drain run
   summaries.
 - Run-status accessors for supervisor drain run summaries.

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -76,6 +76,8 @@ The crate keeps the boundary narrow:
   follow-up pressure
 - supervisor drain reports and summaries expose row-count match helpers for
   host scheduler checks
+- supervisor drain run summaries flatten row-count and follow-up-pressure match
+  alias flags for host scheduler checks
 - supervisor drain run summaries expose exact planned-count match and drift
   flag accessors for host branching
 - supervisor drain run summaries expose typed run-status accessors for

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -1246,7 +1246,9 @@ impl ToolAuditSupervisorDrainRunReport {
             requires_host_plan_drift_investigation: self.requires_host_plan_drift_investigation(),
             requires_host_count_drift_investigation: self.requires_host_count_drift_investigation(),
             matches_planned_record_count: self.matches_planned_record_count(),
+            matches_record_count: self.matches_record_count(),
             matches_planned_follow_up_record_count: self.matches_planned_follow_up_record_count(),
+            matches_follow_up_pressure: self.matches_follow_up_pressure(),
             reached_end_of_log: self.reached_end_of_log(),
             exhausted_tick_budget: self.exhausted_tick_budget(),
             is_idle: self.is_idle(),
@@ -1503,8 +1505,12 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub requires_host_count_drift_investigation: bool,
     /// Whether the actual run delivered the planned number of rows.
     pub matches_planned_record_count: bool,
+    /// Whether planned and replayed row counts match.
+    pub matches_record_count: bool,
     /// Whether the actual run preserved the planned follow-up pressure count.
     pub matches_planned_follow_up_record_count: bool,
+    /// Whether planned and replayed follow-up pressure counts match.
+    pub matches_follow_up_pressure: bool,
     /// Whether the actual run reached the current end of the audit log.
     pub reached_end_of_log: bool,
     /// Whether the actual run used every allowed tick.
@@ -1662,12 +1668,12 @@ impl ToolAuditSupervisorDrainRunSummary {
 
     /// Return whether planned and replayed row counts match.
     pub fn matches_record_count(&self) -> bool {
-        self.matches_planned_record_count()
+        self.matches_record_count
     }
 
     /// Return whether planned and replayed follow-up pressure counts match.
     pub fn matches_follow_up_pressure(&self) -> bool {
-        self.matches_planned_follow_up_record_count()
+        self.matches_follow_up_pressure
     }
 
     /// Return whether the actual run delivered the planned number of rows.
@@ -4489,9 +4495,11 @@ mod tests {
         assert!(summary.is_no_host_investigation());
         assert!(summary.matches_planned_record_count);
         assert!(summary.matches_planned_record_count());
+        assert!(summary.matches_record_count);
         assert!(summary.matches_record_count());
         assert!(summary.matches_planned_follow_up_record_count);
         assert!(summary.matches_planned_follow_up_record_count());
+        assert!(summary.matches_follow_up_pressure);
         assert!(summary.matches_follow_up_pressure());
         assert!(!summary.reached_end_of_log);
         assert!(!summary.reached_end_of_log());
@@ -4670,6 +4678,7 @@ mod tests {
         assert!(!summary.replayed_extra_records());
         assert!(summary.missed_planned_records);
         assert!(summary.missed_planned_records());
+        assert!(!summary.matches_record_count);
         assert!(!summary.matches_record_count());
         assert!(summary.has_record_count_drift);
         assert!(!summary.has_follow_up_record_count_drift);
@@ -4794,6 +4803,7 @@ mod tests {
         assert!(summary.matches_planned_record_count());
         assert!(!summary.matches_planned_follow_up_record_count);
         assert!(!summary.matches_planned_follow_up_record_count());
+        assert!(!summary.matches_follow_up_pressure);
         assert!(!summary.matches_follow_up_pressure());
         assert!(!summary.replayed_extra_follow_up_records());
         assert!(summary.missed_planned_follow_up_records());


### PR DESCRIPTION
Summary:
- Flatten matches_record_count and matches_follow_up_pressure onto ToolAuditSupervisorDrainRunSummary
- Wire summary match alias accessors to the flattened fields and cover raw/accessor values in matching and drift tests
- Document the new flattened row-count and follow-up-pressure match alias flags in README/CHANGELOG

Validation:
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-match-alias-summary-flags/mise.toml cargo test -p chief-of-staff-tool-audit-store
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-chief-tool-audit-match-alias-summary-flags/mise.toml sh BUILD