### PR TITLE
feat(cas-summation): Phase 51 + Phase 53 — sqrt numerator patterns (Python, 1.1.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 1.1.0 — 2026-05-23
+
+**Phase 51 + Phase 53 — Sqrt numerator patterns (Python port).**
+
+Ports Rust/TypeScript ``cas-summation`` Phase 51 (0.9.0) and introduces
+Phase 53 in all three languages simultaneously.  Extends
+``_g_vanishes_at_infinity`` with two new branches for square-root
+numerator shapes, both using ×2 integer arithmetic to avoid floating-point
+comparisons.
+
+Bumps 1.0.0 → 1.1.0.
+
+### Added
+
+- **``_sqrt_effective_half_degree_x2(node, k)``** — Phase 51 helper.
+  Returns ``deg(P)`` (= 2 × effective half-degree) for ``Sqrt(P(k))``
+  with a positive-leading-coefficient polynomial inner ``P``.  Returns
+  ``None`` for non-Sqrt nodes, non-polynomial inners, and negative-leading-
+  coefficient polynomials (those produce complex values for large ``k``).
+
+- **``_sqrt_poly_numerator_effective_degree_x2(node, k)``** — Phase 53
+  helper.  For a ``Mul`` node containing exactly one ``Sqrt(P)`` factor
+  and any number of polynomial-in-``k`` factors, returns
+  ``deg(P) + 2·deg(Q)`` (= 2 × the combined effective growth degree).
+  Returns ``None`` for plain ``Sqrt`` nodes (handled by Phase 51),
+  non-Mul nodes, or Mul nodes with more than one Sqrt factor, non-
+  polynomial non-Sqrt factors, or negative-leading-coefficient inner
+  polynomials.
+
+### Changed
+
+- ``_g_vanishes_at_infinity`` adds two new branches after Phase 50 (log
+  numerator) and Phase 49/52 (bounded / bounded×poly):
+
+  **Phase 51 branch** — fires when ``num = Sqrt(P)`` with
+  ``_sqrt_effective_half_degree_x2(num, k) = d``.  Closes when
+  ``2 * deg(den) > d`` (i.e. denominator degree strictly exceeds the
+  sqrt half-degree).
+
+  **Phase 53 branch** — fires when ``num = Mul(Sqrt(P), polynomial)``
+  with ``_sqrt_poly_numerator_effective_degree_x2(num, k) = e``.
+  Closes when ``2 * deg(den) > e``.
+
+  Both branches insert between Phase 52 (bounded × polynomial) and
+  Phase 42 (pure rational degree comparison).
+
+### Added — tests
+
+``tests/test_summation.py``
+
+**``TestEvaluateSumPhase51SqrtNumerator``** — 4 new cases:
+- ``phase51_sqrt_k_over_k_squared_closes`` — eff deg ½ < 2.
+- ``phase51_sqrt_k_squared_over_k_cubed_closes`` — eff deg 1 < 3.
+- ``phase51_sqrt_k_over_k_equal_degrees_refused`` — eff deg 1 = 1.
+- ``phase51_sqrt_of_negative_polynomial_refused`` — Sqrt(−k) refused.
+
+**``TestEvaluateSumPhase53SqrtTimesPolynomialNumerator``** — 5 new cases:
+- ``phase53_sqrt_k_times_k_over_k_cubed_closes`` — eff deg 3/2 < 3.
+- ``phase53_sqrt_k_squared_times_k_over_k_cubed_closes`` — eff 2 < 3.
+- ``phase53_sqrt_k_times_k_squared_over_k_cubed_closes`` — eff 5/2 < 3.
+- ``phase53_sqrt_k_times_k_squared_over_k_squared_stays`` — eff 5/2 > 2.
+- ``phase53_regression_sqrt_k_over_k_squared_still_via_phase51`` — plain
+  Sqrt bypasses Phase 53 and closes via Phase 51.
+
+Full suite: **116 passed** (was 107; +9 net new — 4 Phase 51 + 5 Phase 53).
+
 ## 1.0.0 — 2026-05-22
 
 **Phase 52 — Bounded × polynomial numerator pattern.**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.0.0"
+version = "1.1.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -58,6 +58,7 @@ from symbolic_ir import (
     NEG,
     POW,
     PRODUCT,
+    SQRT,
     SUB,
     SUM,
     IRApply,
@@ -690,6 +691,18 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     # divergence check used elsewhere.
     if _is_log_of_diverging_in_k(num, k) and _h_diverges_at_infinity(den, k):
         return True
+    # Phase 51: ``Sqrt(P(k))`` numerator pattern.  ``sqrt(P)`` has
+    # effective growth rate ``deg(P)/2``.  The quotient
+    # ``Sqrt(P)/Q`` vanishes when ``deg(Q) > deg(P)/2``, i.e. when
+    # ``2*deg(Q) > deg(P)``.  We use ×2 integer arithmetic throughout
+    # to avoid fractions.  ``_sqrt_effective_half_degree_x2`` returns
+    # ``deg(P)`` and requires the leading coefficient of ``P`` to be
+    # positive (so ``Sqrt(P)`` is real-valued and diverging).
+    sqrt_inner_deg = _sqrt_effective_half_degree_x2(num, k)
+    if sqrt_inner_deg is not None:
+        den_deg_sq = _polynomial_degree_in_k(den, k)
+        if den_deg_sq is not None and 2 * den_deg_sq > sqrt_inner_deg:
+            return True
     # Phase 52: ``Mul(bounded, polynomial)`` numerator pattern.  When the
     # numerator factorises as ``bounded × P(k)`` (with ``bounded`` non-
     # constant — so Phase 49 missed it — and ``P`` a positive-degree
@@ -700,6 +713,17 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
         _, poly_deg = bounded_poly
         den_deg_bp = _polynomial_degree_in_k(den, k)
         if den_deg_bp is not None and den_deg_bp > poly_deg:
+            return True
+    # Phase 53: ``Mul(Sqrt(P), polynomial_factors)`` numerator pattern.
+    # The effective growth rate is ``deg(P)/2 + deg(Q)``.  Using ×2
+    # integer arithmetic: vanishes when ``2*deg(den) > deg(P) + 2*deg(Q)``.
+    # ``_sqrt_poly_numerator_effective_degree_x2`` returns
+    # ``deg(P) + 2*deg(Q)`` and requires exactly one Sqrt factor with a
+    # positive-leading-coefficient polynomial inner.
+    sqrt_poly_eff = _sqrt_poly_numerator_effective_degree_x2(num, k)
+    if sqrt_poly_eff is not None:
+        den_deg_sp = _polynomial_degree_in_k(den, k)
+        if den_deg_sp is not None and 2 * den_deg_sp > sqrt_poly_eff:
             return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
@@ -789,6 +813,117 @@ def _split_bounded_polynomial_factor(
     else:
         bounded_aggregate = IRApply(MUL, tuple(bounded_factors))
     return (bounded_aggregate, poly_degree)
+
+
+def _sqrt_effective_half_degree_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 51 helper: return 2× the effective half-degree of a ``Sqrt(P(k))``
+    node, or ``None`` when the shape isn't recognised.
+
+    For ``Sqrt(P(k))`` the effective growth rate is ``deg(P) / 2``.  To
+    avoid floating-point arithmetic, we return ``deg(P)`` (i.e., twice the
+    half-degree) and let the caller compare against ``2 * den_deg``
+    instead of against the fractional ``deg(P) / 2``.
+
+    Requirements:
+      - ``node = Sqrt(P)`` (exactly one argument under the Sqrt head).
+      - ``P`` is a polynomial in ``k``.
+      - The leading coefficient of ``P`` in ``k`` is positive (so
+        ``Sqrt(P(k))`` is real-valued and diverges to ``+∞``).  This
+        refuses shapes like ``Sqrt(Mul(-1, k))`` where ``P(k) = -k``
+        goes negative for large ``k``.
+
+    Returns ``deg(P)`` (a non-negative integer), which equals
+    ``2 * effective_half_degree``.
+
+    +------------------------+----------------------+
+    | Input                  | Return               |
+    +========================+======================+
+    | ``Sqrt(k)``            | 1 (deg 1 poly)       |
+    | ``Sqrt(k²)``           | 2                    |
+    | ``Sqrt(k² + k + 1)``   | 2                    |
+    | ``Sqrt(Mul(-1, k))``   | None (neg leading)   |
+    | ``k``                  | None (not Sqrt)      |
+    | ``Sqrt(Sin(k))``       | None (not poly)      |
+    +------------------------+----------------------+
+    """
+    if not isinstance(node, IRApply):
+        return None
+    if node.head != SQRT or len(node.args) != 1:
+        return None
+    inner = node.args[0]
+    # Inner must be a polynomial in k.
+    deg = _polynomial_degree_in_k(inner, k)
+    if deg is None:
+        return None
+    # Degree-0 inner (constant) means Sqrt(c) is a constant — no effective
+    # polynomial growth.  Return None so Phase 42 handles it.
+    if deg == 0:
+        return None
+    # Leading coefficient of the inner polynomial must be positive so that
+    # P(k) → +∞ (real-valued and diverging).  Reject if we can't confirm
+    # sign.
+    if _polynomial_leading_coeff_sign_in_k(inner, k) != 1:
+        return None
+    return deg  # = 2 × effective half-degree
+
+
+def _sqrt_poly_numerator_effective_degree_x2(
+    node: IRNode, k: IRSymbol
+) -> int | None:
+    """Phase 53 helper: return 2× the effective growth degree of a
+    ``Mul(Sqrt(P), polynomial_factors)`` numerator, or ``None`` when
+    the shape isn't recognised.
+
+    The numerator ``Sqrt(P(k)) · Q(k)`` grows at rate
+    ``deg(P)/2 + deg(Q)``.  To keep the comparison integral, we return
+    ``deg(P) + 2·deg(Q)`` (= 2 × the effective degree).  The caller
+    compares ``2 * den_deg > effective_x2`` to decide whether the
+    quotient vanishes.
+
+    Requirements:
+      - ``node = Mul(...)`` (Phase 51 handles the plain-Sqrt case).
+      - Exactly one factor is a ``Sqrt(P)`` with positive-leading-coeff
+        polynomial inner (via :func:`_sqrt_effective_half_degree_x2`).
+      - All other factors are polynomials in ``k``.
+
+    Returns ``deg(P) + 2·deg(Q)`` (a non-negative integer).
+
+    +----------------------------------+----------------+
+    | Input (numerator node)           | Return         |
+    +==================================+================+
+    | ``Mul(Sqrt(k²), k)``             | 2 + 2 = 4      |
+    | ``Mul(Sqrt(k), k²)``             | 1 + 4 = 5      |
+    | ``Mul(Sqrt(k), Sin(k))``         | None (Sin not  |
+    |                                  |  poly)         |
+    | ``Sqrt(k)`` (plain, not Mul)     | None (→ Ph 51) |
+    | ``Mul(Sqrt(k), Sqrt(k))``        | None (two Sqrt)|
+    +----------------------------------+----------------+
+    """
+    if not isinstance(node, IRApply):
+        return None
+    if node.head != MUL:
+        return None
+    sqrt_inner_deg: int | None = None
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        # Try to classify this factor as a Sqrt(P) shape.
+        eff = _sqrt_effective_half_degree_x2(arg, k)
+        if eff is not None:
+            # Only one Sqrt factor is allowed — if we see a second, bail.
+            if sqrt_inner_deg is not None:
+                return None
+            sqrt_inner_deg = eff
+            continue
+        # Otherwise it must be a polynomial in k.
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is None:
+            # Neither a Sqrt shape nor a polynomial — pattern rejected.
+            return None
+        poly_deg_sum += deg
+    # Must have found exactly one Sqrt factor.
+    if sqrt_inner_deg is None:
+        return None
+    return sqrt_inner_deg + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1290,3 +1290,197 @@ class TestEvaluateSumPhase52BoundedTimesPolynomial:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
+
+
+class TestEvaluateSumPhase51SqrtNumerator:
+    """Phase 51 — ``Sqrt(P(k))`` as numerator: effective degree = deg(P)/2.
+
+    ``Sqrt(P(k)) / Q(k)`` vanishes at infinity when ``deg(Q) > deg(P)/2``,
+    i.e. when ``2*deg(Q) > deg(P)``.  Integer arithmetic keeps comparisons
+    exact.
+
+    Examples:
+    - ``Sqrt(k) / k``      — ½ < 1 → vanishes (2*1 = 2 > 1)
+    - ``Sqrt(k²) / k²``    — 1 = 1 → stays (2*2 = 4 > 2, wait: 2 = 2 exactly...
+      actually Sqrt(k²) = k, effective deg 1, den deg 2: 2*2=4>2 → vanishes)
+    """
+
+    def test_sqrt_k_over_k_squared_closes(self):
+        """``Sqrt(k)/k²``: effective degree ½ < 2 → vanishes.
+
+        ``2 * 2 = 4 > 1 = deg(k)`` → closes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        g_k = IRApply(DIV, (IRApply(SQRT, (_k,)), IRApply(POW, (_k, IRInteger(2)))))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_kp1 = IRApply(DIV, (IRApply(SQRT, (kp1,)), IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 51: Sqrt(k)/k² should close; got {result!r}"
+        )
+
+    def test_sqrt_k_squared_over_k_cubed_closes(self):
+        """``Sqrt(k²)/k³``: effective degree 1 < 3 → vanishes.
+
+        ``Sqrt(k²)`` has inner deg 2; effective half-degree = 1.
+        ``2 * 3 = 6 > 2 = deg(k²)`` → closes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        g_k = IRApply(DIV, (IRApply(SQRT, (k_sq,)), IRApply(POW, (_k, IRInteger(3)))))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        g_kp1 = IRApply(DIV, (IRApply(SQRT, (kp1_sq,)), IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_over_k_equal_degrees_refused(self):
+        """``Sqrt(k)/Sqrt(k)`` stays unevaluated — same effective degree
+        (but expressed as ``Sqrt(k)/k^{1/2}``, which we test via the
+        case ``Sqrt(k)/k``: effective deg ½ vs deg 1 → vanishes since ½ < 1).
+
+        Test the boundary: ``Sqrt(k) / 1`` is NOT a Div form → skip.
+        Test the tight case: ``Sqrt(k²) / k`` → effective deg 1 = den deg 1
+        → equal, should NOT close.
+        """
+        from symbolic_ir import SQRT, SUB
+
+        # Numerator effective degree 1 (= deg(k²)/2), denominator degree 1.
+        # 2*1 = 2 is NOT > 2 = deg(k²), so Phase 51 refuses.
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        g_k = IRApply(DIV, (IRApply(SQRT, (k_sq,)), _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        g_kp1 = IRApply(DIV, (IRApply(SQRT, (kp1_sq,)), kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # deg(Sqrt(k²)) effective = 1, deg(den) = 1 → tie → unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM, (
+            f"Phase 51: Sqrt(k²)/k has equal effective degree; should stay unevaluated; got {result!r}"
+        )
+
+    def test_sqrt_of_negative_polynomial_refused(self):
+        """``Sqrt(-k)/k²``: inner polynomial has negative leading coeff.
+
+        Phase 51 must refuse this shape (Sqrt of a negative-leading-coeff
+        polynomial is not real-valued for large k).
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        neg_k = IRApply(MUL, (IRInteger(-1), _k))
+        g_k = IRApply(DIV, (IRApply(SQRT, (neg_k,)), IRApply(POW, (_k, IRInteger(2)))))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        neg_kp1 = IRApply(MUL, (IRInteger(-1), kp1))
+        g_kp1 = IRApply(DIV, (IRApply(SQRT, (neg_kp1,)), IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Phase 51 refuses Sqrt(-k); falls through to Phase 42 which also
+        # refuses (numerator is not polynomial) → stays unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase53SqrtTimesPolynomialNumerator:
+    """Phase 53 — ``Mul(Sqrt(P), polynomial_factors)`` as numerator.
+
+    Effective growth = ``deg(P)/2 + deg(Q)``.  The quotient vanishes when
+    ``deg(den) > deg(P)/2 + deg(Q)``, equivalently
+    ``2*deg(den) > deg(P) + 2*deg(Q)``.
+
+    Examples:
+    - ``Sqrt(k) · k / k³``:  eff = ½ + 1 = 3/2 < 3 → closes
+    - ``Sqrt(k²) · k / k³``: eff = 1 + 1 = 2 < 3 → closes
+    - ``Sqrt(k) · k² / k²``: eff = ½ + 2 = 5/2 > 2 → stays
+    """
+
+    def test_sqrt_k_times_k_over_k_cubed_closes(self):
+        """``Sqrt(k)·k/k³``: effective degree = ½+1 = 3/2, den deg 3 → vanishes.
+
+        ``2*3 = 6 > 1 + 2*1 = 3`` → closes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 53: Sqrt(k)·k/k³ should close; got {result!r}"
+        )
+
+    def test_sqrt_k_squared_times_k_over_k_cubed_closes(self):
+        """``Sqrt(k²)·k/k³``: effective degree = 1+1 = 2, den deg 3 → vanishes.
+
+        ``2*3 = 6 > 2 + 2*1 = 4`` → closes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k_sq,)), _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_sq,)), kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_times_k_squared_over_k_cubed_closes(self):
+        """``Sqrt(k)·k²/k³``: effective degree = ½+2 = 5/2, den deg 3 → vanishes.
+
+        ``2*3 = 6 > 1 + 2*2 = 5`` → closes.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), k_sq))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), kp1_sq))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_times_k_squared_over_k_squared_stays(self):
+        """``Sqrt(k)·k²/k²``: effective degree = ½+2 = 5/2 > 2 → stays.
+
+        ``2*2 = 4 NOT > 1 + 2*2 = 5`` → unevaluated.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), k_sq))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), kp1_sq))
+        g_k = IRApply(DIV, (num_k, k_sq))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_sq))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Effective degree 5/2 > 2 → can't prove vanishing → unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_regression_sqrt_k_over_k_squared_still_via_phase51(self):
+        """Regression: plain ``Sqrt(k)/k²`` still closes via Phase 51.
+
+        Phase 53 requires a Mul node; plain Sqrt is handled by Phase 51.
+        """
+        from symbolic_ir import POW, SQRT, SUB
+
+        g_k = IRApply(DIV, (IRApply(SQRT, (_k,)), IRApply(POW, (_k, IRInteger(2)))))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        g_kp1 = IRApply(DIV, (IRApply(SQRT, (kp1,)), IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Regression: Sqrt(k)/k² should close via Phase 51; got {result!r}"
+        )


### PR DESCRIPTION
## Summary

- Ports Phase 51 (Sqrt numerator) from Rust/TypeScript to Python, which was missing from the Python package despite existing in both other languages since 0.9.0
- Introduces Phase 53 (Mul(Sqrt(P), polynomial_factors) numerator) in Python — a new pattern across all three languages
- Both phases use ×2 integer arithmetic to avoid floating-point degree comparisons

## Details

**Phase 51** — `_sqrt_effective_half_degree_x2(node, k)`:
- Recognizes `Sqrt(P(k))` numerators with positive-leading-coeff polynomial inner
- Returns `deg(P)` (= 2× effective half-degree); branch closes when `2*deg(den) > deg(P)`
- Refuses `Sqrt(-k)` and other negative-leading-coeff shapes (would be complex for large k)

**Phase 53** — `_sqrt_poly_numerator_effective_degree_x2(node, k)`:
- Recognizes `Mul(Sqrt(P), polynomial_factors)` with exactly one Sqrt factor
- Returns `deg(P) + 2*deg(Q)`; branch closes when `2*deg(den) > deg(P) + 2*deg(Q)`
- Plain `Sqrt(P)` falls through to Phase 51 (not Mul)

## Test plan

- [ ] 116 tests pass locally (was 107; +9 new)
- [ ] 4 Phase 51 tests: closes, closes, equal-degree-refused, negative-polynomial-refused
- [ ] 5 Phase 53 tests: closes×3, stays (effective deg > den), regression (plain Sqrt → Phase 51)
- [ ] Coverage remains at 88%+

🤖 Generated with [Claude Code](https://claude.com/claude-code)