### PR TITLE
feat(cas-summation): Phase 54 — Log×polynomial numerator pattern (TS+Rust port, 1.2.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.2.0 — 2026-05-23
+
+**Phase 54 — Log×polynomial numerator pattern (Rust port).**
+
+Ports Python `cas-summation` 1.2.0 Phase 54 to Rust.  Adds
+`split_log_polynomial_factor` helper and a Phase 54 branch in
+`g_vanishes_at_infinity`.  Uses the same sub-polynomial growth argument
+as the Python/TS ports: `log(h(k)) = o(k^ε)` for any `ε > 0`.
+
+Bumps 1.1.0 → 1.2.0.
+
+### Added
+
+- **`split_log_polynomial_factor<'a>(node, k)`** — Phase 54 helper.
+  Splits a `Mul` node into exactly one `Log(diverging)` factor (by ref)
+  and a summed polynomial degree; returns `Some((&IRNode, i64))` or
+  `None`.
+
+- **Phase 54 branch in `g_vanishes_at_infinity`** — inserted after
+  Phase 53 and before Phase 42.  Closes
+  `Div(Mul(Log(diverging), P), Q)` when `den_deg > poly_deg`.
+
+- **5 new tests** (`#[test] fn phase54_*`):
+  - `phase54_log_k_times_k_over_k_cubed_closes` — poly_deg=1 < 3
+  - `phase54_log_k_times_k_squared_over_k_cubed_closes` — poly_deg=2 < 3
+  - `phase54_log_k_times_k_over_k_squared_closes` — poly_deg=1 < 2
+  - `phase54_log_k_times_k_squared_over_k_squared_stays` — equal degrees
+  - `phase54_regression_log_k_over_k_cubed_still_closes_via_phase50`
+
+### Tests
+
+61 passed (was 56; +5 net new — Phase 54).
+
+---
+
 ## 1.1.0 — 2026-05-23
 
 **Phase 53 — Sqrt × polynomial numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1094,6 +1094,47 @@ fn sqrt_poly_numerator_effective_degree_x2(node: &IRNode, k: &IRNode) -> Option<
     Some(sid + 2 * poly_deg_sum)
 }
 
