### PR TITLE
feat(closure-pass-constant-fold): scaffold pass (CLOC06 Phase 1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -480,6 +480,7 @@ members = [
     "irc-server",
     "irc-net-stdlib",
     "url-parser",
+    "closure-pass-constant-fold",
     "closure-pass-pipeline",
     "closure-typechecker",
     "compiler-ir",

--- a/code/packages/rust/closure-pass-constant-fold/BUILD
+++ b/code/packages/rust/closure-pass-constant-fold/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-constant-fold -- --nocapture

--- a/code/packages/rust/closure-pass-constant-fold/BUILD_windows
+++ b/code/packages/rust/closure-pass-constant-fold/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-constant-fold -- --nocapture

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-23
+
+### Added
+- New crate per CLOC06 — first concrete optimization pass plugged into the `closure-pass-pipeline` harness.
+- `ConstantFoldPass` zero-sized type implementing `Pass`:
+  - `name = "constant-fold"`
+  - `iteration_policy = IterationPolicy::FixedPoint` (folds expose further folds; full multi-iteration loop arrives when the pipeline grows past v0.1.0)
+  - `cost = 2` pass-units (tree walk + small constant work per visit)
+  - `depends_on()` / `invalidates()` empty in v1
+- `ConstantFoldPass::new()` zero-arg constructor for ergonomic `PassPipeline::add(Box::new(ConstantFoldPass::new()))` registration.
+- `Pass::run` is **identity** in v1: `javascript-ast` ships only `Program` / `SourceType` today (CLOC02 Phase 1), so there's nothing to fold. The pass clones the input `Program` unchanged, returns `changed = false`, `nodes_touched = 1`, no contributions (per CLOC03 §"When a pass keeps a node unchanged").
+- 8 tests covering: `name()` value, `iteration_policy` is FixedPoint, `cost` is 2, `depends_on`/`invalidates` empty, run on empty Program is identity (program unchanged, no contributions, stats correct), full `PassPipeline` integration as solo pass (verifies FixedPoint note diagnostic flows through), pipeline integration alongside an unrelated upstream pass (registration order preserved), pass is `Default` + `Clone`.
+
+### Notes
+- Dependencies: `coding-adventures-closure-pass-pipeline` (Pass trait + types), `coding-adventures-javascript-ast` (Program), `coding-adventures-type-sidecar` (future type-aware fold safety), `coding_adventures_correlation_vector` (Contribution plumbing), `serde_json` (meta JSON values). Dev-dep: `coding-adventures-javascript-tokens` for `EsVersion` in tests.
+- v1 is scaffolding. Real folding (number/string/boolean/typeof/negation/comparison/conditional) lands once `javascript-ast` grows `Statement` / `Expression` variants — at that point this file becomes a real pass without any API churn upstream.

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "coding-adventures-closure-pass-constant-fold"
+version = "0.1.0"
+edition = "2021"
+description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
+
+[dependencies]
+coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-javascript-ast = { path = "../javascript-ast" }
+coding-adventures-type-sidecar = { path = "../type-sidecar" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
+
+[dev-dependencies]
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }

--- a/code/packages/rust/closure-pass-constant-fold/README.md
+++ b/code/packages/rust/closure-pass-constant-fold/README.md
@@ -1,0 +1,57 @@
+# coding-adventures-closure-pass-constant-fold
+
+The **first concrete optimization pass** for the Closure Compiler
+clone. Folds compile-time-evaluable expressions per
+[CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s canonical
+pass set.
+
+## What's here (v1)
+
+- `ConstantFoldPass` implementing the `Pass` trait from
+  [`coding-adventures-closure-pass-pipeline`](../closure-pass-pipeline).
+- Metadata pinned:
+  - `name = "constant-fold"`
+  - `iteration_policy = FixedPoint` (folds expose further folds —
+    `2 + 3 + 4` becomes `5 + 4` becomes `9` over two iterations)
+  - `cost = 2` pass-units (tree walk + small constant work per visit)
+  - no `depends_on` or `invalidates` in v1
+- `Pass::run` is **identity** in v1: `javascript-ast` ships only
+  `Program` / `SourceType` today (per CLOC02 Phase 1), so there's
+  nothing to fold. The pass clones the input `Program` unchanged,
+  reports `changed = false` and `nodes_touched = 1`, and emits no
+  contributions per CLOC03 §"When a pass keeps a node unchanged."
+
+## Why this PR matters even though it's identity
+
+1. Establishes the crate layout future `closure-pass-*` crates mirror.
+2. Pins the pass metadata the scheduler reads (name, iteration
+   policy, cost).
+3. Wires up the CLOC03 contribution-emission path so once the AST
+   grows foldable nodes, the integration is in place.
+
+## What's coming
+
+Once `javascript-ast` grows `Statement` / `Expression` variants:
+
+- Number folding: `2 + 3 → 5`, `10 * 4 → 40`, `7 - 9 → -2`.
+- String concatenation: `"foo" + "bar" → "foobar"`.
+- Boolean short-circuit: `true && x → x`, `false || y → y`.
+- `typeof` of literals: `typeof "s" → "string"`, `typeof 0 → "number"`.
+- Negation folding: `!true → false`.
+- Comparison: `1 < 2 → true`.
+- Conditional folding when condition is constant: `true ? a : b → a`.
+
+Type-aware folding (via the sidecar) lets us avoid folding NaN-vs-NaN
+comparisons or anything where the typechecker is uncertain.
+
+## Dependency whitelist
+
+- `coding-adventures-closure-pass-pipeline` — the `Pass` trait + types.
+- `coding-adventures-javascript-ast` — `Program` input/output.
+- `coding-adventures-type-sidecar` — type-aware fold safety.
+- `coding_adventures_correlation_vector` — `Contribution` plumbing
+  per CLOC03.
+- `serde_json` — `Contribution.meta` JSON values.
+
+Plus `coding-adventures-javascript-tokens` as a dev-dependency for
+`EsVersion` in tests.

--- a/code/packages/rust/closure-pass-constant-fold/required_capabilities.json
+++ b/code/packages/rust/closure-pass-constant-fold/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closure-pass-constant-fold",
+  "capabilities": [],
+  "justification": "Pure data transformation over an AST. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1,0 +1,228 @@
+//! Constant-folding pass for the Closure Compiler clone.
+//!
+//! First concrete optimization pass plugged into the
+//! [`coding_adventures_closure_pass_pipeline::Pass`] trait per
+//! [CLOC06's canonical pass set](../../../specs/CLOC06-pass-interface-contract.md).
+//!
+//! # Scope (v1)
+//!
+//! Once we have an expression AST, this pass folds compile-time-
+//! evaluable expressions: `2 + 3 → 5`, `"foo" + "bar" → "foobar"`,
+//! `true && x → x`, `typeof "s" → "string"`. It's `IterationPolicy::FixedPoint`
+//! so it runs until no further folds are possible (the v1 pipeline
+//! caps the iteration count at 1 with a diagnostic — see
+//! `closure-pass-pipeline` v0.1.0).
+//!
+//! **v1 is identity.** `javascript-ast` ships only `Program` /
+//! `SourceType` today (per CLOC02 Phase 1); there are no expressions
+//! to fold, so [`ConstantFoldPass::run`] clones the input `Program`
+//! unchanged and returns `changed = false`. Per CLOC03 §"When a pass
+//! keeps a node unchanged," no [`Contribution`]s get appended — the
+//! pass is silent until it actually changes something.
+//!
+//! Even so, this PR does real work:
+//!
+//! 1. Establishes the crate layout for future `closure-pass-*` crates
+//!    to mirror (deps, BUILD layout, README/CHANGELOG shape).
+//! 2. Pins the pass metadata — name, iteration policy, cost — that the
+//!    scheduler reads.
+//! 3. Wires up CLOC03 plumbing so once the pass actually folds, the
+//!    contribution-emission path is already in place.
+//!
+//! [`Contribution`]: coding_adventures_correlation_vector::Contribution
+
+use coding_adventures_closure_pass_pipeline::{
+    IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
+};
+
+/// Constant-folding pass. v1 is identity — see crate-level docs.
+///
+/// Zero-sized type: no per-instance state. Pass-internal state
+/// (reaching-defs, escape analysis, etc.) lives in pass-local maps
+/// constructed inside [`Pass::run`] per CLOC06 §"Pass-internal state."
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ConstantFoldPass;
+
+impl ConstantFoldPass {
+    /// Convenient zero-arg constructor — matches the
+    /// `PassPipeline::add(Box::new(ConstantFoldPass::new()))`
+    /// registration idiom.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Pass for ConstantFoldPass {
+    fn name(&self) -> &'static str {
+        "constant-fold"
+    }
+
+    fn iteration_policy(&self) -> IterationPolicy {
+        // Folds expose further folds — `2 + 3 + 4` becomes `5 + 4`
+        // becomes `9` over two iterations. FixedPoint signals that
+        // intent; v1 still only runs once because the AST has no
+        // foldable nodes yet.
+        IterationPolicy::FixedPoint
+    }
+
+    fn cost(&self) -> u32 {
+        // Tree walk + small constant work per visit. ~2 pass-units.
+        2
+    }
+
+    fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        // v1 has nothing to fold. Real folding lands once
+        // javascript-ast grows `Statement` / `Expression` variants.
+        Ok(PassOutput {
+            program: ctx.program.clone(),
+            contributions: Vec::new(),
+            changed: false,
+            diagnostics: Vec::new(),
+            stats: PassStats {
+                // We "touched" the program root in the sense that we
+                // visited it — nothing else exists yet.
+                nodes_touched: 1,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};
+    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_javascript_ast::{Program, SourceType};
+    use coding_adventures_javascript_tokens::EsVersion;
+    use coding_adventures_type_sidecar::Sidecar;
+
+    fn program() -> Program {
+        Program::new(
+            "prog.1".to_string(),
+            EsVersion::Es2025,
+            SourceType::Module,
+        )
+    }
+
+    #[test]
+    fn name_is_constant_fold() {
+        assert_eq!(ConstantFoldPass::new().name(), "constant-fold");
+    }
+
+    #[test]
+    fn iteration_policy_is_fixed_point() {
+        assert_eq!(
+            ConstantFoldPass::new().iteration_policy(),
+            IterationPolicy::FixedPoint
+        );
+    }
+
+    #[test]
+    fn cost_is_two_pass_units() {
+        assert_eq!(ConstantFoldPass::new().cost(), 2);
+    }
+
+    #[test]
+    fn no_depends_on_or_invalidates_in_v1() {
+        let p = ConstantFoldPass::new();
+        assert!(p.depends_on().is_empty());
+        assert!(p.invalidates().is_empty());
+    }
+
+    #[test]
+    fn run_on_empty_program_returns_unchanged_identity() {
+        let pass = ConstantFoldPass::new();
+        let prog = program();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+
+        let ctx = PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        };
+        let out = pass.run(ctx).expect("pass should succeed");
+
+        assert_eq!(out.program.cv, prog.cv);
+        assert_eq!(out.program.version, prog.version);
+        assert_eq!(out.program.source_type, prog.source_type);
+        assert!(!out.changed);
+        assert!(
+            out.contributions.is_empty(),
+            "v1 emits no contributions per CLOC03 §\"unchanged nodes\""
+        );
+        assert!(out.diagnostics.is_empty());
+        assert_eq!(out.stats.nodes_touched, 1);
+    }
+
+    #[test]
+    fn integrates_with_pass_pipeline_as_solo_pass() {
+        // Smoke-test the full PassPipeline registration path: build a
+        // pipeline, add the pass, run end-to-end.
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(ConstantFoldPass::new()));
+
+        let mut cv = CVLog::new(true);
+        let out: PipelineOutput = pipeline
+            .run(program(), &Sidecar::new(), &mut cv)
+            .expect("pipeline should run cleanly");
+
+        assert_eq!(out.execution_order, vec!["constant-fold".to_string()]);
+        assert!(out.stats.contains_key("constant-fold"));
+        assert_eq!(out.stats["constant-fold"].nodes_touched, 1);
+
+        // v1 FixedPoint policy => pipeline emits the
+        // "not yet iterated" note diagnostic.
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|d| d.group.0 == "pipeline.fixed-point-not-yet-iterated"),
+            "expected the pipeline's FixedPoint note diagnostic; got {:?}",
+            out.diagnostics
+        );
+    }
+
+    #[test]
+    fn integrates_with_pass_pipeline_alongside_other_passes() {
+        // ConstantFoldPass should play nicely with a tagging upstream
+        // pass that has no depends_on relation — they should run in
+        // registration order.
+        struct UpstreamTag;
+        impl Pass for UpstreamTag {
+            fn name(&self) -> &'static str {
+                "upstream-tag"
+            }
+            fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+                Ok(PassOutput {
+                    program: ctx.program.clone(),
+                    contributions: Vec::new(),
+                    changed: false,
+                    diagnostics: Vec::new(),
+                    stats: PassStats { nodes_touched: 0 },
+                })
+            }
+        }
+
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(UpstreamTag));
+        pipeline.add(Box::new(ConstantFoldPass::new()));
+
+        let mut cv = CVLog::new(true);
+        let out = pipeline.run(program(), &Sidecar::new(), &mut cv).unwrap();
+
+        assert_eq!(
+            out.execution_order,
+            vec!["upstream-tag".to_string(), "constant-fold".to_string()]
+        );
+    }
+
+    #[test]
+    fn pass_is_default_and_clone() {
+        // Bookkeeping: the zero-sized type derives Default + Clone so
+        // callers can construct it in ergonomic ways.
+        let _a: ConstantFoldPass = Default::default();
+        let _b: ConstantFoldPass = ConstantFoldPass::new();
+        let _c = _b;
+        let _d = _c.clone();
+    }
+}


