### PR TITLE
feat(cas-summation): Phase 54 — Log×polynomial numerator pattern (Python, 1.2.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 1.2.0 — 2026-05-23
+
+**Phase 54 — Log×polynomial numerator pattern (Python).**
+
+Extends ``_g_vanishes_at_infinity`` with a new branch for
+``Div(Mul(Log(diverging), P(k)), Q(k))`` shapes.  ``log(h(k))`` grows
+sub-polynomially — slower than any positive power of ``k`` — so the
+effective growth degree is just ``deg(P)``.  The quotient vanishes when
+``deg(Q) > deg(P)`` (strictly; equal degrees are refused because
+``log(k) × constant`` diverges).
+
+Bumps 1.1.0 → 1.2.0.
+
+### Added
+
+- **``_split_log_polynomial_factor(node, k)``** — Phase 54 helper.
+  Splits a ``Mul`` node into exactly one ``Log(diverging)`` factor and
+  a polynomial part in ``k``; returns ``(log_factor, poly_deg_sum)`` or
+  ``None`` when the shape isn't recognised (no Log factor, more than one
+  Log factor, or a non-polynomial non-Log factor).
+
+- **Phase 54 branch in ``_g_vanishes_at_infinity``** — inserted after
+  Phase 53 and before the Phase 42 polynomial widening.  Closes
+  ``Div(Mul(Log(diverging), P), Q)`` when ``deg(Q) > deg(poly_part)``.
+
+- **5 new tests** in ``TestEvaluateSumPhase54LogTimesPolynomialNumerator``
+  (``test_summation.py``):
+  - ``test_log_k_times_k_over_k_cubed_closes`` — log×k / k³ → closes
+  - ``test_log_k_times_k_squared_over_k_cubed_closes`` — log×k² / k³ → closes
+  - ``test_log_k_times_k_over_k_squared_closes`` — log×k / k² → closes
+  - ``test_log_k_times_k_squared_over_k_squared_refused`` — equal degrees
+    refused (log(k)*k²/k² = log(k) → diverges)
+  - ``test_regression_log_k_over_k_cubed_still_phase50`` — plain Log(k)/k³
+    still closes via Phase 50 (not Phase 54)
+
+### Tests
+
+121 passed (was 116; +5 net new — Phase 54).
+
+---
+
 ## 1.1.0 — 2026-05-23
 
 **Phase 51 + Phase 53 — Sqrt numerator patterns (Python port).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.1.0"
+version = "1.2.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -725,6 +725,22 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
         den_deg_sp = _polynomial_degree_in_k(den, k)
         if den_deg_sp is not None and 2 * den_deg_sp > sqrt_poly_eff:
             return True
