### PR TITLE
feat(sql-pipeline): COLLATE in column defs + ORDER BY propagation

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -211,6 +211,7 @@ col_type          = NAME [ "(" NUMBER { "," NUMBER } ")" ] ;
 col_constraint    = ( "NOT" "NULL" ) | "NULL" | ( "PRIMARY" "KEY" )
                   | "UNIQUE" | ( "DEFAULT" primary )
                   | ( "CHECK" "(" expr ")" )
+                  | ( "COLLATE" NAME )
                   | ( "REFERENCES" NAME [ "(" NAME ")" ] ) ;
 
 drop_table_stmt   = "DROP" "TABLE" [ "IF" "EXISTS" ] NAME ;

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [1.85.0] - 2026-05-23
+
+### Added
+
+- ``COLLATE name`` accepted as a column constraint in CREATE TABLE:
+
+      CREATE TABLE users(email TEXT COLLATE NOCASE);
+
+  Plays through the full pipeline (parser → adapter → codegen → VM
+  → backend) and is then read back by the planner when an ORDER BY
+  references the column without an explicit COLLATE override.  So::
+
+      CREATE TABLE t(name TEXT COLLATE NOCASE);
+      INSERT INTO t VALUES ('Banana'), ('apple'), ('CHERRY');
+      SELECT name FROM t ORDER BY name;
+      -- ('apple',), ('Banana',), ('CHERRY',)   ← NOCASE order
+
+  matches stdlib sqlite3 byte-for-byte.  Explicit ``COLLATE`` on the
+  ORDER BY clause still overrides the column's declared collation.
+
+- 15 oracle tests in ``tests/test_tier3_column_collate.py``: parsing
+  of COLLATE alongside every other column constraint (NOT NULL,
+  DEFAULT, UNIQUE, PRIMARY KEY), implicit / explicit / RTRIM
+  propagation, per-column independence, and ``ALTER TABLE ADD COLUMN
+  … COLLATE`` round-trip.
+
+### Changed
+
+- Adapter ``_col_def`` recognises the new ``COLLATE NAME``
+  ``col_constraint`` and stores the upper-cased name on the column's
+  ``BackendColumnDef.collation`` field.
+
 ## [1.84.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.84.0"
+version = "1.85.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1345,6 +1345,7 @@ def _col_def(node: ASTNode, state: _PlaceholderCounter | None = None) -> Backend
     check_expression = None
     foreign_key: tuple[str, str | None] | None = None
     col_default = NO_DEFAULT   # "no DEFAULT clause" sentinel