### PR DESCRIPTION
## Summary

Third Stage-3 crate; **first concrete optimization pass** plugged into
the `closure-pass-pipeline` harness. Folds compile-time-evaluable
expressions per [CLOC06](../../code/specs/CLOC06-pass-interface-contract.md)'s
canonical pass set.

### What's here (v1)

- `ConstantFoldPass` zero-sized type implementing `Pass`:
  - `name = "constant-fold"`
  - `iteration_policy = FixedPoint` (folds expose further folds —
    `2 + 3 + 4 → 5 + 4 → 9` over two iterations; the loop arrives
    when `closure-pass-pipeline` grows past v0.1.0)
  - `cost = 2`
  - no `depends_on` / `invalidates`
- `Pass::run` is **identity** in v1 since `javascript-ast` ships only
  `Program` / `SourceType` today. Clones input unchanged, reports
  `changed = false`, `nodes_touched = 1`, no contributions emitted
  (per CLOC03 §"When a pass keeps a node unchanged").

### Why ship now if it's identity

1. Establishes the crate layout the rest of the `closure-pass-*`
   family mirrors.
2. Pins the pass metadata the scheduler reads.
3. Wires the CLOC03 contribution-emission path so once the AST grows
   foldable nodes, integration is in place with **no API churn
   upstream**.

### What's coming

Once `javascript-ast` grows `Expression` variants: number folding,
string concat, boolean short-circuit, `typeof` on literals, negation,
comparison, conditional. Sidecar-aware safety so we don't fold NaN
or type-uncertain cases.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-constant-fold` —
      **8/8 pass on first try**
- [x] `cargo build --workspace` clean (pre-existing `uefi panic_impl`
      unrelated)
- [ ] CI matrix (Linux/macOS/Windows)

Public-API coverage:
- `name()` value
- `iteration_policy` is FixedPoint
- `cost` is 2
- `depends_on` / `invalidates` empty
- run on empty Program is identity (unchanged + no contributions +
  correct stats)
- full `PassPipeline` integration as solo pass (FixedPoint note
  diagnostic flows through)
- pipeline integration alongside unrelated upstream pass
  (registration order preserved)
- `Default` + `Clone` impls

## Stage 3 progress

- ✅ `closure-typechecker` (#3983)
- ✅ `closure-pass-pipeline` (#3989)
- 🟡 `closure-pass-constant-fold` (this PR — first concrete pass)
- ⏭ More passes — DCE, rename, inline, treeshake, … each in its own
  crate following this scaffold pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)