### PR TITLE
spice: plan 1970s compatibility workstream

### DIFF
--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -1,0 +1,235 @@
+# SPICE 1970s Compatibility Plan
+
+## Overview
+
+This plan defines the remaining work to make the local SPICE engines feel like
+a credible Berkeley SPICE1/SPICE2-era simulator rather than a modern collection
+of isolated analysis helpers.
+
+The target is not HSPICE, ngspice, BSIM-era process accuracy, or full SPICE3
+compatibility. The target is the practical 1970s core:
+
+- nonlinear DC operating point and sweeps
+- nonlinear transient analysis
+- linear AC small-signal analysis
+- classic passive, source, controlled-source, and semiconductor devices
+- SPICE-style model cards, netlist cards, options, and text outputs
+- the small-signal analyses and convergence aids that made SPICE2 useful on
+  real transistor circuits
+
+Historical references:
+
+- Laurence W. Nagel, *SPICE2: A Computer Program to Simulate Semiconductor
+  Circuits*, UCB/ERL M520, 1975.
+- Ellis Cohen, *Program Reference for SPICE2*, UCB/ERL M592, 1976.
+- SPICE Version 2G User's Guide, 1981, used only as a post-1970s compatibility
+  cross-check because it documents the mature SPICE2 family surface.
+
+## Current Baseline
+
+The repo already has the essential solver spine:
+
+- MNA-based DC operating point with Newton-Raphson.
+- DC source sweep, transfer function, sensitivity, Monte Carlo, noise, AC
+  sweep, transient analysis, and recent PSS footholds.
+- R, C, L, independent V/I sources, all four dependent sources, diode, BJT,
+  MOSFET, behavioral sources, subcircuits, and sparse real solve support.
+- Python, TypeScript, and Rust `spice-engine` packages.
+- Python, TypeScript, and Rust `spice-netlist-parser` packages with main cards
+  for `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
+  `.options`, `.model`, and `.subckt`.
+
+The gaps below are the remaining compatibility work for a recognizable
+1970s-SPICE profile.
+
+## Compatibility Goal
+
+A representative SPICE2-era deck should be able to:
+
+1. Parse with familiar element and analysis cards.
+2. Build equivalent circuit objects in Python, TypeScript, and Rust.
+3. Run the relevant analysis with comparable result fields.
+4. Exercise the same behavior through cross-language tests.
+5. Document unsupported cards with explicit parser errors rather than silent
+   misinterpretation.
+
+## Work Queue
+
+### Phase 1 - JFET Device and Model Cards
+
+Add `JFET` as the missing SPICE2-era semiconductor family.
+
+Scope:
+
+- Python, TypeScript, and Rust `Jfet`/`JFET` element types.
+- N-channel and P-channel Shichman-Hodges model foothold.
+- DC operating-point stamping.
+- AC small-signal stamping from the DC bias point.
+- Transient participation through the existing nonlinear solve path where
+  applicable.
+- `.model <name> NJF(...)` / `.model <name> PJF(...)` parser support.
+- `J` device-card parser support.
+
+Acceptance:
+
+- Cross-language DC tests for an N-channel source resistor bias circuit.
+- Cross-language AC tests for a small-signal common-source JFET stage.
+- Parser tests for model cards, device cards, and subcircuit terminal remapping.
+
+### Phase 2 - Mutual Inductors (`K` Cards)
+
+Add classic coupled inductors.
+
+Scope:
+
+- Mutual-coupling element that references two named inductors and a coupling
+  coefficient.
+- DC behavior remains compatible with inductor shorts.
+- AC and transient stamps include the mutual terms.
+- Parser support for `Kname L1 L2 coefficient`.
+
+Acceptance:
+
+- AC transformer ratio fixture with two coupled inductors.
+- Transient coupled-inductor smoke test.
+- Parser rejection for missing referenced inductors and non-finite coupling.
+
+### Phase 3 - Ideal Transmission Lines (`T` Cards)
+
+Add ideal lossless transmission-line support as the classic distributed element.
+
+Scope:
+
+- Four-terminal transmission-line element with characteristic impedance and
+  delay.
+- Parser support for a conservative `Tname n1 n2 n3 n4 Z0=<z> TD=<delay>`
+  form first.
+- Transient delay-line behavior.
+- AC phase-shift behavior.
+
+Acceptance:
+
+- Transient delayed step fixture.
+- AC phase-delay fixture.
+- Parser tests for supported and unsupported line parameter forms.
+
+### Phase 4 - Gear-2 / BDF2 Transient Integration
+
+Complete the integration-method set expected by the spec.
+
+Scope:
+
+- `method="gear2"` / equivalent enum support across languages.
+- Capacitor and inductor BDF2 companion histories.
+- Adaptive-step interaction at the same surface as existing trap/euler.
+- Netlist `.options method=gear2` or `.tran ... method=gear2` route if already
+  supported by the parser shape.
+
+Acceptance:
+
+- Cross-language RC and RL fixtures showing Gear-2 produces stable results.
+- LC damped fixture showing Gear-2 suppresses trapezoidal ringing better than
+  trap at the same coarse step.
+
+### Phase 5 - Pseudo-Transient DC Continuation
+
+Finish the convergence-aid chain named in `spice-engine.md`.
+
+Scope:
+
+- If regular DC, Gmin stepping, and source stepping fail, run a short transient
+  continuation toward a DC solution.
+- Preserve existing `DcResult` metadata so callers can see which aid converged.
+- Options to cap pseudo-transient steps and tolerances.
+
+Acceptance:
+
+- Nonlinear diode/BJT/MOS bias fixtures that fail with aids disabled and
+  converge through the full aid chain.
+- Tests proving pseudo-transient does not run when earlier aids succeed.
+
+### Phase 6 - 1970s Model-Card Depth
+
+Deepen semiconductor models enough for SPICE2-style examples.
+
+Scope:
+
+- Diode junction capacitance, transit time, emission coefficient, breakdown
+  footholds, and temperature scaling.
+- BJT charge-storage and capacitance footholds beyond current Ebers-Moll-like
+  DC behavior.
+- MOS Level-1 parameter coverage audit and missing parser/model aliases.
+- Temperature directive plumbing into analyses.
+
+Acceptance:
+
+- Parser/model-card tests for common SPICE2 parameters.
+- DC/AC/transient fixtures that prove capacitance and temperature parameters
+  change results in expected directions.
+
+### Phase 7 - Classic Text Output and Control Cards
+
+Make deck-level output feel like SPICE rather than only package APIs.
+
+Scope:
+
+- `.print` and `.plot` parse records.
+- `.four` Fourier analysis over transient output.
+- `.temp` directive.
+- More `.options` keys wired into engine calls.
+- Text output helpers for tabular node voltages and branch currents.
+
+Acceptance:
+
+- Parser fixtures for `.print`, `.plot`, `.four`, `.temp`, and selected
+  `.options`.
+- Fourier fixture for a sinusoidal transient output.
+- Text-output snapshot tests with stable ordering.
+
+### Phase 8 - Small-Signal Distortion and Pole-Zero
+
+Complete the lower-frequency SPICE2 analysis surface after the core device and
+parser work is in place.
+
+Scope:
+
+- Distortion-card parser and a first small-signal distortion result shape.
+- Pole-zero parser and analysis result shape.
+- Start with constrained linearized examples; leave rich nonlinear distortion
+  accuracy as follow-up if needed.
+
+Acceptance:
+
+- Parser and result-shape tests across languages.
+- At least one simple RC pole fixture and one nonlinear-device distortion smoke
+  fixture.
+
+## Loop Policy
+
+Each implementation phase should be handled as a focused PR:
+
+1. Start from fresh `origin/main` in a sibling worktree.
+2. Keep Python, TypeScript, and Rust behavior comparable unless a phase is
+   explicitly parser-only or engine-only.
+3. Update this plan or the SPICE pending-work spec as each phase lands.
+4. Run focused validation for touched packages.
+5. Push a PR and monitor it with `gh pr view` and `gh pr checks --watch=false`.
+6. If CI fails or a merge conflict appears, fix it immediately, commit, push,
+   and restart the monitor.
+7. Once merged, delete the old monitor and move to the next phase.
+
+## Initial Implementation Order
+
+The next implementation slice is Phase 1, JFET.
+
+Recommended subdivision:
+
+1. Add cross-language JFET element data structures plus parser model/device
+   support.
+2. Add Python DC/AC engine behavior for JFET.
+3. Port DC/AC behavior to TypeScript and Rust.
+4. Add transient participation if not already covered by the shared nonlinear
+   DC solve path.
+
+This lets parser and public API compatibility land before the more delicate
+nonlinear model math broadens.

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -205,13 +205,11 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- PSS analysis helpers across Python, TypeScript, and Rust SPICE
-  engines: ordered residual vectors, L2/RMS norms, finite-difference residual
-  Jacobians, reactive initial-condition update deltas, and Newton candidate
-  circuits have landed. One-step Newton iteration acceptance and bounded
-  Newton solves have landed; this follow-up wraps the solve in a direct PSS
-  analysis result that returns one steady-state transient period from the
-  solved circuit.
+- 1970s SPICE compatibility planning: the next workstream is tracked in
+  `spice-1970s-compatibility.md`, starting with JFET device/model-card support,
+  then mutual inductors, ideal transmission lines, Gear-2 transient integration,
+  pseudo-transient DC continuation, model-card depth, classic text output cards,
+  and the remaining SPICE2 small-signal analysis surface.
 
 ---
 
@@ -237,6 +235,14 @@ and the sparse real solver path landed in PR #3391.
 | **Multi-corner parallel sweep** | Run the same analysis at N PVT corners in parallel goroutines / subprocesses. Mostly an orchestration problem once the core engine is solid. DC operating-point corners shipped in PR #3495; DC source sweep corners shipped in PR #3501; AC frequency sweep corners shipped in PR #3511; transfer-function corners shipped in PR #3516. |
 | **Mixed-signal coupling with `hardware-vm`** | AMS simulation — digital events feed into analog SPICE nodes and vice versa. Long-range project; `hardware-vm.md` spec describes the interface. |
 | **Verilog-A compact models** | Custom device models. Requires a Verilog-A parser (`code/specs/verilog-a-parser.md` is referenced but not written). |
+
+#### SPICE 1970s compatibility
+
+The compatibility workstream is now split into concrete phases in
+`code/specs/spice-1970s-compatibility.md`. This is the plan to move the current
+solver from a strong SPICE-compatible educational engine toward a recognizable
+Berkeley SPICE1/SPICE2-era simulator surface. The first implementation phase is
+JFET device and `.model` / `J` card support.
 
 ---
 


### PR DESCRIPTION
## Summary

- add a spec-native 1970s SPICE compatibility roadmap
- split the remaining Berkeley SPICE1/SPICE2-era gaps into ordered phases
- point the live SPICE pending-work spec at the new plan

## Plan Highlights

- start with JFET device/model-card support
- follow with mutual inductors, ideal transmission lines, Gear-2 transient integration, and pseudo-transient continuation
- then deepen classic model cards, output directives, distortion, and pole-zero analysis

## Validation

- `git diff --check`