### PR TITLE
feat(toolkit)!: v0.3 — Checkbox + Radio on UI29-2 native primitives

### DIFF
--- a/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,5 +1,96 @@
 # Changelog — mosaic-pkg-toolkit
 
+## [0.3.0] — UI29-2 — Checkbox + Radio rewritten on native primitives
+
+**Breaking change.** `Checkbox` and `Radio` previously composed from
+`HostButton` + an `If/Else` to fake checked/unchecked glyph states.
+That shape lost the platform-native a11y role, focus ring, tri-state
+visual, keyboard semantics, and (for radios) browser/platform-enforced
+group mutex. UI29-2 added `HostCheckbox` and `HostRadio` to the kernel
+as the 17th and 18th primitives; v0.3 makes both userland components
+thin wrappers around those primitives.
+
+### `Checkbox`
+
+- **Layout:** `Row[checkbox]{If/Else{HostButton},HostButton,Text[label]}`
+  collapses to a single `HostCheckbox[checkbox]` line.
+- **Interface changes:**
+  - `onChange` now carries `checked: bool` (was payloadless).
+  - New optional slot `indeterminate: bool` for tri-state. Fully
+    wired on Qt / XAML / HTML / WebComponent; React backend
+    silently ignores it pending the indeterminate follow-up PR.
+- **Parts removed:** `checkbox-box-checked`, `checkbox-box-unchecked`,
+  `checkbox-label`. The native widget renders its own glyph and the
+  label is wired internally; only the `checkbox` root part survives.
+- **.msl files trimmed** to just the root-part padding rule.
+
+### `Radio`
+
+- **Layout:** identical `Row{If/Else{HostButton},HostButton,Text}`
+  collapse to a single `HostRadio[radio]` line.
+- **Interface changes:**
+  - Slot `selected` renamed to `checked` for consistency with both
+    Checkbox and the kernel-canonical `HostRadio.checked`.
+  - `onSelect` now carries `value: text` (was payloadless).
+  - New slot `value: text` — the value this radio represents,
+    carried as the `onSelect` payload.
+  - New slot `group: text` — the radio-group name. Backends with
+    native group semantics (HTML `name=`, WinUI `GroupName=`) wire
+    this to the platform's mutex; backends without (SwiftUI / Qt v1)
+    preserve it as metadata.
+- **Parts removed:** `radio-box-selected`, `radio-box-unselected`,
+  `radio-label`. Only the `radio` root part survives.
+
+### Migration
+
+Pre-v0.3 hosts using `Checkbox`:
+
+```moslayout
+// Before (v0.2):
+Checkbox (
+  label    : "Remember me" ,
+  checked  : slot: remember ,
+  disabled : false ,
+  onChange : emit: onToggle      // host inverted slot manually
+)
+
+// After (v0.3): same usage; host receives the new value.
+Checkbox (
+  label    : "Remember me" ,
+  checked  : slot: remember ,
+  disabled : false ,
+  onChange : emit: onToggle      // payload: { checked: bool }
+)
+```
+
+Pre-v0.3 hosts using `Radio`:
+
+```moslayout
+// Before (v0.2):
+Radio (
+  label    : "Vanilla" ,
+  selected : slot: is-vanilla ,
+  disabled : false ,
+  onSelect : emit: onPick
+)
+
+// After (v0.3):
+Radio (
+  label    : "Vanilla" ,
+  checked  : slot: is-vanilla ,
+  value    : "vanilla" ,
+  group    : "flavor" ,
+  disabled : false ,
+  onSelect : emit: onPick        // payload: { value: text }
+)
+```
+
+### Tests
+
+Two existing tests (`checkbox_interface_matches_spec`,
+`radio_interface_matches_spec`) updated for the new slot rosters and
+emit payloads. Full test suite stays at 16 passing.
+
 ## [Unreleased] — v0.1 PR-5 — Field (form group)
 
 ### Added

--- a/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
@@ -7,12 +7,12 @@
 #
 # See `code/specs/mosaic-pkg-toolkit.md` for the design.
 #
-# Phase: v0.1 (PR-1) — scaffold + Button + Alert.
-# The full v0.1 catalog (13 components) lands across follow-up PRs.
+# Phase: v0.3 — Checkbox + Radio rewritten on UI29-2 HostCheckbox /
+# HostRadio kernel primitives. Breaking changes; see CHANGELOG.
 
 [package]
 name        = "mosaic-pkg-toolkit"
-version     = "0.1.0"
+version     = "0.3.0"
 description = "Bootstrap-shaped Mosaic UI component library — ready-made components composed purely from UI29 kernel primitives"
 license     = "MIT OR Apache-2.0"
 

--- a/code/packages/mosaic-pkg-toolkit/src/Checkbox.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Checkbox.dark.msl
@@ -1,30 +1,11 @@
-// Checkbox.dark.msl — dark-theme styling.
+// Checkbox.dark.msl — dark-theme styling (v0.3 trim).
+//
+// See Checkbox.light.msl header for the rewrite rationale. Only the
+// `checkbox` root part survives in v0.3; native widget renders its
+// own check glyph and exposes no inner element to style.
 
 style Checkbox {
   part checkbox {
-    padding : 4 ;
-  }
-  part checkbox-box-checked {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 3 ;
-    background    : "#3b82f6" ;
-    color         : "#0f172a" ;
-    border-width  : 1 ;
-    border-color  : "#3b82f6" ;
-    font-size     : 14 ;
-    padding       : 0 ;
-  }
-  part checkbox-box-unchecked {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 3 ;
-    background    : "#1e293b" ;
-    border-width  : 1 ;
-    border-color  : "#475569" ;
-    padding       : 0 ;
-  }
-  part checkbox-label {
     padding : 4 ;
   }
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Checkbox.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Checkbox.light.msl
@@ -1,30 +1,20 @@
-// Checkbox.light.msl — default light-theme styling.
+// Checkbox.light.msl — default light-theme styling (v0.3).
+//
+// **v0.3 trim.** The pre-v0.3 .msl carried two sibling rules for
+// the fake `checkbox-box-checked` / `checkbox-box-unchecked` parts.
+// Those parts no longer exist — the v0.3 `Checkbox.mll` is a thin
+// wrapper around the native `HostCheckbox` widget, which renders
+// its own check glyph and exposes no inner element to style. Only
+// the `checkbox` root part survives.
+//
+// Native platform checkboxes already ship with sensible default
+// padding/sizing, so this style mostly just controls outer
+// spacing. Authors who want heavy custom skinning should compose
+// their own component on top of `HostCheckbox` rather than fight
+// the native widget through `part` overrides.
 
 style Checkbox {
   part checkbox {
-    padding : 4 ;
-  }
-  part checkbox-box-checked {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 3 ;
-    background    : "#0d6efd" ;
-    color         : "#ffffff" ;
-    border-width  : 1 ;
-    border-color  : "#0d6efd" ;
-    font-size     : 14 ;
-    padding       : 0 ;
-  }
-  part checkbox-box-unchecked {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 3 ;
-    background    : "#ffffff" ;
-    border-width  : 1 ;
-    border-color  : "#ced4da" ;
-    padding       : 0 ;
-  }
-  part checkbox-label {
     padding : 4 ;
   }
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Checkbox.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Checkbox.mil
@@ -1,26 +1,59 @@
-// Checkbox.mil — interface for the toolkit's Checkbox.
+// Checkbox.mil — interface for the toolkit's Checkbox (v0.3).
 //
-// A labeled checkbox. The kernel has no `HostCheckbox` (UI29 v1
-// scope), so this composes from HostButton (the toggle) + an inline
-// If/Else to swap a checkmark glyph + a Text label.
+// **v0.3 rewrite.** Previously this composed from `HostButton` + an
+// inline `If/Else` to fake two checkmark glyph states (v0.1/v0.2).
+// That shape lost the platform-native a11y role (`role="checkbox"` /
+// `AccessibilityRole.checkBox` / `AutomationPeer.CheckBox`), the
+// platform focus ring, the tri-state visual, and the keyboard
+// semantics that a real checkbox widget ships.
 //
-// State is host-owned: the toolkit doesn't track checked-ness
-// internally. The host passes `checked: bool`, receives onChange
-// when the user clicks, and flips the slot value.
+// v0.3 makes `Checkbox` a thin wrapper around the UI29-2 kernel
+// primitive `HostCheckbox`. Every backend lowers the wrapper to its
+// platform's actual checkbox widget (DOM `<input type="checkbox">`,
+// SwiftUI `Toggle`, Qt `CheckBox`, WinUI `CheckBox`, etc.).
+//
+// **Breaking changes from v0.2.**
+//
+// 1. `onChange` now carries a `checked: bool` payload. The previous
+//    signature was payloadless ("the host already knows the current
+//    value and just inverts it"); UI29-2 §2.2 makes the new state
+//    canonical on the emit so consumers don't need to derive it.
+// 2. The internal part names `checkbox-box-checked` and
+//    `checkbox-box-unchecked` are gone — the native widget renders
+//    its own check glyph and there's no inner element to style.
+//    Only the `checkbox` root part survives.
+//
+// New optional slot:
+//
+// - `indeterminate: bool` — when truthy, the checkbox renders in
+//   "mixed" state (commonly used for a parent checkbox whose
+//   children are partially checked). Backends that fully wire
+//   indeterminate today: Qt, XAML, HTML, WebComponent. React
+//   support is deferred to a follow-up (the slot is accepted but
+//   silently ignored on React; two-state behaviour still works).
 
 component Checkbox {
-  // Display label rendered to the right of the box.
+  // Display label rendered next to the checkbox box. Backend lowering
+  // wraps the input in a `<label>` element (or platform equivalent)
+  // so clicking the label toggles the checkbox — the idiomatic form
+  // pattern.
   slot label : text ;
 
-  // Current checked state. Host owns it; toggle on each onChange.
+  // Current checked state. Host owns it; flip the slot value when
+  // `onChange` fires.
   slot checked : bool ;
 
-  // Disabled flag. When true the button stops firing onChange and
-  // paints the disabled style.
+  // Disabled flag. When true the widget rejects clicks and paints
+  // the platform's disabled style.
   slot disabled : bool ;
 
-  // Fired when the user clicks the checkbox. The toolkit does NOT
-  // include the new value in the payload — the host already knows
-  // the current value and just inverts it on receipt.
-  emit onChange ;
+  // Tri-state "mixed" indicator. When true, the platform renders
+  // the indeterminate visual (a dash on macOS/iOS/WinUI; a hatched
+  // box in some Linux themes). Has no effect on the React backend
+  // pending the indeterminate follow-up PR.
+  slot indeterminate : bool ;
+
+  // Fired when the user toggles the checkbox. Carries the new
+  // state — host updates its `checked:` slot to match.
+  emit onChange ( checked : bool ) ;
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Checkbox.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Checkbox.mll
@@ -1,44 +1,25 @@
-// Checkbox.mll — layout for the Checkbox.
+// Checkbox.mll — layout for the Checkbox (v0.3 rewrite).
 //
-//   Row [ checkbox ]
-//     If (when: slot: checked) {
-//       HostButton [ checkbox-box-checked ]  ← styled square with check
-//     } Else {
-//       HostButton [ checkbox-box-unchecked ]  ← styled empty square
-//     }
-//     Text [ checkbox-label ]
+// Pre-v0.3 the layout fanned out into a `Row` containing two
+// `HostButton`s wrapped in an `If/Else` (one with a `✓` glyph, one
+// blank) plus a sibling `Text` for the label. That fake-checkbox
+// pattern lost native a11y role, focus ring, tri-state, and
+// keyboard semantics.
 //
-// The two HostButton instances allow the .msl to style each state
-// independently (different background, border, glyph). Both fire the
-// same `onChange` emit on click — the host inverts its slot value.
-//
-// Why two HostButtons via If/Else instead of one with a slot-bound label?
-// ----------------------------------------------------------------------
-// A single button with `label : "✓" if checked else ""` would work
-// IF the kernel supported expressions in label props. It accepts a
-// SlotRef OR a literal string, but not a conditional expression
-// directly. The If/Else block produces two distinct nodes that the
-// backend lowers into a runtime visibility-toggle (XAML's
-// BoolToVisibilityConverter, React's `cond ? ... : ...`).
+// v0.3 is a one-line wrapper: the layout root is the UI29-2 kernel
+// primitive `HostCheckbox`. Every backend lowers it to its
+// platform's actual checkbox widget. The `label:` slot lives on
+// the native widget so the input + label are wired together (DOM
+// `<label><input/> body</label>`, SwiftUI `Toggle(label, isOn:)`,
+// Qt `CheckBox { text: ... }`, WinUI `<CheckBox Content="..."/>`),
+// which means clicking the label toggles the box for free.
 
 layout Checkbox {
-  Row [ checkbox ] {
-    If ( when: slot: checked ) {
-      HostButton [ checkbox-box-checked ] (
-        label : "✓" ,
-        disabled : slot: disabled ,
-        onClick : emit: onChange
-      )
-    }
-    Else {
-      HostButton [ checkbox-box-unchecked ] (
-        label : "" ,
-        disabled : slot: disabled ,
-        onClick : emit: onChange
-      )
-    }
-    Text [ checkbox-label ] (
-      content : slot: label
-    )
-  }
+  HostCheckbox [ checkbox ] (
+    label         : slot: label ,
+    checked       : slot: checked ,
+    disabled      : slot: disabled ,
+    indeterminate : slot: indeterminate ,
+    onToggle      : emit: onChange
+  )
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Radio.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Radio.dark.msl
@@ -1,30 +1,10 @@
-// Radio.dark.msl — dark-theme styling.
+// Radio.dark.msl — dark-theme styling (v0.3 trim).
+//
+// See Radio.light.msl header for the rewrite rationale. Only the
+// `radio` root part survives in v0.3.
 
 style Radio {
   part radio {
-    padding : 4 ;
-  }
-  part radio-box-selected {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 9 ;
-    background    : "#1e293b" ;
-    color         : "#3b82f6" ;
-    border-width  : 1 ;
-    border-color  : "#3b82f6" ;
-    font-size     : 14 ;
-    padding       : 0 ;
-  }
-  part radio-box-unselected {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 9 ;
-    background    : "#1e293b" ;
-    border-width  : 1 ;
-    border-color  : "#475569" ;
-    padding       : 0 ;
-  }
-  part radio-label {
     padding : 4 ;
   }
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Radio.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Radio.light.msl
@@ -1,30 +1,13 @@
-// Radio.light.msl — default light-theme styling.
+// Radio.light.msl — default light-theme styling (v0.3 trim).
+//
+// Pre-v0.3 styled two fake `radio-box-selected` / `radio-box-unselected`
+// parts on synthesised HostButton bullets. v0.3's `Radio.mll` is a
+// thin wrapper around the native `HostRadio` widget — those parts no
+// longer exist, and the native widget renders its own indicator dot.
+// Only the `radio` root part survives.
 
 style Radio {
   part radio {
-    padding : 4 ;
-  }
-  part radio-box-selected {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 9 ;
-    background    : "#ffffff" ;
-    color         : "#0d6efd" ;
-    border-width  : 1 ;
-    border-color  : "#0d6efd" ;
-    font-size     : 14 ;
-    padding       : 0 ;
-  }
-  part radio-box-unselected {
-    width         : 18 ;
-    height        : 18 ;
-    border-radius : 9 ;
-    background    : "#ffffff" ;
-    border-width  : 1 ;
-    border-color  : "#ced4da" ;
-    padding       : 0 ;
-  }
-  part radio-label {
     padding : 4 ;
   }
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Radio.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Radio.mil
@@ -1,23 +1,66 @@
-// Radio.mil — interface for the toolkit's Radio button.
+// Radio.mil — interface for the toolkit's Radio (v0.3 rewrite).
 //
-// Visually identical surface to Checkbox; the difference is
-// semantic. A Radio belongs to a group; only one in the group can
-// be selected at a time. The toolkit doesn't model groups —
-// authors handle that in their host state (passing `selected:
-// bool` per Radio).
+// **v0.3 rewrite.** Pre-v0.3 the toolkit's Radio mirrored Checkbox
+// exactly — a `HostButton` faking a bullet glyph through `If/Else`.
+// That lost native a11y role (`role="radio"` /
+// `AccessibilityRole.radioButton` / `AutomationPeer.RadioButton`),
+// the platform focus ring, the group-mutex visual, and arrow-key
+// navigation between radios in a group.
+//
+// v0.3 makes `Radio` a thin wrapper around the UI29-2 kernel
+// primitive `HostRadio`. Every backend lowers it to its platform's
+// real radio widget (DOM `<input type="radio">` with shared `name`,
+// SwiftUI `Toggle`, Qt `RadioButton` with `ButtonGroup`-ready
+// metadata, WinUI `RadioButton` with `GroupName`, etc.).
+//
+// **Breaking changes from v0.2.**
+//
+// 1. `selected` slot renamed to `checked` for consistency with
+//    Checkbox and with the kernel-canonical `HostRadio.checked`.
+// 2. `onSelect` now carries a `value: text` payload (the radio's
+//    value, see new `value:` slot below). Pre-v0.3 the signature
+//    was payloadless and required the host to derive the new
+//    selection from external knowledge.
+// 3. The internal part names `radio-box-selected` and
+//    `radio-box-unselected` are gone — the native widget renders
+//    its own indicator. Only the `radio` root part survives.
+//
+// New slots:
+//
+// - `value: text` — the value this radio represents. Carried as the
+//   payload of `onSelect` so the host can update group state in a
+//   single dispatch.
+// - `group: text` — the radio-group name. Backends that have
+//   native group semantics (HTML `name=`, WinUI `GroupName=`) wire
+//   this to the platform's mutex; backends without
+//   (SwiftUI/Qt v1) preserve it as metadata for the host to act on.
 
 component Radio {
-  // Display label rendered to the right of the bullet.
+  // Display label rendered next to the radio bullet. The native
+  // widget wires `<label>` so clicking the text selects the radio.
   slot label : text ;
 
-  // Current selected state. Host owns it.
-  slot selected : bool ;
+  // Current selected state. Host owns it; the host typically
+  // tracks one "selected-value" per group and computes each
+  // radio's `checked:` as `selected-value == this-radio-value`.
+  slot checked : bool ;
+
+  // The value this radio represents. Backends that lower to a
+  // native `value` attribute (HTML / WebComponent) put this on the
+  // input; the others surface it through the `onSelect` dispatch
+  // payload.
+  slot value : text ;
+
+  // The radio group this radio belongs to. Required by HTML and
+  // WinUI for browser/platform-enforced mutex; informational on
+  // SwiftUI and Qt.
+  slot group : text ;
 
   // Disabled flag.
   slot disabled : bool ;
 
-  // Fired when the user clicks the Radio. The host typically
-  // updates a group-level "selected-id" slot in response and
-  // propagates the new value to every Radio in the group.
-  emit onSelect ;
+  // Fired when the user selects this radio (and *only* when
+  // selected — sibling-caused deselects don't fire). Payload is
+  // the radio's `value:`.
+  emit onSelect ( value : text ) ;
 }

--- a/code/packages/mosaic-pkg-toolkit/src/Radio.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Radio.mll
@@ -1,27 +1,22 @@
-// Radio.mll — layout for the Radio.
+// Radio.mll — layout for the Radio (v0.3 rewrite).
 //
-// Same If/Else swap pattern as Checkbox.mll. The .msl renders the
-// box as a circle and the selected indicator as a filled dot
-// rather than a checkmark.
+// Pre-v0.3 the layout fanned out into a `Row` containing two
+// `HostButton`s wrapped in an `If/Else` (one with a `•` glyph, one
+// blank) plus a sibling `Text` for the label. That fake-radio
+// pattern lost native a11y role, focus ring, group-mutex visual,
+// and arrow-key navigation.
+//
+// v0.3 is a one-line wrapper around the UI29-2 kernel primitive
+// `HostRadio`. The native widget owns label wiring and (where the
+// platform supports it) the group-mutex behaviour.
 
 layout Radio {
-  Row [ radio ] {
-    If ( when: slot: selected ) {
-      HostButton [ radio-box-selected ] (
-        label : "•" ,
-        disabled : slot: disabled ,
-        onClick : emit: onSelect
-      )
-    }
-    Else {
-      HostButton [ radio-box-unselected ] (
-        label : "" ,
-        disabled : slot: disabled ,
-        onClick : emit: onSelect
-      )
-    }
-    Text [ radio-label ] (
-      content : slot: label
-    )
-  }
+  HostRadio [ radio ] (
+    label    : slot: label ,
+    checked  : slot: checked ,
+    value    : slot: value ,
+    group    : slot: group ,
+    disabled : slot: disabled ,
+    onSelect : emit: onSelect
+  )
 }

--- a/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -82,8 +82,8 @@ fn manifest_declares_expected_exports() {
         .and_then(|v| v.as_str())
         .expect("[package].version must be set");
     assert_eq!(
-        version, "0.1.0",
-        "[package].version must be 0.1.0 for the v0.1 PR-1 release"
+        version, "0.3.0",
+        "[package].version must be 0.3.0 for the UI29-2 Checkbox/Radio rewrite"
     );
 
     let exports = value
@@ -249,28 +249,45 @@ fn input_interface_matches_spec() {
     assert_eq!(emit_names, vec!["onChange", "onCommit"]);
 }
 
-/// Checkbox — toggle button + label, host-owned state.
+/// Checkbox v0.3 — native `HostCheckbox` wrapper with optional
+/// `indeterminate` slot. Breaking changes from v0.2 documented in
+/// CHANGELOG: `onChange` now carries `checked: bool`, and the slot
+/// roster grew an `indeterminate` slot.
 #[test]
 fn checkbox_interface_matches_spec() {
     let mil_src = read_source("Checkbox.mil");
     let out = mosmodel_compiler::compile(&mil_src).unwrap();
     let c = &out.component;
     let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
-    assert_eq!(slot_names, vec!["label", "checked", "disabled"]);
+    assert_eq!(slot_names, vec!["label", "checked", "disabled", "indeterminate"]);
     let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
     assert_eq!(emit_names, vec!["onChange"]);
+    // v0.3 — onChange now carries a `checked: bool` parameter.
+    let on_change = c.emits.iter().find(|e| e.name == "onChange").unwrap();
+    let param_names: Vec<&str> = on_change.params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(param_names, vec!["checked"]);
 }
 
-/// Radio — single-select toggle, host owns group state.
+/// Radio v0.3 — native `HostRadio` wrapper. Breaking changes from
+/// v0.2: `selected` renamed to `checked` (consistent with HostRadio
+/// and Checkbox); new `value` and `group` slots; `onSelect` carries
+/// `value: text` payload.
 #[test]
 fn radio_interface_matches_spec() {
     let mil_src = read_source("Radio.mil");
     let out = mosmodel_compiler::compile(&mil_src).unwrap();
     let c = &out.component;
     let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
-    assert_eq!(slot_names, vec!["label", "selected", "disabled"]);
+    assert_eq!(
+        slot_names,
+        vec!["label", "checked", "value", "group", "disabled"]
+    );
     let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
     assert_eq!(emit_names, vec!["onSelect"]);
+    // v0.3 — onSelect now carries a `value: text` parameter.
+    let on_select = c.emits.iter().find(|e| e.name == "onSelect").unwrap();
+    let param_names: Vec<&str> = on_select.params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(param_names, vec!["value"]);
 }
 
 /// ListGroup — vertical list of selectable text rows. Iterates via For.


### PR DESCRIPTION
## Summary

- **Closes the UI29-2 batch.** Rewrites \`mosaic-pkg-toolkit\`'s \`Checkbox\` and \`Radio\` from fake-HostButton shapes into one-line wrappers around the new kernel primitives \`HostCheckbox\` / \`HostRadio\`.
- Every backend now lowers these userland components to its platform's actual checkbox/radio widget (DOM \`<input type=…>\`, SwiftUI \`Toggle\`, Qt \`CheckBox\`/\`RadioButton\`, WinUI \`CheckBox\`/\`RadioButton\`), restoring the native a11y role, focus ring, tri-state visual, keyboard semantics, and group mutex.
- **Breaking changes**: package version 0.1.0 → 0.3.0. Migration guide in CHANGELOG.

## Breaking changes

- \`Checkbox.onChange\` now carries \`checked: bool\`; new optional \`indeterminate\` slot; inner parts gone.
- \`Radio\`: \`selected\` slot renamed to \`checked\`; \`onSelect\` carries \`value: text\`; new \`value\` and \`group\` slots; inner parts gone.

## Test plan

- [x] \`cargo test -p mosaic-pkg-toolkit-smoke\` — 16 passing
- [x] Security review passed
- [ ] CI green

Refs UI29-2 spec #3978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)