+    collation: str | None = None  # COLLATE clause on the column def
     _state = state or _PlaceholderCounter()
     for c in _child_nodes(node, "col_constraint"):
         kw_seq = tuple(
@@ -1373,6 +1374,19 @@ def _col_def(node: ASTNode, state: _PlaceholderCounter | None = None) -> Backend
             ref_table = ref_names[0] if ref_names else ""
             ref_col: str | None = ref_names[1] if len(ref_names) > 1 else None
             foreign_key = (ref_table, ref_col)
+        elif kw_seq[0:1] == ("COLLATE",):
+            # col_constraint grammar: "COLLATE" NAME
+            # The NAME is the collation name (BINARY / NOCASE / RTRIM,
+            # or any user-defined name).  Stored upper-cased on the
+            # column definition; the planner consults it as the default
+            # collation when an ORDER BY references the column without
+            # an explicit COLLATE override.
+            name_token = next(
+                (t for t in c.children if isinstance(t, Token) and _token_type(t) == "NAME"),
+                None,
+            )
+            if name_token is not None:
+                collation = name_token.value.upper()
         elif kw_seq[0:1] == ("DEFAULT",):
             # col_constraint grammar: "DEFAULT" primary
             #
@@ -1401,6 +1415,7 @@ def _col_def(node: ASTNode, state: _PlaceholderCounter | None = None) -> Backend
         default=col_default,
         check_expr=check_expression,
         foreign_key=foreign_key,
+        collation=collation,
     )
 
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_column_collate.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_column_collate.py
@@ -1,0 +1,173 @@
+"""``COLLATE name`` as a column constraint in ``CREATE TABLE``.
+
+This is the third part of the COLLATE work, building on PRs #3985
+(ORDER BY ... COLLATE) and #4002 (COLLATE postfix in comparison
+operands).  Here we let the user declare a column's *default*
+collation at table-creation time::
+
+    CREATE TABLE users (
+        email TEXT COLLATE NOCASE,
+        …
+    );
+
+After this, ``ORDER BY email`` against this table sorts case-
+insensitively even without an explicit ``COLLATE NOCASE`` on the
+ORDER BY clause — matching SQLite.  Explicit ``COLLATE`` on the
+ORDER BY overrides the column's declaration.
+
+These oracle tests pin the behaviour byte-for-byte against stdlib
+``sqlite3``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _check_with_setup(setup: list[str], query: str) -> None:
+    mc = mini_sqlite.connect(":memory:")
+    rc = sqlite3.connect(":memory:")
+    for stmt in setup:
+        mc.execute(stmt)
+        rc.execute(stmt)
+    m = list(mc.execute(query))
+    r = list(rc.execute(query))
+    assert m == r, f"SQL: {query!r}\n  mini: {m}\n  ref:  {r}"
+
+
+# ---------------------------------------------------------------------------
+# CREATE TABLE parsing — the column-constraint COLLATE clause must parse
+# alongside every combination of other constraints.
+# ---------------------------------------------------------------------------
+
+
+class TestCollateParses:
+    def test_collate_only(self) -> None:
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT COLLATE NOCASE)"
+        )
+
+    def test_collate_with_not_null(self) -> None:
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT NOT NULL COLLATE NOCASE)"
+        )
+
+    def test_collate_with_default(self) -> None:
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT COLLATE NOCASE DEFAULT 'anon')"
+        )
+
+    def test_collate_with_unique(self) -> None:
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT UNIQUE COLLATE NOCASE)"
+        )
+
+    def test_collate_with_primary_key(self) -> None:
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT PRIMARY KEY COLLATE NOCASE)"
+        )
+
+    def test_collate_rtrim(self) -> None:
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT COLLATE RTRIM)"
+        )
+
+    def test_collate_binary(self) -> None:
+        # Explicit BINARY is a no-op (matches the default), but should parse.
+        mini_sqlite.connect(":memory:").execute(
+            "CREATE TABLE t(name TEXT COLLATE BINARY)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default-collation propagation: ``ORDER BY column`` against a column
+# declared ``COLLATE NOCASE`` sorts case-insensitively without the
+# user repeating COLLATE on the ORDER BY.
+# ---------------------------------------------------------------------------
+
+
+class TestOrderByPropagation:
+    setup = [
+        "CREATE TABLE t(name TEXT COLLATE NOCASE)",
+        "INSERT INTO t VALUES ('Banana'), ('apple'), ('CHERRY')",
+    ]
+
+    def test_implicit_nocase(self) -> None:
+        _check_with_setup(self.setup, "SELECT name FROM t ORDER BY name")
+
+    def test_implicit_nocase_desc(self) -> None:
+        _check_with_setup(self.setup, "SELECT name FROM t ORDER BY name DESC")
+
+    def test_explicit_binary_overrides(self) -> None:
+        # Per SQLite, an explicit COLLATE on the ORDER BY beats the
+        # column's declared collation.
+        _check_with_setup(
+            self.setup, "SELECT name FROM t ORDER BY name COLLATE BINARY"
+        )
+
+    def test_explicit_nocase_redundant(self) -> None:
+        # Explicit COLLATE NOCASE produces the same result as the
+        # implicit one (column-declared NOCASE).
+        _check_with_setup(
+            self.setup, "SELECT name FROM t ORDER BY name COLLATE NOCASE"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-column table — some columns declared COLLATE NOCASE, others
+# left as BINARY default.  The propagation is per-column.
+# ---------------------------------------------------------------------------
+
+
+class TestPerColumnDefault:
+    setup = [
+        "CREATE TABLE u(name TEXT COLLATE NOCASE, raw TEXT)",
+        "INSERT INTO u VALUES ('Banana', 'Banana'), ('apple', 'apple'), ('CHERRY', 'CHERRY')",
+    ]
+
+    def test_collated_column_sorts_nocase(self) -> None:
+        _check_with_setup(
+            self.setup, "SELECT name FROM u ORDER BY name"
+        )
+
+    def test_binary_column_sorts_binary(self) -> None:
+        # ``raw`` has no COLLATE declaration, so it uses BINARY default.
+        _check_with_setup(
+            self.setup, "SELECT raw FROM u ORDER BY raw"
+        )
+
+
+# ---------------------------------------------------------------------------
+# RTRIM column collation propagates the same way.
+# ---------------------------------------------------------------------------
+
+
+class TestRtrimColumn:
+    setup = [
+        "CREATE TABLE t(name TEXT COLLATE RTRIM)",
+        "INSERT INTO t VALUES ('foo   '), ('bar'), ('foo')",
+    ]
+
+    def test_implicit_rtrim_sort(self) -> None:
+        _check_with_setup(self.setup, "SELECT name FROM t ORDER BY name")
+
+
+# ---------------------------------------------------------------------------
+# ALTER TABLE ADD COLUMN with COLLATE — the new column's declared
+# collation should propagate the same way.
+# ---------------------------------------------------------------------------
+
+
+class TestAlterTable:
+    def test_add_column_with_collate(self) -> None:
+        # ALTER TABLE … ADD COLUMN with a COLLATE constraint should
+        # accept the syntax and the new column should sort according
+        # to its declared collation.
+        setup = [
+            "CREATE TABLE t(id INTEGER)",
+            "ALTER TABLE t ADD COLUMN name TEXT COLLATE NOCASE",
+            "INSERT INTO t(id, name) VALUES (1, 'Banana'), (2, 'apple'), (3, 'CHERRY')",
+        ]
+        _check_with_setup(setup, "SELECT name FROM t ORDER BY name")

--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-05-23
+
+### Added
+
+- ``ColumnDef.collation: str | None`` field — carries the column's
+  declared ``COLLATE name`` from ``CREATE TABLE``.  Stored upper-cased
+  (or ``None`` for BINARY / unspecified).  Used by the planner to set
+  the default sort collation when an ``ORDER BY`` references the
+  column without an explicit ``COLLATE`` override.
+- ``SchemaProvider.column_collation(table, column)`` — optional
+  method returning the declared collation for a column, or ``None``.
+  Default implementation returns ``None``; the ``_BackendSchemaProvider``
+  override reads the underlying ``ColumnDef.collation`` field, so
+  any Backend wired through ``backend_as_schema_provider`` advertises
+  its column-level collations to the planner automatically.
+
 ## [0.12.0] - 2026-05-12
 
 ### Added

--- a/code/packages/python/sql-backend/pyproject.toml
+++ b/code/packages/python/sql-backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-backend"
-version = "0.12.0"
+version = "0.13.0"
 description = "Pluggable data-source interface for the SQL pipeline — ships the Backend ABC, supporting types, an InMemoryBackend reference, and conformance test helpers."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-backend/src/sql_backend/backend.py
+++ b/code/packages/python/sql-backend/src/sql_backend/backend.py
@@ -431,6 +431,18 @@ class SchemaProvider(ABC):
     def columns(self, table: str) -> list[str]:
         """Return the column *names* of ``table`` (not full ColumnDefs)."""
 
+    def column_collation(self, table: str, column: str) -> str | None:
+        """Return the declared ``COLLATE name`` for a column, or ``None``.
+
+        Default implementation returns ``None`` for *every* column — minimal
+        :class:`SchemaProvider` implementations don't track collation.  Real
+        :class:`Backend`-backed providers override this to look up the
+        :class:`ColumnDef.collation` field on the underlying column metadata,
+        so that ``ORDER BY name`` against a column declared
+        ``name TEXT COLLATE NOCASE`` automatically sorts NOCASE.
+        """
+        return None
+
 
 class _BackendSchemaProvider(SchemaProvider):
     """Adapter: expose a Backend as a SchemaProvider.
@@ -446,6 +458,17 @@ class _BackendSchemaProvider(SchemaProvider):
 
     def columns(self, table: str) -> list[str]:
         return [col.name for col in self._backend.columns(table)]
+
+    def column_collation(self, table: str, column: str) -> str | None:
+        """Look up the declared collation for *table.column*, if any."""
+        try:
+            cols = self._backend.columns(table)
+        except Exception:  # noqa: BLE001 — unknown table → no collation info
+            return None
+        for col in cols:
+            if col.name == column:
+                return col.collation
+        return None
 
     def list_indexes(self, table: str) -> list[IndexDef]:
         """Proxy ``Backend.list_indexes`` filtered to *table*."""

--- a/code/packages/python/sql-backend/src/sql_backend/schema.py
+++ b/code/packages/python/sql-backend/src/sql_backend/schema.py
@@ -103,6 +103,11 @@ class ColumnDef:
     # (ref_table, ref_col_or_None) — None ref_col means "reference the PK".
     # Typed as object to avoid circular import with planner types.
     foreign_key: object = field(default=None, compare=False, hash=False)
+    # ``COLLATE name`` from CREATE TABLE — the column's declared default
+    # comparison-collation.  Used as the default when an ORDER BY clause
+    # references this column without an explicit COLLATE override.
+    # ``None`` means BINARY (the SQLite default).  Stored upper-cased.
+    collation: str | None = None
 
     def effective_not_null(self) -> bool:
         """PRIMARY KEY implies NOT NULL. Convenience for the constraint enforcer."""

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.35.0] - 2026-05-23
+
+### Added
+
+- ``ColumnDef.collation: str | None`` IR field — carries the column's
+  declared COLLATE clause from CREATE TABLE through to the VM.  The
+  codegen's column-def builder forwards
+  ``planner_col.collation → ir_col.collation`` unchanged.
+
 ## [1.34.0] - 2026-05-22
 
 ### Added

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.34.0"
+version = "1.35.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -1843,6 +1843,7 @@ def _to_ir_col(c: AstColumnDef) -> IrColumnDef:
         default=ir_default,
         check_instrs=check_instrs,
         foreign_key=fk,
