### PR TITLE
Add HTML parser browser readiness suite

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
@@ -126,6 +126,11 @@ FORMAT_REGISTRY: tuple[FixtureFormat, ...] = (
         "lexer-token",
     ),
     FixtureFormat(
+        "html-parser/tests/fixtures/html-browser-readiness.json",
+        "venture-html-browser-readiness/v1",
+        "parser-browser-readiness",
+    ),
+    FixtureFormat(
         "html-parser/tests/fixtures/whatwg-block-boundary-audit.json",
         "whatwg-html-block-boundary-audit/v1",
         "parser-audit",
@@ -364,6 +369,10 @@ def check_category_contract(
         require_cases(relative_path, data, errors)
         require_top_level(relative_path, data, "source_fixture", str, errors)
         require_top_level(relative_path, data, "case_count", int, errors)
+    elif category == "parser-browser-readiness":
+        require_cases(relative_path, data, errors)
+        require_top_level(relative_path, data, "suite", str, errors)
+        require_case_field(relative_path, data, "expected", dict, errors)
     else:
         errors.append(f"{relative_path}: unknown registry category {category!r}")
     return errors

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -15,6 +15,7 @@ FIXTURE_DIR = Path(__file__).resolve().parent
 RUST_DIR = FIXTURE_DIR.parents[2]
 PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
 PARSER_SOURCE_FIXTURE = "html5lib-tree-construction-smoke.dat"
+BROWSER_READINESS_FORMAT = "venture-html-browser-readiness/v1"
 NUMERIC_REFERENCE_FIXTURE = "whatwg-numeric-references.json"
 INPUT_STREAM_FIXTURE = "whatwg-input-stream.json"
 CHUNK_BOUNDARY_FIXTURE = "whatwg-chunk-boundaries.json"
@@ -78,7 +79,9 @@ def check_fixture_schemas() -> tuple[list[str], FixtureStats]:
             if not isinstance(case, dict):
                 errors.append(f"{relative_path}: cases[{index}] must be an object")
                 continue
-            if fixture_path.parent == PARSER_FIXTURE_DIR:
+            if data.get("format") == BROWSER_READINESS_FORMAT:
+                errors.extend(check_browser_readiness_case(relative_path, index, case))
+            elif fixture_path.parent == PARSER_FIXTURE_DIR:
                 errors.extend(check_parser_audit_case(relative_path, index, case))
             else:
                 errors.extend(check_lexer_case(relative_path, fixture_path.name, index, case))
@@ -115,7 +118,9 @@ def check_top_level_schema(relative_path: str, data: dict[str, Any]) -> list[str
     require_non_empty_string(relative_path, data, "format", errors)
     require_non_empty_string(relative_path, data, "description", errors)
 
-    if relative_path.startswith("html-parser/"):
+    if data.get("format") == BROWSER_READINESS_FORMAT:
+        require_non_empty_string(relative_path, data, "suite", errors)
+    elif relative_path.startswith("html-parser/"):
         if data.get("source_fixture") != PARSER_SOURCE_FIXTURE:
             errors.append(
                 f"{relative_path}: source_fixture must be {PARSER_SOURCE_FIXTURE!r}"
@@ -194,6 +199,35 @@ def check_parser_audit_case(
     return errors
 
 
+def check_browser_readiness_case(
+    relative_path: str,
+    index: int,
+    case: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    case_path = f"{relative_path}: cases[{index}]"
+
+    require_non_empty_string(case_path, case, "id", errors)
+    require_optional_non_empty_string(case_path, case, "description", errors)
+    require_string(case_path, case, "input", errors)
+
+    expected = case.get("expected")
+    if not isinstance(expected, dict):
+        errors.append(f"{case_path}.expected must be an object")
+        return errors
+
+    require_optional_nullable_string(case_path, expected, "title", errors)
+    require_optional_nullable_string(case_path, expected, "base_href", errors)
+    require_string(f"{case_path}.expected", expected, "body_text", errors)
+    require_object_list(f"{case_path}.expected", expected, "headings", errors)
+    require_object_list(f"{case_path}.expected", expected, "links", errors)
+    require_object_list(f"{case_path}.expected", expected, "images", errors)
+    require_object_list(f"{case_path}.expected", expected, "forms", errors)
+    require_object_list(f"{case_path}.expected", expected, "tables", errors)
+
+    return errors
+
+
 def check_split_points(
     case_path: str,
     case: dict[str, Any],
@@ -258,6 +292,16 @@ def require_optional_string(
         require_string(path, data, field, errors)
 
 
+def require_optional_nullable_string(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    if field in data and data[field] is not None and not isinstance(data[field], str):
+        errors.append(f"{path}.{field} must be a string or null")
+
+
 def require_integer(
     path: str,
     data: dict[str, Any],
@@ -277,6 +321,17 @@ def require_string_list(
     value = data.get(field)
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         errors.append(f"{path}.{field} must be a list of strings")
+
+
+def require_object_list(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    value = data.get(field)
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        errors.append(f"{path}.{field} must be a list of objects")
 
 
 def require_optional_string_list(

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
@@ -34,6 +34,7 @@ class HtmlFixtureFormatRegistryTest(unittest.TestCase):
                 "lexer-numeric-reference",
                 "lexer-token",
                 "parser-audit",
+                "parser-browser-readiness",
             },
         )
 

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
@@ -31,6 +31,28 @@ class HtmlFixtureSchemasTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_browser_readiness_cases_require_browser_expected_shape(self) -> None:
+        errors = schema_check.check_browser_readiness_case(
+            "html-parser/tests/fixtures/html-browser-readiness.json",
+            0,
+            {
+                "id": "example",
+                "input": "<title>x</title><p>body",
+                "expected": {
+                    "title": "x",
+                    "base_href": None,
+                    "body_text": "body",
+                    "headings": [],
+                    "links": [],
+                    "images": [],
+                    "forms": [],
+                    "tables": [],
+                },
+            },
+        )
+
+        self.assertEqual(errors, [])
+
     def test_chunk_split_points_must_stay_inside_input(self) -> None:
         errors = schema_check.check_lexer_case(
             "html-lexer/tests/fixtures/whatwg-chunk-boundaries.json",

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -58,6 +58,8 @@ The current parser surface includes:
 - parser diagnostics for unmatched end tags
 - body-fragment parsing that returns DOM nodes without the implied
   `html/head/body` shell while preserving lexer/parser diagnostics
+- browser-facing document extraction for title, base URL, body text, headings,
+  links, image attributes, form controls, and table summaries
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources
@@ -319,12 +321,18 @@ audit report and pinned-count checks into the same local guard.
 ```rust
 use coding_adventures_html_lexer::HtmlScriptingMode;
 use coding_adventures_html_parser::{
-    parse_html, parse_html_fragment, parse_html_with_options, HtmlInitialTokenizerContext,
-    HtmlParseOptions,
+    parse_browser_document, parse_html, parse_html_fragment, parse_html_with_options,
+    HtmlInitialTokenizerContext, HtmlParseOptions,
 };
 use dom_core::Node;
 
 let document = parse_html("<p>Hello <strong>Venture</strong></p>").unwrap();
+let browser_document = parse_browser_document(
+    "<title>Example</title><h1>Example</h1><p><a href=next.html>Next</a></p>"
+).unwrap();
+
+assert_eq!(browser_document.title.as_deref(), Some("Example"));
+assert_eq!(browser_document.links[0].href.as_deref(), Some("next.html"));
 
 match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -621,6 +621,16 @@ pub fn parse_html(source: &str) -> Result<Document, ParseError> {
     Ok(parse_html_with_diagnostics(source)?.document)
 }
 
+/// Parse a complete HTML string and extract browser-facing document facts.
+pub fn parse_browser_document(source: &str) -> Result<BrowserDocument, ParseError> {
+    parse_html(source).map(|document| extract_browser_document(&document))
+}
+
+/// Extract browser-facing facts from a parsed DOM document.
+pub fn extract_browser_document(document: &Document) -> BrowserDocument {
+    BrowserDocument::from_document(document)
+}
+
 /// Parse a complete HTML string into a DOM document plus lexer/parser diagnostics.
 pub fn parse_html_with_diagnostics(source: &str) -> Result<ParseOutput, ParseError> {
     parse_html_with_diagnostics_and_options(source, HtmlParseOptions::default())
@@ -776,6 +786,93 @@ pub fn parse_html_fragment_for_context_with_diagnostics_and_options(
         lexer_diagnostics,
         parser_diagnostics: parser.diagnostics,
     })
+}
+
+/// Browser-facing summary of the parsed DOM.
+///
+/// This intentionally stays above raw DOM and below layout/CSS. It gives a
+/// browser pipeline stable document facts without forcing layout code to know
+/// every parser recovery detail.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BrowserDocument {
+    pub title: Option<String>,
+    pub base_href: Option<String>,
+    pub body_text: String,
+    pub headings: Vec<BrowserHeading>,
+    pub links: Vec<BrowserLink>,
+    pub images: Vec<BrowserImage>,
+    pub forms: Vec<BrowserForm>,
+    pub tables: Vec<BrowserTable>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserHeading {
+    pub level: u8,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserLink {
+    pub href: Option<String>,
+    pub name: Option<String>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserImage {
+    pub src: Option<String>,
+    pub alt: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserForm {
+    pub action: Option<String>,
+    pub method: String,
+    pub controls: Vec<BrowserFormControl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormControl {
+    pub control_type: String,
+    pub name: Option<String>,
+    pub value: Option<String>,
+    pub text: String,
+    pub options: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTable {
+    pub caption: Option<String>,
+    pub row_count: usize,
+    pub cell_count: usize,
+    pub header_cell_count: usize,
+}
+
+impl BrowserDocument {
+    pub fn from_document(document: &Document) -> Self {
+        let head = find_first_element_in_nodes(&document.children, "head");
+        let body = find_first_element_in_nodes(&document.children, "body");
+        let body_children = body
+            .map(|element| element.children.as_slice())
+            .unwrap_or(document.children.as_slice());
+
+        let mut summary = Self {
+            title: head
+                .and_then(|element| find_first_element_in_nodes(&element.children, "title"))
+                .map(element_text),
+            base_href: head
+                .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
+                .and_then(|element| element.attribute("href"))
+                .map(ToOwned::to_owned),
+            body_text: visible_text_for_nodes(body_children),
+            ..Self::default()
+        };
+
+        collect_browser_facts(body_children, &mut summary);
+        summary
+    }
 }
 
 /// Streaming-friendly parser core over already-tokenized HTML.
@@ -2665,10 +2762,7 @@ impl HtmlParser {
         if name == "b" && self.adopt_b_end_tag_across_cite_div() {
             return;
         }
-        if name == "body"
-            && self.has_open_element("body")
-            && self.current_element_is("bdy")
-        {
+        if name == "body" && self.has_open_element("body") && self.current_element_is("bdy") {
             return;
         }
         if name == "body" {
@@ -4872,16 +4966,18 @@ fn wrap_aside_bold_in_em(mut aside: Node) -> Node {
 
 fn element_has_em_with_foo_chain_depth(element: &Element, depth: usize) -> bool {
     element.children.iter().any(|child| match child {
-        Node::Element(child) if child.name == "em" => child
-            .children
-            .iter()
-            .find_map(|grandchild| match grandchild {
-                Node::Element(grandchild) if grandchild.name == "foo" => {
-                    Some(foo_chain_depth(grandchild))
-                }
-                _ => None,
-            })
-            == Some(depth),
+        Node::Element(child) if child.name == "em" => {
+            child
+                .children
+                .iter()
+                .find_map(|grandchild| match grandchild {
+                    Node::Element(grandchild) if grandchild.name == "foo" => {
+                        Some(foo_chain_depth(grandchild))
+                    }
+                    _ => None,
+                })
+                == Some(depth)
+        }
         Node::Element(child) => element_has_em_with_foo_chain_depth(child, depth),
         _ => false,
     })
@@ -5056,7 +5152,9 @@ fn repair_select_button_selectedcontent(nodes: &mut Vec<Node>) {
             })
             .or_else(|| {
                 select.children.iter().find_map(|child| match child {
-                    Node::Element(option) if option.name == "option" && !option.children.is_empty() => {
+                    Node::Element(option)
+                        if option.name == "option" && !option.children.is_empty() =>
+                    {
                         Some(option.children.clone())
                     }
                     _ => None,
@@ -5151,11 +5249,9 @@ fn repair_empty_formatting_paragraph_continuation(nodes: &mut Vec<Node>, index: 
     if !is_formatting_element(&inner_formatting.name) {
         return false;
     }
-    if !inner_formatting
-        .children
-        .last()
-        .is_some_and(|node| matches!(node, Node::Text(text) if text.data.ends_with(" Italic only.")))
-    {
+    if !inner_formatting.children.last().is_some_and(
+        |node| matches!(node, Node::Text(text) if text.data.ends_with(" Italic only.")),
+    ) {
         return false;
     }
 
@@ -5263,10 +5359,7 @@ fn split_tail_text(nodes: &mut [Node], tail: &str) -> Option<String> {
     Some(tail.to_string())
 }
 
-fn repair_paragraph_inside_previous_font_continuation(
-    nodes: &mut Vec<Node>,
-    index: usize,
-) -> bool {
+fn repair_paragraph_inside_previous_font_continuation(nodes: &mut Vec<Node>, index: usize) -> bool {
     if index == 0 {
         return false;
     }
@@ -5576,10 +5669,9 @@ fn repair_definition_list_bold_children(children: &mut [Node]) -> bool {
                     .any(|child| matches!(child, Node::Element(child) if child.name == "b"));
             }
             "dd" if previous_dt_had_bold => {
-                let already_bold = element
-                    .children
-                    .first()
-                    .is_some_and(|child| matches!(child, Node::Element(child) if child.name == "b"));
+                let already_bold = element.children.first().is_some_and(
+                    |child| matches!(child, Node::Element(child) if child.name == "b"),
+                );
                 if !already_bold {
                     let mut bold = Node::element("b".to_string(), Vec::new());
                     if let Node::Element(bold_element) = &mut bold {
@@ -5711,14 +5803,15 @@ fn repair_insanely_badly_nested_table_sequence(nodes: &mut Vec<Node>) {
     }) else {
         return;
     };
-    let Some(outer_table_index) = nodes
-        .iter()
-        .enumerate()
-        .skip(font_index + 1)
-        .find_map(|(index, node)| match node {
-            Node::Element(element) if element.name == "table" => Some(index),
-            _ => None,
-        })
+    let Some(outer_table_index) =
+        nodes
+            .iter()
+            .enumerate()
+            .skip(font_index + 1)
+            .find_map(|(index, node)| match node {
+                Node::Element(element) if element.name == "table" => Some(index),
+                _ => None,
+            })
     else {
         return;
     };
@@ -5771,7 +5864,9 @@ fn repair_insanely_badly_nested_table_sequence(nodes: &mut Vec<Node>) {
     }
     let mut anchor_with_font = Node::element("a".to_string(), Vec::new());
     if let Node::Element(element) = &mut anchor_with_font {
-        element.children.push(Node::element("font".to_string(), Vec::new()));
+        element
+            .children
+            .push(Node::element("font".to_string(), Vec::new()));
     }
 
     nodes.insert(font_index, font);
@@ -6078,10 +6173,7 @@ fn apply_scripted_id_mutation(nodes: &mut [Node]) {
             continue;
         };
         if element.attribute("id") == Some("A")
-            && element_contains_script_text(
-                element,
-                "document.getElementById(\"A\").id = \"B\"",
-            )
+            && element_contains_script_text(element, "document.getElementById(\"A\").id = \"B\"")
         {
             set_attribute_value(&mut element.attributes, "id", "B");
         }
@@ -6605,9 +6697,12 @@ fn fragment_context_shell(context_element: &str) -> (Document, Vec<Vec<usize>>) 
         let child_index = {
             let parent = element_at_path_mut(&mut document, &parent_path)
                 .expect("fragment shell parent must exist");
-            parent
-                .children
-                .push(marked_shell_element(element_name, marker, context_element, namespace));
+            parent.children.push(marked_shell_element(
+                element_name,
+                marker,
+                context_element,
+                namespace,
+            ));
             parent.children.len() - 1
         };
 
@@ -6659,7 +6754,11 @@ fn foreign_fragment_context(context_element: &str) -> Option<(&'static str, &str
     context_element
         .strip_prefix("svg ")
         .map(|name| ("svg", name))
-        .or_else(|| context_element.strip_prefix("math ").map(|name| ("math", name)))
+        .or_else(|| {
+            context_element
+                .strip_prefix("math ")
+                .map(|name| ("math", name))
+        })
 }
 
 fn is_fragment_table_shell_wrapper(element_name: &str, context_element: &str) -> bool {
@@ -7677,6 +7776,225 @@ fn is_void_element(name: &str) -> bool {
             | "source"
             | "track"
             | "wbr"
+    )
+}
+
+fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+
+        match element.name.as_str() {
+            "a" => summary.links.push(BrowserLink {
+                href: element.attribute("href").map(ToOwned::to_owned),
+                name: element.attribute("name").map(ToOwned::to_owned),
+                text: visible_text_for_nodes(&element.children),
+            }),
+            "img" => summary.images.push(BrowserImage {
+                src: element.attribute("src").map(ToOwned::to_owned),
+                alt: element.attribute("alt").map(ToOwned::to_owned),
+                width: element.attribute("width").map(ToOwned::to_owned),
+                height: element.attribute("height").map(ToOwned::to_owned),
+            }),
+            "form" => summary.forms.push(BrowserForm {
+                action: element.attribute("action").map(ToOwned::to_owned),
+                method: element
+                    .attribute("method")
+                    .map(|method| method.to_ascii_lowercase())
+                    .unwrap_or_else(|| "get".to_string()),
+                controls: collect_form_controls(&element.children),
+            }),
+            "table" => summary.tables.push(BrowserTable {
+                caption: find_first_element_in_nodes(&element.children, "caption")
+                    .map(element_text),
+                row_count: count_elements_named(&element.children, "tr"),
+                cell_count: count_elements_matching(&element.children, |element| {
+                    matches!(element.name.as_str(), "td" | "th")
+                }),
+                header_cell_count: count_elements_named(&element.children, "th"),
+            }),
+            name if heading_level(name).is_some() => summary.headings.push(BrowserHeading {
+                level: heading_level(name).expect("heading level was checked above"),
+                text: visible_text_for_nodes(&element.children),
+            }),
+            _ => {}
+        }
+
+        collect_browser_facts(&element.children, summary);
+    }
+}
+
+fn collect_form_controls(nodes: &[Node]) -> Vec<BrowserFormControl> {
+    let mut controls = Vec::new();
+    collect_form_controls_into(nodes, &mut controls);
+    controls
+}
+
+fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormControl>) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+
+        match element.name.as_str() {
+            "input" => controls.push(BrowserFormControl {
+                control_type: element
+                    .attribute("type")
+                    .map(|input_type| input_type.to_ascii_lowercase())
+                    .unwrap_or_else(|| "text".to_string()),
+                name: element.attribute("name").map(ToOwned::to_owned),
+                value: element.attribute("value").map(ToOwned::to_owned),
+                text: String::new(),
+                options: Vec::new(),
+            }),
+            "button" => controls.push(BrowserFormControl {
+                control_type: element
+                    .attribute("type")
+                    .map(|button_type| button_type.to_ascii_lowercase())
+                    .unwrap_or_else(|| "submit".to_string()),
+                name: element.attribute("name").map(ToOwned::to_owned),
+                value: element.attribute("value").map(ToOwned::to_owned),
+                text: visible_text_for_nodes(&element.children),
+                options: Vec::new(),
+            }),
+            "select" => controls.push(BrowserFormControl {
+                control_type: "select".to_string(),
+                name: element.attribute("name").map(ToOwned::to_owned),
+                value: None,
+                text: visible_text_for_nodes(&element.children),
+                options: collect_select_options(&element.children),
+            }),
+            "textarea" => controls.push(BrowserFormControl {
+                control_type: "textarea".to_string(),
+                name: element.attribute("name").map(ToOwned::to_owned),
+                value: None,
+                text: element_text(element),
+                options: Vec::new(),
+            }),
+            _ => collect_form_controls_into(&element.children, controls),
+        }
+    }
+}
+
+fn collect_select_options(nodes: &[Node]) -> Vec<String> {
+    let mut options = Vec::new();
+    collect_select_options_into(nodes, &mut options);
+    options
+}
+
+fn collect_select_options_into(nodes: &[Node], options: &mut Vec<String>) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if element.name == "option" {
+            options.push(visible_text_for_nodes(&element.children));
+        } else {
+            collect_select_options_into(&element.children, options);
+        }
+    }
+}
+
+fn visible_text_for_nodes(nodes: &[Node]) -> String {
+    let mut text = String::new();
+    collect_visible_text(nodes, &mut text);
+    collapse_html_whitespace(&text)
+}
+
+fn collect_visible_text(nodes: &[Node], text: &mut String) {
+    for node in nodes {
+        match node {
+            Node::Text(value) => text.push_str(&value.data),
+            Node::Element(element) if is_browser_invisible_element(&element.name) => {}
+            Node::Element(element) => {
+                collect_visible_text(&element.children, text);
+                text.push(' ');
+            }
+            Node::DocumentType(_) | Node::Comment(_) => {}
+        }
+    }
+}
+
+fn element_text(element: &Element) -> String {
+    let mut text = String::new();
+    collect_browser_text_content(&element.children, &mut text);
+    collapse_html_whitespace(&text)
+}
+
+fn collect_browser_text_content(nodes: &[Node], text: &mut String) {
+    for node in nodes {
+        match node {
+            Node::Text(value) => text.push_str(&value.data),
+            Node::Element(element) => collect_browser_text_content(&element.children, text),
+            Node::DocumentType(_) | Node::Comment(_) => {}
+        }
+    }
+}
+
+fn collapse_html_whitespace(text: &str) -> String {
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut normalized = String::with_capacity(collapsed.len());
+    for character in collapsed.chars() {
+        if matches!(character, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']')
+            && normalized.ends_with(' ')
+        {
+            normalized.pop();
+        }
+        normalized.push(character);
+    }
+    normalized
+}
+
+fn find_first_element_in_nodes<'a>(nodes: &'a [Node], name: &str) -> Option<&'a Element> {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if element.name == name {
+            return Some(element);
+        }
+        if let Some(found) = find_first_element_in_nodes(&element.children, name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn count_elements_named(nodes: &[Node], name: &str) -> usize {
+    count_elements_matching(nodes, |element| element.name == name)
+}
+
+fn count_elements_matching(nodes: &[Node], predicate: impl Fn(&Element) -> bool + Copy) -> usize {
+    let mut count = 0;
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if predicate(element) {
+            count += 1;
+        }
+        count += count_elements_matching(&element.children, predicate);
+    }
+    count
+}
+
+fn heading_level(name: &str) -> Option<u8> {
+    match name {
+        "h1" => Some(1),
+        "h2" => Some(2),
+        "h3" => Some(3),
+        "h4" => Some(4),
+        "h5" => Some(5),
+        "h6" => Some(6),
+        _ => None,
+    }
+}
+
+fn is_browser_invisible_element(name: &str) -> bool {
+    matches!(
+        name,
+        "base" | "link" | "meta" | "script" | "style" | "template" | "title"
     )
 }
 

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,0 +1,202 @@
+use coding_adventures_html_parser::{
+    parse_browser_document, BrowserDocument, BrowserForm, BrowserFormControl, BrowserHeading,
+    BrowserImage, BrowserLink, BrowserTable,
+};
+use serde::Deserialize;
+
+const BROWSER_READINESS_FIXTURE: &str = include_str!("fixtures/html-browser-readiness.json");
+
+#[derive(Debug, Deserialize)]
+struct BrowserReadinessSuite {
+    format: String,
+    suite: String,
+    cases: Vec<BrowserReadinessCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BrowserReadinessCase {
+    id: String,
+    input: String,
+    expected: ExpectedBrowserDocument,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedBrowserDocument {
+    title: Option<String>,
+    base_href: Option<String>,
+    body_text: String,
+    headings: Vec<ExpectedHeading>,
+    links: Vec<ExpectedLink>,
+    images: Vec<ExpectedImage>,
+    forms: Vec<ExpectedForm>,
+    tables: Vec<ExpectedTable>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedHeading {
+    level: u8,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedLink {
+    href: Option<String>,
+    name: Option<String>,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedImage {
+    src: Option<String>,
+    alt: Option<String>,
+    width: Option<String>,
+    height: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedForm {
+    action: Option<String>,
+    method: String,
+    controls: Vec<ExpectedFormControl>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormControl {
+    control_type: String,
+    name: Option<String>,
+    value: Option<String>,
+    text: String,
+    options: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedTable {
+    caption: Option<String>,
+    row_count: usize,
+    cell_count: usize,
+    header_cell_count: usize,
+}
+
+#[test]
+fn browser_readiness_cases_extract_browser_document_facts() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+
+    assert_eq!(suite.format, "venture-html-browser-readiness/v1");
+    assert_eq!(suite.suite, "browser-readiness");
+    assert!(!suite.cases.is_empty(), "fixture should contain cases");
+
+    for case in suite.cases {
+        let actual = parse_browser_document(&case.input)
+            .unwrap_or_else(|error| panic!("{} should parse: {error}", case.id));
+
+        assert_eq!(
+            actual,
+            case.expected.into_browser_document(),
+            "{} extracted browser facts should match",
+            case.id
+        );
+    }
+}
+
+impl ExpectedBrowserDocument {
+    fn into_browser_document(self) -> BrowserDocument {
+        BrowserDocument {
+            title: self.title,
+            base_href: self.base_href,
+            body_text: self.body_text,
+            headings: self
+                .headings
+                .into_iter()
+                .map(ExpectedHeading::into_browser_heading)
+                .collect(),
+            links: self
+                .links
+                .into_iter()
+                .map(ExpectedLink::into_browser_link)
+                .collect(),
+            images: self
+                .images
+                .into_iter()
+                .map(ExpectedImage::into_browser_image)
+                .collect(),
+            forms: self
+                .forms
+                .into_iter()
+                .map(ExpectedForm::into_browser_form)
+                .collect(),
+            tables: self
+                .tables
+                .into_iter()
+                .map(ExpectedTable::into_browser_table)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedHeading {
+    fn into_browser_heading(self) -> BrowserHeading {
+        BrowserHeading {
+            level: self.level,
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedLink {
+    fn into_browser_link(self) -> BrowserLink {
+        BrowserLink {
+            href: self.href,
+            name: self.name,
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedImage {
+    fn into_browser_image(self) -> BrowserImage {
+        BrowserImage {
+            src: self.src,
+            alt: self.alt,
+            width: self.width,
+            height: self.height,
+        }
+    }
+}
+
+impl ExpectedForm {
+    fn into_browser_form(self) -> BrowserForm {
+        BrowserForm {
+            action: self.action,
+            method: self.method,
+            controls: self
+                .controls
+                .into_iter()
+                .map(ExpectedFormControl::into_browser_form_control)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedFormControl {
+    fn into_browser_form_control(self) -> BrowserFormControl {
+        BrowserFormControl {
+            control_type: self.control_type,
+            name: self.name,
+            value: self.value,
+            text: self.text,
+            options: self.options,
+        }
+    }
+}
+
+impl ExpectedTable {
+    fn into_browser_table(self) -> BrowserTable {
+        BrowserTable {
+            caption: self.caption,
+            row_count: self.row_count,
+            cell_count: self.cell_count,
+            header_cell_count: self.header_cell_count,
+        }
+    }
+}

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -9,6 +9,11 @@ The format is the upstream tree-construction test format documented in
 that format lets this crate grow toward WHATWG tree-construction compliance
 without inventing a Rust-only test schema.
 
+`html-browser-readiness.json` is a checked parser acceptance corpus for
+browser-facing extraction. It verifies that broad HTML documents produce stable
+title, base URL, body text, heading, link, image, form, and table facts that a
+browser pipeline can consume before layout and Paint VM rendering.
+
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 
 ```bash

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1,0 +1,79 @@
+{
+  "format": "venture-html-browser-readiness/v1",
+  "suite": "browser-readiness",
+  "description": "Browser-facing parser acceptance cases for broad document extraction, independent of a specific rendering era.",
+  "cases": [
+    {
+      "id": "legacy-directory-page",
+      "description": "Omitted shell, title/base metadata, anchors, image attributes, and implied list-item endings.",
+      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\"><h1>Example Directory</h1><p>Welcome to <a href=\"intro.html\">Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
+      "expected": {
+        "title": "Example & Links",
+        "base_href": "https://example.test/docs/",
+        "body_text": "Example Directory Welcome to Venture HTML. One Two",
+        "headings": [
+          { "level": 1, "text": "Example Directory" }
+        ],
+        "links": [
+          { "href": "intro.html", "name": null, "text": "Venture HTML" }
+        ],
+        "images": [
+          { "src": "logo.gif", "alt": "Logo", "width": "88", "height": "31" }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "catalog-form-table-page",
+      "description": "Form controls, select options, textarea text, button text, and table summaries.",
+      "input": "<html><head><title>Search</title></head><body><h2>Catalog</h2><form action=\"/search\" method=POST><input name=q value=\"rust html\"><input type=hidden name=page value=1><select name=section><option>Books<option>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
+      "expected": {
+        "title": "Search",
+        "base_href": null,
+        "body_text": "Catalog Books Manuals Line one Line two Search Results Name Kind Mosaic Browser",
+        "headings": [
+          { "level": 2, "text": "Catalog" }
+        ],
+        "links": [],
+        "images": [],
+        "forms": [
+          {
+            "action": "/search",
+            "method": "post",
+            "controls": [
+              { "control_type": "text", "name": "q", "value": "rust html", "text": "", "options": [] },
+              { "control_type": "hidden", "name": "page", "value": "1", "text": "", "options": [] },
+              { "control_type": "select", "name": "section", "value": null, "text": "Books Manuals", "options": ["Books", "Manuals"] },
+              { "control_type": "textarea", "name": "notes", "value": null, "text": "Line one Line two", "options": [] },
+              { "control_type": "submit", "name": "go", "value": null, "text": "Search", "options": [] }
+            ]
+          }
+        ],
+        "tables": [
+          { "caption": "Results", "row_count": 2, "cell_count": 4, "header_cell_count": 2 }
+        ]
+      }
+    },
+    {
+      "id": "tag-soup-formatting-page",
+      "description": "Bad nesting, formatting reconstruction, named anchors, same-page links, pre text, and invisible script/style contents.",
+      "input": "<body><p>Alpha <b>bold<p>Beta <i>italic</b> tail</i><center><h3>Archive</h3><a name=top></a><a href=\"#top\">Back</a></center><pre>  spaced\n text</pre><script>document.write(\"x\")</script><style>p{color:red}</style>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "body_text": "Alpha bold Beta italic tail Archive Back spaced text",
+        "headings": [
+          { "level": 3, "text": "Archive" }
+        ],
+        "links": [
+          { "href": null, "name": "top", "text": "" },
+          { "href": "#top", "name": null, "text": "Back" }
+        ],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a browser-facing document extraction API on top of the parsed DOM
- cover title/base/body text/headings/links/images/forms/tables in a broad parser readiness fixture
- register the new fixture format with the existing schema, registry, and README inventory checks

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser