### PR TITLE
[codex] Add Board VM input callback result summaries

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -111,6 +111,10 @@ dispatch should be woken.
 into the callback execution handoff: callback program id, instruction budget,
 event identity, queue action, and cooperative dispatch reason stay in Rust,
 while language adapters only schedule the native callback runner.
+`input_callback_result_for_dispatch_plan` closes that loop by preserving the
+dispatch metadata while normalizing the callback runner status, executed
+instruction count, and elapsed time into a Rust-owned completion,
+budget-exceeded, incomplete, or failure summary.
 
 Frontends that already have an Arduino CLI platform or FQBN should pass it back
 to Rust rather than carrying their own selector table. `detect_target` resolves

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -768,6 +768,40 @@ pub struct LanguageInputCallbackDispatchPlan {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackResultKind {
+    Completed,
+    BudgetExceeded,
+    Incomplete,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackResultSummary {
+    pub board_id: String,
+    pub pin: u8,
+    pub label: String,
+    pub event_kind: String,
+    pub dispatch_reason: String,
+    pub callback_program_id: u16,
+    pub callback_instruction_budget: u32,
+    pub sequence: u32,
+    pub timestamp_ms: u64,
+    pub queue_depth_after: u8,
+    pub queue_action: LanguageInputCallbackQueueAction,
+    pub dropped_existing_event: bool,
+    pub interrupt_backed: bool,
+    pub dispatch_model: String,
+    pub run_status: String,
+    pub result_kind: LanguageInputCallbackResultKind,
+    pub instructions_executed: u32,
+    pub elapsed_ms: u32,
+    pub completed: bool,
+    pub budget_exceeded: bool,
+    pub retryable: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackQueuePlanErrorKind {
     EmptyQueue,
     QueueDepthExceedsCapacity,
@@ -2045,6 +2079,43 @@ pub fn input_callback_dispatch_plan_for_queue_plan(
     })
 }
 
+pub fn input_callback_result_for_dispatch_plan(
+    dispatch: &LanguageInputCallbackDispatchPlan,
+    run_status: RunStatus,
+    instructions_executed: u32,
+    elapsed_ms: u32,
+) -> LanguageInputCallbackResultSummary {
+    let result_kind = input_callback_result_kind(run_status);
+    let budget_exceeded = result_kind == LanguageInputCallbackResultKind::BudgetExceeded;
+    let completed = result_kind == LanguageInputCallbackResultKind::Completed;
+    let retryable = result_kind == LanguageInputCallbackResultKind::Incomplete;
+
+    LanguageInputCallbackResultSummary {
+        board_id: dispatch.board_id.clone(),
+        pin: dispatch.pin,
+        label: dispatch.label.clone(),
+        event_kind: dispatch.event_kind.clone(),
+        dispatch_reason: dispatch.dispatch_reason.clone(),
+        callback_program_id: dispatch.callback_program_id,
+        callback_instruction_budget: dispatch.callback_instruction_budget,
+        sequence: dispatch.sequence,
+        timestamp_ms: dispatch.timestamp_ms,
+        queue_depth_after: dispatch.queue_depth_after,
+        queue_action: dispatch.queue_action,
+        dropped_existing_event: dispatch.dropped_existing_event,
+        interrupt_backed: dispatch.interrupt_backed,
+        dispatch_model: dispatch.dispatch_model.clone(),
+        run_status: run_status_name(run_status).to_owned(),
+        result_kind,
+        instructions_executed,
+        elapsed_ms,
+        completed,
+        budget_exceeded,
+        retryable,
+        message: input_callback_result_message(result_kind).to_owned(),
+    }
+}
+
 pub fn parse_serial_endpoint(endpoint: &str) -> Option<LanguageSerialEndpoint> {
     let (scheme, port) = endpoint.split_once("://")?;
     if scheme != "serial" {
@@ -2611,6 +2682,28 @@ fn input_callback_queue_plan_error(
         queue_capacity: invocation.queue_capacity,
         queue_depth,
         kind,
+    }
+}
+
+fn input_callback_result_kind(run_status: RunStatus) -> LanguageInputCallbackResultKind {
+    match run_status {
+        RunStatus::Halted => LanguageInputCallbackResultKind::Completed,
+        RunStatus::BudgetExceeded => LanguageInputCallbackResultKind::BudgetExceeded,
+        RunStatus::Running => LanguageInputCallbackResultKind::Incomplete,
+        RunStatus::Stopped | RunStatus::Faulted => LanguageInputCallbackResultKind::Failed,
+    }
+}
+
+fn input_callback_result_message(kind: LanguageInputCallbackResultKind) -> &'static str {
+    match kind {
+        LanguageInputCallbackResultKind::Completed => "Input callback completed.",
+        LanguageInputCallbackResultKind::BudgetExceeded => {
+            "Input callback exhausted its instruction budget."
+        }
+        LanguageInputCallbackResultKind::Incomplete => {
+            "Input callback is still running; keep cooperative dispatch scheduled."
+        }
+        LanguageInputCallbackResultKind::Failed => "Input callback stopped before completion.",
     }
 }
 
@@ -6663,6 +6756,84 @@ mod tests {
             input_callback_invocation_for_event(&custom, &custom_event).unwrap();
         let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
         assert!(input_callback_dispatch_plan_for_queue_plan(&newest_drop).is_none());
+    }
+
+    #[test]
+    fn input_callback_results_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let dispatch = input_callback_dispatch_plan_for_queue_plan(&queue_plan).unwrap();
+
+        let completed =
+            input_callback_result_for_dispatch_plan(&dispatch, RunStatus::Halted, 11, 3);
+        assert_eq!(completed.board_id, "arduino-uno-r4-wifi");
+        assert_eq!(completed.pin, 3);
+        assert_eq!(completed.label, "D3");
+        assert_eq!(completed.event_kind, LANGUAGE_INPUT_CALLBACK_EVENT_KIND);
+        assert_eq!(
+            completed.dispatch_reason,
+            LANGUAGE_INPUT_CALLBACK_DISPATCH_REASON
+        );
+        assert_eq!(completed.callback_program_id, 7);
+        assert_eq!(completed.callback_instruction_budget, 64);
+        assert_eq!(completed.sequence, 42);
+        assert_eq!(completed.timestamp_ms, 9001);
+        assert_eq!(completed.queue_depth_after, 3);
+        assert_eq!(
+            completed.queue_action,
+            LanguageInputCallbackQueueAction::Enqueue
+        );
+        assert!(!completed.dropped_existing_event);
+        assert!(completed.interrupt_backed);
+        assert_eq!(
+            completed.dispatch_model,
+            LANGUAGE_INPUT_CALLBACK_DISPATCH_MODEL
+        );
+        assert_eq!(completed.run_status, "halted");
+        assert_eq!(
+            completed.result_kind,
+            LanguageInputCallbackResultKind::Completed
+        );
+        assert_eq!(completed.instructions_executed, 11);
+        assert_eq!(completed.elapsed_ms, 3);
+        assert!(completed.completed);
+        assert!(!completed.budget_exceeded);
+        assert!(!completed.retryable);
+        assert_eq!(completed.message, "Input callback completed.");
+
+        let budget =
+            input_callback_result_for_dispatch_plan(&dispatch, RunStatus::BudgetExceeded, 64, 9);
+        assert_eq!(budget.run_status, "budget_exceeded");
+        assert_eq!(
+            budget.result_kind,
+            LanguageInputCallbackResultKind::BudgetExceeded
+        );
+        assert!(!budget.completed);
+        assert!(budget.budget_exceeded);
+        assert!(!budget.retryable);
+
+        let running = input_callback_result_for_dispatch_plan(&dispatch, RunStatus::Running, 12, 4);
+        assert_eq!(running.run_status, "running");
+        assert_eq!(
+            running.result_kind,
+            LanguageInputCallbackResultKind::Incomplete
+        );
+        assert!(!running.completed);
+        assert!(!running.budget_exceeded);
+        assert!(running.retryable);
+
+        let stopped = input_callback_result_for_dispatch_plan(&dispatch, RunStatus::Stopped, 6, 2);
+        assert_eq!(stopped.run_status, "stopped");
+        assert_eq!(stopped.result_kind, LanguageInputCallbackResultKind::Failed);
+        assert!(!stopped.completed);
+        assert!(!stopped.budget_exceeded);
+        assert!(!stopped.retryable);
+
+        let faulted = input_callback_result_for_dispatch_plan(&dispatch, RunStatus::Faulted, 6, 2);
+        assert_eq!(faulted.run_status, "faulted");
+        assert_eq!(faulted.result_kind, LanguageInputCallbackResultKind::Failed);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned input callback result summaries for dispatch plans
- preserve dispatch metadata while normalizing runner status into completed, budget-exceeded, incomplete, or failed results
- carry instruction/elapsed counters and frontend-friendly booleans so language adapters stay thin over Rust-owned callback completion metadata

## Validation
- `cargo fmt -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-result-summary cargo test -p board-vm-language-core`
- `bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-result-summary cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

## Notes
- Removed generated `code/packages/rust/Cargo.lock` and `build-plan.json` before commit if present.
- The external `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool` helper is still unavailable at that path, so the detector validation could not run in this worktree.