+        collation=c.collation,
     )
 
 

--- a/code/packages/python/sql-codegen/src/sql_codegen/ir.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/ir.py
@@ -849,6 +849,11 @@ class ColumnDef:
     check_instrs: tuple[Instruction, ...] = ()
     # (ref_table, ref_col_or_None) where None means "reference the parent PK".
     foreign_key: tuple[str, str | None] | None = None
+    # ``COLLATE name`` from the CREATE TABLE source.  Passed through to the
+    # backend's ColumnDef so the planner can consult it when an ORDER BY
+    # references this column without an explicit COLLATE override.
+    # ``None`` means BINARY (the SQLite default).
+    collation: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/sql-parser/CHANGELOG.md
+++ b/code/packages/python/sql-parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the SQL parser package will be documented in this file.
 
+## [0.36.0] - 2026-05-23
+
+### Added
+
+- ``col_constraint`` now accepts ``COLLATE name`` as one of its
+  alternatives, matching SQLite's column-constraint grammar:
+
+      col_constraint = ( "NOT" "NULL" ) | "NULL" | ( "PRIMARY" "KEY" )
+                     | "UNIQUE" | ( "DEFAULT" primary )
+                     | ( "CHECK" "(" expr ")" )
+                     | ( "COLLATE" NAME )                            ← new
+                     | ( "REFERENCES" NAME [ "(" NAME ")" ] ) ;
+
+  This lets users declare a column's default comparison-collation at
+  CREATE TABLE time: ``CREATE TABLE users(email TEXT COLLATE NOCASE)``.
+- Regenerated ``_grammar.py`` to embed the new alternative.
+
 ## [0.35.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-parser/pyproject.toml
+++ b/code/packages/python/sql-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-parser"
-version = "0.35.0"
+version = "0.36.0"
 description = "Parses SQL text into ASTs using the grammar-driven parser — a thin wrapper that loads sql.grammar"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-parser/src/sql_parser/_grammar.py
