### PR TITLE
spice: add JFET DC and AC stamps

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **JFET DC/AC analysis foothold** — `JFET` now participates in nonlinear DC
+  operating-point solves and AC small-signal analysis using the DC bias point.
+
 - **JFET element foothold** — `JFET` now exposes the public three-terminal
   device shape needed by SPICE `J` cards; nonlinear analysis stamping follows
   in a later compatibility slice.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -1190,6 +1190,8 @@ def _stamp_dc(
         _stamp_bsource(G, b, x, node_to_idx, branch_srcs, el)
     elif isinstance(el, Diode):
         _stamp_diode(G, b, x, node_to_idx, el)
+    elif isinstance(el, JFET):
+        _stamp_jfet(G, b, x, node_to_idx, el)
     elif isinstance(el, Mosfet):
         _stamp_mosfet(G, b, x, node_to_idx, el)
     elif isinstance(el, BJT):
@@ -1619,6 +1621,74 @@ def _stamp_mosfet(
             G[s][node_to_idx[el.source]] += gm
     # Companion current source for Id at this operating point
     Ieq = Id - gm * V_GS - gds * V_DS
+    if not _is_ground(el.drain):
+        b[node_to_idx[el.drain]] -= Ieq
+    if not _is_ground(el.source):
+        b[node_to_idx[el.source]] += Ieq
+
+
+def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
+    if not math.isfinite(el.beta) or el.beta <= 0.0:
+        raise ValueError(f"JFET '{el.name}' beta must be finite and positive")
+    if not math.isfinite(el.vto):
+        raise ValueError(f"JFET '{el.name}' VTO must be finite")
+    if not math.isfinite(el.lambda_):
+        raise ValueError(f"JFET '{el.name}' LAMBDA must be finite")
+    if el.polarity == "PJF":
+        ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
+        return -ids, gm, gds
+    if el.polarity != "NJF":
+        raise ValueError(f"JFET '{el.name}' polarity must be 'NJF' or 'PJF'")
+    return _eval_njf(vgs, vds, el.vto, el.beta, el.lambda_)
+
+
+def _eval_njf(
+    vgs: float, vds: float, vto: float, beta: float, lambda_: float
+) -> tuple[float, float, float]:
+    overdrive = vgs - vto
+    if overdrive <= 0.0 or vds < 0.0:
+        return (0.0, 0.0, 0.0)
+    if vds < overdrive:
+        channel = 2.0 * overdrive * vds - vds * vds
+        modulation = 1.0 + lambda_ * vds
+        ids = beta * channel * modulation
+        gm = 2.0 * beta * vds * modulation
+        gds = beta * (2.0 * overdrive - 2.0 * vds) * modulation + beta * channel * lambda_
+        return (ids, gm, gds)
+    ids = beta * overdrive * overdrive * (1.0 + lambda_ * vds)
+    gm = 2.0 * beta * overdrive * (1.0 + lambda_ * vds)
+    gds = beta * overdrive * overdrive * lambda_
+    return (ids, gm, gds)
+
+
+def _stamp_jfet(
+    G: list[list[float]],
+    b: list[float],
+    x: list[float],
+    node_to_idx: dict[str, int],
+    el: JFET,
+) -> None:
+    Vd = 0.0 if _is_ground(el.drain) else x[node_to_idx[el.drain]]
+    Vg = 0.0 if _is_ground(el.gate) else x[node_to_idx[el.gate]]
+    Vs = 0.0 if _is_ground(el.source) else x[node_to_idx[el.source]]
+    vgs = Vg - Vs
+    vds = Vd - Vs
+    ids, gm, gds = _eval_jfet(el, vgs, vds)
+
+    _stamp_g(G, node_to_idx, el.drain, el.source, gds)
+    if not _is_ground(el.drain):
+        d = node_to_idx[el.drain]
+        if not _is_ground(el.gate):
+            G[d][node_to_idx[el.gate]] += gm
+        if not _is_ground(el.source):
+            G[d][node_to_idx[el.source]] -= gm
+    if not _is_ground(el.source):
+        s = node_to_idx[el.source]
+        if not _is_ground(el.gate):
+            G[s][node_to_idx[el.gate]] -= gm
+        if not _is_ground(el.source):
+            G[s][node_to_idx[el.source]] += gm
+    Ieq = ids - gm * vgs - gds * vds
     if not _is_ground(el.drain):
         b[node_to_idx[el.drain]] -= Ieq
     if not _is_ground(el.source):
@@ -3185,6 +3255,25 @@ def _stamp_ac(
         gd = (el.Is / el.Vt) * math.exp(Vd / el.Vt)
         _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 0j)
 
+    elif isinstance(el, JFET):
+        Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+        Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
+        Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+        _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
+        _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_j + 0j)
+        if not _is_ground(el.drain):
+            d = node_to_idx[el.drain]
+            if not _is_ground(el.gate):
+                G[d][node_to_idx[el.gate]] += gm_j + 0j
+            if not _is_ground(el.source):
+                G[d][node_to_idx[el.source]] -= gm_j + 0j
+        if not _is_ground(el.source):
+            s = node_to_idx[el.source]
+            if not _is_ground(el.gate):
+                G[s][node_to_idx[el.gate]] -= gm_j + 0j
+            if not _is_ground(el.source):
+                G[s][node_to_idx[el.source]] += gm_j + 0j
+
     elif isinstance(el, Mosfet):
         # Small-signal model: gds (output conductance) + gm (transconductance).
         # The gm VCCS is stamped as off-diagonal conductance entries.
@@ -3725,6 +3814,25 @@ def _build_ss_matrix(
             Vd = min(Va - Vk, 0.7)
             gd = (el.Is / el.Vt) * math.exp(Vd / el.Vt)
             _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
+
+        elif isinstance(el, JFET):
+            Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+            Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
+            Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+            _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
+            _stamp_g(G, node_to_idx, el.drain, el.source, gds_j)
+            if not _is_ground(el.drain):
+                d = node_to_idx[el.drain]
+                if not _is_ground(el.gate):
+                    G[d][node_to_idx[el.gate]] += gm_j
+                if not _is_ground(el.source):
+                    G[d][node_to_idx[el.source]] -= gm_j
+            if not _is_ground(el.source):
+                s = node_to_idx[el.source]
+                if not _is_ground(el.gate):
+                    G[s][node_to_idx[el.gate]] -= gm_j
+                if not _is_ground(el.source):
+                    G[s][node_to_idx[el.source]] += gm_j
 
         elif isinstance(el, Mosfet):
             # Small-signal model: gds (drain–source) + gm VCCS (gate–source

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -101,6 +101,7 @@ from spice_engine import (
     Diode,
     ExpWaveform,
     Inductor,
+    JFET,
     McPoint,
     McResult,
     NoiseEntry,
@@ -1085,6 +1086,35 @@ def test_bjt_pnp_dataclass():
     """PNP BJT stores polarity correctly."""
     q = BJT("Q2", collector="c", base="b", emitter="vcc", polarity="PNP")
     assert q.polarity == "PNP"
+
+
+def test_jfet_n_channel_source_resistor_bias_dc() -> None:
+    c = Circuit()
+    c.add(VoltageSource("Vdd", "vdd", "0", voltage=10.0))
+    c.add(VoltageSource("Vg", "gate", "0", voltage=0.0))
+    c.add(Resistor("Rd", "vdd", "drain", 2_000.0))
+    c.add(Resistor("Rs", "source", "0", 1_000.0))
+    c.add(JFET("J1", "drain", "gate", "source", beta=1.0e-3, vto=-2.0))
+
+    result = dc_op(c)
+
+    assert result.converged
+    assert result.node_voltages["source"] == pytest.approx(1.0, abs=0.05)
+    assert result.node_voltages["drain"] == pytest.approx(8.0, abs=0.1)
+
+
+def test_jfet_common_source_ac_gain_from_bias_point() -> None:
+    c = Circuit()
+    c.add(VoltageSource("Vdd", "vdd", "0", voltage=10.0))
+    c.add(VoltageSource("Vin", "gate", "0", voltage=0.0, ac=AcSource(1.0)))
+    c.add(Resistor("Rd", "vdd", "drain", 1_000.0))
+    c.add(JFET("J1", "drain", "gate", "0", beta=1.0e-3, vto=-2.0))
+
+    result = ac_sweep(c, f_start=1_000.0, f_stop=1_000.0, n_points=1)
+
+    out = result.points[0].node_voltages["drain"]
+    assert out.real == pytest.approx(-4.0, abs=1.0e-6)
+    assert out.imag == pytest.approx(0.0, abs=1.0e-12)
 
 
 def test_bjt_npn_off():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add JFET nonlinear DC operating-point stamping and AC small-signal analysis
+  from the solved DC bias point.
 - Add a public `Jfet` element and `JfetPolarity` as the parser-facing
   three-terminal SPICE `J` card foothold; nonlinear analysis stamping follows
   in a later compatibility slice.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3750,7 +3750,11 @@ fn solve_linear_circuit_with_options(
     let has_nonlinear = circuit.elements().iter().any(|element| {
         matches!(
             element,
-            Element::Diode(_) | Element::Bjt(_) | Element::Mosfet(_) | Element::BSource(_)
+            Element::Diode(_)
+                | Element::Jfet(_)
+                | Element::Bjt(_)
+                | Element::Mosfet(_)
+                | Element::BSource(_)
         )
     });
     let return_singular_as_unconverged = options.return_singular_as_unconverged && has_nonlinear;
@@ -3920,10 +3924,7 @@ fn solve_linear_circuit_at_operating_point(
                 stamp_diode(diode, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
             Element::Jfet(jfet) => {
-                return Err(SpiceError::InvalidElement {
-                    name: jfet.name.clone(),
-                    reason: "JFET analysis is not implemented yet".to_string(),
-                });
+                stamp_jfet(jfet, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
             Element::Bjt(bjt) => {
                 stamp_bjt(bjt, node_indices, &mut matrix, &mut rhs, operating_point)?
@@ -4132,10 +4133,7 @@ fn build_ac_matrix(
                 );
             }
             Element::Jfet(jfet) => {
-                return Err(SpiceError::InvalidElement {
-                    name: jfet.name.clone(),
-                    reason: "JFET analysis is not implemented yet".to_string(),
-                });
+                stamp_ac_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point)?
             }
             Element::Bjt(bjt) => {
                 stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point)?
@@ -4234,10 +4232,7 @@ fn build_small_signal_matrix(
                 );
             }
             Element::Jfet(jfet) => {
-                return Err(SpiceError::InvalidElement {
-                    name: jfet.name.clone(),
-                    reason: "JFET analysis is not implemented yet".to_string(),
-                });
+                stamp_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point)?
             }
             Element::Bjt(bjt) => {
                 stamp_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point)?
@@ -4891,6 +4886,95 @@ struct MosfetDcResult {
     gmb: f64,
 }
 
+struct JfetDcResult {
+    drain_current: f64,
+    gm: f64,
+    gds: f64,
+}
+
+fn stamp_jfet(
+    jfet: &Jfet,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_jfet(jfet)?;
+    let drain = node_index(node_indices, &jfet.drain);
+    let gate = node_index(node_indices, &jfet.gate);
+    let source = node_index(node_indices, &jfet.source);
+    let drain_voltage = vector_voltage(operating_point, drain);
+    let gate_voltage = vector_voltage(operating_point, gate);
+    let source_voltage = vector_voltage(operating_point, source);
+    let vgs = gate_voltage - source_voltage;
+    let vds = drain_voltage - source_voltage;
+    let result = evaluate_jfet(jfet, vgs, vds);
+    let equivalent_current = result.drain_current - result.gm * vgs - result.gds * vds;
+
+    stamp_conductance(matrix, drain, source, result.gds);
+    stamp_transconductance(matrix, drain, source, gate, source, result.gm);
+    stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
+    Ok(())
+}
+
+fn evaluate_jfet(jfet: &Jfet, vgs: f64, vds: f64) -> JfetDcResult {
+    match jfet.polarity {
+        JfetPolarity::Pjf => {
+            let result = evaluate_njf(
+                -vgs,
+                -vds,
+                -jfet.threshold_voltage,
+                jfet.beta,
+                jfet.channel_length_modulation,
+            );
+            JfetDcResult {
+                drain_current: -result.drain_current,
+                gm: result.gm,
+                gds: result.gds,
+            }
+        }
+        JfetPolarity::Njf => evaluate_njf(
+            vgs,
+            vds,
+            jfet.threshold_voltage,
+            jfet.beta,
+            jfet.channel_length_modulation,
+        ),
+    }
+}
+
+fn evaluate_njf(
+    vgs: f64,
+    vds: f64,
+    threshold_voltage: f64,
+    beta: f64,
+    channel_length_modulation: f64,
+) -> JfetDcResult {
+    let overdrive = vgs - threshold_voltage;
+    if overdrive <= 0.0 || vds < 0.0 {
+        return JfetDcResult {
+            drain_current: 0.0,
+            gm: 0.0,
+            gds: 0.0,
+        };
+    }
+    if vds < overdrive {
+        let channel = 2.0 * overdrive * vds - vds * vds;
+        let modulation = 1.0 + channel_length_modulation * vds;
+        return JfetDcResult {
+            drain_current: beta * channel * modulation,
+            gm: 2.0 * beta * vds * modulation,
+            gds: beta * (2.0 * overdrive - 2.0 * vds) * modulation
+                + beta * channel * channel_length_modulation,
+        };
+    }
+    JfetDcResult {
+        drain_current: beta * overdrive * overdrive * (1.0 + channel_length_modulation * vds),
+        gm: 2.0 * beta * overdrive * (1.0 + channel_length_modulation * vds),
+        gds: beta * overdrive * overdrive * channel_length_modulation,
+    }
+}
+
 fn stamp_mosfet(
     mosfet: &Mosfet,
     node_indices: &HashMap<String, usize>,
@@ -5014,6 +5098,29 @@ fn stamp_mosfet_small_signal(
     Ok(())
 }
 
+fn stamp_jfet_small_signal(
+    jfet: &Jfet,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_jfet(jfet)?;
+    let drain = node_index(node_indices, &jfet.drain);
+    let gate = node_index(node_indices, &jfet.gate);
+    let source = node_index(node_indices, &jfet.source);
+    let drain_voltage = vector_voltage(operating_point, drain);
+    let gate_voltage = vector_voltage(operating_point, gate);
+    let source_voltage = vector_voltage(operating_point, source);
+    let result = evaluate_jfet(
+        jfet,
+        gate_voltage - source_voltage,
+        drain_voltage - source_voltage,
+    );
+    stamp_conductance(matrix, drain, source, result.gds);
+    stamp_transconductance(matrix, drain, source, gate, source, result.gm);
+    Ok(())
+}
+
 fn stamp_ac_mosfet_small_signal(
     mosfet: &Mosfet,
     node_indices: &HashMap<String, usize>,
@@ -5049,6 +5156,36 @@ fn stamp_ac_mosfet_small_signal(
         body,
         source,
         Complex::new(result.gmb, 0.0),
+    );
+    Ok(())
+}
+
+fn stamp_ac_jfet_small_signal(
+    jfet: &Jfet,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+    operating_point: &[f64],
+) -> Result<(), SpiceError> {
+    validate_jfet(jfet)?;
+    let drain = node_index(node_indices, &jfet.drain);
+    let gate = node_index(node_indices, &jfet.gate);
+    let source = node_index(node_indices, &jfet.source);
+    let drain_voltage = vector_voltage(operating_point, drain);
+    let gate_voltage = vector_voltage(operating_point, gate);
+    let source_voltage = vector_voltage(operating_point, source);
+    let result = evaluate_jfet(
+        jfet,
+        gate_voltage - source_voltage,
+        drain_voltage - source_voltage,
+    );
+    stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
+    stamp_complex_transconductance(
+        matrix,
+        drain,
+        source,
+        gate,
+        source,
+        Complex::new(result.gm, 0.0),
     );
     Ok(())
 }
@@ -5097,6 +5234,28 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "thermal voltage must be finite and positive".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
+    if !jfet.beta.is_finite() || jfet.beta <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "beta must be finite and positive".to_string(),
+        });
+    }
+    if !jfet.threshold_voltage.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "threshold voltage must be finite".to_string(),
+        });
+    }
+    if !jfet.channel_length_modulation.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "channel length modulation must be finite".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,7 +1,7 @@
 use spice_engine::{
     ac_sweep, ac_sweep_corners, s_parameters, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit,
-    CornerOverride, CornerSpec, CurrentSource, Element, Inductor, Mosfet, MosfetLevel1Params,
-    MosfetType, Resistor, SpiceError, Vcvs, VoltageSource,
+    CornerOverride, CornerSpec, CurrentSource, Element, Inductor, Jfet, JfetPolarity, Mosfet,
+    MosfetLevel1Params, MosfetType, Resistor, SpiceError, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -271,6 +271,38 @@ fn ac_mosfet_common_source_suppresses_dc_supplies_without_ac_spec() {
     assert_eq!(points.len(), 1);
     let out = points[0].voltage("out").unwrap();
     assert_close(out.real, -1.0);
+    assert_close(out.imag, 0.0);
+    assert_close(points[0].voltage("vdd").unwrap().abs(), 0.0);
+}
+
+#[test]
+fn ac_jfet_common_source_uses_dc_bias_for_small_signal_gain() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 10.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+        "Vin", "gate", "0", 0.0, 1.0, 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rd", "vdd", "drain", 1_000.0,
+    )));
+    circuit.add(Element::Jfet(Jfet::with_model(
+        "J1",
+        "drain",
+        "gate",
+        "0",
+        JfetPolarity::Njf,
+        1.0e-3,
+        -2.0,
+        0.0,
+    )));
+
+    let points = ac_sweep(&circuit, 1_000.0, 1_000.0, 10).unwrap();
+
+    assert_eq!(points.len(), 1);
+    let out = points[0].voltage("drain").unwrap();
+    assert_close(out.real, -4.0);
     assert_close(out.imag, 0.0);
     assert_close(points[0].voltage("vdd").unwrap().abs(), 0.0);
 }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,8 +1,9 @@
 use spice_engine::{
     dc_corners, dc_op, dc_op_with_options, dc_sweep, dc_sweep_corners, BSource, Bjt, BjtPolarity,
     Cccs, Ccvs, Circuit, CornerOverride, CornerSpec, CurrentSource, DcOpOptions, Diode, Element,
-    Inductor, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform, SpiceError,
-    SubcircuitDefinition, SubcircuitElement, Vccs, Vcvs, VoltageSource, Waveform, XInstance,
+    Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform,
+    SpiceError, SubcircuitDefinition, SubcircuitElement, Vccs, Vcvs, VoltageSource, Waveform,
+    XInstance,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -369,6 +370,39 @@ fn dc_mosfet_solves_nmos_source_follower_operating_point() {
     assert!(out < 2.5, "expected source below gate bias, got {out}");
     assert!(result.converged);
     assert!(result.iterations > 0);
+}
+
+#[test]
+fn dc_jfet_solves_n_channel_source_resistor_bias() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 10.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vg", "gate", "0", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rd", "vdd", "drain", 2_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rs", "source", "0", 1_000.0,
+    )));
+    circuit.add(Element::Jfet(Jfet::with_model(
+        "J1",
+        "drain",
+        "gate",
+        "source",
+        JfetPolarity::Njf,
+        1.0e-3,
+        -2.0,
+        0.0,
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+
+    assert!(result.converged);
+    assert!((result.voltage("source").unwrap() - 1.0).abs() < 0.05);
+    assert!((result.voltage("drain").unwrap() - 8.0).abs() < 0.1);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add JFET nonlinear DC operating-point stamping and AC small-signal analysis
+  from the solved DC bias point.
 - Add a public `Jfet` element and `jfet` factory as the parser-facing
   three-terminal SPICE `J` card foothold; nonlinear analysis stamping follows
   in a later compatibility slice.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1446,7 +1446,17 @@ export function tf(
   const input = findInputSource(circuit, inputSource);
   const voltageSources = collectAcVoltageSources(circuit);
   const nodeCount = nodeIndices.size;
-  const matrix = buildSmallSignalMatrix(circuit, nodeIndices, voltageSources);
+  const operatingPoint = solveDcOperatingPointForSmallSignal(
+    circuit,
+    nodeIndices,
+    voltageSources,
+  );
+  const matrix = buildSmallSignalMatrix(
+    circuit,
+    nodeIndices,
+    voltageSources,
+    operatingPoint,
+  );
   const size = matrix.length;
   const outputIndex = nodeIndex(nodeIndices, outputNode);
 
@@ -1687,6 +1697,11 @@ export function noiseAc(
     nodeIndices,
     temperatureKelvin,
   );
+  const operatingPoint = solveDcOperatingPointForSmallSignal(
+    circuit,
+    nodeIndices,
+    voltageSources,
+  );
 
   const points = frequenciesHz.map((frequencyHz) => {
     if (outputIndex === undefined || matrixSize === 0) {
@@ -1698,6 +1713,7 @@ export function noiseAc(
       TWO_PI * frequencyHz,
       nodeIndices,
       voltageSources,
+      operatingPoint,
     );
     const rhs = Array.from({ length: matrixSize }, () => complex(0.0, 0.0));
     rhs[outputIndex] = complex(1.0, 0.0);
@@ -2351,6 +2367,12 @@ function elementParameter(element: Element): ElementParameter | undefined {
         parameter: "saturationCurrent",
         nominalValue: element.saturationCurrent,
       };
+    case "jfet":
+      return {
+        elementName: element.name,
+        parameter: "beta",
+        nominalValue: element.beta,
+      };
     case "bjt":
       return {
         elementName: element.name,
@@ -2427,6 +2449,9 @@ function circuitWithPerturbedElement(
           ...element,
           saturationCurrent: element.saturationCurrent + delta,
         });
+        break;
+      case "jfet":
+        perturbed.add({ ...element, beta: element.beta + delta });
         break;
       case "bjt":
         perturbed.add({
@@ -2718,6 +2743,38 @@ function solveDcNewton(
   );
 }
 
+function solveDcOperatingPointForSmallSignal(
+  circuit: Circuit,
+  nodeIndices: ReadonlyMap<string, number>,
+  voltageSources: ReadonlyMap<string, number>,
+): readonly number[] {
+  const matrixSize = nodeIndices.size + voltageSources.size;
+  if (matrixSize === 0 || !circuit.elements().some(isNonlinearElement)) {
+    return Array.from({ length: matrixSize }, () => 0.0);
+  }
+
+  const options = validatedDcOpOptions({});
+  const solution = solveDcNewton(circuit, options);
+  if (solution.converged || !options.convergenceAids) {
+    return solution.vector;
+  }
+
+  const aided =
+    solveDcWithGminStepping(circuit, options, solution.vector) ??
+    solveDcWithSourceStepping(circuit, options);
+  return (aided ?? solution).vector;
+}
+
+function isNonlinearElement(element: Element): boolean {
+  return (
+    element.kind === "diode" ||
+    element.kind === "jfet" ||
+    element.kind === "bjt" ||
+    element.kind === "mosfet" ||
+    element.kind === "b-source"
+  );
+}
+
 function solveLinearCircuitWithOptions(
   circuit: Circuit,
   capacitorStates: readonly CapacitorState[],
@@ -2741,15 +2798,7 @@ function solveLinearCircuitWithOptions(
     };
   }
 
-  const hasNonlinearElement = circuit
-    .elements()
-    .some(
-      (element) =>
-        element.kind === "diode" ||
-        element.kind === "bjt" ||
-        element.kind === "mosfet" ||
-        element.kind === "b-source",
-    );
+  const hasNonlinearElement = circuit.elements().some(isNonlinearElement);
   const returnSingularAsUnconverged =
     (options.returnSingularAsUnconverged ?? false) && hasNonlinearElement;
   let operatingPoint =
@@ -3160,6 +3209,9 @@ function solveLinearCircuitAtOperatingPoint(
       case "diode":
         stampDiode(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
+      case "jfet":
+        stampJfet(element, nodeIndices, matrix, rhs, operatingPoint);
+        break;
       case "bjt":
         stampBjt(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
@@ -3254,6 +3306,7 @@ function buildSmallSignalMatrix(
   circuit: Circuit,
   nodeIndices: ReadonlyMap<string, number>,
   voltageSources: ReadonlyMap<string, number>,
+  operatingPoint: readonly number[],
 ): number[][] {
   const nodeCount = nodeIndices.size;
   const matrixSize = nodeCount + voltageSources.size;
@@ -3304,11 +3357,14 @@ function buildSmallSignalMatrix(
           element.saturationCurrent / element.thermalVoltage,
         );
         break;
+      case "jfet":
+        stampJfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
+        break;
       case "bjt":
         stampBjtSmallSignal(element, nodeIndices, matrix);
         break;
       case "mosfet":
-        stampMosfetSmallSignal(element, nodeIndices, matrix);
+        stampMosfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -3352,7 +3408,18 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
     return { nodeVoltages: new Map(), branchCurrents: new Map() };
   }
 
-  const matrix = buildAcMatrix(circuit, omega, nodeIndices, voltageSources);
+  const operatingPoint = solveDcOperatingPointForSmallSignal(
+    circuit,
+    nodeIndices,
+    voltageSources,
+  );
+  const matrix = buildAcMatrix(
+    circuit,
+    omega,
+    nodeIndices,
+    voltageSources,
+    operatingPoint,
+  );
   const rhs = Array.from({ length: matrixSize }, () => complex(0.0, 0.0));
 
   for (const element of circuit.elements()) {
@@ -3373,6 +3440,7 @@ function solveAcCircuit(circuit: Circuit, omega: number): AcSolution {
       case "capacitor":
       case "inductor":
       case "diode":
+      case "jfet":
       case "bjt":
       case "mosfet":
       case "vccs":
@@ -3404,6 +3472,7 @@ function buildAcMatrix(
   omega: number,
   nodeIndices: ReadonlyMap<string, number>,
   voltageSources: ReadonlyMap<string, number>,
+  operatingPoint: readonly number[],
 ): Complex[][] {
   const nodeCount = nodeIndices.size;
   const matrixSize = nodeCount + voltageSources.size;
@@ -3445,11 +3514,14 @@ function buildAcMatrix(
           complex(element.saturationCurrent / element.thermalVoltage, 0.0),
         );
         break;
+      case "jfet":
+        stampAcJfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
+        break;
       case "bjt":
         stampAcBjtSmallSignal(element, nodeIndices, matrix);
         break;
       case "mosfet":
-        stampAcMosfetSmallSignal(element, nodeIndices, matrix);
+        stampAcMosfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
         break;
       case "vccs":
         stampAcVccs(element, nodeIndices, matrix);
@@ -3768,6 +3840,7 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
         element.kind === "capacitor" ||
         element.kind === "inductor" ||
         element.kind === "diode" ||
+        element.kind === "jfet" ||
         element.kind === "bjt" ||
         element.kind === "mosfet" ||
         element.kind === "vccs" ||
@@ -4084,6 +4157,103 @@ interface MosfetDcResult {
   readonly gm: number;
   readonly gds: number;
   readonly gmb: number;
+}
+
+interface JfetDcResult {
+  readonly drainCurrent: number;
+  readonly gm: number;
+  readonly gds: number;
+}
+
+function validateJfet(element: Jfet): void {
+  if (!Number.isFinite(element.beta) || element.beta <= 0.0) {
+    throw invalidElement(element.name, "beta must be finite and positive");
+  }
+  if (!Number.isFinite(element.thresholdVoltage)) {
+    throw invalidElement(element.name, "threshold voltage must be finite");
+  }
+  if (!Number.isFinite(element.channelLengthModulation)) {
+    throw invalidElement(element.name, "channel length modulation must be finite");
+  }
+}
+
+function stampJfet(
+  element: Jfet,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+  operatingPoint: readonly number[],
+): void {
+  validateJfet(element);
+  const drain = nodeIndex(nodeIndices, element.drain);
+  const gate = nodeIndex(nodeIndices, element.gate);
+  const source = nodeIndex(nodeIndices, element.source);
+  const drainVoltage = vectorVoltage(operatingPoint, drain);
+  const gateVoltage = vectorVoltage(operatingPoint, gate);
+  const sourceVoltage = vectorVoltage(operatingPoint, source);
+  const vgs = gateVoltage - sourceVoltage;
+  const vds = drainVoltage - sourceVoltage;
+  const result = evaluateJfet(element, vgs, vds);
+  const equivalentCurrent =
+    result.drainCurrent - result.gm * vgs - result.gds * vds;
+
+  stampConductance(matrix, drain, source, result.gds);
+  stampTransconductance(matrix, drain, source, gate, source, result.gm);
+  stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
+}
+
+function evaluateJfet(element: Jfet, vgs: number, vds: number): JfetDcResult {
+  if (element.polarity === "PJF") {
+    const result = evaluateNjf(
+      -vgs,
+      -vds,
+      -element.thresholdVoltage,
+      element.beta,
+      element.channelLengthModulation,
+    );
+    return {
+      drainCurrent: -result.drainCurrent,
+      gm: result.gm,
+      gds: result.gds,
+    };
+  }
+  return evaluateNjf(
+    vgs,
+    vds,
+    element.thresholdVoltage,
+    element.beta,
+    element.channelLengthModulation,
+  );
+}
+
+function evaluateNjf(
+  vgs: number,
+  vds: number,
+  thresholdVoltage: number,
+  beta: number,
+  channelLengthModulation: number,
+): JfetDcResult {
+  const overdrive = vgs - thresholdVoltage;
+  if (overdrive <= 0.0 || vds < 0.0) {
+    return { drainCurrent: 0.0, gm: 0.0, gds: 0.0 };
+  }
+  if (vds < overdrive) {
+    const channel = 2.0 * overdrive * vds - vds * vds;
+    const modulation = 1.0 + channelLengthModulation * vds;
+    return {
+      drainCurrent: beta * channel * modulation,
+      gm: 2.0 * beta * vds * modulation,
+      gds:
+        beta * (2.0 * overdrive - 2.0 * vds) * modulation +
+        beta * channel * channelLengthModulation,
+    };
+  }
+  return {
+    drainCurrent:
+      beta * overdrive * overdrive * (1.0 + channelLengthModulation * vds),
+    gm: 2.0 * beta * overdrive * (1.0 + channelLengthModulation * vds),
+    gds: beta * overdrive * overdrive * channelLengthModulation,
+  };
 }
 
 function stampMosfet(
@@ -4953,16 +5123,48 @@ function stampMosfetSmallSignal(
   element: Mosfet,
   nodeIndices: ReadonlyMap<string, number>,
   matrix: number[][],
+  operatingPoint: readonly number[],
 ): void {
   validateMosfet(element);
   const drain = nodeIndex(nodeIndices, element.drain);
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const body = nodeIndex(nodeIndices, element.body);
-  const result = evaluateMosfetLevel1(element, 0.0, 0.0, 0.0);
+  const drainVoltage = vectorVoltage(operatingPoint, drain);
+  const gateVoltage = vectorVoltage(operatingPoint, gate);
+  const sourceVoltage = vectorVoltage(operatingPoint, source);
+  const bodyVoltage = vectorVoltage(operatingPoint, body);
+  const result = evaluateMosfetLevel1(
+    element,
+    gateVoltage - sourceVoltage,
+    drainVoltage - sourceVoltage,
+    bodyVoltage - sourceVoltage,
+  );
   stampConductance(matrix, drain, source, result.gds);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
+}
+
+function stampJfetSmallSignal(
+  element: Jfet,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  operatingPoint: readonly number[],
+): void {
+  validateJfet(element);
+  const drain = nodeIndex(nodeIndices, element.drain);
+  const gate = nodeIndex(nodeIndices, element.gate);
+  const source = nodeIndex(nodeIndices, element.source);
+  const drainVoltage = vectorVoltage(operatingPoint, drain);
+  const gateVoltage = vectorVoltage(operatingPoint, gate);
+  const sourceVoltage = vectorVoltage(operatingPoint, source);
+  const result = evaluateJfet(
+    element,
+    gateVoltage - sourceVoltage,
+    drainVoltage - sourceVoltage,
+  );
+  stampConductance(matrix, drain, source, result.gds);
+  stampTransconductance(matrix, drain, source, gate, source, result.gm);
 }
 
 function stampAcResistor(
@@ -5379,13 +5581,23 @@ function stampAcMosfetSmallSignal(
   element: Mosfet,
   nodeIndices: ReadonlyMap<string, number>,
   matrix: Complex[][],
+  operatingPoint: readonly number[],
 ): void {
   validateMosfet(element);
   const drain = nodeIndex(nodeIndices, element.drain);
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const body = nodeIndex(nodeIndices, element.body);
-  const result = evaluateMosfetLevel1(element, 0.0, 0.0, 0.0);
+  const drainVoltage = vectorVoltage(operatingPoint, drain);
+  const gateVoltage = vectorVoltage(operatingPoint, gate);
+  const sourceVoltage = vectorVoltage(operatingPoint, source);
+  const bodyVoltage = vectorVoltage(operatingPoint, body);
+  const result = evaluateMosfetLevel1(
+    element,
+    gateVoltage - sourceVoltage,
+    drainVoltage - sourceVoltage,
+    bodyVoltage - sourceVoltage,
+  );
   stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
   stampComplexTransconductance(
     matrix,
@@ -5402,6 +5614,35 @@ function stampAcMosfetSmallSignal(
     body,
     source,
     complex(result.gmb, 0.0),
+  );
+}
+
+function stampAcJfetSmallSignal(
+  element: Jfet,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+  operatingPoint: readonly number[],
+): void {
+  validateJfet(element);
+  const drain = nodeIndex(nodeIndices, element.drain);
+  const gate = nodeIndex(nodeIndices, element.gate);
+  const source = nodeIndex(nodeIndices, element.source);
+  const drainVoltage = vectorVoltage(operatingPoint, drain);
+  const gateVoltage = vectorVoltage(operatingPoint, gate);
+  const sourceVoltage = vectorVoltage(operatingPoint, source);
+  const result = evaluateJfet(
+    element,
+    gateVoltage - sourceVoltage,
+    drainVoltage - sourceVoltage,
+  );
+  stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
+  stampComplexTransconductance(
+    matrix,
+    drain,
+    source,
+    gate,
+    source,
+    complex(result.gm, 0.0),
   );
 }
 

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -12,6 +12,7 @@ import {
   currentSource,
   currentSourceWithAc,
   inductor,
+  jfet,
   resistor,
   sParameters,
   vcvs,
@@ -169,6 +170,23 @@ describe("acSweep", () => {
     expectClose(bias!.imag, 0.0);
     expectClose(out!.real, 0.0);
     expectClose(out!.imag, 0.5);
+  });
+
+  it("uses JFET common-source gain from the DC bias point", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 10.0));
+    circuit.add(voltageSourceWithAc("Vin", "gate", "0", 0.0, 1.0, 0.0));
+    circuit.add(resistor("Rd", "vdd", "drain", 1_000.0));
+    circuit.add(jfet("J1", "drain", "gate", "0", "NJF", 1.0e-3, -2.0));
+
+    const points = acSweep(circuit, 1_000.0, 1_000.0, 10);
+
+    expect(points).toHaveLength(1);
+    const out = points[0].voltage("drain");
+    expect(out).not.toBeUndefined();
+    expectClose(out!.real, -4.0);
+    expectClose(out!.imag, 0.0);
+    expectClose(complexAbs(points[0].voltage("vdd")!), 0.0);
   });
 
   it("applies VCVS gain in AC analysis", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -15,6 +15,7 @@ import {
   dcSweepCorners,
   diode,
   inductor,
+  jfet,
   mosfet,
   resistor,
   subcircuitDefinition,
@@ -260,6 +261,21 @@ describe("dcOp", () => {
     expect(result.voltage("out")).toBeLessThan(1.8);
     expect(result.converged).toBe(true);
     expect(result.iterations).toBeGreaterThan(0);
+  });
+
+  it("solves an N-channel JFET source-resistor bias point", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 10.0));
+    circuit.add(voltageSource("Vg", "gate", "0", 0.0));
+    circuit.add(resistor("Rd", "vdd", "drain", 2_000.0));
+    circuit.add(resistor("Rs", "source", "0", 1_000.0));
+    circuit.add(jfet("J1", "drain", "gate", "source", "NJF", 1.0e-3, -2.0));
+
+    const result = dcOp(circuit);
+
+    expect(result.converged).toBe(true);
+    expect(result.voltage("source")).toBeCloseTo(1.0, 1);
+    expect(result.voltage("drain")).toBeCloseTo(8.0, 0);
   });
 
   it("reports unconverged nonlinear operating points when aids are disabled", () => {


### PR DESCRIPTION
## Summary

- add Shichman-Hodges-style JFET DC Newton stamping across Python, TypeScript, and Rust
- include JFET small-signal conductance/transconductance in AC and transfer-function matrix assembly from the DC bias point
- add cross-language source-bias DC and common-source AC fixtures plus changelog entries

## Validation

- `sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This is the JFET DC/AC engine slice following the parser/data foothold in #3988.