### PR TITLE
feat(closure-typechecker): scaffold crate with passthrough judgment (CLOC06 Phase 1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -480,6 +480,7 @@ members = [
     "irc-server",
     "irc-net-stdlib",
     "url-parser",
+    "closure-typechecker",
     "compiler-ir",
     "compiler-source-map",
     "brainfuck-ir-compiler",

--- a/code/packages/rust/closure-typechecker/BUILD
+++ b/code/packages/rust/closure-typechecker/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-typechecker -- --nocapture

--- a/code/packages/rust/closure-typechecker/BUILD_windows
+++ b/code/packages/rust/closure-typechecker/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-typechecker -- --nocapture

--- a/code/packages/rust/closure-typechecker/CHANGELOG.md
+++ b/code/packages/rust/closure-typechecker/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closure-typechecker` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-23
+
+### Added
+- **Stage 3 begins.** First crate in the typechecker + pass pipeline per CLOC06.
+- `check(program: &Program, sidecar: &Sidecar, cv: &mut CVLog) -> CheckResult` — v1 passthrough: every `Program`-root CvId with a `ty`-bearing record in the sidecar lands in `CheckResult::judgments` as a typed entry, and a `"judged"` `Contribution` gets appended to the CV log per CLOC03 §"Stage 3 — Typechecker."
+- `CheckResult { judgments: HashMap<String, Type>, diagnostics: Vec<Diagnostic> }` with `has_judgment(cv)` and `judgment(cv)` accessors plus `new()` / `Default`.
+- `Diagnostic { cv: String, severity: Severity, group: DiagnosticGroup, message: String }` — the diagnostic shape from CLOC08 pinned for downstream consumers.
+- `Severity::Error / Warning / Note`.
+- `DiagnosticGroup(String)` with `DiagnosticGroup::new(name)`.
+- `type_label` helper renders `Type` values into the strings used in `Contribution.meta["type"]`.
+- 10 tests covering: empty sidecar, record with `ty` → judgment + CV contribution, record with `ty = None` → no judgment, no sidecar entry → no judgment, accessor methods, Diagnostic API buildability, `type_label` for primitives and `Opaque`, disabled CV log still works (CLOC03 production fast path).
+
+### Notes
+- Dependencies: `coding-adventures-javascript-ast`, `coding-adventures-type-sidecar`, `coding_adventures_correlation_vector`, `serde_json`. No `closure-pass-*` (those depend on this crate); no `javascript-parser`/`-lexer` (the typechecker operates on the AST + sidecar, not on tokens).
+- v1 is **scaffolding**: real inference lands once `javascript-ast` grows `Statement` / `Expression` variants. Even so, this PR does real work — establishes the `check` API the future `closurec` CLI calls, plumbs CV contributions, and pins the Diagnostic surface for passes and CLI to be written against now.

--- a/code/packages/rust/closure-typechecker/Cargo.toml
+++ b/code/packages/rust/closure-typechecker/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "coding-adventures-closure-typechecker"
+version = "0.1.0"
+edition = "2021"
+description = "JavaScript type checker for the Closure Compiler clone. Consumes (Program, Sidecar) and produces typed judgments + diagnostics. Per CLOC06."
+
+[dependencies]
+coding-adventures-javascript-ast = { path = "../javascript-ast" }
+coding-adventures-type-sidecar = { path = "../type-sidecar" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
+
+[dev-dependencies]
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }

--- a/code/packages/rust/closure-typechecker/README.md
+++ b/code/packages/rust/closure-typechecker/README.md
@@ -1,0 +1,39 @@
+# coding-adventures-closure-typechecker
+
+JavaScript type checker (Closure-style). Consumes `(Program, Sidecar)`
+and produces typed judgments plus diagnostics per
+[CLOC06](../../../specs/CLOC06-pass-interface-contract.md), with the
+severity model from
+[CLOC08](../../../specs/CLOC08-closurec-cli-surface.md).
+
+## What's here (v1)
+
+- `check(program, sidecar, cv) -> CheckResult` — passthrough judgment.
+  Looks up each node's CvId in the sidecar; if a record has a concrete
+  `ty`, the result map gets the judgment and a `"judged"` CV
+  contribution is appended per
+  [CLOC03 §"Stage 3 — Typechecker"](../../../specs/CLOC03-correlation-vector-plumbing.md).
+- `CheckResult { judgments: HashMap<CvId, Type>, diagnostics: Vec<Diagnostic> }`
+  with `has_judgment()`/`judgment()` accessors.
+- `Diagnostic { cv, severity, group, message }`, `Severity::Error / Warning / Note`,
+  `DiagnosticGroup(String)` — the surface CLOC08's CLI will render.
+
+## What's deferred
+
+- **Real inference.** v1 is passthrough — once `javascript-ast` grows
+  `Statement` / `Expression` variants (deferred from CLOC02 Phase 1),
+  the inference engine slots in here.
+- **Diagnostic emission.** v1 emits no diagnostics; the type surface
+  is pinned so passes and the CLI can be written against it now.
+
+## Dependency whitelist
+
+- `coding-adventures-javascript-ast` — Program input.
+- `coding-adventures-type-sidecar` — Sidecar/Type/Record input.
+- `coding_adventures_correlation_vector` — for `CVLog` + `Contribution`
+  plumbing.
+- `serde_json` — for `Contribution.meta` JSON values.
+
+No `closure-pass-*` deps — passes depend on *this* crate, not the
+other way. No `javascript-parser`/`-lexer` — the typechecker operates
+on the AST + sidecar, not on tokens.

--- a/code/packages/rust/closure-typechecker/required_capabilities.json
+++ b/code/packages/rust/closure-typechecker/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closure-typechecker",
+  "capabilities": [],
+  "justification": "Pure data transformation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/closure-typechecker/src/lib.rs
+++ b/code/packages/rust/closure-typechecker/src/lib.rs
@@ -1,0 +1,338 @@
+//! JavaScript type checker (Closure-style).
+//!
+//! Consumes a [`Program`] from `javascript-ast` and a [`Sidecar`] from
+//! `type-sidecar` and produces typed judgments per
+//! [CLOC06](../../../specs/CLOC06-pass-interface-contract.md). Diagnostic
+//! reporting follows
+//! [CLOC08](../../../specs/CLOC08-closurec-cli-surface.md)'s severity
+//! model (`Error` / `Warning` / `Note` + `DiagnosticGroup`).
+//!
+//! # Scope (v1)
+//!
+//! v1 is **passthrough**: each AST node that carries a CV ID and has a
+//! matching sidecar [`Record`] gets that record's `ty` copied into the
+//! returned [`CheckResult::judgments`] map. No actual inference yet —
+//! the API surface is what's being established. Once `javascript-ast`
+//! grows `Statement` / `Expression` variants (deferred from CLOC02
+//! Phase 1), the inference engine slots in here.
+//!
+//! Even without inference, this scaffolding does real work:
+//!
+//! 1. Establishes the [`check`] API the future
+//!    `closurec` CLI will call.
+//! 2. Plumbs CV [`Contribution`]s per CLOC03 §"Stage 3 — Typechecker"
+//!    so every judged node carries a `"judged"` tag in the log.
+//! 3. Pins the [`Diagnostic`] / [`Severity`] / [`DiagnosticGroup`]
+//!    types so passes and the CLI can be written against them now.
+
+use std::collections::HashMap;
+
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::Program;
+use coding_adventures_type_sidecar::{Sidecar, Type};
+
+/// Result of a [`check`] call.
+#[derive(Debug, Clone, Default)]
+pub struct CheckResult {
+    /// One entry per AST node we have a type for, keyed by the node's
+    /// correlation-vector ID. v1 fills this with `ty` values copied
+    /// from the input [`Sidecar`].
+    pub judgments: HashMap<String, Type>,
+
+    /// Diagnostics surfaced during checking. v1 emits nothing here —
+    /// the inference engine is deferred — but the type is pinned so
+    /// downstream consumers (the CLI per CLOC08) can be written
+    /// against it.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl CheckResult {
+    /// Construct an empty result.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Is `cv` known to the checker?
+    pub fn has_judgment(&self, cv: &str) -> bool {
+        self.judgments.contains_key(cv)
+    }
+
+    /// The resolved type for `cv`, if any.
+    pub fn judgment(&self, cv: &str) -> Option<&Type> {
+        self.judgments.get(cv)
+    }
+}
+
+/// One diagnostic emitted by the checker. Shape matches CLOC08's
+/// severity model; the future `closurec` CLI will render these into
+/// the standard rustc-style output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    /// Correlation-vector ID of the AST node the diagnostic is about.
+    pub cv: String,
+    /// How serious it is.
+    pub severity: Severity,
+    /// Which diagnostic group it belongs to (used by
+    /// `--strict-group` / `--allow-group` / `--quiet-group` per
+    /// CLOC08).
+    pub group: DiagnosticGroup,
+    /// Human-readable one-line message.
+    pub message: String,
+}
+
+/// Diagnostic severity per CLOC08.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Compile-stopping.
+    Error,
+    /// Surfaced but doesn't fail the compile.
+    Warning,
+    /// Informational — attached to other diagnostics for context.
+    Note,
+}
+
+/// Diagnostic group name. Free-form for now (free strings let the
+/// inference engine introduce groups without coordinating). Once the
+/// set stabilises we can switch to an enum.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DiagnosticGroup(pub String);
+
+impl DiagnosticGroup {
+    /// Construct from a static or owned string.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+/// Check `program` against `sidecar`, appending CV contributions to
+/// `cv`. Returns a [`CheckResult`] containing the judgments and any
+/// diagnostics.
+///
+/// v1 is passthrough:
+///
+/// - The `Program`'s root CV is looked up in the sidecar.
+/// - If a record exists and has a concrete `ty`, it lands in
+///   [`CheckResult::judgments`] and a `"judged"` `Contribution` is
+///   appended to the CV log per CLOC03 §"Stage 3 — Typechecker".
+/// - Records with `ty = None` are not copied (no judgment).
+///
+/// Once `javascript-ast` grows `Statement` / `Expression` variants,
+/// this routine extends to walk every node, doing real inference
+/// against the sidecar.
+pub fn check(program: &Program, sidecar: &Sidecar, cv: &mut CVLog) -> CheckResult {
+    let mut result = CheckResult::new();
+    judge_node(&program.cv, sidecar, &mut result, cv);
+    result
+}
+
+/// Look up `node_cv` in the sidecar and, if it carries a typed record,
+/// add the judgment to `result` and append a CV contribution.
+fn judge_node(node_cv: &str, sidecar: &Sidecar, result: &mut CheckResult, cv: &mut CVLog) {
+    let Some(record) = sidecar.get(&node_cv.to_string()) else {
+        return;
+    };
+    let Some(ty) = record.ty.clone() else {
+        // Producer explicitly has no opinion. Nothing to judge.
+        return;
+    };
+
+    // Record the judgment for downstream consumers.
+    result.judgments.insert(node_cv.to_string(), ty.clone());
+
+    // Per CLOC03 §"Stage 3 — Typechecker", append a tagged
+    // contribution. We use `tag = "judged"` and stash the resolved
+    // type name in meta for debuggability.
+    let mut meta = std::collections::HashMap::new();
+    meta.insert(
+        "type".to_string(),
+        serde_json::Value::String(type_label(&ty)),
+    );
+    // The error path (Err) only fires when the entity is deleted; we
+    // just created the typechecker judgment so this can't happen here.
+    let _ = cv.contribute(node_cv, "typechecker", "judged", meta);
+}
+
+/// Human-readable label for a [`Type`] used in `Contribution.meta`.
+fn type_label(ty: &Type) -> String {
+    match ty {
+        Type::Never => "Never".into(),
+        Type::Unknown => "Unknown".into(),
+        Type::Any => "Any".into(),
+        Type::Undefined => "Undefined".into(),
+        Type::Null => "Null".into(),
+        Type::Boolean => "Boolean".into(),
+        Type::Number => "Number".into(),
+        Type::BigInt => "BigInt".into(),
+        Type::String => "String".into(),
+        Type::Symbol => "Symbol".into(),
+        Type::Opaque { raw } => format!("Opaque({raw})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_javascript_ast::SourceType;
+    use coding_adventures_javascript_tokens::EsVersion;
+    use coding_adventures_type_sidecar::{Attributes, EvidenceStep, ProducerId, Provenance, Record};
+
+    fn program_with_cv(cv: &str) -> Program {
+        Program::new(cv.to_string(), EsVersion::Es2025, SourceType::Module)
+    }
+
+    fn record(cv: &str, ty: Option<Type>) -> Record {
+        Record {
+            cv: cv.to_string(),
+            ty,
+            attributes: Attributes::default(),
+            provenance: Provenance {
+                producer: ProducerId::new("test"),
+                producer_version: "0.0.0".into(),
+                source_file: None,
+                source_location: None,
+                generated_at: None,
+                evidence: vec![EvidenceStep {
+                    stage: "test".into(),
+                    note: "test fixture".into(),
+                    at: None,
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn empty_sidecar_yields_no_judgments() {
+        let program = program_with_cv("program.1");
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        let result = check(&program, &sidecar, &mut cv);
+        assert!(result.judgments.is_empty());
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn record_with_ty_produces_judgment() {
+        let program = program_with_cv("program.1");
+        let mut sidecar = Sidecar::new();
+        sidecar.insert(record("program.1", Some(Type::Number)));
+        let mut cv = CVLog::new(true);
+
+        let result = check(&program, &sidecar, &mut cv);
+
+        assert!(result.has_judgment("program.1"));
+        assert_eq!(result.judgment("program.1"), Some(&Type::Number));
+    }
+
+    #[test]
+    fn record_with_no_ty_produces_no_judgment() {
+        let program = program_with_cv("program.1");
+        let mut sidecar = Sidecar::new();
+        sidecar.insert(record("program.1", None));
+        let mut cv = CVLog::new(true);
+
+        let result = check(&program, &sidecar, &mut cv);
+
+        assert!(!result.has_judgment("program.1"));
+    }
+
+    #[test]
+    fn judged_node_gets_cv_contribution() {
+        // CLOC03 §Stage 3 contract: every judged node must get a
+        // "judged" Contribution in the CV log so downstream
+        // source-map and debug tooling can explain the type.
+        //
+        // The CV crate generates IDs from origins; we can't pin
+        // `program.1` directly. Instead: mint a real ID with
+        // `cv.create()`, use that ID for both the Program and the
+        // sidecar Record, then assert the contribution lands on it.
+        let mut cv = CVLog::new(true);
+        let prog_cv = cv.create(None);
+
+        let program = program_with_cv(&prog_cv);
+        let mut sidecar = Sidecar::new();
+        sidecar.insert(record(&prog_cv, Some(Type::String)));
+
+        let _result = check(&program, &sidecar, &mut cv);
+
+        let history = cv.history(&prog_cv);
+        assert!(
+            history
+                .iter()
+                .any(|c| c.source == "typechecker" && c.tag == "judged"),
+            "expected a typechecker/judged contribution; got {history:?}"
+        );
+        // And the meta payload should carry the resolved type name.
+        let judged = history
+            .iter()
+            .find(|c| c.source == "typechecker" && c.tag == "judged")
+            .unwrap();
+        assert_eq!(judged.meta.get("type").and_then(|v| v.as_str()), Some("String"));
+    }
+
+    #[test]
+    fn no_judgment_when_sidecar_missing_cv() {
+        let program = program_with_cv("program.1");
+        let mut sidecar = Sidecar::new();
+        sidecar.insert(record("other.1", Some(Type::Number)));
+        let mut cv = CVLog::new(true);
+
+        let result = check(&program, &sidecar, &mut cv);
+        assert!(result.judgments.is_empty());
+    }
+
+    #[test]
+    fn check_result_accessors_work() {
+        let mut r = CheckResult::new();
+        assert!(!r.has_judgment("x"));
+        assert!(r.judgment("x").is_none());
+
+        r.judgments.insert("x".into(), Type::Boolean);
+        assert!(r.has_judgment("x"));
+        assert_eq!(r.judgment("x"), Some(&Type::Boolean));
+    }
+
+    #[test]
+    fn diagnostic_types_are_buildable() {
+        // Pin the Diagnostic API surface so downstream consumers can
+        // be written against it before inference fills it in.
+        let d = Diagnostic {
+            cv: "x.1".into(),
+            severity: Severity::Warning,
+            group: DiagnosticGroup::new("missing-types"),
+            message: "implicit any in parameter `id`".into(),
+        };
+        assert_eq!(d.severity, Severity::Warning);
+        assert_eq!(d.group, DiagnosticGroup::new("missing-types"));
+        assert!(d.message.contains("any"));
+    }
+
+    #[test]
+    fn type_label_renders_primitives() {
+        assert_eq!(type_label(&Type::Number), "Number");
+        assert_eq!(type_label(&Type::String), "String");
+        assert_eq!(type_label(&Type::Undefined), "Undefined");
+    }
+
+    #[test]
+    fn type_label_renders_opaque_with_raw() {
+        assert_eq!(
+            type_label(&Type::Opaque {
+                raw: "Foo<Bar>".into()
+            }),
+            "Opaque(Foo<Bar>)"
+        );
+    }
+
+    #[test]
+    fn check_with_disabled_cv_log_still_works() {
+        // CLOC03 production fast path: log disabled, but checker
+        // shouldn't panic and should still produce judgments.
+        let program = program_with_cv("p.1");
+        let mut sidecar = Sidecar::new();
+        sidecar.insert(record("p.1", Some(Type::Boolean)));
+        let mut cv = CVLog::new(false);
+
+        let result = check(&program, &sidecar, &mut cv);
+        assert_eq!(result.judgment("p.1"), Some(&Type::Boolean));
+    }
+}


### PR DESCRIPTION
## Summary

**Stage 3 begins.** First crate in the typechecker + optimization-pass
pipeline per [CLOC06](../../code/specs/CLOC06-pass-interface-contract.md).
Consumes `(Program, Sidecar)` and produces typed judgments +
diagnostics; v1 is passthrough so the API surface is established for
the `closure-pass-*` family and the future `closurec` CLI to be
written against.

### What's here (v1)

- **`check(program, sidecar, cv) -> CheckResult`** — looks up the
  Program-root CvId in the sidecar; if a record carries a concrete
  `ty`, lands a judgment in `CheckResult.judgments` and appends a
  `"judged"` Contribution to the CV log per
  [CLOC03 §"Stage 3 — Typechecker"](../../code/specs/CLOC03-correlation-vector-plumbing.md).
  Contribution meta carries the resolved type name.
- **`CheckResult { judgments, diagnostics }`** with
  `has_judgment(cv)` / `judgment(cv)` accessors.
- **`Diagnostic { cv, severity, group, message }`** pinning CLOC08's
  CLI surface so passes and the CLI can be written against it now.
- **`Severity` / `DiagnosticGroup`** types.

### What v1 doesn't do

- **Real inference.** Once `javascript-ast` grows `Statement` /
  `Expression` variants, the inference engine slots in here. Until
  then, the checker has nothing to walk past `Program` — that's fine
  for the scaffolding.
- **Diagnostics.** Emits zero — pinning the surface is enough.

### Dependency whitelist (CLOC06)

- `coding-adventures-javascript-ast` — Program input.
- `coding-adventures-type-sidecar` — Sidecar/Type input.
- `coding_adventures_correlation_vector` — CVLog + Contribution.
- `serde_json` — Contribution meta values.
- `coding-adventures-javascript-tokens` (dev-dependency for EsVersion
  in tests; `javascript-ast` doesn't re-export it).
- **No** `closure-pass-*` (those depend on this crate); **no**
  `javascript-parser` / `-lexer` (the typechecker operates on AST +
  sidecar, not tokens).

## Test plan

- [x] `cargo test -p coding-adventures-closure-typechecker` —
      **10/10 pass**
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      error unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

Public-API coverage:
- empty sidecar / record with `ty` / record with `ty = None` / no
  sidecar entry
- `"judged"` CV contribution appended with `meta["type"]` correct
- `CheckResult` accessor methods
- `Diagnostic` buildability with `Severity` + `DiagnosticGroup`
- `type_label` for primitives + `Opaque`
- disabled CV log still produces judgments (CLOC03 fast path)

## Stage progress

- ✅ Stage 1 (JS frontend) — complete (PRs landed earlier this loop)
- ✅ Stage 2 (sidecar + JSDoc pipeline) — complete (6 crates)
- 🟡 Stage 3 (typechecker + passes) — this PR starts it

## What's next

The `closure-pass-*` family per CLOC06. Start with
`closure-pass-constant-fold` (smallest, no inter-pass dependencies),
then DCE, rename, inline, treeshake, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)