### PR TITLE
feat(ml-framework-core): MX10 Phase 2b — Rust fast path for PowFunction scalar exponent (forward + backward)

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+### Added — MX10 Phase 2b: optional Rust fast path for `PowFunction` scalar-exponent (forward + backward)
+
+Closes the only remaining forward op in the MX10 dispatch table.
+Phase 2 had deferred `PowFunction` because matrix-cpu's `Pow` op
+is binary (`output[i] = lhs[i] ^ rhs[i]`, no scalar broadcast) and
+`PowFunction`'s public API takes a `float` exponent.
+
+This PR ships the **broadcast-the-scalar workaround**: materialise
+the scalar exponent as a full-shape constant tensor in Python before
+the FFI call, then route through matrix-cpu's binary `Pow`.  Costs
+`numel * 4` bytes per call to ship the broadcast scalar, dwarfed by
+the `numel` f32 exponentiations the Rust op then runs.
+
+Backward uses the **power rule** `grad_in = n * x^(n-1) * grad`
+composed as a 3-op graph (`Pow(x, c_(n-1)) → Mul(by c_n) →
+Mul(by grad)`) with two scalar constants broadcast to full shape.
+
+#### Behaviour matrix
+
+| Situation | Path taken |
+|-----------|-----------|
+| Extension installed, `numel ≥ 100_000` | **Rust** (single binary `Pow` for forward; 3-op composed for backward) |
+| Extension installed, `numel < 100_000` | Pure-Python `x**n` loop |
+| Extension NOT installed | Pure-Python `x**n` loop |
+
+#### Tests (92 total MX10 tests, was 88)
+
+- **`PowParityTests`** (2 cases, skip if extension missing):
+  forward and backward parity for `a ** 2.5` (non-integer exponent
+  exercises the actual `Pow` op, not just trivial squaring) on a
+  `(500, 200)` tensor of positive values, with `rtol=1e-3,
+  atol=1e-4` tolerance.
+- **`PowFallbackTests`** (4 cases, always run): defence-in-depth
+  `RuntimeError` for both helpers, plus hand-computed forward
+  correctness (`[1,2,3].pow(2) == [1,4,9]`) and backward
+  correctness (`d(x²)/dx = 2x` on `[1,2,3]` → `[2,4,6]`).
+
+All passing locally on darwin-arm64 py 3.10.6.  Full suite:
+**381 passed + 37 skipped + the pre-existing test_device.py failure
+on main**.
+
 ### Added — MX10 acceptance gate: end-to-end MLP training integration test
 
 Adds `tests/test_end_to_end_training.py` — **the broadest correctness

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/_rust_backend.py
@@ -2038,3 +2038,172 @@ def relu_backward_via_rust(
         )
     out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
     return _Tensor(out_floats, target_shape, device=device)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Pow scalar-exponent dispatch (MX10 Phase 2b)