+++ b/code/packages/python/sql-parser/src/sql_parser/_grammar.py
@@ -843,6 +843,12 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Group(element=
                     Sequence(elements=[
+                        Literal(value='COLLATE'),
+                        RuleReference(name='NAME', is_token=True),
+                    ]),
+                ),
+                Group(element=
+                    Sequence(elements=[
                         Literal(value='REFERENCES'),
                         RuleReference(name='NAME', is_token=True),
                         Optional(element=
@@ -871,7 +877,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=216,
+            line_number=217,
         ),
         GrammarRule(
             name='alter_table_stmt',
@@ -886,7 +892,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='col_def', is_token=False),
             ]),
-            line_number=220,
+            line_number=221,
         ),
         GrammarRule(
             name='create_index_stmt',
@@ -920,7 +926,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='where_clause', is_token=False),
                 ),
             ]),
-            line_number=229,
+            line_number=230,
         ),
         GrammarRule(
             name='index_col',
@@ -940,7 +946,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=246,
+            line_number=247,
         ),
         GrammarRule(
             name='drop_index_stmt',
@@ -956,7 +962,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=248,
+            line_number=249,
         ),
         GrammarRule(
             name='create_view_stmt',
@@ -975,7 +981,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='AS'),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=256,
+            line_number=257,
         ),
         GrammarRule(
             name='drop_view_stmt',
@@ -991,7 +997,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=258,
+            line_number=259,
         ),
         GrammarRule(
             name='begin_stmt',
@@ -1002,7 +1008,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=264,
+            line_number=265,
         ),
         GrammarRule(
             name='commit_stmt',
@@ -1013,7 +1019,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=265,
+            line_number=266,
         ),
         GrammarRule(
             name='rollback_stmt',
@@ -1024,7 +1030,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=266,
+            line_number=267,
         ),
         GrammarRule(
             name='savepoint_stmt',
@@ -1033,7 +1039,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='SAVEPOINT'),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=282,
+            line_number=283,
         ),
         GrammarRule(
             name='release_stmt',
@@ -1045,7 +1051,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=283,
+            line_number=284,
         ),
         GrammarRule(
             name='rollback_to_stmt',
@@ -1058,13 +1064,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=284,
+            line_number=285,
         ),
         GrammarRule(
             name='expr',
             body=
             RuleReference(name='or_expr', is_token=False),
-            line_number=288,
+            line_number=289,
         ),
         GrammarRule(
             name='or_expr',
@@ -1078,7 +1084,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=289,
+            line_number=290,
         ),
         GrammarRule(
             name='and_expr',
@@ -1092,7 +1098,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=290,
+            line_number=291,
         ),
         GrammarRule(
             name='not_expr',
@@ -1104,7 +1110,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='comparison', is_token=False),
             ]),
-            line_number=291,
+            line_number=292,
         ),
         GrammarRule(
             name='collated',
@@ -1118,7 +1124,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=304,
+            line_number=305,
         ),
         GrammarRule(
             name='comparison',
@@ -1216,7 +1222,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=305,
+            line_number=306,
         ),
         GrammarRule(
             name='in_expr',
@@ -1225,7 +1231,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='query_stmt', is_token=False),
                 RuleReference(name='value_list', is_token=False),
             ]),
-            line_number=321,
+            line_number=322,
         ),
         GrammarRule(
             name='cmp_op',
@@ -1238,7 +1244,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='<='),
                 Literal(value='>='),
             ]),
-            line_number=323,
+            line_number=324,
         ),
         GrammarRule(
             name='bitwise',
@@ -1259,7 +1265,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=337,
+            line_number=338,
         ),
         GrammarRule(
             name='additive',
@@ -1281,7 +1287,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=338,
+            line_number=339,
         ),
         GrammarRule(
             name='multiplicative',
@@ -1301,7 +1307,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=339,
+            line_number=340,
         ),
         GrammarRule(
             name='unary',
@@ -1318,7 +1324,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='primary', is_token=False),
             ]),
-            line_number=340,
+            line_number=341,
         ),
         GrammarRule(
             name='primary',
@@ -1352,7 +1358,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value=')'),
                 ]),
             ]),
-            line_number=360,
+            line_number=361,
         ),
         GrammarRule(
             name='column_ref',
@@ -1366,7 +1372,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=370,
+            line_number=371,
         ),
         GrammarRule(
             name='function_call',
@@ -1396,7 +1402,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='filter_clause', is_token=False),
                 ),
             ]),
