### PR TITLE
feat(ml-framework-core): MX11 — implement NumPy interop on Tensor (from_numpy / to_numpy / numpy)

### DIFF
--- a/code/packages/python/ml-framework-core/CHANGELOG.md
+++ b/code/packages/python/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+### Added — MX11 implementation: NumPy interop for `Tensor`
+
+Implements the spec from `code/specs/MX11-numpy-interop.md` (landed
+in a prior PR).  Three new methods on `Tensor`:
+
+- `Tensor.from_numpy(arr, *, requires_grad=False, device=None)` —
+  classmethod; copies the ndarray into a new Tensor.
+- `Tensor.to_numpy()` — instance method; returns a fresh `np.float64`
+  copy.
+- `Tensor.numpy()` — PyTorch-style alias for `to_numpy()`.
+
+#### Behaviour summary (full contract in the spec)
+
+- **Soft dependency on numpy.**  Try/except `import numpy as np` at
+  call time inside each method; on `ImportError` we re-raise with the
+  message `"numpy is required for Tensor.{from,to}_numpy; install it
+  with 'pip install numpy'"`.  The package itself imports cleanly
+  without numpy installed.
+- **Both directions copy.**  No view sharing; mutating the returned
+  ndarray does not affect the source Tensor and vice versa.
+- **Output dtype always f64.**  Callers cast with
+  `arr.astype(np.float32)` if they need f32.
+- **0-d arrays → shape `(1,)`** to match the
+  `SumFunction(dim=None)` scalar convention.
+- **Empty arrays → ValueError** (Tensor's `numel >= 1` invariant).
+- **Unsupported dtypes** (complex/object/string/structured) →
+  `TypeError` with a message listing the supported set
+  (floats/ints/uints/bool).
+- **Non-contiguous arrays** are copied via `np.ascontiguousarray`
+  before flattening — transposed/strided inputs round-trip with the
+  expected C-order layout.
+
+#### Tests
+
+- `tests/test_numpy_interop.py` — 17 round-trip and error-case tests
+  (skip if numpy isn't installed; matches the
+  `test_rust_backend_parity.py` skip pattern).  Covers each numpy
+  dtype in the spec's matrix, the unsupported-dtype error paths,
+  empty/scalar/non-contiguous edge cases, copy-not-view, dtype-is-f64,
+  and the `requires_grad`/`device` parameter propagation.
+- `tests/test_numpy_interop_no_numpy.py` — 2 tests that **always
+  run**.  Monkey-patch `sys.modules["numpy"] = None`, call
+  `Tensor.from_numpy(...)` and `t.to_numpy()`, confirm each raises
+  `ImportError` with `"pip install numpy"` in the message.
+
+Full suite locally: **388 passed + 57 skipped** + the pre-existing
+`test_device.py` failure that's on main throughout this work.
+
 ### Added — MX11 spec: NumPy interop for `Tensor`
 
 Spec-only PR (`code/specs/MX11-numpy-interop.md`) defining the

--- a/code/packages/python/ml-framework-core/src/ml_framework_core/tensor.py
+++ b/code/packages/python/ml-framework-core/src/ml_framework_core/tensor.py
@@ -258,6 +258,120 @@ class Tensor:
         return Tensor(flat, shape, requires_grad, device)
 
     # =====================================================================
+    # NumPy interop (MX11)
+    #
+    # See code/specs/MX11-numpy-interop.md for the full contract.  TL;DR:
+    # numpy is a soft dependency (try/except at call time); both directions
+    # copy (no view sharing); output dtype is always f64.
+    # =====================================================================
+
+    @classmethod
+    def from_numpy(
+        cls,
+        arr,
+        *,
+        requires_grad: bool = False,
+        device: str | None = None,
+    ) -> Tensor:
+        """Build a Tensor from a numpy ndarray.
+
+        Always copies (the source ndarray and the resulting Tensor share
+        no memory — mutating one does not affect the other).  Supported
+        numpy dtypes are cast to Python ``float``; see the MX11 spec for
+        the full dtype matrix.
+
+        Args:
+            arr: numpy.ndarray.  Must have a numeric or bool dtype, must
+                not be empty (any dim == 0 raises ``ValueError``).
+                0-d arrays are accepted and produce a shape-``(1,)``
+                Tensor matching the SumFunction(dim=None) convention.
+            requires_grad: whether the resulting Tensor should track
+                gradients.  Default False.
+            device: device string; defaults to the Tensor default ("cpu").
+
+        Raises:
+            ImportError: if numpy isn't installed.
+            TypeError: if ``arr`` isn't a numpy ndarray, or if its dtype
+                is unsupported (complex, object, string, structured, ...).
+            ValueError: if ``arr`` is empty (any dim == 0).
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            raise ImportError(
+                "numpy is required for Tensor.from_numpy; "
+                "install it with 'pip install numpy'"
+            ) from None
+        if not isinstance(arr, np.ndarray):
+            raise TypeError(
+                f"Tensor.from_numpy expected numpy.ndarray, got "
+                f"{type(arr).__name__}"
+            )
+        # Only numeric and bool dtypes are supported.  ``kind`` letters:
+        #   'f' = float, 'i' = signed int, 'u' = unsigned int, 'b' = bool.
+        # Everything else (complex 'c', object 'O', string 'U'/'S',
+        # structured 'V', ...) raises with a clear message.
+        if arr.dtype.kind not in ("f", "i", "u", "b"):
+            raise TypeError(
+                f"Tensor.from_numpy: unsupported numpy dtype "
+                f"{arr.dtype!r}; only floats, ints, uints, and bool "
+                f"are supported"
+            )
+        if arr.size == 0:
+            raise ValueError(
+                "Tensor.from_numpy: empty arrays (any dim == 0) are not "
+                "supported because ml_framework_core.Tensor requires "
+                "numel >= 1"
+            )
+        # 0-d (scalar) arrays become shape (1,) — matches the
+        # SumFunction(dim=None) scalar convention.
+        if arr.ndim == 0:
+            return cls(
+                [float(arr.item())],
+                (1,),
+                requires_grad=requires_grad,
+                device=device if device is not None else "cpu",
+            )
+        # Non-contiguous (transposed, strided) arrays: copy via
+        # ascontiguousarray so the flat-list extraction matches the
+        # user-visible shape ordering.
+        contig = np.ascontiguousarray(arr)
+        data = [float(x) for x in contig.flatten().tolist()]
+        shape = tuple(int(d) for d in arr.shape)
+        return cls(
+            data,
+            shape,
+            requires_grad=requires_grad,
+            device=device if device is not None else "cpu",
+        )
+
+    def to_numpy(self):
+        """Convert this Tensor to a numpy ndarray.
+
+        Always returns a fresh ``np.float64`` copy — mutating the
+        returned array is safe and does not affect the Tensor.  Output
+        shape matches ``self.shape``.
+
+        Raises:
+            ImportError: if numpy isn't installed.
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            raise ImportError(
+                "numpy is required for Tensor.to_numpy; "
+                "install it with 'pip install numpy'"
+            ) from None
+        # np.array(list, dtype=np.float64) constructs a fresh f64 buffer
+        # from the Python floats; reshape into the Tensor's shape.
+        # Both steps copy — the returned ndarray owns its own buffer.
+        return np.array(self.data, dtype=np.float64).reshape(self.shape)
+
+    def numpy(self):
+        """PyTorch-style alias for :meth:`to_numpy`."""
+        return self.to_numpy()
+
+    # =====================================================================
     # Arithmetic operators (each creates an autograd-tracked result)
     # =====================================================================
 

--- a/code/packages/python/ml-framework-core/tests/test_numpy_interop.py
+++ b/code/packages/python/ml-framework-core/tests/test_numpy_interop.py
@@ -1,0 +1,160 @@
+"""
+================================================================
+test_numpy_interop — MX11 acceptance gate (with numpy installed)
+================================================================
+
+Round-trip and error-case tests for ``Tensor.from_numpy`` /
+``Tensor.to_numpy``.  All tests here **skip** if numpy isn't installed
+— matches the existing skip pattern from MX10's
+``test_rust_backend_parity.py``.
+
+The complementary file ``test_numpy_interop_no_numpy.py`` exercises
+the soft-dependency path (numpy unavailable → ImportError) and is
+always run.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ml_framework_core import Tensor
+
+try:
+    import numpy as np
+
+    NUMPY_AVAILABLE = True
+except ImportError:
+    NUMPY_AVAILABLE = False
+
+
+@unittest.skipUnless(
+    NUMPY_AVAILABLE,
+    "numpy not installed; install with 'pip install numpy' to exercise these tests.",
+)
+class NumpyRoundTripTests(unittest.TestCase):
+    """Build a numpy array, convert to Tensor, convert back, compare."""
+
+    def test_roundtrip_float64(self) -> None:
+        """f64 → Tensor → f64 should be exact (Tensor is f64-internal)."""
+        arr = np.array([[1.5, 2.5], [3.5, 4.5]], dtype=np.float64)
+        t = Tensor.from_numpy(arr)
+        self.assertEqual(t.shape, (2, 2))
+        back = t.to_numpy()
+        self.assertTrue(np.array_equal(arr, back))
+        self.assertEqual(back.dtype, np.float64)
+
+    def test_roundtrip_float32(self) -> None:
+        """f32 → Tensor → cast back to f32 should round-trip exactly."""
+        arr = np.array([0.5, -1.25, 3.75], dtype=np.float32)
+        t = Tensor.from_numpy(arr)
+        back = t.to_numpy().astype(np.float32)
+        self.assertTrue(np.array_equal(arr, back))
+
+    def test_roundtrip_int8(self) -> None:
+        arr = np.array([1, -2, 3, -128, 127], dtype=np.int8)
+        t = Tensor.from_numpy(arr)
+        back = t.to_numpy().astype(np.int8)
+        self.assertTrue(np.array_equal(arr, back))
+
+    def test_roundtrip_int32(self) -> None:
+        arr = np.array([[1, 2, 3], [-4, -5, -6]], dtype=np.int32)
+        t = Tensor.from_numpy(arr)
+        back = t.to_numpy().astype(np.int32)
+        self.assertTrue(np.array_equal(arr, back))
+
+    def test_roundtrip_int64(self) -> None:
+        # Stay within 2^53 so f64 cast is exact.
+        arr = np.array([1, 2, 3, 100_000_000], dtype=np.int64)
+        t = Tensor.from_numpy(arr)
+        back = t.to_numpy().astype(np.int64)
+        self.assertTrue(np.array_equal(arr, back))
+
+    def test_roundtrip_uint8(self) -> None:
+        arr = np.array([0, 1, 255], dtype=np.uint8)
+        t = Tensor.from_numpy(arr)
+        back = t.to_numpy().astype(np.uint8)
+        self.assertTrue(np.array_equal(arr, back))
+
+    def test_roundtrip_bool(self) -> None:
+        """``bool`` → Tensor maps True/False to 1.0/0.0."""
+        arr = np.array([[True, False], [False, True]], dtype=bool)
+        t = Tensor.from_numpy(arr)
+        self.assertEqual(t.data, [1.0, 0.0, 0.0, 1.0])
+        # Round-trip back to bool via != 0
+        back = (t.to_numpy() != 0).astype(bool)
+        self.assertTrue(np.array_equal(arr, back))
+
+    def test_unsupported_dtype_complex(self) -> None:
+        arr = np.array([1 + 2j, 3 - 4j], dtype=np.complex128)
+        with self.assertRaises(TypeError) as ctx:
+            Tensor.from_numpy(arr)
+        self.assertIn("unsupported numpy dtype", str(ctx.exception))
+
+    def test_unsupported_dtype_object(self) -> None:
+        arr = np.array(["a", "b", "c"], dtype=object)
+        with self.assertRaises(TypeError):
+            Tensor.from_numpy(arr)
+
+    def test_from_numpy_non_array_raises_typeerror(self) -> None:
+        """Pass a Python list → TypeError (only ndarray accepted)."""
+        with self.assertRaises(TypeError) as ctx:
+            Tensor.from_numpy([1, 2, 3])
+        self.assertIn("expected numpy.ndarray", str(ctx.exception))
+
+    def test_from_numpy_empty_array_raises_valueerror(self) -> None:
+        """Any zero-sized dim → ValueError (Tensor requires numel >= 1)."""
+        arr = np.zeros((0, 5), dtype=np.float32)
+        with self.assertRaises(ValueError) as ctx:
+            Tensor.from_numpy(arr)
+        self.assertIn("empty", str(ctx.exception).lower())
+
+    def test_from_numpy_zero_dim_returns_shape_1(self) -> None:
+        """0-d (scalar) ndarray → Tensor of shape (1,)."""
+        arr = np.array(7.5, dtype=np.float64)
+        t = Tensor.from_numpy(arr)
+        self.assertEqual(t.shape, (1,))
+        self.assertEqual(t.data, [7.5])
+
+    def test_from_numpy_non_contiguous(self) -> None:
+        """Transposed (non-contiguous) array → values preserved in C-order."""
+        arr = np.arange(6, dtype=np.float32).reshape(2, 3).T  # shape (3, 2)
+        self.assertFalse(arr.flags["C_CONTIGUOUS"])
+        t = Tensor.from_numpy(arr)
+        self.assertEqual(t.shape, (3, 2))
+        # ascontiguousarray(arr).flatten() = [0, 3, 1, 4, 2, 5]
+        self.assertEqual(t.data, [0.0, 3.0, 1.0, 4.0, 2.0, 5.0])
+
+    def test_to_numpy_returns_copy_not_view(self) -> None:
+        """Mutating the returned ndarray must not affect the Tensor."""
+        t = Tensor([1.0, 2.0, 3.0], (3,))
+        arr = t.to_numpy()
+        arr[0] = 999.0
+        # Tensor unchanged
+        self.assertEqual(t.data, [1.0, 2.0, 3.0])
+
+    def test_to_numpy_dtype_is_float64(self) -> None:
+        """Output dtype is always np.float64 regardless of input source."""
+        t = Tensor([1.0, 2.0, 3.0], (3,))
+        self.assertEqual(t.to_numpy().dtype, np.float64)
+
+    def test_from_numpy_preserves_requires_grad(self) -> None:
+        arr = np.array([1.0, 2.0], dtype=np.float64)
+        t = Tensor.from_numpy(arr, requires_grad=True)
+        self.assertTrue(t.requires_grad)
+
+    def test_from_numpy_preserves_device(self) -> None:
+        arr = np.array([1.0, 2.0], dtype=np.float64)
+        t = Tensor.from_numpy(arr, device="cpu")
+        # Tensor stores device as a private attribute; just confirm the
+        # round-trip survives without error and the public property
+        # returns the requested value.
+        self.assertEqual(t.device, "cpu")
+
+    def test_numpy_alias_calls_to_numpy(self) -> None:
+        """``t.numpy()`` is a PyTorch-style alias for ``t.to_numpy()``."""
+        t = Tensor([1.0, 2.0, 3.0], (3,))
+        self.assertTrue(np.array_equal(t.numpy(), t.to_numpy()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/packages/python/ml-framework-core/tests/test_numpy_interop_no_numpy.py
+++ b/code/packages/python/ml-framework-core/tests/test_numpy_interop_no_numpy.py
@@ -1,0 +1,62 @@
+"""
+================================================================
+test_numpy_interop_no_numpy — MX11 soft-dependency tests
+================================================================
+
+The MX11 spec mandates that ``Tensor.from_numpy`` and
+``Tensor.to_numpy`` raise ``ImportError`` with a helpful message
+pointing at ``pip install numpy`` when numpy isn't available at call
+time — without crashing the package import or polluting state.
+
+We simulate the "numpy not installed" environment by monkey-patching
+``sys.modules["numpy"] = None``, which is the same trick Python's
+import machinery uses to make a previously-imported module raise
+``ImportError`` on the next ``import numpy`` attempt.
+
+These tests **always run** (not skipped by NUMPY_AVAILABLE) because
+the soft-dep behaviour is critical regardless of whether numpy is
+installed in the test environment — we always want to know the error
+path works.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from unittest import mock
+
+from ml_framework_core import Tensor
+
+
+class NumpyInteropNoNumpyTests(unittest.TestCase):
+    """Confirm both methods raise ImportError when numpy is missing."""
+
+    def test_from_numpy_raises_importerror_when_numpy_missing(self) -> None:
+        """Without numpy, ``from_numpy`` must raise ImportError pointing
+        at the fix (`pip install numpy`), not crash with a NameError or
+        confusing ModuleNotFoundError trace.
+        """
+        with mock.patch.dict(sys.modules, {"numpy": None}):
+            # Setting the entry to None makes Python's import machinery
+            # raise ModuleNotFoundError on `import numpy` — which our
+            # method catches and re-raises as ImportError with the
+            # canonical message.
+            with self.assertRaises(ImportError) as ctx:
+                Tensor.from_numpy([1, 2, 3])  # any non-array also fine
+        msg = str(ctx.exception)
+        self.assertIn("numpy", msg.lower())
+        self.assertIn("pip install numpy", msg)
+
+    def test_to_numpy_raises_importerror_when_numpy_missing(self) -> None:
+        """Same for ``to_numpy`` — must give the same helpful message."""
+        t = Tensor([1.0, 2.0, 3.0], (3,))
+        with mock.patch.dict(sys.modules, {"numpy": None}):
+            with self.assertRaises(ImportError) as ctx:
+                t.to_numpy()
+        msg = str(ctx.exception)
+        self.assertIn("numpy", msg.lower())
+        self.assertIn("pip install numpy", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the MX11 spec landed in #4014. Three new methods on `Tensor`:

- `Tensor.from_numpy(arr, *, requires_grad=False, device=None)` — classmethod
- `Tensor.to_numpy()` — instance method (returns fresh `np.float64` copy)
- `Tensor.numpy()` — PyTorch-style alias

### Behaviour (full contract in the spec)

- **Soft dep on numpy.** Try/except `import numpy as np` at call time; raises `ImportError("numpy is required for Tensor.{from,to}_numpy; install it with 'pip install numpy'")` if missing. Package imports cleanly without numpy.
- **Both directions copy.** No view sharing.
- **Output dtype always f64.** Callers `arr.astype(np.float32)` if needed.
- **0-d arrays → shape `(1,)`** (matches `SumFunction(dim=None)` convention).
- **Empty arrays → ValueError.**
- **Unsupported dtypes → TypeError** with the supported set listed.
- **Non-contiguous arrays** copied via `np.ascontiguousarray` before flatten.

### Tests

- `test_numpy_interop.py` — 17 round-trip + error-case tests (skip if numpy isn't installed)
- `test_numpy_interop_no_numpy.py` — 2 tests **always run** via `sys.modules["numpy"]=None` monkey-patch, confirm `ImportError` message includes `"pip install numpy"`

Full suite: **388 passed + 57 skipped + 1 pre-existing unrelated failure**. Security review: PASSED.

## Test plan

- [x] `python3 -m pytest tests/` passes
- [x] New round-trip tests skip cleanly without numpy
- [x] New no-numpy tests always run and verify ImportError message
- [ ] CI green (numpy is installed in CI per pyproject test-deps, so the round-trip tests should run there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)