+#
+# matrix-cpu's ``Pow`` is binary: ``output[i] = lhs[i] ^ rhs[i]``
+# with both operands the same shape, no broadcasting.  PowFunction
+# takes a *scalar* exponent at the Python API level, so we have to
+# materialise that scalar as a full-shape constant tensor before
+# dispatching.  Costs ``numel * 4`` bytes per call to ship the
+# constant, but the binary Pow op then does ``numel`` exponentiations
+# in optimised Rust which dominates for any non-trivial tensor.
+#
+# Backward uses the power rule ``grad_in = n * x^(n-1) * grad`` and
+# composes as a 3-op graph: Pow(x, c_(n-1)) → Mul(by c_n) → Mul(by
+# grad).  Two constants (``n`` and ``n-1``) materialised at full
+# shape.
+#
+# Same elementwise threshold as Phase 2 — Pow has lower per-cell
+# cost than matmul but comparable to other elementwise ops.
+# ──────────────────────────────────────────────────────────────────
+
+
+def pow_via_rust(a: Tensor, exponent: float) -> Tensor:
+    """``a ** exponent`` (elementwise scalar Pow) via matrix-cpu's
+    binary ``Pow`` op.
+
+    The scalar ``exponent`` is broadcast to a full-shape constant
+    tensor in Python before the FFI call (matrix-cpu's Pow doesn't
+    broadcast scalars).  Single-op graph: ``Pow(a, c_exp)`` where
+    ``c_exp`` is the broadcast scalar.
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "pow_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_elementwise() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(a.data)
+    shape_list = list(a.shape)
+
+    a_bytes = struct.pack(f"<{numel}f", *a.data)
+    # Broadcast scalar exponent to full-shape constant tensor.
+    exp_hex = struct.pack(f"<{numel}f", *([float(exponent)] * numel)).hex()
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    {"id": 0, "dtype": "f32", "shape": shape_list},  # a
+                    {"id": 1, "dtype": "f32", "shape": shape_list},  # c_exp
+                    {"id": 2, "dtype": "f32", "shape": shape_list},  # a ^ exp
+                ],
+                "inputs": [0],
+                "outputs": [2],
+                "ops": [
+                    {"kind": "Pow", "lhs": 0, "rhs": 1, "output": 2},
+                ],
+                "constants": [
+                    {
+                        "tensor_id": 1,
+                        "dtype": "f32",
+                        "shape": shape_list,
+                        "bytes_hex": exp_hex,
+                    }
+                ],
+            },
+            "inputs": [a_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_bytes = bytes.fromhex(result["outputs"][0])
+
+    expected_bytes = numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"pow_via_rust: expected {expected_bytes} output bytes "
+            f"({numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
+    return _Tensor(out_floats, a.shape, device=a.device)
+
+
+def pow_backward_via_rust(
+    grad_data: list[float],
+    input_data: list[float],
+    exponent: float,
+    target_shape: tuple[int, ...],
+    *,
+    device: str | None = None,
+) -> Tensor:
+    """``n * x^(n-1) * grad`` as a 3-op composed graph.
+
+    Topology::
+
+        x(0) ──Pow(x, c_(n-1)(1))──> x^(n-1)(2)
+        Mul(x^(n-1)(2), c_n(3)) ──> n * x^(n-1)(4)
+        Mul(n * x^(n-1)(4), g(5)) ──> output(6)
+
+    3 ops, 7 tensors, 2 constants (full-shape ``c_(n-1)`` and
+    ``c_n`` broadcast scalars).
+    """
+    if not _RUST_AVAILABLE or _mxr is None:
+        raise RuntimeError(
+            "pow_backward_via_rust called but Rust backend is not available; "
+            "callers must check should_use_rust_for_elementwise() first"
+        )
+
+    from .tensor import Tensor as _Tensor
+
+    numel = len(grad_data)
+    if len(input_data) != numel:
+        raise RuntimeError(
+            f"pow_backward_via_rust: grad has {numel} cells but input "
+            f"has {len(input_data)} cells — must match"
+        )
+
+    target_shape_list = list(target_shape)
+    grad_bytes = struct.pack(f"<{numel}f", *grad_data)
+    x_bytes = struct.pack(f"<{numel}f", *input_data)
+    n_minus_1_hex = struct.pack(f"<{numel}f", *([float(exponent) - 1.0] * numel)).hex()
+    n_hex = struct.pack(f"<{numel}f", *([float(exponent)] * numel)).hex()
+
+    envelope = json.dumps(
+        {
+            "graph": {
+                "matrix_ir_version": 1,
+                "tensors": [
+                    {"id": 0, "dtype": "f32", "shape": target_shape_list},  # x
+                    {"id": 1, "dtype": "f32", "shape": target_shape_list},  # c_(n-1)
+                    {"id": 2, "dtype": "f32", "shape": target_shape_list},  # x^(n-1)
+                    {"id": 3, "dtype": "f32", "shape": target_shape_list},  # c_n
+                    {"id": 4, "dtype": "f32", "shape": target_shape_list},  # n * x^(n-1)
+                    {"id": 5, "dtype": "f32", "shape": target_shape_list},  # g
+                    {"id": 6, "dtype": "f32", "shape": target_shape_list},  # output
+                ],
+                "inputs": [0, 5],
+                "outputs": [6],
+                "ops": [
+                    {"kind": "Pow", "lhs": 0, "rhs": 1, "output": 2},
+                    {"kind": "Mul", "lhs": 2, "rhs": 3, "output": 4},
+                    {"kind": "Mul", "lhs": 4, "rhs": 5, "output": 6},
+                ],
+                "constants": [
+                    {"tensor_id": 1, "dtype": "f32", "shape": target_shape_list, "bytes_hex": n_minus_1_hex},
+                    {"tensor_id": 3, "dtype": "f32", "shape": target_shape_list, "bytes_hex": n_hex},
+                ],
+            },
+            "inputs": [x_bytes.hex(), grad_bytes.hex()],
+        }
+    )
+
+    out_envelope = _mxr.run_graph_on_cpu(envelope)
+    result = json.loads(out_envelope)
+    out_bytes = bytes.fromhex(result["outputs"][0])
+
+    expected_bytes = numel * 4
+    if len(out_bytes) != expected_bytes:
+        raise RuntimeError(
+            f"pow_backward_via_rust: expected {expected_bytes} output "
+            f"bytes ({numel} f32), got {len(out_bytes)}"
+        )
+    out_floats = list(struct.unpack(f"<{numel}f", out_bytes))
+    return _Tensor(out_floats, target_shape, device=device)

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/functions.py
@@ -56,6 +56,8 @@ from ._rust_backend import (
     mean_via_rust,
     mul_via_rust,
     neg_via_rust,
+    pow_backward_via_rust,
+    pow_via_rust,
     relu_backward_via_rust,
     relu_via_rust,
     should_use_rust_for_activation,
@@ -243,12 +245,26 @@ class PowFunction(Function):
     def forward(self, a: Tensor, exponent: float) -> Tensor:
         self.save_for_backward(a)
         self.saved_metadata["exponent"] = exponent
+        # MX10 Phase 2b — optional Rust fast path.  Broadcasts the
+        # scalar exponent to a full-shape constant tensor in Python
+        # then routes through matrix-cpu's binary Pow op.
+        if should_use_rust_for_elementwise(len(a.data)):
+            return pow_via_rust(a, exponent)
         data = [x**exponent for x in a.data]
         return Tensor(data, a.shape, device=a.device)
 
     def backward(self, grad_output: Tensor) -> tuple[Tensor | None, ...]:
         (a,) = self.saved_tensors
         n = self.saved_metadata["exponent"]
+        # MX10 Phase 2b — optional Rust fast path.  Power-rule
+        # backward composed as Pow → Mul → Mul with two scalar
+        # constants broadcast to full shape (n-1 and n).
+        if should_use_rust_for_elementwise(len(a.data)):
+            return (
+                pow_backward_via_rust(
+                    grad_output.data, a.data, n, a.shape, device=a.device
+                ),
+            )
         pairs = zip(a.data, grad_output.data, strict=False)
         grad_a = Tensor(
             [n * (x ** (n - 1)) * g for x, g in pairs],

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_fallback.py
@@ -259,6 +259,52 @@ class ElementwiseFallbackTests(unittest.TestCase):
 
 
 # ──────────────────────────────────────────────────────────────────
+# MX10 Phase 2b — Pow (scalar exponent) fallback tests
+# ──────────────────────────────────────────────────────────────────
+
+
+class PowFallbackTests(unittest.TestCase):
+    """Confirm PowFunction still works when the Rust path is disabled."""
+
+    def setUp(self) -> None:
+        self._saved_available = _rust_backend._RUST_AVAILABLE
+        _rust_backend._RUST_AVAILABLE = False
+
+    def tearDown(self) -> None:
+        _rust_backend._RUST_AVAILABLE = self._saved_available
+
+    def test_pow_via_rust_raises_when_unavailable(self) -> None:
+        a = Tensor([1.0, 2.0, 3.0], (3,))
+        with self.assertRaises(RuntimeError) as ctx:
+            _rust_backend.pow_via_rust(a, 2.0)
+        self.assertIn("Rust backend is not available", str(ctx.exception))
+
+    def test_pow_backward_via_rust_raises_when_unavailable(self) -> None:
+        with self.assertRaises(RuntimeError):
+            _rust_backend.pow_backward_via_rust(
+                [1.0, 1.0, 1.0], [1.0, 2.0, 3.0], 2.0, (3,)
+            )
+
+    def test_pow_correct_via_fallback(self) -> None:
+        """``[1, 2, 3].pow(2) == [1, 4, 9]`` (no f32 ops, exact equality)."""
+        from ml_framework_core import PowFunction
+        a = Tensor([1.0, 2.0, 3.0], (3,))
+        result = PowFunction.apply(a, 2.0)
+        self.assertEqual(result.shape, (3,))
+        self.assertEqual(result.data, [1.0, 4.0, 9.0])
+
+    def test_pow_backward_correct_via_fallback(self) -> None:
+        """Power rule: ``d(x²)/dx = 2x``.  For ``a = [1, 2, 3]``,
+        ``grad = [1, 1, 1]``, backward gives ``[2, 4, 6]``."""
+        from ml_framework_core import PowFunction
+        a = Tensor([1.0, 2.0, 3.0], (3,), requires_grad=True)
+        y = PowFunction.apply(a, 2.0)
+        y.backward(Tensor([1.0, 1.0, 1.0], (3,)))
+        self.assertIsNotNone(a.grad)
+        self.assertEqual(a.grad.data, [2.0, 4.0, 6.0])
+
+
+# ──────────────────────────────────────────────────────────────────
 # MX10 Phase 3 — reduction fallback tests
 #
 # Same pattern as elementwise: monkey-patch ``_RUST_AVAILABLE = False``

--- a/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
+++ b/code/packages/python/ml-framework-core/tests/test_rust_backend_parity.py
@@ -389,6 +389,89 @@ class ElementwiseParityTests(unittest.TestCase):
     EXTENSION_AVAILABLE,
     "matrix_rust_python C extension not installed; see parity-tests skip-reason.",
 )
+class PowParityTests(unittest.TestCase):
+    """Compare PowFunction Rust and pure-Python kernels.
+
+    Phase 2b — Pow is the first op with a scalar parameter (the
+    exponent) that's broadcast to a full-shape constant before
+    dispatch.  The graph is a single binary ``Pow`` op for forward,
+    3-op composed (Pow + Mul + Mul) for backward.
+    """
+
+    SHAPE = (500, 200)  # 100_000 cells
+
+    def _make_tensor(self, seed: int):
+        import random
+
+        from ml_framework_core import Tensor
+
+        rng = random.Random(seed)
+        # Use positive values so non-integer exponents are well-defined.
+        data = [rng.uniform(0.1, 2.0) for _ in range(500 * 200)]
+        return Tensor(data, self.SHAPE)
+
+    def _assert_close(
+        self,
+        actual: list[float],
+        expected: list[float],
+        rtol: float = 1e-3,
+        atol: float = 1e-4,
+    ) -> None:
+        self.assertEqual(len(actual), len(expected))
+        for i, (a, e) in enumerate(zip(actual, expected, strict=False)):
+            denom = max(abs(a), abs(e), atol)
+            err = abs(a - e) / denom
+            self.assertLess(
+                err,
+                rtol,
+                f"index {i}: rust={a!r}, python={e!r}, relative error {err:.2e}",
+            )
+
+    def test_pow_forward_parity(self) -> None:
+        """``a ** 2.5`` Rust matches pure-Python (non-integer exponent
+        exercises the f32 Pow path, not just trivial squaring)."""
+        from ml_framework_core import PowFunction, _rust_backend
+
+        a = self._make_tensor(seed=11)
+        rust_result = PowFunction.apply(a, 2.5)
+        self.assertEqual(rust_result.shape, self.SHAPE)
+
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            python_result = PowFunction.apply(a, 2.5)
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_result.data, python_result.data)
+
+    def test_pow_backward_parity(self) -> None:
+        """``a ** 2.5 .backward(grad)`` Rust matches pure-Python."""
+        from ml_framework_core import PowFunction, Tensor, _rust_backend
+
+        a = self._make_tensor(seed=22)
+        a.requires_grad = True
+        y = PowFunction.apply(a, 2.5)
+        grad_data = [1.0] * (500 * 200)
+        y.backward(Tensor(list(grad_data), self.SHAPE))
+        rust_grad = a.grad
+
+        a2 = Tensor(list(a.data), self.SHAPE, requires_grad=True)
+        saved = _rust_backend._RUST_AVAILABLE
+        try:
+            _rust_backend._RUST_AVAILABLE = False
+            y2 = PowFunction.apply(a2, 2.5)
+            y2.backward(Tensor(list(grad_data), self.SHAPE))
+        finally:
+            _rust_backend._RUST_AVAILABLE = saved
+
+        self._assert_close(rust_grad.data, a2.grad.data)
+
+
+@unittest.skipUnless(
+    EXTENSION_AVAILABLE,
+    "matrix_rust_python C extension not installed; see parity-tests skip-reason.",
+)
 class ReductionParityTests(unittest.TestCase):
     """Compare each reduce-all op's Rust and pure-Python kernels."""
 


### PR DESCRIPTION
## Summary

**Closes the only remaining forward op in the MX10 dispatch table.** Phase 2 had deferred PowFunction because matrix-cpu's Pow is binary (no scalar broadcast) and the public API takes a `float` exponent.

This PR ships the **broadcast-the-scalar workaround**: materialise the scalar exponent as a full-shape constant tensor in Python, then route through matrix-cpu's binary Pow.

- Forward: single binary `Pow(a, c_exp)`
- Backward: 3-op composed graph `Pow(x, c_(n-1)) → Mul(by c_n) → Mul(by grad)` (power rule)

Costs `numel * 4` bytes per call to ship the broadcast scalar — dwarfed by the `numel` f32 exponentiations the Rust op runs.

- +6 tests (2 parity, 4 fallback). Full suite: **381 passed + 37 skipped + 1 pre-existing unrelated failure**.
- Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes
- [x] New `PowParityTests` (2 cases) skip without C extension
- [x] New `PowFallbackTests` (4 cases) always run; hand-computed `[1,2,3].pow(2) == [1,4,9]` and power-rule backward verified
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)