-            line_number=384,
+            line_number=385,
         ),
         GrammarRule(
             name='filter_clause',
@@ -1408,7 +1414,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='expr', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=388,
+            line_number=389,
         ),
         GrammarRule(
             name='cast_expr',
@@ -1421,7 +1427,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='NAME', is_token=True),
                 Literal(value=')'),
             ]),
-            line_number=394,
+            line_number=395,
         ),
         GrammarRule(
             name='window_func_call',
@@ -1443,7 +1449,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='window_spec', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=423,
+            line_number=424,
         ),
         GrammarRule(
             name='window_spec',
@@ -1459,7 +1465,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_clause', is_token=False),
                 ),
             ]),
-            line_number=424,
+            line_number=425,
         ),
         GrammarRule(
             name='partition_clause',
@@ -1475,7 +1481,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=425,
+            line_number=426,
         ),
         GrammarRule(
             name='value_list',
@@ -1489,7 +1495,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=426,
+            line_number=427,
         ),
         GrammarRule(
             name='frame_clause',
@@ -1507,7 +1513,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_bound', is_token=False),
                 ]),
             ]),
-            line_number=448,
+            line_number=449,
         ),
         GrammarRule(
             name='frame_unit',
@@ -1517,7 +1523,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='RANGE'),
                 Literal(value='GROUPS'),
             ]),
-            line_number=450,
+            line_number=451,
         ),
         GrammarRule(
             name='frame_bound',
@@ -1544,7 +1550,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='FOLLOWING'),
                 ]),
             ]),
-            line_number=451,
+            line_number=452,
         ),
         GrammarRule(
             name='create_trigger_stmt',
@@ -1582,7 +1588,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=477,
+            line_number=478,
         ),
         GrammarRule(
             name='trigger_body_stmt',
@@ -1594,7 +1600,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='delete_stmt', is_token=False),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=482,
+            line_number=483,
         ),
         GrammarRule(
             name='drop_trigger_stmt',
@@ -1610,7 +1616,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=484,
+            line_number=485,
         ),
         GrammarRule(
             name='case_expr',
@@ -1632,13 +1638,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=499,
+            line_number=500,
         ),
         GrammarRule(
             name='case_operand',
             body=
             RuleReference(name='expr', is_token=False),
-            line_number=500,
+            line_number=501,
         ),
         GrammarRule(
             name='case_when',
@@ -1649,7 +1655,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='THEN'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=501,
+            line_number=502,
         ),
     ],
 )

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.38.0] - 2026-05-23
+
+### Added
+
+- ``_resolve_order_key`` consults ``schema.column_collation(table,
+  column)`` when an ORDER BY references a column without an explicit
+  ``COLLATE`` override.  This lets ``CREATE TABLE t(name TEXT COLLATE
+  NOCASE); SELECT * FROM t ORDER BY name`` sort case-insensitively
+  without the user repeating the COLLATE clause on every query —
+  matching SQLite.  Lookup is via ``getattr(schema, 'column_collation',
+  None)`` so minimal schema providers (e.g. ``InMemorySchemaProvider``
+  used in unit tests) that don't expose the method are silently
+  treated as "no declared collation".
+
 ## [0.37.0] - 2026-05-22
 
 ### Added

--- a/code/packages/python/sql-planner/pyproject.toml
+++ b/code/packages/python/sql-planner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-planner"
-version = "0.37.0"
+version = "0.38.0"
 description = "Translates a structured SQL AST into a Logical Plan Tree of relational-algebra nodes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-planner/src/sql_planner/planner.py
