### PR TITLE
feat(cas-summation): Phase 53 — Sqrt × polynomial numerator pattern (TS+Rust port, 1.1.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 1.1.0 — 2026-05-23
+
+**Phase 53 — Sqrt × polynomial numerator pattern (Rust port).**
+
+Extends ``g_vanishes_at_infinity`` to recognise that
+``Mul(Sqrt(P), polynomial_factors)`` numerators have effective growth
+equal to ``deg(P)/2 + deg(Q)``.  Closes telescopes like
+``sqrt(k)·k/k³`` and ``sqrt(k²)·k/k³`` that fall through all
+earlier phases.  Uses ×2 integer arithmetic to avoid float comparisons.
+
+Builds on Phase 51 (0.9.0) which added the plain-``Sqrt`` case.
+Bumps 1.0.0 → 1.1.0.
+
+### Added
+
+- **``sqrt_poly_numerator_effective_degree_x2(node, k)``** — returns
+  ``deg(P) + 2·deg(Q)`` (an ``i64``) when
+  ``node = Mul(Sqrt(P), polynomial_factors)`` with exactly one Sqrt
+  factor and all others polynomial.  Returns ``None`` for plain
+  ``Sqrt`` nodes (handled by Phase 51), non-Mul nodes, multiple Sqrt
+  factors, non-polynomial non-Sqrt factors, and negative-leading-coeff
+  inner polynomials.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds a Phase 53 branch between Phase 52
+  (bounded × polynomial) and Phase 42 (pure rational degree comparison):
+  closes when ``2 * den_deg > sqrt_poly_numerator_effective_degree_x2(num, k)``.
+
+### Added — tests
+
+5 new ``phase53_*`` cases:
+- ``phase53_sqrt_k_times_k_over_k_cubed_closes`` — eff x2 = 3, 2·3 = 6 > 3.
+- ``phase53_sqrt_k_squared_times_k_over_k_cubed_closes`` — eff x2 = 4, 6 > 4.
+- ``phase53_sqrt_k_times_k_squared_over_k_cubed_closes`` — eff x2 = 5, 6 > 5.
+- ``phase53_sqrt_k_times_k_squared_over_k_squared_stays`` — eff x2 = 5, 4 not > 5.
+- ``phase53_regression_sqrt_k_over_k_squared_still_closes_via_phase51`` — plain
+  Sqrt bypasses Phase 53 and closes via Phase 51.
+
+Full suite: **56 passed** (was 51; +5 net new).
+
 ## 1.0.0 — 2026-05-23
 
 **Phase 52 — Bounded × polynomial numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1051,6 +1051,49 @@ fn split_bounded_polynomial_factor(
     Some((bounded_aggregate, poly_deg))
 }
 
+/// Phase 53 (Rust port): Return ``Some(sqrt_inner_deg + 2 * poly_deg_sum)``
+/// when ``node = Mul(Sqrt(P), polynomial_factors)``; ``None`` otherwise.
+///
+/// The numerator ``Sqrt(P(k)) · Q(k)`` has effective growth rate
+/// ``deg(P)/2 + deg(Q)``.  Returning ``deg(P) + 2·deg(Q)`` (= 2× the
+/// effective degree) lets the caller compare against ``2 * den_deg``
+/// to avoid float arithmetic.
+///
+/// Requirements:
+///   - ``node = Mul(...)`` — Phase 51 handles the plain ``Sqrt(P)`` case.
+///   - Exactly one factor passes ``sqrt_effective_half_degree_x2``.
+///   - All remaining factors are polynomials in ``k``.
+fn sqrt_poly_numerator_effective_degree_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut sqrt_inner_deg: Option<i64> = None;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &apply_node.args {
+        // Try the Sqrt(P) shape first.
+        if let Some(eff) = sqrt_effective_half_degree_x2(arg, k) {
+            // Only one Sqrt factor allowed — bail on a second.
+            if sqrt_inner_deg.is_some() {
+                return None;
+            }
+            sqrt_inner_deg = Some(eff);
+            continue;
+        }
+        // Otherwise must be polynomial in k.
+        match polynomial_degree_in_k(arg, k) {
+            Some(d) => poly_deg_sum += d,
+            None => return None, // Neither Sqrt shape nor polynomial.
+        }
+    }
+    // Must have found exactly one Sqrt factor.
+    let sid = sqrt_inner_deg?;
+    Some(sid + 2 * poly_deg_sum)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1094,6 +1137,16 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some((_bounded, poly_deg)) = split_bounded_polynomial_factor(num, k) {
         if let Some(den_deg_bp) = polynomial_degree_in_k(den, k) {
             if den_deg_bp > poly_deg {
+                return true;
+            }
+        }
+    }
+    // Phase 53: Mul(Sqrt(P), polynomial_factors) numerator pattern.
+    // Effective growth = deg(P)/2 + deg(Q).  Using ×2 integer arithmetic:
+    // vanishes when 2*den_deg > deg(P) + 2*deg(Q).
+    if let Some(sqrt_poly_eff) = sqrt_poly_numerator_effective_degree_x2(num, k) {
+        if let Some(den_deg_sp) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sp > sqrt_poly_eff {
                 return true;
             }
         }

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1050,3 +1050,97 @@ fn phase52_regression_k_over_k_squared_still_closes_via_phase42() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 53 (Rust port): Sqrt × polynomial numerator.
+//
+// The numerator is Mul(Sqrt(P(k)), polynomial_in_k).  Phase 53 catches
+// shapes like sqrt(k)·k/k³ (eff deg x2 = 1+2 = 3, den deg = 3, 2*3 = 6 > 3)
+// that fall through all earlier phases.
+//
+// Uses ×2 integer arithmetic: effective_x2 = deg(P) + 2*deg(Q).
+// Closes when 2*den_deg > effective_x2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase53_sqrt_k_times_k_over_k_cubed_closes() {
+    // Numerator = Sqrt(k)·k: eff deg x2 = 1 + 2*1 = 3.  Denominator = k³: deg 3.
+    // 2*3 = 6 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let num_k = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![k.clone()]), k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![kp1.clone()]), kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase53_sqrt_k_squared_times_k_over_k_cubed_closes() {
+    // Numerator = Sqrt(k²)·k: eff deg x2 = 2 + 2*1 = 4.  Denominator = k³: deg 3.
+    // 2*3 = 6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_sq = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![k_sq]), k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![kp1_sq]), kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase53_sqrt_k_times_k_squared_over_k_cubed_closes() {
+    // Numerator = Sqrt(k)·k²: eff deg x2 = 1 + 2*2 = 5.  Denominator = k³: deg 3.
+    // 2*3 = 6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_sq = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![k.clone()]), k_sq]);
+    let num_kp1 = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![kp1.clone()]), kp1_sq]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase53_sqrt_k_times_k_squared_over_k_squared_stays() {
+    // Numerator = Sqrt(k)·k²: eff deg x2 = 1 + 2*2 = 5.  Denominator = k²: deg 2.
+    // 2*2 = 4 NOT > 5 → stays unevaluated.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_sq = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![k.clone()]), k_sq.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![apply(sym("Sqrt"), vec![kp1.clone()]), kp1_sq.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k_sq]),
+        apply(sym(DIV), vec![num_kp1, kp1_sq]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase53_regression_sqrt_k_over_k_squared_still_closes_via_phase51() {
+    // Plain Sqrt(k)/k² — Phase 53 requires Mul; Phase 51 handles this.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![apply(sym("Sqrt"), vec![k.clone()]), apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![apply(sym("Sqrt"), vec![kp1.clone()]), apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 1.1.0 — 2026-05-23
+
+**Phase 53 — Sqrt × polynomial numerator pattern (TypeScript port).**
+
+Extends ``gVanishesAtInfinity`` to recognise that
+``Mul(Sqrt(P), polynomial_factors)`` numerators have effective growth
+equal to ``deg(P)/2 + deg(Q)``.  Closes telescopes like
+``sqrt(k)·k/k³`` and ``sqrt(k²)·k/k³`` that fall through all
+earlier phases.
+
+Builds on Phase 51 (0.9.0) which added the plain-``Sqrt`` case.
+Bumps 1.0.0 → 1.1.0.
+
+### Added
+
+- **``sqrtPolyNumeratorEffectiveDegree(node, k)``** — returns
+  ``deg(P)/2 + deg(Q)`` (a number) when ``node = Mul(Sqrt(P), Q_poly)``
+  with exactly one Sqrt factor and all other factors polynomial.
+  Returns ``undefined`` for plain ``Sqrt`` nodes (handled by Phase 51),
+  non-Mul nodes, multiple Sqrt factors, non-polynomial non-Sqrt factors.
+
+### Changed
+
+- ``gVanishesAtInfinity`` adds a Phase 53 branch between Phase 52
+  (bounded × polynomial) and Phase 42 (pure rational degree comparison):
+  closes when ``den_deg > sqrtPolyNumeratorEffectiveDegree(num, k)``.
+
+### Added — tests
+
+5 new ``phase53_*`` cases:
+- ``phase53_sqrt_k_times_k_over_k_cubed_closes`` — eff 3/2 < 3.
+- ``phase53_sqrt_k_squared_times_k_over_k_cubed_closes`` — eff 2 < 3.
+- ``phase53_sqrt_k_times_k_squared_over_k_cubed_closes`` — eff 5/2 < 3.
+- ``phase53_sqrt_k_times_k_squared_over_k_squared_stays`` — eff 5/2 > 2.
+- ``phase53_regression_sqrt_k_over_k_squared_still_closes_via_phase51`` — plain
+  Sqrt bypasses Phase 53 and closes via Phase 51.
+
+Full suite: **56 passed** (was 51; +5 net new).
+
 ## 1.0.0 — 2026-05-23
 
 **Phase 52 — Bounded × polynomial numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -760,6 +760,44 @@ function splitBoundedPolynomialFactor(
   return { bounded, polyDeg };
 }
 
+/**
+ * Phase 53 (TypeScript port): Return the effective growth degree of a
+ * ``Mul(Sqrt(P), polynomial_factors)`` numerator, or ``undefined`` when
+ * the shape isn't recognised.
+ *
+ * The numerator ``Sqrt(P(k)) · Q(k)`` grows at rate
+ * ``deg(P)/2 + deg(Q)``.  Returns that combined value (a possibly
+ * fractional number).  The caller compares against ``den_deg`` directly.
+ *
+ * Requirements:
+ *   - ``node = Mul(...)`` — the plain-``Sqrt`` case is handled by Phase 51.
+ *   - Exactly one factor is a ``Sqrt(P)`` with positive-leading-coeff poly inner.
+ *   - All remaining factors are polynomials in ``k``.
+ */
+function sqrtPolyNumeratorEffectiveDegree(
+  node: IRNode,
+  k: IRNode
+): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let polyDegSum = 0;
+  for (const arg of node.args) {
+    const sqrtDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (sqrtDeg !== undefined) {
+      // Only one Sqrt factor is allowed; bail on a second.
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = sqrtDeg;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg === undefined) return undefined; // Neither Sqrt nor polynomial.
+    polyDegSum += deg;
+  }
+  // Must have found exactly one Sqrt factor.
+  if (sqrtHalfDeg === undefined) return undefined;
+  return sqrtHalfDeg + polyDegSum;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -798,6 +836,17 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (bpResult !== undefined) {
     const denDegBp = polynomialDegreeInK(den, k);
     if (denDegBp !== undefined && denDegBp > bpResult.polyDeg) {
+      return true;
+    }
+  }
+  // Phase 53: Mul(Sqrt(P), polynomial_factors) numerator pattern.
+  // The effective growth rate is deg(P)/2 + deg(Q).  Vanishes when
+  // deg(den) > deg(P)/2 + deg(Q).  Handled by sqrtPolyNumeratorEffectiveDegree
+  // which requires exactly one Sqrt factor and all others polynomial.
+  const sqrtPolyEff = sqrtPolyNumeratorEffectiveDegree(num, k);
+  if (sqrtPolyEff !== undefined) {
+    const denDegSp = polynomialDegreeInK(den, k);
+    if (denDegSp !== undefined && denDegSp > sqrtPolyEff) {
       return true;
     }
   }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -826,3 +826,87 @@ describe("summation: Phase 52 bounded × polynomial numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 53 (TypeScript port): Sqrt × polynomial numerator.
+//
+// The numerator is Mul(Sqrt(P(k)), polynomial_in_k).  Phase 53 catches
+// shapes like sqrt(k)·k/k³ (eff deg = ½+1 = 3/2 < 3) and
+// sqrt(k²)·k/k³ (eff deg = 1+1 = 2 < 3) that fall through all earlier phases.
+//
+// Effective degree = deg(P)/2 + deg(Q).  Closes when deg(den) > eff_deg.
+// Tests mirror Python Phase 53 (cas-summation 1.1.0).
+// ---------------------------------------------------------------------------
+describe("summation: Phase 53 Sqrt × polynomial numerator", () => {
+  it("Sqrt(k)·k/k³ closes (eff deg = ½+1 = 3/2 < 3)", () => {
+    // Numerator = Sqrt(k)·k: eff deg 1/2 + 1 = 3/2.  Denominator = k³: deg 3.
+    // 3 > 3/2 → closes.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sqrt"), [k]), k]);
+    const numKp1 = app(MUL, [app(sym("Sqrt"), [kp1]), kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("Sqrt(k²)·k/k³ closes (eff deg = 1+1 = 2 < 3)", () => {
+    // Numerator = Sqrt(k²)·k: eff deg 2/2 + 1 = 2.  Denominator = k³: deg 3.
+    // 3 > 2 → closes.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sqrt"), [app(POW, [k, int(2)])]), k]);
+    const numKp1 = app(MUL, [app(sym("Sqrt"), [app(POW, [kp1, int(2)])]), kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("Sqrt(k)·k²/k³ closes (eff deg = ½+2 = 5/2 < 3)", () => {
+    // Numerator = Sqrt(k)·k²: eff deg 1/2 + 2 = 5/2.  Denominator = k³: deg 3.
+    // 3 > 5/2 → closes.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sqrt"), [k]), app(POW, [k, int(2)])]);
+    const numKp1 = app(MUL, [app(sym("Sqrt"), [kp1]), app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: Sqrt(k)·k²/k² stays unevaluated (eff deg 5/2 > 2)", () => {
+    // Numerator = Sqrt(k)·k²: eff deg 1/2 + 2 = 5/2.  Denominator = k²: deg 2.
+    // 2 > 5/2 is false → stays unevaluated.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sqrt"), [k]), app(POW, [k, int(2)])]);
+    const numKp1 = app(MUL, [app(sym("Sqrt"), [kp1]), app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+
+  it("regression: plain Sqrt(k)/k² still closes via Phase 51 (not Phase 53)", () => {
+    // Phase 53 requires a Mul node; plain Sqrt(P) is handled by Phase 51.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const f = app(SUB, [
+      app(DIV, [app(sym("Sqrt"), [k]), app(POW, [k, int(2)])]),
+      app(DIV, [app(sym("Sqrt"), [kp1]), app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Ports Phase 53 (`Mul(Sqrt(P), polynomial_factors) / Q` numerator pattern) to TypeScript and Rust
- Phase 53 closes telescopes where the numerator combines a sqrt factor with polynomial factors, e.g. `sqrt(k)·k/k³` (eff deg 3/2 < 3)
- TypeScript uses float arithmetic (`deg(P)/2 + deg(Q)`), Rust uses ×2 integer arithmetic (`deg(P) + 2·deg(Q)`) matching Phase 51 style in each language

## Details

**TypeScript** (`sqrtPolyNumeratorEffectiveDegree`):
- Returns `deg(P)/2 + deg(Q)` (number) for `Mul(Sqrt(P), poly_factors)`
- Branch closes when `den_deg > result` (consistent with Phase 51 float comparisons)

**Rust** (`sqrt_poly_numerator_effective_degree_x2`):
- Returns `deg(P) + 2·deg(Q)` (i64) — the ×2 representation
- Branch closes when `2·den_deg > result` (integer-exact, consistent with Phase 51 Rust style)

Both: require exactly one Sqrt factor in the Mul node; plain `Sqrt(P)` falls through to Phase 51.

## Test plan

- [ ] 56 tests pass in TypeScript (was 51; +5 phase53_* tests)
- [ ] 56 tests pass in Rust (was 51; +5 phase53_* tests)
- [ ] Tests include: 3 closes cases, 1 stays (eff deg > den), 1 regression (plain Sqrt → Phase 51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)