+    # Phase 54: ``Mul(Log(diverging), polynomial_factors)`` numerator
+    # pattern.  ``log(h(k))`` grows sub-polynomially — slower than any
+    # positive power of ``k`` — so the effective growth degree of
+    # ``log(h) · P(k)`` equals ``deg(P)`` (the log factor is negligible
+    # for degree comparisons).  The quotient vanishes when
+    # ``deg(den) > deg(P)`` (strictly).
+    #
+    # Note: When ``deg(den) == deg(P)`` the expression reduces to
+    # ``log(h(k)) * constant``, which diverges to ±∞, so equality is
+    # correctly refused.
+    log_poly = _split_log_polynomial_factor(num, k)
+    if log_poly is not None:
+        _, poly_deg_lp = log_poly
+        den_deg_lp = _polynomial_degree_in_k(den, k)
+        if den_deg_lp is not None and den_deg_lp > poly_deg_lp:
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -924,6 +940,63 @@ def _sqrt_poly_numerator_effective_degree_x2(
     if sqrt_inner_deg is None:
         return None
     return sqrt_inner_deg + 2 * poly_deg_sum
+
+
+def _split_log_polynomial_factor(
+    node: IRNode, k: IRSymbol
+) -> tuple[IRNode, int] | None:
+    """Return ``(log_factor, poly_degree)`` when ``node`` is a ``Mul``
+    whose factors split into exactly one ``Log(diverging)`` part and a
+    polynomial part in ``k``; ``None`` otherwise.
+
+    Phase 54 — Used by :func:`_g_vanishes_at_infinity` to recognise that
+    ``log(k)·k/k³`` (and similar shapes) vanish at infinity.  The key
+    mathematical fact is that ``log(h(k)) = o(k^ε)`` for any ``ε > 0``,
+    so ``log(h) · P(k)`` has the same effective growth degree as ``P(k)``
+    alone — the log factor is negligible for degree comparisons.
+
+    +-----------------------------------+---------------------+
+    | Input                             | Return              |
+    +===================================+=====================+
+    | ``Mul(Log(k), k)``                | ``(Log(k), 1)``     |
+    | ``Mul(Log(k), k²)``               | ``(Log(k), 2)``     |
+    | ``Mul(Log(k+1), k³)``             | ``(Log(k+1), 3)``   |
+    | ``Mul(Log(k), Sin(k))``           | None (Sin not poly) |
+    | ``Mul(Log(k), Log(k))``           | None (two Log)      |
+    | ``Mul(Sin(k), k)``                | None (no Log factor)|
+    | ``Log(k)`` (plain, not Mul)       | None (→ Phase 50)   |
+    +-----------------------------------+---------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. Partition each factor:
+         - Exactly one :func:`_is_log_of_diverging_in_k` factor → ``log_factor``.
+         - All others must be polynomials in ``k``; sum their degrees.
+         - Any factor that is neither → bail.
+      3. Must find exactly one log factor; zero or two → return ``None``.
+      4. Return ``(log_factor, poly_deg_sum)``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_factor: IRNode | None = None
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            # Only one Log(diverging) factor is allowed.
+            if log_factor is not None:
+                return None
+            log_factor = arg
+            continue
+        # Otherwise it must be a polynomial in k.
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is None:
+            # Neither a Log(diverging) shape nor a polynomial — bail.
+            return None
+        poly_deg_sum += deg
+    # Must have found exactly one Log(diverging) factor.
+    if log_factor is None:
+        return None
+    return (log_factor, poly_deg_sum)
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1484,3 +1484,125 @@ class TestEvaluateSumPhase53SqrtTimesPolynomialNumerator:
         assert not (isinstance(result, IRApply) and result.head == SUM), (
             f"Regression: Sqrt(k)/k² should close via Phase 51; got {result!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 54 — Log × polynomial numerator pattern.
+# ---------------------------------------------------------------------------
+# ``log(h(k)) · P(k) / Q(k)`` vanishes at infinity when ``deg(Q) > deg(P)``
+# (strictly).  The log factor grows sub-polynomially — slower than any
+# positive power of k — so the effective growth degree is just ``deg(P)``.
+#
+# The helper ``_split_log_polynomial_factor`` requires exactly one
+# Log(diverging) factor in a Mul node; all other factors must be polynomial.
+# It returns ``(log_factor, poly_deg_sum)``.  The branch in
+# ``_g_vanishes_at_infinity`` closes when ``den_deg > poly_deg_sum``.
+#
+# Equal degrees are refused because ``log(k) * constant`` diverges to ±∞.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase54LogTimesPolynomialNumerator:
+    """Phase 54: Mul(Log(diverging), polynomial_factors) numerator."""
+
+    def test_log_k_times_k_over_k_cubed_closes(self):
+        """``log(k)·k/k³``: log×poly_deg_1 over deg_3.  Phase 54 closes.
+
+        The summand comes from a telescoping difference
+        ``g(k) − g(k+1)`` where ``g(k) = log(k)·k/k³ = log(k)/k²``.
+        poly_deg=1, den_deg=3, so 3 > 1 → vanishes.
+        """
+        from symbolic_ir import LOG, POW, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (log_k, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 54 should close log(k)·k/k³; got {result!r}"
+        )
+
+    def test_log_k_times_k_squared_over_k_cubed_closes(self):
+        """``log(k)·k²/k³``: log×poly_deg_2 over deg_3.  3 > 2 → closes."""
+        from symbolic_ir import LOG, POW, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (log_k, k_sq))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (log_kp1, kp1_sq))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 54 should close log(k)·k²/k³; got {result!r}"
+        )
+
+    def test_log_k_times_k_over_k_squared_closes(self):
+        """``log(k)·k/k²``: log×poly_deg_1 over deg_2.  2 > 1 → closes."""
+        from symbolic_ir import LOG, POW, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (log_k, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 54 should close log(k)·k/k²; got {result!r}"
+        )
+
+    def test_log_k_times_k_squared_over_k_squared_refused(self):
+        """``log(k)·k²/k²`` reduces to ``log(k)`` — diverges.
+
+        poly_deg=2, den_deg=2.  Equality means the expression is
+        ``log(k) * constant``, which grows without bound.  Phase 54
+        must refuse (equal degrees are not strictly greater).
+        """
+        from symbolic_ir import LOG, POW, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (log_k, k_sq))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (log_kp1, kp1_sq))
+        g_k = IRApply(DIV, (num_k, k_sq))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_sq))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # log(k)*k²/k² = log(k) → diverges; must stay unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM, (
+            f"Phase 54: equal degrees should stay unevaluated; got {result!r}"
+        )
+
+    def test_regression_log_k_over_k_cubed_still_phase50(self):
+        """Regression: plain ``log(k)/k³`` still closes via Phase 50.
+
+        Phase 54 requires a Mul node; a bare Log(k) numerator goes via
+        Phase 50's ``_is_log_of_diverging_in_k`` fast path.
+        """
+        from symbolic_ir import LOG, POW, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        g_k = IRApply(DIV, (log_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (log_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Regression: log(k)/k³ should close via Phase 50; got {result!r}"
+        )


### PR DESCRIPTION
## Summary

- Extends `_g_vanishes_at_infinity` with a **Phase 54** branch for `Div(Mul(Log(diverging), P(k)), Q(k))` shapes
- New helper `_split_log_polynomial_factor(node, k)` partitions a `Mul` node into exactly one `Log(diverging)` factor and polynomial factors; returns `(log_factor, poly_deg_sum)`
- `log(h(k)) = o(k^ε)` for any `ε > 0`, so the effective growth degree of `log(h) * P(k)` equals `deg(P)` — the log factor is negligible for degree comparisons
- Quotient vanishes when `deg(Q) > deg(P)` strictly; equal degrees correctly refused (`log(k)*k²/k² = log(k)` diverges)
- 5 new tests; 121 total (was 116); coverage 88.23%; bumps 1.1.0 → 1.2.0

## Test plan

- [ ] `test_log_k_times_k_over_k_cubed_closes` — log(k)·k / k³, poly_deg=1 < 3 → closes
- [ ] `test_log_k_times_k_squared_over_k_cubed_closes` — log(k)·k² / k³, poly_deg=2 < 3 → closes
- [ ] `test_log_k_times_k_over_k_squared_closes` — log(k)·k / k², poly_deg=1 < 2 → closes
- [ ] `test_log_k_times_k_squared_over_k_squared_refused` — equal degrees → refused
- [ ] `test_regression_log_k_over_k_cubed_still_phase50` — plain log(k)/k³ still routes via Phase 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)