+++ b/code/packages/python/sql-planner/src/sql_planner/planner.py
@@ -367,12 +367,35 @@ def _plan_select(
                 k_expr = _substitute_aliases(k_expr, select_aliases)
             k_expr = _resolve(k_expr, scope, schema, outer_scope)
 
+        # If no explicit COLLATE on the ORDER BY clause itself, fall back
+        # to the column's declared collation (from CREATE TABLE's
+        # ``COLLATE name`` column constraint).  SQLite applies the
+        # column's collation in that situation; this keeps
+        # ``CREATE TABLE t(name TEXT COLLATE NOCASE); SELECT * FROM t
+        # ORDER BY name`` sorting case-insensitively without the user
+        # having to repeat the COLLATE clause.  Only the simple case
+        # ``ORDER BY column`` is handled here — when the sort expression
+        # is more complex (e.g. ``ORDER BY length(name)``), SQLite uses
+        # BINARY regardless.
+        effective_collation = k.collation
+        if effective_collation is None and isinstance(k_expr, Column):
+            table_name = k_expr.table
+            col_name = k_expr.col
+            # ``column_collation`` is an optional method on SchemaProvider —
+            # full backend-backed providers expose it; minimal test
+            # providers (e.g. InMemorySchemaProvider) don't.  Use
+            # ``getattr(...)`` so the missing case is silently treated
+            # as "no declared collation" rather than crashing.
+            lookup = getattr(schema, "column_collation", None)
+            if lookup is not None and table_name is not None:
+                effective_collation = lookup(table_name, col_name)
+
         return P.SortKey(
             expr=k_expr,
             descending=k.descending,
             nulls_first=k.nulls_first,
             positional_index=positional_index,
-            collation=k.collation,
+            collation=effective_collation,
         )
 
     order_by = tuple(_resolve_order_key(k) for k in stmt.order_by)

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.51.0 — 2026-05-23
+
+### Changed
+
+- ``_do_create_table`` and ``_do_alter_table`` now forward the
+  ``collation`` field from the IR ``ColumnDef`` to the backend's
+  ``ColumnDef``.  This is the last hop on the journey from
+  ``CREATE TABLE t(name TEXT COLLATE NOCASE)`` SQL through to the
+  backend column metadata — the planner then reads it back via
+  ``SchemaProvider.column_collation`` when resolving an ORDER BY
+  clause.
+
 ## 1.50.0 — 2026-05-22
 
 ### Added

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.50.0"
+version = "1.51.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -2574,6 +2574,7 @@ def _do_create_table(ins: CreateTable, st: _VmState) -> None:
             # Any other value (including None = SQL NULL) is a literal default
             # that passes through unchanged.
             default=_BE_NO_DEFAULT if c.default is _IR_NO_DEFAULT else c.default,
+            collation=c.collation,
         )
         for c in ins.columns
     ]
@@ -2782,6 +2783,7 @@ def _do_alter_table(ins: AlterTable, st: _VmState) -> None:
         name=ins.column.name,
         type_name=ins.column.type,
         not_null=not ins.column.nullable,
+        collation=ins.column.collation,
     )
     try:
         st.backend.add_column(ins.table, col)


### PR DESCRIPTION
## Summary

Third part of the COLLATE work — building on PR #3985 (ORDER BY) and PR #4002 (comparison operands). Lets the user declare a column's default collation at CREATE TABLE time:

```sql
CREATE TABLE users(email TEXT COLLATE NOCASE);

-- Now this sorts case-insensitively without explicit COLLATE:
SELECT email FROM users ORDER BY email;
```

Explicit `COLLATE` on the ORDER BY clause still overrides the column's declaration.

## Pipeline changes

| Package | Change |
|---|---|
| sql-parser 0.35 → 0.36 | `col_constraint` accepts `COLLATE NAME` |
| sql-backend 0.12 → 0.13 | `ColumnDef.collation` field; `SchemaProvider.column_collation()` optional method |
| sql-planner 0.37 → 0.38 | `_resolve_order_key` falls back to column's declared collation |
| sql-codegen 1.34 → 1.35 | IR `ColumnDef.collation` field |
| sql-vm 1.50 → 1.51 | `_do_create_table` / `_do_alter_table` forward to backend |
| mini-sqlite 1.84 → 1.85 | Adapter parses `COLLATE NAME` column constraint |

## Test plan

- [x] 15 oracle tests in `test_tier3_column_collate.py`
- [x] All 2060 mini-sqlite tests pass at 91.40% coverage
- [x] All sql-backend (132), sql-planner (219), sql-codegen (82), sql-vm (916), sql-optimizer (165), sql-parser (91) tests pass
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)