### PR TITLE
spice: add mutual inductor parser foothold

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Mutual-inductor element foothold** — `MutualInductor` now exposes the
+  public `K`-card coupling shape for future coupled-inductor AC/transient
+  stamping.
+
 - **JFET DC/AC analysis foothold** — `JFET` now participates in nonlinear DC
   operating-point solves and AC small-signal analysis using the DC bias point.
 

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -16,6 +16,7 @@ from spice_engine.elements import (
     Inductor,
     JFET,
     Mosfet,
+    MutualInductor,
     PulseWaveform,
     PwlWaveform,
     Resistor,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -295,6 +295,16 @@ class Inductor:
 
 
 @dataclass(frozen=True, slots=True)
+class MutualInductor:
+    """K<name> L1 L2 coupling"""
+
+    name: str
+    primary: str
+    secondary: str
+    coupling: float
+
+
+@dataclass(frozen=True, slots=True)
 class VoltageSource:
     """V<name> n+ n- value [waveform] [ac]
 
@@ -729,6 +739,7 @@ Element = (
     Resistor
     | Capacitor
     | Inductor
+    | MutualInductor
     | VoltageSource
     | CurrentSource
     | BSource

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -70,6 +70,7 @@ from spice_engine.elements import (
     Inductor,
     JFET,
     Mosfet,
+    MutualInductor,
     Resistor,
     SubcircuitDefinition,
     VoltageSource,
@@ -226,6 +227,8 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
         return Capacitor(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.capacitance, element.initial_voltage)
     if isinstance(element, Inductor):
         return Inductor(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.inductance, element.initial_current)
+    if isinstance(element, MutualInductor):
+        return MutualInductor(name, _map_subckt_source_ref(element.primary, instance_name), _map_subckt_source_ref(element.secondary, instance_name), element.coupling)
     if isinstance(element, VoltageSource):
         return VoltageSource(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), element.voltage, element.waveform, element.ac)
     if isinstance(element, CurrentSource):

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Parse SPICE `K` mutual-inductor cards into `MutualInductor` elements,
+  including subcircuit-local inductor reference remapping.
+
 ## 0.2.0 — 2026-05-16
 
 - Parse SPICE `J` JFET elements via `.model <name> NJF(...)` and

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -22,6 +22,7 @@ from spice_engine import (
     Inductor,
     JFET,
     Mosfet,
+    MutualInductor,
     PulseWaveform,
     PwlWaveform,
     Resistor,
@@ -342,6 +343,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             parse_value(fields[3]),
             initial_current=params.get("IC", 0.0),
         )
+    if prefix == "K":
+        _require_fields(fields, 4, "mutual inductor")
+        return MutualInductor(name, fields[1], fields[2], parse_value(fields[3]))
     if prefix == "V":
         _require_min_fields(fields, 4, "voltage source")
         source = _parse_source_value(fields[3:])
@@ -531,6 +535,10 @@ def _map_subckt_fields(
         mapped[1] = _map_subckt_node(fields[1], instance_name, node_map)
         mapped[2] = _map_subckt_node(fields[2], instance_name, node_map)
         mapped[3] = _map_subckt_source_ref(fields[3], instance_name)
+    elif prefix == "K":
+        _require_fields(fields, 4, "subcircuit mutual inductor")
+        mapped[1] = _map_subckt_source_ref(fields[1], instance_name)
+        mapped[2] = _map_subckt_source_ref(fields[2], instance_name)
     elif prefix == "X":
         mapped[1:-1] = [
             _map_subckt_node(node, instance_name, node_map) for node in fields[1:-1]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -15,6 +15,7 @@ from spice_engine import (
     Inductor,
     JFET,
     Mosfet,
+    MutualInductor,
     Resistor,
     VoltageSource,
     ac_sweep,
@@ -95,6 +96,23 @@ G1 out 0 in 0 2m
         DcAnalysis(source_name="Vstep", start=0.0, stop=1.0, step=0.5),
         AcAnalysis(mode="dec", points=10, start_hz=1.0e3, stop_hz=1.0e6),
     ]
+
+
+def test_parse_mutual_inductor_card() -> None:
+    parsed = parse_netlist(
+        """
+Lpri p 0 10m
+Lsec s 0 40m
+Kcouple Lpri Lsec 0.75
+"""
+    )
+
+    assert isinstance(parsed.circuit.elements[2], MutualInductor)
+    mutual = parsed.circuit.elements[2]
+    assert mutual.name == "Kcouple"
+    assert mutual.primary == "Lpri"
+    assert mutual.secondary == "Lsec"
+    assert mutual.coupling == 0.75
 
 
 def test_parse_options_analysis_card() -> None:
@@ -749,6 +767,26 @@ Xbuf out in 0 source_follower
     assert isinstance(resistor, Resistor)
     assert resistor.n_plus == "Xbuf.inner"
     assert resistor.n_minus == "0"
+
+
+def test_expands_subcircuit_mutual_inductor_refs_into_engine_elements() -> None:
+    parsed = parse_netlist(
+        """
+.subckt transformer p1 p2 s1 s2
+Lpri p1 p2 10m
+Lsec s1 s2 40m
+Kcore Lpri Lsec 0.9
+.ends transformer
+Xtx in 0 out 0 transformer
+"""
+    )
+
+    mutual = parsed.circuit.elements[2]
+    assert isinstance(mutual, MutualInductor)
+    assert mutual.name == "Xtx.Kcore"
+    assert mutual.primary == "Xtx.Lpri"
+    assert mutual.secondary == "Xtx.Lsec"
+    assert mutual.coupling == 0.9
 
 
 def test_expands_subcircuit_mosfet_nodes_into_engine_elements() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a public `MutualInductor` element as the parser-facing SPICE `K` card
+  foothold; coupled AC/transient stamping follows in a later compatibility
+  slice.
 - Add JFET nonlinear DC operating-point stamping and AC small-signal analysis
   from the solved DC bias point.
 - Add a public `Jfet` element and `JfetPolarity` as the parser-facing

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -253,6 +253,12 @@ fn clone_subckt_element(
             element.inductance_henrys,
             element.initial_current,
         )),
+        Element::MutualInductor(element) => Element::MutualInductor(MutualInductor::new(
+            format!("{instance_name}.{}", element.name),
+            map_subckt_source_ref(&element.primary, instance_name),
+            map_subckt_source_ref(&element.secondary, instance_name),
+            element.coupling,
+        )),
         Element::VoltageSource(element) => Element::VoltageSource(VoltageSource {
             name: format!("{instance_name}.{}", element.name),
             positive: map_subckt_node(&element.positive, instance_name, node_map),
@@ -669,6 +675,7 @@ pub enum Element {
     Resistor(Resistor),
     Capacitor(Capacitor),
     Inductor(Inductor),
+    MutualInductor(MutualInductor),
     VoltageSource(VoltageSource),
     CurrentSource(CurrentSource),
     BSource(BSource),
@@ -811,6 +818,30 @@ impl Inductor {
             n2: n2.into(),
             inductance_henrys,
             initial_current,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MutualInductor {
+    pub name: String,
+    pub primary: String,
+    pub secondary: String,
+    pub coupling: f64,
+}
+
+impl MutualInductor {
+    pub fn new(
+        name: impl Into<String>,
+        primary: impl Into<String>,
+        secondary: impl Into<String>,
+        coupling: f64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            primary: primary.into(),
+            secondary: secondary.into(),
+            coupling,
         }
     }
 }
@@ -3460,7 +3491,10 @@ fn element_parameter(element: &Element) -> Option<(String, String, f64)> {
             "transresistance_ohms".to_string(),
             source.transresistance_ohms,
         )),
-        Element::BSource(_) | Element::Capacitor(_) | Element::Inductor(_) => None,
+        Element::BSource(_)
+        | Element::Capacitor(_)
+        | Element::Inductor(_)
+        | Element::MutualInductor(_) => None,
     }
 }
 
@@ -3481,7 +3515,10 @@ fn perturb_element_parameter(element: &mut Element, delta: f64) {
         Element::Vcvs(source) => source.gain += delta,
         Element::Cccs(source) => source.gain += delta,
         Element::Ccvs(source) => source.transresistance_ohms += delta,
-        Element::BSource(_) | Element::Capacitor(_) | Element::Inductor(_) => {}
+        Element::BSource(_)
+        | Element::Capacitor(_)
+        | Element::Inductor(_)
+        | Element::MutualInductor(_) => {}
     }
 }
 
@@ -3609,7 +3646,10 @@ fn randomized_element(
                 randomized_value(varied.transresistance_ohms, tolerance, distribution, rng);
             Element::Ccvs(varied)
         }
-        Element::BSource(_) | Element::Capacitor(_) | Element::Inductor(_) => element.clone(),
+        Element::BSource(_)
+        | Element::Capacitor(_)
+        | Element::Inductor(_)
+        | Element::MutualInductor(_) => element.clone(),
     }
 }
 
@@ -3899,6 +3939,7 @@ fn solve_linear_circuit_at_operating_point(
                 &mut matrix,
                 &mut rhs,
             )?,
+            Element::MutualInductor(_) => {}
             Element::VoltageSource(source) => stamp_voltage_source(
                 source,
                 node_indices,
@@ -4050,6 +4091,7 @@ fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceEr
             Element::Resistor(_)
             | Element::Capacitor(_)
             | Element::Inductor(_)
+            | Element::MutualInductor(_)
             | Element::Diode(_)
             | Element::Jfet(_)
             | Element::Bjt(_)
@@ -4097,6 +4139,7 @@ fn build_ac_matrix(
             Element::Inductor(inductor) => {
                 stamp_ac_inductor(inductor, omega, node_indices, &mut matrix)?
             }
+            Element::MutualInductor(_) => {}
             Element::VoltageSource(source) => stamp_ac_voltage_source_matrix(
                 source,
                 node_indices,
@@ -4189,6 +4232,7 @@ fn build_small_signal_matrix(
                 let n2 = node_index(node_indices, &inductor.n2);
                 stamp_conductance(&mut matrix, n1, n2, 1.0e12);
             }
+            Element::MutualInductor(_) => {}
             Element::VoltageSource(source) => {
                 if !source.voltage.is_finite() {
                     return Err(SpiceError::InvalidElement {
@@ -4312,6 +4356,7 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &inductor.n1);
                 insert_node(&mut names, &inductor.n2);
             }
+            Element::MutualInductor(_) => {}
             Element::VoltageSource(source) => {
                 insert_node(&mut names, &source.positive);
                 insert_node(&mut names, &source.negative);

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse SPICE `K` mutual-inductor cards into `MutualInductor` elements,
+  including subcircuit-local inductor reference remapping.
 - Parse SPICE `J` JFET elements via `.model <name> NJF(...)` and
   `.model <name> PJF(...)` cards with `BETA` / `B`, `VTO`, and `LAMBDA`
   parameters, including subcircuit drain/gate/source remapping.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, fmt};
 
 use spice_engine::{
     Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform,
-    Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, PulseWaveform,
-    PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
+    Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, MutualInductor,
+    PulseWaveform, PwlWaveform, Resistor, SinWaveform, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -551,6 +551,15 @@ fn parse_element(
                 *params.get("IC").unwrap_or(&0.0),
             )))
         }
+        'K' => {
+            require_fields(fields, 4, "mutual inductor")?;
+            Ok(Element::MutualInductor(MutualInductor::new(
+                name,
+                &fields[1],
+                &fields[2],
+                parse_value(&fields[3])?,
+            )))
+        }
         'V' => {
             require_min_fields(fields, 4, "voltage source")?;
             let (voltage, waveform, ac) = parse_source_value(&fields[3..])?;
@@ -893,6 +902,11 @@ fn map_subckt_fields(
             mapped[1] = map_subckt_node(&fields[1], instance_name, node_map);
             mapped[2] = map_subckt_node(&fields[2], instance_name, node_map);
             mapped[3] = map_subckt_source_ref(&fields[3], instance_name);
+        }
+        'K' => {
+            require_fields(fields, 4, "subcircuit mutual inductor")?;
+            mapped[1] = map_subckt_source_ref(&fields[1], instance_name);
+            mapped[2] = map_subckt_source_ref(&fields[2], instance_name);
         }
         'X' => {
             for index in 1..fields.len() - 1 {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -108,6 +108,26 @@ G1 out 0 in 0 2m
 }
 
 #[test]
+fn parses_mutual_inductor_cards() {
+    let parsed = parse_netlist(
+        r#"
+Lpri p 0 10m
+Lsec s 0 40m
+Kcouple Lpri Lsec 0.75
+"#,
+    )
+    .unwrap();
+
+    let Element::MutualInductor(mutual) = &parsed.circuit.elements()[2] else {
+        panic!("expected mutual inductor");
+    };
+    assert_eq!(mutual.name, "Kcouple");
+    assert_eq!(mutual.primary, "Lpri");
+    assert_eq!(mutual.secondary, "Lsec");
+    assert_close(mutual.coupling, 0.75);
+}
+
+#[test]
 fn parses_options_analysis_cards() {
     let parsed = parse_netlist(
         r#"
@@ -939,6 +959,29 @@ Xbuf vdd in out source_follower
     assert_eq!(jfet.gate, "in");
     assert_eq!(jfet.source, "Xbuf.inner");
     assert_close(jfet.beta, 1.0e-3);
+}
+
+#[test]
+fn expands_subcircuit_mutual_inductor_refs_into_engine_elements() {
+    let parsed = parse_netlist(
+        r#"
+.subckt transformer p1 p2 s1 s2
+Lpri p1 p2 10m
+Lsec s1 s2 40m
+Kcore Lpri Lsec 0.9
+.ends transformer
+Xtx in 0 out 0 transformer
+"#,
+    )
+    .unwrap();
+
+    let Element::MutualInductor(mutual) = &parsed.circuit.elements()[2] else {
+        panic!("expected mutual inductor");
+    };
+    assert_eq!(mutual.name, "Xtx.Kcore");
+    assert_eq!(mutual.primary, "Xtx.Lpri");
+    assert_eq!(mutual.secondary, "Xtx.Lsec");
+    assert_close(mutual.coupling, 0.9);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a public `MutualInductor` element and `mutualInductor` factory as the
+  parser-facing SPICE `K` card foothold; coupled AC/transient stamping follows
+  in a later compatibility slice.
 - Add JFET nonlinear DC operating-point stamping and AC small-signal analysis
   from the solved DC bias point.
 - Add a public `Jfet` element and `jfet` factory as the parser-facing

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7,6 +7,7 @@ export type Element =
   | Resistor
   | Capacitor
   | Inductor
+  | MutualInductor
   | VoltageSource
   | CurrentSource
   | BSource
@@ -43,6 +44,14 @@ export interface Inductor {
   readonly n2: string;
   readonly inductanceHenrys: number;
   readonly initialCurrent: number;
+}
+
+export interface MutualInductor {
+  readonly kind: "mutual-inductor";
+  readonly name: string;
+  readonly primary: string;
+  readonly secondary: string;
+  readonly coupling: number;
 }
 
 export type Waveform =
@@ -891,6 +900,8 @@ function cloneSubcktElement(
       return capacitorWithInitialVoltage(name, mapSubcktNode(element.n1, instanceName, nodeMap), mapSubcktNode(element.n2, instanceName, nodeMap), element.capacitanceFarads, element.initialVoltage);
     case "inductor":
       return inductorWithInitialCurrent(name, mapSubcktNode(element.n1, instanceName, nodeMap), mapSubcktNode(element.n2, instanceName, nodeMap), element.inductanceHenrys, element.initialCurrent);
+    case "mutual-inductor":
+      return mutualInductor(name, mapSubcktSourceRef(element.primary, instanceName), mapSubcktSourceRef(element.secondary, instanceName), element.coupling);
     case "voltage-source":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
     case "current-source":
@@ -974,6 +985,21 @@ export function inductorWithInitialCurrent(
     n2,
     inductanceHenrys,
     initialCurrent,
+  };
+}
+
+export function mutualInductor(
+  name: string,
+  primary: string,
+  secondary: string,
+  coupling: number,
+): MutualInductor {
+  return {
+    kind: "mutual-inductor",
+    name,
+    primary,
+    secondary,
+    coupling,
   };
 }
 
@@ -2636,6 +2662,7 @@ function randomizedElement(
       return element;
     case "capacitor":
     case "inductor":
+    case "mutual-inductor":
       return element;
   }
 }

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse SPICE `K` mutual-inductor cards into `mutualInductor` elements,
+  including subcircuit-local inductor reference remapping.
 - Parse SPICE `J` JFET elements via `.model <name> NJF(...)` and
   `.model <name> PJF(...)` cards with `BETA` / `B`, `VTO`, and `LAMBDA`
   parameters, including subcircuit drain/gate/source remapping.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -16,6 +16,7 @@ import {
   inductorWithInitialCurrent,
   jfet,
   mosfet,
+  mutualInductor,
   resistor,
   vccs,
   vcvs,
@@ -451,6 +452,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       params.get("IC") ?? 0.0,
     );
   }
+  if (prefix === "K") {
+    requireFields(fields, 4, "mutual inductor");
+    return mutualInductor(name, fields[1], fields[2], parseValue(fields[3]));
+  }
   if (prefix === "V") {
     requireMinFields(fields, 4, "voltage source");
     const source = parseSourceValue(fields.slice(3));
@@ -713,6 +718,10 @@ function mapSubcktFields(
     mapped[1] = mapSubcktNode(fields[1], instanceName, nodeMap);
     mapped[2] = mapSubcktNode(fields[2], instanceName, nodeMap);
     mapped[3] = mapSubcktSourceRef(fields[3], instanceName);
+  } else if (prefix === "K") {
+    requireFields(fields, 4, "subcircuit mutual inductor");
+    mapped[1] = mapSubcktSourceRef(fields[1], instanceName);
+    mapped[2] = mapSubcktSourceRef(fields[2], instanceName);
   } else if (prefix === "X") {
     for (let index = 1; index < fields.length - 1; index++) {
       mapped[index] = mapSubcktNode(fields[index], instanceName, nodeMap);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -61,6 +61,22 @@ G1 out 0 in 0 2m
     ]);
   });
 
+  it("parses mutual-inductor K cards", () => {
+    const parsed = parseNetlist(`
+Lpri p 0 10m
+Lsec s 0 40m
+Kcouple Lpri Lsec 0.75
+`);
+
+    expect(parsed.circuit.elements()[2]).toMatchObject({
+      kind: "mutual-inductor",
+      name: "Kcouple",
+      primary: "Lpri",
+      secondary: "Lsec",
+      coupling: 0.75,
+    });
+  });
+
   it("parses .options analysis cards", () => {
     const parsed = parseNetlist(`
 .options reltol=1m abstol=1n gmin=1p method=trap noopiter
@@ -707,6 +723,25 @@ Xbuf out in 0 source_follower
       kind: "resistor",
       n1: "Xbuf.inner",
       n2: "0",
+    });
+  });
+
+  it("expands subcircuit mutual-inductor references into engine elements", () => {
+    const parsed = parseNetlist(`
+.subckt transformer p1 p2 s1 s2
+Lpri p1 p2 10m
+Lsec s1 s2 40m
+Kcore Lpri Lsec 0.9
+.ends transformer
+Xtx in 0 out 0 transformer
+`);
+
+    expect(parsed.circuit.elements()[2]).toMatchObject({
+      kind: "mutual-inductor",
+      name: "Xtx.Kcore",
+      primary: "Xtx.Lpri",
+      secondary: "Xtx.Lsec",
+      coupling: 0.9,
     });
   });
 


### PR DESCRIPTION
## Summary

- add public MutualInductor/K-card element shapes across Python, TypeScript, and Rust SPICE engines
- parse SPICE `K` mutual-inductor cards across all three netlist parsers
- remap subcircuit-local inductor references for expanded `K` cards and cover the behavior with tests

## Validation

- `sh BUILD` in `code/packages/python/spice-netlist-parser`
- `sh BUILD` in `code/packages/typescript/spice-netlist-parser`
- `cargo test -p spice-netlist-parser` in `code/packages/rust`
- `sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This is the parser/data foothold for Phase 2 of the SPICE 1970s compatibility plan. Coupled-inductor AC/transient stamping is intentionally left for the next focused slice.