### PR TITLE
feat(cas-summation): Phase 55 — Bounded×Log(diverging) numerator pattern (1.3.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 1.3.0 — 2026-05-23
+
+**Phase 55 — Bounded×Log(diverging) numerator pattern (Python).**
+
+Extends ``_g_vanishes_at_infinity`` with a new branch for
+``Div(Mul(bounded, Log(diverging)), h(k))`` shapes.  The product of a
+uniformly bounded function (``|f| ≤ C``) and ``log(h(k))`` (sub-polynomial
+growth) is dominated by any polynomial or faster-growing denominator.
+
+This is the bounded-times-log complement of Phase 52
+(``Mul(bounded, polynomial)``) and Phase 54 (``Mul(Log, polynomial)``).
+
+Bumps 1.2.0 → 1.3.0.
+
+### Added
+
+- **``_is_bounded_times_log_in_k(node, k)``** — Phase 55 helper.
+  Returns True when ``node`` is a ``Mul`` with exactly one
+  ``Log(diverging)`` factor and all remaining factors bounded in ``k``
+  (via ``_is_log_of_diverging_in_k`` and ``_is_bounded_in_k``).  Requires
+  exactly one log factor; two or more → False.
+
+- **Phase 55 branch in ``_g_vanishes_at_infinity``** — inserted after
+  Phase 54 and before the Phase 42 polynomial widening.  Closes
+  ``Div(Mul(bounded, Log(diverging)), den)`` when ``den`` diverges
+  (``_h_diverges_at_infinity`` returns True).
+
+- **5 new tests** in ``TestEvaluateSumPhase55BoundedTimesLogNumerator``
+  (``test_summation.py``):
+  - ``test_sin_k_times_log_k_over_k_squared_closes`` — sin×log / k² → closes
+  - ``test_cos_k_times_log_k_over_k_closes`` — cos×log / k → closes
+  - ``test_two_bounded_factors_times_log_over_k_cubed_closes`` — sin·cos·log / k³
+  - ``test_bounded_times_log_of_k_squared_over_k_cubed_closes`` — sin·log(k²) / k³
+  - ``test_bounded_times_log_constant_denominator_refused`` — constant denominator refused
+
+Total: 126 tests (was 121), coverage 88.75%.
+
 ## 1.2.0 — 2026-05-23
 
 **Phase 54 — Log×polynomial numerator pattern (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.2.0"
+version = "1.3.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -648,19 +648,22 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
         closes telescopes like ``k/((k+1)(k+2)(k+3))`` and any other
         proper rational shape Apart might emit.
 
-    +-------------------------------+--------------------------+
-    | ``g`` shape                   | Provably ``→ 0``?        |
-    +===============================+==========================+
-    | ``Div(constant, k+a)``        | yes (Phase 41)           |
-    | ``Div(constant, k²·(k+1))``   | yes (Phase 41)           |
-    | ``Div(k, k²+1)``              | yes (Phase 42)           |
-    | ``Div(k+1, k³−5)``            | yes (Phase 42)           |
-    | constant                      | no (limit is the const)  |
-    | ``k`` or ``k²+1``             | no (limit is ∞)          |
-    | ``1/sin(k)`` / ``log(k)/k``   | no (numerator is not a   |
-    |                               |    polynomial; transcend- |
-    |                               |    ental limits deferred) |
-    +-------------------------------+--------------------------+
+    +-----------------------------------+-----------------------------+
+    | ``g`` shape                       | Provably ``→ 0``?           |
+    +===================================+=============================+
+    | ``Div(constant, k+a)``            | yes (Phase 41)              |
+    | ``Div(constant, k²·(k+1))``       | yes (Phase 41)              |
+    | ``Div(k, k²+1)``                  | yes (Phase 42)              |
+    | ``Div(k+1, k³−5)``                | yes (Phase 42)              |
+    | ``Div(sin(k), k²)``               | yes (Phase 49)              |
+    | ``Div(log(k), k²)``               | yes (Phase 50)              |
+    | ``Div(sin(k)·log(k), k²)``        | yes (Phase 55)              |
+    | constant                          | no (limit is the const)     |
+    | ``k`` or ``k²+1``                 | no (limit is ∞)             |
+    | ``1/sin(k)`` / ``log(k)/k``       | no (numerator is not a      |
+    |                                   |    polynomial; transcend-   |
+    |                                   |    ental limits deferred)   |
+    +-----------------------------------+-----------------------------+
 
     Examples
     --------
@@ -741,6 +744,21 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
         den_deg_lp = _polynomial_degree_in_k(den, k)
         if den_deg_lp is not None and den_deg_lp > poly_deg_lp:
             return True
+    # Phase 55: ``Mul(bounded, Log(diverging))`` numerator + diverging
+    # denominator.  The numerator is the product of a uniformly bounded
+    # function (``|f| ≤ C``) and a logarithm that grows sub-polynomially.
+    # Because ``log(h(k)) = o(k^ε)`` for any ``ε > 0``, the whole
+    # numerator grows sub-polynomially — dominated by any polynomial
+    # (or faster-growing) denominator.  This is the bounded-times-log
+    # complement to Phase 52 (bounded × polynomial) and Phase 54
+    # (log × polynomial).
+    #
+    # Note: Unlike Phase 54, the comparison here is against the denominator's
+    # divergence (not a strict degree inequality), because the numerator's
+    # effective polynomial degree is 0 — it doesn't grow polynomially at all.
+    # Any strictly diverging denominator therefore dominates.
+    if _is_bounded_times_log_in_k(num, k) and _h_diverges_at_infinity(den, k):
+        return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -997,6 +1015,57 @@ def _split_log_polynomial_factor(
     if log_factor is None:
         return None
     return (log_factor, poly_deg_sum)
+
+
+def _is_bounded_times_log_in_k(node: IRNode, k: IRSymbol) -> bool:
+    """Return True when ``node`` is a ``Mul`` with exactly one
+    ``Log(diverging)`` factor and all remaining factors bounded in ``k``.
+
+    Phase 55 — Used by :func:`_g_vanishes_at_infinity` to recognise that
+    ``sin(k)·log(k)/k²`` (and similar shapes) vanish at infinity.  The
+    bounded part is uniformly bounded by some constant ``C``, and
+    ``log(h(k))`` grows sub-polynomially.  Therefore the numerator as a
+    whole grows sub-polynomially, which is dominated by any polynomial
+    denominator of degree ≥ 1 (or any other diverging denominator).
+
+    This is the bounded-times-log analog of Phase 52
+    (``Mul(bounded, polynomial)``) and Phase 54
+    (``Mul(Log(diverging), polynomial_factors)``).
+
+    +-------------------------------------+-----------------------+
+    | Input                               | Return                |
+    +=====================================+=======================+
+    | ``Mul(Sin(k), Log(k))``             | True                  |
+    | ``Mul(Cos(k), Log(k))``             | True                  |
+    | ``Mul(Sin(k), Cos(k), Log(k))``     | True (two bounded)    |
+    | ``Mul(Sin(k), Log(k+1))``           | True (log of k+1)     |
+    | ``Mul(k, Log(k))``                  | False (k not bounded) |
+    | ``Mul(Sin(k), Log(k), Log(k))``     | False (two Log)       |
+    | ``Mul(Sin(k), k, Log(k))``          | False (k not bounded) |
+    | ``Log(k)`` (plain, not Mul)         | False (→ Phase 50)    |
+    | ``Mul(Sin(k), k)`` (no Log)         | False (→ Phase 52)    |
+    +-------------------------------------+-----------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - If it is ``Log(diverging_in_k)`` → count as log factor.
+         - If it is ``bounded_in_k`` → accept as bounded factor.
+         - Otherwise → return False (unrecognised factor).
+      3. Require exactly one log factor; zero or two+ → return False.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return False
+    log_count = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Factor is neither Log(diverging) nor bounded — unrecognised.
+        return False
+    return log_count == 1
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1606,3 +1606,155 @@ class TestEvaluateSumPhase54LogTimesPolynomialNumerator:
         assert not (isinstance(result, IRApply) and result.head == SUM), (
             f"Regression: log(k)/k³ should close via Phase 50; got {result!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 55 — Bounded × Log(diverging) numerator pattern.
+# ---------------------------------------------------------------------------
+# ``sin(k)·log(k)/Q(k)`` (and similar shapes) vanish at infinity when
+# ``Q(k)`` is any diverging function (polynomial degree ≥ 1, exponential,
+# etc.).  The numerator grows sub-polynomially — bounded × log(h) is
+# dominated by any polynomial denominator.
+#
+# The helper ``_is_bounded_times_log_in_k`` requires exactly one
+# Log(diverging) factor in a Mul node; all other factors must be bounded.
+# The branch in ``_g_vanishes_at_infinity`` closes when the denominator
+# passes ``_h_diverges_at_infinity``.
+#
+# This is the bounded-times-log complement of Phase 52 (bounded×polynomial)
+# and Phase 54 (log×polynomial).
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase55BoundedTimesLogNumerator:
+    """Phase 55: Mul(bounded, Log(diverging)) numerator + diverging denominator."""
+
+    def test_sin_k_times_log_k_over_k_squared_closes(self):
+        """``sin(k)·log(k)/k²``: bounded×log over poly-deg-2.  Phase 55 closes.
+
+        ``|sin(k)| ≤ 1`` and ``log(k)`` grows sub-polynomially, so the
+        numerator is dominated by the degree-2 polynomial denominator.
+        poly_deg of numerator = 0 (no polynomial factor); denominator diverges
+        polynomially at rate k² → quotient vanishes.
+        """
+        from symbolic_ir import LOG, POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 55 should close sin(k)·log(k)/k²; got {result!r}"
+        )
+
+    def test_cos_k_times_log_k_over_k_closes(self):
+        """``cos(k)·log(k)/k``: bounded×log over poly-deg-1.  Phase 55 closes.
+
+        Even with a degree-1 denominator (``k``), the sub-polynomial
+        growth of the numerator is dominated → quotient vanishes.
+        """
+        from symbolic_ir import COS, LOG, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (cos_k, log_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (cos_kp1, log_kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 55 should close cos(k)·log(k)/k; got {result!r}"
+        )
+
+    def test_two_bounded_factors_times_log_over_k_cubed_closes(self):
+        """``sin(k)·cos(k)·log(k)/k³``: two bounded factors × log / poly-deg-3.
+
+        Multiple bounded factors in the Mul are all accepted — each
+        individually bounded, and the product of bounded functions is bounded.
+        Phase 55 closes since the denominator diverges.
+        """
+        from symbolic_ir import COS, LOG, POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, cos_k, log_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, cos_kp1, log_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 55 should close sin(k)·cos(k)·log(k)/k³; got {result!r}"
+        )
+
+    def test_bounded_times_log_of_k_squared_over_k_cubed_closes(self):
+        """``sin(k)·log(k²)/k³``: log argument is ``k²`` (diverges).
+
+        ``_is_log_of_diverging_in_k(Log(k²), k)`` returns True since
+        ``k²`` is a positive-degree polynomial.  Using ``k²`` as the log
+        argument avoids nesting issues in the structural telescoping check
+        (``subst(k+1, k, Log(Pow(k,2)))`` produces ``Log(Pow(k+1,2))``
+        which compares structurally equal to the manually-built ``g(k+1)``).
+        Phase 55 closes.
+        """
+        from symbolic_ir import LOG, POW, SIN, SUB
+
+        k_sq = IRApply(POW, (_k, IRInteger(2)))
+        sin_k = IRApply(SIN, (_k,))
+        log_ksq = IRApply(LOG, (k_sq,))  # log(k²) as numerator factor
+        num_k = IRApply(MUL, (sin_k, log_ksq))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_sq = IRApply(POW, (kp1, IRInteger(2)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1_sq = IRApply(LOG, (kp1_sq,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1_sq))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 55 should close sin(k)·log(k²)/k³; got {result!r}"
+        )
+
+    def test_bounded_times_log_constant_denominator_refused(self):
+        """``sin(k)·log(k)/1``: denominator is constant — does not diverge.
+
+        The numerator shape passes ``_is_bounded_times_log_in_k``, but
+        the denominator (``1``) is not recognised as diverging by
+        ``_h_diverges_at_infinity``.  Phase 55 correctly refuses, and
+        no other phase closes the sum.  Result must stay unevaluated.
+        """
+        from symbolic_ir import LOG, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1))
+        # Denominator = 1 (constant): _h_diverges_at_infinity returns False.
+        g_k = IRApply(DIV, (num_k, IRInteger(1)))
+        g_kp1 = IRApply(DIV, (num_kp1, IRInteger(1)))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # sin(k)·log(k)/1 does not vanish; must stay unevaluated.
+        assert isinstance(result, IRApply) and result.head == SUM, (
+            f"Phase 55: constant denominator should stay unevaluated; got {result!r}"
+        )

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.3.0 — 2026-05-23
+
+**Phase 55 — Bounded×Log(diverging) numerator pattern (Rust port).**
+
+Ports Python `cas-summation` 1.3.0 Phase 55 to Rust.  Adds
+`is_bounded_times_log_in_k` helper and a Phase 55 branch in
+`g_vanishes_at_infinity`.  `bounded(k) × log(h(k))` grows sub-polynomially
+(log is dominated by any polynomial denominator).
+
+Bumps 1.2.0 → 1.3.0.
+
+### Added
+
+- **`is_bounded_times_log_in_k(node, k)`** — Phase 55 helper. Returns true
+  when `node` is a `Mul` with exactly one `Log(diverging)` factor and all
+  remaining factors pass `is_bounded_in_k`. Requires exactly one log factor.
+
+- **Phase 55 branch in `g_vanishes_at_infinity`** — after Phase 54, before
+  Phase 42. Closes `Div(Mul(bounded, Log(diverging)), den)` when `den`
+  diverges (`h_diverges_at_infinity` returns true).
+
+- **5 new tests**:
+  - `phase55_sin_k_times_log_k_over_k_squared_closes`
+  - `phase55_cos_k_times_log_k_over_k_closes`
+  - `phase55_sin_cos_times_log_over_k_cubed_closes`
+  - `phase55_sin_times_log_k_squared_over_k_cubed_closes`
+  - `phase55_bounded_times_log_constant_denominator_stays` (refused)
+
+Total: 66 tests (was 61).
+
 ## 1.2.0 — 2026-05-23
 
 **Phase 54 — Log×polynomial numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1135,6 +1135,42 @@ fn split_log_polynomial_factor<'a>(node: &'a IRNode, k: &IRNode) -> Option<(&'a 
     Some((lf, poly_deg_sum))
 }
 
+/// Phase 55 helper: return true when `node` is a `Mul` with exactly one
+/// `Log(diverging)` factor and all remaining factors bounded in `k`.
+///
+/// The bounded part is uniformly bounded (|f| ≤ C) and `log(h(k))` grows
+/// sub-polynomially, so their product is dominated by any polynomial or
+/// faster-growing denominator.  This is the bounded-times-log complement
+/// of Phase 52 (bounded × polynomial) and Phase 54 (log × polynomial).
+///
+/// Requirements:
+///   - `node = Mul(...)`
+///   - Exactly one factor passes `is_log_of_diverging_in_k`
+///   - All remaining factors pass `is_bounded_in_k`
+///   - Any other factor → return false
+fn is_bounded_times_log_in_k(node: &IRNode, k: &IRNode) -> bool {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return false;
+    }
+    let mut log_count = 0usize;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Factor is neither Log(diverging) nor bounded — unrecognised.
+        return false;
+    }
+    log_count == 1
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1203,6 +1239,14 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
                 return true;
             }
         }
+    }
+    // Phase 55: Mul(bounded, Log(diverging)) numerator + diverging denominator.
+    // bounded × log(h(k)) grows sub-polynomially — dominated by any
+    // polynomial or faster-growing denominator.  Unlike Phase 54, we compare
+    // against `h_diverges_at_infinity` (not a strict degree inequality) because
+    // the numerator's effective polynomial degree is 0 (no polynomial factor).
+    if is_bounded_times_log_in_k(num, k) && h_diverges_at_infinity(den, k) {
+        return true;
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1236,3 +1236,113 @@ fn phase54_regression_log_k_over_k_cubed_still_closes_via_phase50() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 55 — Bounded×Log(diverging) numerator (Rust port).
+// ---------------------------------------------------------------------------
+// sin(k)·log(k)/Q(k) vanishes at infinity when Q(k) diverges.
+// The numerator grows sub-polynomially (bounded × log); any polynomial
+// or faster-growing denominator dominates.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase55_sin_k_times_log_k_over_k_squared_closes() {
+    // sin(k)·log(k) / k²: bounded×log / poly-2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase55_cos_k_times_log_k_over_k_closes() {
+    // cos(k)·log(k) / k: bounded×log / poly-1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let cos_k = apply(sym("Cos"), vec![k.clone()]);
+    let cos_kp1 = apply(sym("Cos"), vec![kp1.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![cos_k, log_k]);
+    let num_kp1 = apply(sym(MUL), vec![cos_kp1, log_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k.clone()]),
+        apply(sym(DIV), vec![num_kp1, kp1]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase55_sin_cos_times_log_over_k_cubed_closes() {
+    // sin(k)·cos(k)·log(k) / k³: two bounded factors × log / poly-3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let cos_k = apply(sym("Cos"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let cos_kp1 = apply(sym("Cos"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, cos_k, log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, cos_kp1, log_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase55_sin_times_log_k_squared_over_k_cubed_closes() {
+    // sin(k)·log(k²) / k³: log of k² diverges (positive-degree poly inner).
+    // After k→k+1 substitution: log((k+1)²) matches structurally. → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k_sq = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_sq = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_ksq = apply(sym("Log"), vec![k_sq]);
+    let log_kp1_sq = apply(sym("Log"), vec![kp1_sq]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_ksq]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1_sq]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase55_bounded_times_log_constant_denominator_stays() {
+    // sin(k)·log(k) / 1: constant denominator does not diverge.
+    // h_diverges_at_infinity(1) = false → Phase 55 refuses.
+    // No other phase closes this. Must stay unevaluated.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, int(1)]),
+        apply(sym(DIV), vec![num_kp1, int(1)]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.3.0 — 2026-05-23
+
+**Phase 55 — Bounded×Log(diverging) numerator pattern (TypeScript port).**
+
+Ports Python `cas-summation` 1.3.0 Phase 55 to TypeScript.  Adds
+`isBoundedTimesLogInK` helper and a Phase 55 branch in `gVanishesAtInfinity`.
+`bounded(k) × log(h(k))` grows sub-polynomially — dominated by any
+polynomial or faster-growing denominator.
+
+Bumps 1.2.0 → 1.3.0.
+
+### Added
+
+- **`isBoundedTimesLogInK(node, k)`** — Phase 55 helper. Returns true when
+  `node` is a `Mul` with exactly one `Log(diverging)` factor and all remaining
+  factors pass `isBoundedInK`. Requires exactly one log factor; two+ → false.
+
+- **Phase 55 branch in `gVanishesAtInfinity`** — after Phase 54, before Phase 42.
+  Closes `Div(Mul(bounded, Log(diverging)), den)` when `den` diverges.
+
+- **5 new tests** in `describe("Phase 55 Bounded×Log(diverging) numerator")`:
+  - `sin(k)·log(k) / k² closes`
+  - `cos(k)·log(k) / k closes`
+  - `sin(k)·cos(k)·log(k) / k³ closes`
+  - `sin(k)·log(k²) / k³ closes`
+  - `sin(k)·log(k) / 1 stays unevaluated` (constant denominator refused)
+
+Total: 66 tests (was 61).
+
 ## 1.2.0 — 2026-05-23
 
 **Phase 54 — Log×polynomial numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -835,6 +835,40 @@ function splitLogPolynomialFactor(
   return { logFactor, polyDeg: polyDegSum };
 }
 
+/**
+ * Phase 55 (TypeScript port): Return true when ``node`` is a ``Mul`` with
+ * exactly one ``Log(diverging)`` factor and all remaining factors bounded
+ * in ``k``.
+ *
+ * The bounded part is uniformly bounded by some constant ``C`` and
+ * ``log(h(k))`` grows sub-polynomially, so their product is dominated by
+ * any polynomial or faster-growing denominator.  This is the
+ * bounded-times-log complement of Phase 52 (bounded × polynomial) and
+ * Phase 54 (log × polynomial).
+ *
+ * Requirements:
+ *   - ``node = Mul(...)`` — a bare ``Log(h)`` numerator goes via Phase 50.
+ *   - Exactly one factor passes ``isLogOfDivergingInK``.
+ *   - All remaining factors pass ``isBoundedInK``.
+ *   - Any factor that is neither → return false.
+ */
+function isBoundedTimesLogInK(node: IRNode, k: IRNode): boolean {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return false;
+  let logCount = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Factor is neither Log(diverging) nor bounded — unrecognised.
+    return false;
+  }
+  return logCount === 1;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -897,6 +931,12 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     if (denDegLp !== undefined && denDegLp > logPolyResult.polyDeg) {
       return true;
     }
+  }
+  // Phase 55: Mul(bounded, Log(diverging)) numerator + diverging denominator.
+  // bounded × log(h(k)) grows sub-polynomially (log dominates bounded part,
+  // but log itself is dominated by any polynomial or faster-growing denominator).
+  if (isBoundedTimesLogInK(num, k) && hDivergesAtInfinity(den, k)) {
+    return true;
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -984,3 +984,86 @@ describe("summation: Phase 54 Log×polynomial numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 55 — Bounded×Log(diverging) numerator (TS port).
+// ---------------------------------------------------------------------------
+// ``sin(k)·log(k)/Q(k)`` vanishes at infinity when Q(k) diverges.
+// The numerator is bounded×sub-polynomial — dominated by any polynomial
+// or faster-growing denominator.
+// isBoundedTimesLogInK requires exactly one Log(diverging) factor; all
+// other factors must pass isBoundedInK.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 55 Bounded×Log(diverging) numerator", () => {
+  it("sin(k)·log(k) / k² closes (bounded×log / poly-2)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sin"), [k]), app(sym("Log"), [k])]);
+    const numKp1 = app(MUL, [app(sym("Sin"), [kp1]), app(sym("Log"), [kp1])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("cos(k)·log(k) / k closes (bounded×log / poly-1)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Cos"), [k]), app(sym("Log"), [k])]);
+    const numKp1 = app(MUL, [app(sym("Cos"), [kp1]), app(sym("Log"), [kp1])]);
+    const f = app(SUB, [
+      app(DIV, [numK, k]),
+      app(DIV, [numKp1, kp1]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("sin(k)·cos(k)·log(k) / k³ closes (two bounded×log / poly-3)", () => {
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sin"), [k]), app(sym("Cos"), [k]), app(sym("Log"), [k])]);
+    const numKp1 = app(MUL, [app(sym("Sin"), [kp1]), app(sym("Cos"), [kp1]), app(sym("Log"), [kp1])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("sin(k)·log(k²) / k³ closes (log of k² diverges, bounded×log)", () => {
+    // log(k²) diverges (k² is a positive-degree polynomial).
+    // After substituting k→k+1: log((k+1)²) — structural equality holds.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const kSq = app(POW, [k, int(2)]);
+    const kp1Sq = app(POW, [kp1, int(2)]);
+    const numK = app(MUL, [app(sym("Sin"), [k]), app(sym("Log"), [kSq])]);
+    const numKp1 = app(MUL, [app(sym("Sin"), [kp1]), app(sym("Log"), [kp1Sq])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("sin(k)·log(k) / 1 stays unevaluated (constant denominator — does not diverge)", () => {
+    // Denominator = 1 (constant). hDivergesAtInfinity(1) = false.
+    // Phase 55 correctly refuses; no other phase closes.
+    const k = sym("k");
+    const kp1 = app(ADD, [k, int(1)]);
+    const numK = app(MUL, [app(sym("Sin"), [k]), app(sym("Log"), [k])]);
+    const numKp1 = app(MUL, [app(sym("Sin"), [kp1]), app(sym("Log"), [kp1])]);
+    const f = app(SUB, [
+      app(DIV, [numK, int(1)]),
+      app(DIV, [numKp1, int(1)]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `_g_vanishes_at_infinity` / `gVanishesAtInfinity` / `g_vanishes_at_infinity` (Python, TypeScript, Rust) with **Phase 55**: `Div(Mul(bounded, Log(diverging)), diverging_den)` is recognised as a vanishing term in infinite telescoping sums
- New helpers: `_is_bounded_times_log_in_k` (Python), `isBoundedTimesLogInK` (TS), `is_bounded_times_log_in_k` (Rust) — require exactly one `Log(diverging)` factor in a `Mul` with all other factors bounded (sin, cos, product thereof)
- **15 new tests** (5 per language): `sin(k)·log(k)/k²` closes, `cos(k)·log(k)/k` closes, two-bounded-factor case, log of k² case, refused case (constant denominator)
- Bumps all three packages: **1.2.0 → 1.3.0**

Mathematical justification: `|f(k)| ≤ C` and `log(h(k)) = o(k^ε)` for any `ε > 0`, so their product grows sub-polynomially and is dominated by any polynomial or faster-growing denominator. Complements Phase 52 (`bounded×polynomial`) and Phase 54 (`log×polynomial`).

## Test plan

- [x] Python: 126 tests pass, 88.75% coverage (`mise exec -- python -m pytest`)
- [x] TypeScript: 66 tests pass (`npm test` in cas-summation)
- [x] Rust: 66 tests pass (`cargo test -p cas-summation`)
- [x] Security review passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)