+/// Phase 54 helper: split a `Mul` node into exactly one `Log(diverging)`
+/// factor and a polynomial part in `k`.
+///
+/// Returns `Some((log_factor_ref, poly_deg_sum))` when:
+///   - `node = Mul(...)`
+///   - Exactly one factor passes `is_log_of_diverging_in_k`
+///   - All remaining factors are polynomials in `k`
+///
+/// Returns `None` on any other shape (zero or two log factors, non-poly
+/// non-log factor, or non-Mul node).
+///
+/// Used by `g_vanishes_at_infinity` (Phase 54) to recognise that
+/// `log(h(k)) · P(k) / Q(k)` vanishes when `deg(Q) > deg(P)`.
+fn split_log_polynomial_factor<'a>(node: &'a IRNode, k: &IRNode) -> Option<(&'a IRNode, i64)> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut log_factor: Option<&IRNode> = None;
+    let mut poly_deg_sum: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            // Only one Log(diverging) factor is allowed.
+            if log_factor.is_some() {
+                return None;
+            }
+            log_factor = Some(arg);
+            continue;
+        }
+        match polynomial_degree_in_k(arg, k) {
+            Some(d) => poly_deg_sum += d,
+            None => return None, // Neither Log(diverging) nor polynomial — bail.
+        }
+    }
+    let lf = log_factor?; // Must have found exactly one Log(diverging) factor.
+    Some((lf, poly_deg_sum))
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1147,6 +1188,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(sqrt_poly_eff) = sqrt_poly_numerator_effective_degree_x2(num, k) {
         if let Some(den_deg_sp) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_sp > sqrt_poly_eff {
+                return true;
+            }
+        }
+    }
+    // Phase 54: Mul(Log(diverging), polynomial_factors) numerator pattern.
+    // log(h(k)) grows sub-polynomially (o(k^ε) for any ε > 0), so the
+    // effective growth degree of log(h) · P(k) equals deg(P).  Vanishes
+    // when den_deg > poly_deg (strictly).  Equal degrees are refused:
+    // log(k) * constant diverges to ±∞.
+    if let Some((_log_factor, poly_deg_lp)) = split_log_polynomial_factor(num, k) {
+        if let Some(den_deg_lp) = polynomial_degree_in_k(den, k) {
+            if den_deg_lp > poly_deg_lp {
                 return true;
             }
         }

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1144,3 +1144,95 @@ fn phase53_regression_sqrt_k_over_k_squared_still_closes_via_phase51() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 54 — Log×polynomial numerator (Rust port).
+// ---------------------------------------------------------------------------
+// log(h(k))·P(k)/Q(k) vanishes when deg(Q) > deg(P) (strictly).
+// log grows sub-polynomially so its effective growth degree equals deg(P).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase54_log_k_times_k_over_k_cubed_closes() {
+    // log(k)·k / k³: poly_deg=1, den_deg=3.  3 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k, k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase54_log_k_times_k_squared_over_k_cubed_closes() {
+    // log(k)·k² / k³: poly_deg=2, den_deg=3.  3 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_sq = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![log_k, k_sq]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, kp1_sq]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase54_log_k_times_k_over_k_squared_closes() {
+    // log(k)·k / k²: poly_deg=1, den_deg=2.  2 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k, k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase54_log_k_times_k_squared_over_k_squared_stays() {
+    // log(k)·k² / k² = log(k) → diverges.  Equal degrees must be refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_sq = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![log_k, k_sq.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, kp1_sq.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k_sq]),
+        apply(sym(DIV), vec![num_kp1, kp1_sq]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase54_regression_log_k_over_k_cubed_still_closes_via_phase50() {
+    // Plain Log(k)/k³ — Phase 54 requires Mul; Phase 50 handles this.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![apply(sym("Log"), vec![k.clone()]), apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![apply(sym("Log"), vec![kp1.clone()]), apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.2.0 — 2026-05-23
+
+**Phase 54 — Log×polynomial numerator pattern (TypeScript port).**
+
+Ports Python `cas-summation` 1.2.0 Phase 54 to TypeScript.  Adds
+`splitLogPolynomialFactor` helper and a Phase 54 branch in
+`gVanishesAtInfinity`.  `log(h(k))` grows sub-polynomially so the
+effective growth degree of `log(h) · P(k)` equals `deg(P)`.  Vanishes
+when `den_deg > poly_deg` (strictly).
+
+Bumps 1.1.0 → 1.2.0.
+
+### Added
+
+- **`splitLogPolynomialFactor(node, k)`** — Phase 54 helper.  Splits a
+  `Mul` node into exactly one `Log(diverging)` factor and a polynomial
+  part; returns `{ logFactor, polyDeg }` or `undefined`.
+
+- **Phase 54 branch in `gVanishesAtInfinity`** — inserted after Phase 53
+  and before the Phase 42 polynomial widening.  Closes
+  `Div(Mul(Log(diverging), P), Q)` when `den_deg > poly_deg`.
+
+- **5 new tests** (`describe "summation: Phase 54 Log×polynomial numerator"`):
+  - `log(k)·k / k³ closes (poly_deg=1, den_deg=3)`
+  - `log(k)·k² / k³ closes (poly_deg=2, den_deg=3)`
+  - `log(k)·k / k² closes (poly_deg=1, den_deg=2)`
+  - `log(k)·k² / k² stays unevaluated (equal degrees — diverges)`
+  - `regression: plain log(k)/k³ still closes via Phase 50`
+
+### Tests
+
+61 passed (was 56; +5 net new — Phase 54).
+
+---
+
 ## 1.1.0 — 2026-05-23
 
 **Phase 53 — Sqrt × polynomial numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -798,6 +798,43 @@ function sqrtPolyNumeratorEffectiveDegree(
   return sqrtHalfDeg + polyDegSum;
 }
 
+/**
+ * Phase 54 (TypeScript port): Return the effective polynomial degree of a
+ * ``Mul(Log(diverging), polynomial_factors)`` numerator, or ``undefined``
+ * when the shape isn't recognised.
+ *
+ * ``log(h(k))`` grows sub-polynomially — ``log(h) = o(k^ε)`` for any
+ * ``ε > 0`` — so the effective growth degree of ``log(h) · P(k)``
+ * equals ``deg(P)`` alone.  The quotient vanishes when
+ * ``den_deg > poly_deg`` (strictly).
+ *
+ * Requirements:
+ *   - ``node = Mul(...)`` — a bare ``Log(h)`` numerator goes via Phase 50.
+ *   - Exactly one factor passes ``isLogOfDivergingInK``.
+ *   - All remaining factors are polynomials in ``k``.
+ */
+function splitLogPolynomialFactor(
+  node: IRNode,
+  k: IRNode
+): { logFactor: IRNode; polyDeg: number } | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logFactor: IRNode | undefined;
+  let polyDegSum = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      // Only one Log(diverging) factor allowed; bail on a second.
+      if (logFactor !== undefined) return undefined;
+      logFactor = arg;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg === undefined) return undefined; // Neither Log(diverging) nor polynomial.
+    polyDegSum += deg;
+  }
+  if (logFactor === undefined) return undefined; // No Log factor found.
+  return { logFactor, polyDeg: polyDegSum };
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -847,6 +884,17 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (sqrtPolyEff !== undefined) {
     const denDegSp = polynomialDegreeInK(den, k);
     if (denDegSp !== undefined && denDegSp > sqrtPolyEff) {
+      return true;
+    }
+  }
+  // Phase 54: Mul(Log(diverging), polynomial_factors) numerator pattern.
+  // log(h(k)) grows sub-polynomially so the effective growth degree is just
+  // deg(poly_part).  Vanishes when den_deg > poly_deg (strictly).
+  // Equal degrees are refused: log(k)*constant diverges to ±∞.
+  const logPolyResult = splitLogPolynomialFactor(num, k);
+  if (logPolyResult !== undefined) {
+    const denDegLp = polynomialDegreeInK(den, k);
+    if (denDegLp !== undefined && denDegLp > logPolyResult.polyDeg) {
       return true;
     }
   }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -910,3 +910,77 @@ describe("summation: Phase 53 Sqrt × polynomial numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 54 — Log×polynomial numerator (TS port).
+// ---------------------------------------------------------------------------
+// log(h(k))·P(k)/Q(k) vanishes when deg(Q) > deg(P) (strictly).
+// log grows sub-polynomially so its effective growth degree equals deg(P).
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 54 Log×polynomial numerator", () => {
+  it("log(k)·k / k³ closes (poly_deg=1, den_deg=3)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Log"), [k]), k]);
+    const numKp1 = app(MUL, [app(sym("Log"), [kp1]), kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("log(k)·k² / k³ closes (poly_deg=2, den_deg=3)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Log"), [k]), app(POW, [k, int(2)])]);
+    const numKp1 = app(MUL, [app(sym("Log"), [kp1]), app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("log(k)·k / k² closes (poly_deg=1, den_deg=2)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Log"), [k]), k]);
+    const numKp1 = app(MUL, [app(sym("Log"), [kp1]), kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("log(k)·k² / k² stays unevaluated (equal degrees — diverges)", () => {
+    // log(k)*k²/k² = log(k) → diverges; equal degrees must be refused.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Log"), [k]), app(POW, [k, int(2)])]);
+    const numKp1 = app(MUL, [app(sym("Log"), [kp1]), app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+
+  it("regression: plain log(k)/k³ still closes via Phase 50", () => {
+    // Phase 54 requires a Mul node; bare Log(k) is handled by Phase 50.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const f = app(SUB, [
+      app(DIV, [app(sym("Log"), [k]), app(POW, [k, int(3)])]),
+      app(DIV, [app(sym("Log"), [kp1]), app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Ports Python Phase 54 (PR #4008) to TypeScript and Rust
- `log(h(k)) = o(k^ε)` for any `ε > 0` → effective growth degree of `log(h) · P(k)` is just `deg(P)`
- New helpers: `splitLogPolynomialFactor` (TS) / `split_log_polynomial_factor<'a>` (Rust)
- Phase 54 branch in `gVanishesAtInfinity` / `g_vanishes_at_infinity` after Phase 53, before Phase 42
- Equal degrees correctly refused (`log(k)*k²/k² = log(k)` diverges)
- 61 tests each (was 56; +5); both bumped 1.1.0 → 1.2.0

## Test plan

- [ ] `log(k)·k / k³ closes` — poly_deg=1 < den_deg=3
- [ ] `log(k)·k² / k³ closes` — poly_deg=2 < den_deg=3
- [ ] `log(k)·k / k² closes` — poly_deg=1 < den_deg=2
- [ ] `log(k)·k² / k² stays` — equal degrees refused
- [ ] `regression: plain log(k)/k³ still closes via Phase 50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)