### PR TITLE
spice: add mutual inductor AC stamps

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Mutual-inductor AC stamping** — `MutualInductor` now couples referenced
+  inductor pairs in AC analysis using the inverted two-winding inductance
+  matrix.
+
 - **Mutual-inductor element foothold** — `MutualInductor` now exposes the
   public `K`-card coupling shape for future coupled-inductor AC/transient
   stamping.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -3074,6 +3074,109 @@ def _stamp_g_c(
         G[node_to_idx[n_minus]][node_to_idx[n_plus]] -= g
 
 
+def _stamp_vccs_c(
+    G: list[list[complex]],
+    node_to_idx: dict[str, int],
+    n_plus: str,
+    n_minus: str,
+    ctrl_plus: str,
+    ctrl_minus: str,
+    gm: complex,
+) -> None:
+    if not _is_ground(n_plus):
+        rp = node_to_idx[n_plus]
+        if not _is_ground(ctrl_plus):
+            G[rp][node_to_idx[ctrl_plus]] += gm
+        if not _is_ground(ctrl_minus):
+            G[rp][node_to_idx[ctrl_minus]] -= gm
+    if not _is_ground(n_minus):
+        rm = node_to_idx[n_minus]
+        if not _is_ground(ctrl_plus):
+            G[rm][node_to_idx[ctrl_plus]] -= gm
+        if not _is_ground(ctrl_minus):
+            G[rm][node_to_idx[ctrl_minus]] += gm
+
+
+def _inductor_by_name(circuit: Circuit) -> dict[str, Inductor]:
+    return {el.name: el for el in circuit.elements if isinstance(el, Inductor)}
+
+
+def _coupled_inductor_names(circuit: Circuit) -> set[str]:
+    names: set[str] = set()
+    for el in circuit.elements:
+        if isinstance(el, MutualInductor):
+            names.add(el.primary)
+            names.add(el.secondary)
+    return names
+
+
+def _validate_mutual_inductor(
+    mutual: MutualInductor,
+    inductors: dict[str, Inductor],
+) -> tuple[Inductor, Inductor, float]:
+    if not math.isfinite(mutual.coupling):
+        raise ValueError(f"{mutual.name}: coupling must be finite")
+    if abs(mutual.coupling) >= 1.0:
+        raise ValueError(f"{mutual.name}: coupling magnitude must be less than one")
+    if mutual.primary == mutual.secondary:
+        raise ValueError(f"{mutual.name}: coupled inductors must be distinct")
+    primary = inductors.get(mutual.primary)
+    if primary is None:
+        raise ValueError(f"{mutual.name}: referenced inductor {mutual.primary!r} was not found")
+    secondary = inductors.get(mutual.secondary)
+    if secondary is None:
+        raise ValueError(f"{mutual.name}: referenced inductor {mutual.secondary!r} was not found")
+    if primary.inductance <= 0.0 or not math.isfinite(primary.inductance):
+        raise ValueError(f"{primary.name}: inductance must be finite and positive")
+    if secondary.inductance <= 0.0 or not math.isfinite(secondary.inductance):
+        raise ValueError(f"{secondary.name}: inductance must be finite and positive")
+    mutual_inductance = mutual.coupling * math.sqrt(primary.inductance * secondary.inductance)
+    return primary, secondary, mutual_inductance
+
+
+def _stamp_ac_mutual_inductor(
+    mutual: MutualInductor,
+    inductors: dict[str, Inductor],
+    G: list[list[complex]],
+    omega: float,
+    node_to_idx: dict[str, int],
+) -> None:
+    primary, secondary, mutual_inductance = _validate_mutual_inductor(mutual, inductors)
+    if omega == 0.0:
+        _stamp_g_c(G, node_to_idx, primary.n_plus, primary.n_minus, 1e12 + 0j)
+        _stamp_g_c(G, node_to_idx, secondary.n_plus, secondary.n_minus, 1e12 + 0j)
+        return
+
+    determinant = primary.inductance * secondary.inductance - mutual_inductance**2
+    if determinant <= 0.0 or not math.isfinite(determinant):
+        raise ValueError(f"{mutual.name}: coupled inductance matrix is singular")
+
+    scale = 1.0 / (1j * omega * determinant)
+    y11 = secondary.inductance * scale
+    y12 = -mutual_inductance * scale
+    y22 = primary.inductance * scale
+    _stamp_g_c(G, node_to_idx, primary.n_plus, primary.n_minus, y11)
+    _stamp_g_c(G, node_to_idx, secondary.n_plus, secondary.n_minus, y22)
+    _stamp_vccs_c(
+        G,
+        node_to_idx,
+        primary.n_plus,
+        primary.n_minus,
+        secondary.n_plus,
+        secondary.n_minus,
+        y12,
+    )
+    _stamp_vccs_c(
+        G,
+        node_to_idx,
+        secondary.n_plus,
+        secondary.n_minus,
+        primary.n_plus,
+        primary.n_minus,
+        y12,
+    )
+
+
 def _has_explicit_ac_sources(circuit: Circuit) -> bool:
     """Return True when at least one independent source has an AC spec."""
 
@@ -3112,6 +3215,8 @@ def _stamp_ac(
     node_to_idx: dict[str, int],
     branch_srcs: list[VoltageSource | VCVS | CCVS],
     dc_x: list[float],
+    inductors: dict[str, Inductor],
+    coupled_inductor_names: set[str],
     *,
     explicit_ac_sources: bool = False,
 ) -> None:
@@ -3160,6 +3265,8 @@ def _stamp_ac(
         _stamp_g_c(G, node_to_idx, el.n_plus, el.n_minus, 1j * omega * el.capacitance)
 
     elif isinstance(el, Inductor):
+        if el.name in coupled_inductor_names:
+            return
         # Admittance Y_L = 1/(jωL).  At ω = 0, Y → ∞ (short circuit); model
         # as a very large conductance to keep the matrix non-singular.
         if omega == 0.0:
@@ -3167,6 +3274,9 @@ def _stamp_ac(
         else:
             y_l = 1.0 / (1j * omega * el.inductance)
         _stamp_g_c(G, node_to_idx, el.n_plus, el.n_minus, y_l)
+
+    elif isinstance(el, MutualInductor):
+        _stamp_ac_mutual_inductor(el, inductors, G, omega, node_to_idx)
 
     elif isinstance(el, VoltageSource):
         # Ideal voltage source stamp: adds branch current as an unknown.
@@ -3433,6 +3543,8 @@ def ac_sweep(
     n_branch = len(branch_srcs)
     size = n_nodes + n_branch
     explicit_ac_sources = _has_explicit_ac_sources(circuit)
+    inductors = _inductor_by_name(circuit)
+    coupled_inductor_names = _coupled_inductor_names(circuit)
 
     # Reconstruct the indexed dc_x vector from the DcResult dict.
     dc_x: list[float] = [0.0] * size
@@ -3475,6 +3587,8 @@ def ac_sweep(
                 node_to_idx,
                 branch_srcs,
                 dc_x,
+                inductors,
+                coupled_inductor_names,
                 explicit_ac_sources=explicit_ac_sources,
             )
 
@@ -5432,6 +5546,8 @@ def noise_ac(
     n_nodes = len(node_to_idx)
     n_branch_noise = len(branch_srcs_noise)
     size = n_nodes + n_branch_noise
+    inductors = _inductor_by_name(circuit)
+    coupled_inductor_names = _coupled_inductor_names(circuit)
 
     # Reconstruct dc_x solution vector for linearisation of nonlinear devices.
     dc_x: list[float] = [0.0] * size
@@ -5498,6 +5614,8 @@ def noise_ac(
                 node_to_idx,
                 branch_srcs_noise,
                 dc_x,
+                inductors,
+                coupled_inductor_names,
                 explicit_ac_sources=_has_explicit_ac_sources(circuit),
             )
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -102,6 +102,7 @@ from spice_engine import (
     ExpWaveform,
     Inductor,
     JFET,
+    MutualInductor,
     McPoint,
     McResult,
     NoiseEntry,
@@ -1775,6 +1776,39 @@ def test_ac_rl_highpass_3db_at_cutoff():
         f"RL high-pass gain at f_c={closest.freq:.0f} Hz: {gain:.5f},"
         f" expected {expected_gain:.5f}"
     )
+
+
+def test_ac_mutual_inductor_transformer_ratio():
+    primary_l = 1.0e-3
+    secondary_l = 4.0e-3
+    coupling = 0.9
+    load = 1_000.0
+    freq = 1_000.0
+    mutual_l = coupling * math.sqrt(primary_l * secondary_l)
+    expected = (1j * 2.0 * math.pi * freq * mutual_l) / (
+        1.0 + 1j * 2.0 * math.pi * freq * secondary_l / load
+    )
+
+    c = Circuit()
+    c.add(CurrentSource("Iin", "0", "pri", 0.0, ac=AcSource(1.0)))
+    c.add(Inductor("Lpri", "pri", "0", primary_l))
+    c.add(Inductor("Lsec", "sec", "0", secondary_l))
+    c.add(MutualInductor("K1", "Lpri", "Lsec", coupling))
+    c.add(Resistor("Rload", "sec", "0", load))
+
+    point = ac_sweep(c, f_start=freq, f_stop=freq, n_points=1, sweep="lin").points[0]
+
+    assert point.node_voltages["sec"] == pytest.approx(expected)
+
+
+def test_ac_mutual_inductor_rejects_missing_reference():
+    c = Circuit()
+    c.add(VoltageSource("Vin", "pri", "0", 1.0))
+    c.add(Inductor("Lpri", "pri", "0", 1.0e-3))
+    c.add(MutualInductor("Kbad", "Lpri", "Lmissing", 0.9))
+
+    with pytest.raises(ValueError, match="referenced inductor"):
+        ac_sweep(c, f_start=1_000.0, f_stop=1_000.0, n_points=1, sweep="lin")
 
 
 # ============================================================================

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject SPICE `K` mutual-inductor cards that reference missing inductors or
+  use non-finite coupling coefficients.
 - Parse SPICE `K` mutual-inductor cards into `MutualInductor` elements,
   including subcircuit-local inductor reference remapping.
 

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass, field
 from dataclasses import fields as dataclass_fields
@@ -292,6 +293,7 @@ def parse_netlist(text: str) -> ParsedNetlist:
                 parsed.circuit.add(_parse_element(statement.fields, parsed.models))
         except NetlistParseError as exc:
             raise NetlistParseError(f"line {statement.line_number}: {exc}") from exc
+    _validate_mutual_inductors(parsed.circuit)
     return parsed
 
 
@@ -443,6 +445,31 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
         _require_fields(fields, 5, "CCVS")
         return CCVS(name, fields[1], fields[2], fields[3], parse_value(fields[4]))
     raise NetlistParseError(f"unsupported element {name!r}")
+
+
+def _validate_mutual_inductors(circuit: Circuit) -> None:
+    inductors = {
+        element.name: element for element in circuit.elements if isinstance(element, Inductor)
+    }
+    for element in circuit.elements:
+        if not isinstance(element, MutualInductor):
+            continue
+        if not math.isfinite(element.coupling):
+            raise NetlistParseError(f"{element.name}: coupling must be finite")
+        if abs(element.coupling) >= 1.0:
+            raise NetlistParseError(
+                f"{element.name}: coupling magnitude must be less than one"
+            )
+        if element.primary == element.secondary:
+            raise NetlistParseError(f"{element.name}: coupled inductors must be distinct")
+        if element.primary not in inductors:
+            raise NetlistParseError(
+                f"{element.name}: referenced inductor {element.primary!r} was not found"
+            )
+        if element.secondary not in inductors:
+            raise NetlistParseError(
+                f"{element.name}: referenced inductor {element.secondary!r} was not found"
+            )
 
 
 def _start_subckt(

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -115,6 +115,27 @@ Kcouple Lpri Lsec 0.75
     assert mutual.coupling == 0.75
 
 
+def test_mutual_inductor_rejects_missing_referenced_inductor() -> None:
+    with pytest.raises(NetlistParseError, match="referenced inductor"):
+        parse_netlist(
+            """
+Lpri p 0 10m
+Kbad Lpri Lmissing 0.75
+"""
+        )
+
+
+def test_mutual_inductor_rejects_non_finite_coupling() -> None:
+    with pytest.raises(NetlistParseError, match="coupling must be finite"):
+        parse_netlist(
+            """
+Lpri p 0 10m
+Lsec s 0 40m
+Kbad Lpri Lsec 1e999
+"""
+        )
+
+
 def test_parse_options_analysis_card() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add AC analysis stamping for `MutualInductor` by coupling referenced
+  inductor pairs through the inverted two-winding inductance matrix.
 - Add a public `MutualInductor` element as the parser-facing SPICE `K` card
   foothold; coupled AC/transient stamping follows in a later compatibility
   slice.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 
 const PIVOT_EPSILON: f64 = 1.0e-12;
@@ -4129,6 +4129,8 @@ fn build_ac_matrix(
     let node_count = node_indices.len();
     let matrix_size = node_count + voltage_sources.len();
     let mut matrix = vec![vec![Complex::zero(); matrix_size]; matrix_size];
+    let inductors = inductor_by_name(circuit);
+    let coupled_inductor_names = coupled_inductor_names(circuit);
 
     for element in circuit.elements() {
         match element {
@@ -4137,9 +4139,13 @@ fn build_ac_matrix(
                 stamp_ac_capacitor(capacitor, omega, node_indices, &mut matrix)?
             }
             Element::Inductor(inductor) => {
-                stamp_ac_inductor(inductor, omega, node_indices, &mut matrix)?
+                if !coupled_inductor_names.contains(&inductor.name) {
+                    stamp_ac_inductor(inductor, omega, node_indices, &mut matrix)?
+                }
             }
-            Element::MutualInductor(_) => {}
+            Element::MutualInductor(mutual) => {
+                stamp_ac_mutual_inductor(mutual, &inductors, omega, node_indices, &mut matrix)?
+            }
             Element::VoltageSource(source) => stamp_ac_voltage_source_matrix(
                 source,
                 node_indices,
@@ -6244,6 +6250,130 @@ fn stamp_ac_inductor(
     let n1 = node_index(node_indices, &inductor.n1);
     let n2 = node_index(node_indices, &inductor.n2);
     stamp_complex_conductance(matrix, n1, n2, admittance);
+    Ok(())
+}
+
+fn inductor_by_name(circuit: &Circuit) -> HashMap<String, &Inductor> {
+    circuit
+        .elements()
+        .iter()
+        .filter_map(|element| match element {
+            Element::Inductor(inductor) => Some((inductor.name.clone(), inductor)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn coupled_inductor_names(circuit: &Circuit) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for element in circuit.elements() {
+        if let Element::MutualInductor(mutual) = element {
+            names.insert(mutual.primary.clone());
+            names.insert(mutual.secondary.clone());
+        }
+    }
+    names
+}
+
+fn validate_mutual_inductor<'a>(
+    mutual: &MutualInductor,
+    inductors: &'a HashMap<String, &Inductor>,
+) -> Result<(&'a Inductor, &'a Inductor, f64), SpiceError> {
+    if !mutual.coupling.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: mutual.name.clone(),
+            reason: "coupling must be finite".to_string(),
+        });
+    }
+    if mutual.coupling.abs() >= 1.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mutual.name.clone(),
+            reason: "coupling magnitude must be less than one".to_string(),
+        });
+    }
+    if mutual.primary == mutual.secondary {
+        return Err(SpiceError::InvalidElement {
+            name: mutual.name.clone(),
+            reason: "coupled inductors must be distinct".to_string(),
+        });
+    }
+    let primary =
+        inductors
+            .get(&mutual.primary)
+            .copied()
+            .ok_or_else(|| SpiceError::InvalidElement {
+                name: mutual.name.clone(),
+                reason: format!("referenced inductor {:?} was not found", mutual.primary),
+            })?;
+    let secondary =
+        inductors
+            .get(&mutual.secondary)
+            .copied()
+            .ok_or_else(|| SpiceError::InvalidElement {
+                name: mutual.name.clone(),
+                reason: format!("referenced inductor {:?} was not found", mutual.secondary),
+            })?;
+    validate_inductor(primary)?;
+    validate_inductor(secondary)?;
+    let mutual_inductance =
+        mutual.coupling * (primary.inductance_henrys * secondary.inductance_henrys).sqrt();
+    Ok((primary, secondary, mutual_inductance))
+}
+
+fn stamp_ac_mutual_inductor(
+    mutual: &MutualInductor,
+    inductors: &HashMap<String, &Inductor>,
+    omega: f64,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    let (primary, secondary, mutual_inductance) = validate_mutual_inductor(mutual, inductors)?;
+    if omega == 0.0 {
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &primary.n1),
+            node_index(node_indices, &primary.n2),
+            Complex::new(1.0e12, 0.0),
+        );
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &secondary.n1),
+            node_index(node_indices, &secondary.n2),
+            Complex::new(1.0e12, 0.0),
+        );
+        return Ok(());
+    }
+
+    let determinant =
+        primary.inductance_henrys * secondary.inductance_henrys - mutual_inductance.powi(2);
+    if !determinant.is_finite() || determinant <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mutual.name.clone(),
+            reason: "coupled inductance matrix is singular".to_string(),
+        });
+    }
+
+    let scale = Complex::new(0.0, -1.0 / (omega * determinant));
+    let y11 = Complex::new(
+        scale.real * secondary.inductance_henrys,
+        scale.imag * secondary.inductance_henrys,
+    );
+    let y12 = Complex::new(
+        scale.real * -mutual_inductance,
+        scale.imag * -mutual_inductance,
+    );
+    let y22 = Complex::new(
+        scale.real * primary.inductance_henrys,
+        scale.imag * primary.inductance_henrys,
+    );
+    let p1 = node_index(node_indices, &primary.n1);
+    let p2 = node_index(node_indices, &primary.n2);
+    let s1 = node_index(node_indices, &secondary.n1);
+    let s2 = node_index(node_indices, &secondary.n2);
+    stamp_complex_conductance(matrix, p1, p2, y11);
+    stamp_complex_conductance(matrix, s1, s2, y22);
+    stamp_complex_transconductance(matrix, p1, p2, s1, s2, y12);
+    stamp_complex_transconductance(matrix, s1, s2, p1, p2, y12);
     Ok(())
 }
 

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,7 +1,7 @@
 use spice_engine::{
     ac_sweep, ac_sweep_corners, s_parameters, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit,
     CornerOverride, CornerSpec, CurrentSource, Element, Inductor, Jfet, JfetPolarity, Mosfet,
-    MosfetLevel1Params, MosfetType, Resistor, SpiceError, Vcvs, VoltageSource,
+    MosfetLevel1Params, MosfetType, MutualInductor, Resistor, SpiceError, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -133,6 +133,63 @@ fn ac_rl_high_pass_has_minus_three_db_corner() {
     let out = points[0].voltage("out").unwrap();
     assert_close(out.abs(), 1.0 / 2.0_f64.sqrt());
     assert_close(out.phase(), std::f64::consts::FRAC_PI_4);
+}
+
+#[test]
+fn ac_mutual_inductor_transformer_ratio() {
+    let primary_l: f64 = 1.0e-3;
+    let secondary_l: f64 = 4.0e-3;
+    let coupling: f64 = 0.9;
+    let load: f64 = 1_000.0;
+    let frequency: f64 = 1_000.0;
+    let mutual_l = coupling * (primary_l * secondary_l).sqrt();
+    let denom_real: f64 = 1.0;
+    let denom_imag = 2.0 * std::f64::consts::PI * frequency * secondary_l / load;
+    let numerator_imag = 2.0 * std::f64::consts::PI * frequency * mutual_l;
+    let scale = denom_real.powi(2) + denom_imag.powi(2);
+    let expected_real = numerator_imag * denom_imag / scale;
+    let expected_imag = numerator_imag * denom_real / scale;
+
+    let mut circuit = Circuit::new();
+    circuit.add(Element::CurrentSource(CurrentSource::with_ac(
+        "Iin", "0", "pri", 0.0, 1.0, 0.0,
+    )));
+    circuit.add(Element::Inductor(Inductor::new(
+        "Lpri", "pri", "0", primary_l,
+    )));
+    circuit.add(Element::Inductor(Inductor::new(
+        "Lsec",
+        "sec",
+        "0",
+        secondary_l,
+    )));
+    circuit.add(Element::MutualInductor(MutualInductor::new(
+        "K1", "Lpri", "Lsec", coupling,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rload", "sec", "0", load)));
+
+    let points = ac_sweep(&circuit, frequency, frequency, 10).unwrap();
+
+    let secondary = points[0].voltage("sec").unwrap();
+    assert_close(secondary.real, expected_real);
+    assert_close(secondary.imag, expected_imag);
+}
+
+#[test]
+fn ac_mutual_inductor_rejects_missing_reference() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "pri", "0", 1.0,
+    )));
+    circuit.add(Element::Inductor(Inductor::new("Lpri", "pri", "0", 1.0e-3)));
+    circuit.add(Element::MutualInductor(MutualInductor::new(
+        "Kbad", "Lpri", "Lmissing", 0.9,
+    )));
+
+    assert!(matches!(
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 10),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Kbad"
+    ));
 }
 
 #[test]

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject SPICE `K` mutual-inductor cards that reference missing inductors or
+  use non-finite coupling coefficients.
 - Parse SPICE `K` mutual-inductor cards into `MutualInductor` elements,
   including subcircuit-local inductor reference remapping.
 - Parse SPICE `J` JFET elements via `.model <name> NJF(...)` and

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -345,6 +345,7 @@ pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
             circuit.add(element);
         }
     }
+    validate_mutual_inductors(&circuit)?;
 
     Ok(ParsedNetlist {
         circuit,
@@ -352,6 +353,55 @@ pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
         models,
         title,
     })
+}
+
+fn validate_mutual_inductors(circuit: &Circuit) -> Result<(), NetlistParseError> {
+    let inductors: std::collections::HashSet<String> = circuit
+        .elements()
+        .iter()
+        .filter_map(|element| match element {
+            Element::Inductor(inductor) => Some(inductor.name.clone()),
+            _ => None,
+        })
+        .collect();
+
+    for element in circuit.elements() {
+        let Element::MutualInductor(mutual) = element else {
+            continue;
+        };
+        if !mutual.coupling.is_finite() {
+            return Err(NetlistParseError::new(format!(
+                "{}: coupling must be finite",
+                mutual.name
+            )));
+        }
+        if mutual.coupling.abs() >= 1.0 {
+            return Err(NetlistParseError::new(format!(
+                "{}: coupling magnitude must be less than one",
+                mutual.name
+            )));
+        }
+        if mutual.primary == mutual.secondary {
+            return Err(NetlistParseError::new(format!(
+                "{}: coupled inductors must be distinct",
+                mutual.name
+            )));
+        }
+        if !inductors.contains(&mutual.primary) {
+            return Err(NetlistParseError::new(format!(
+                "{}: referenced inductor {:?} was not found",
+                mutual.name, mutual.primary
+            )));
+        }
+        if !inductors.contains(&mutual.secondary) {
+            return Err(NetlistParseError::new(format!(
+                "{}: referenced inductor {:?} was not found",
+                mutual.name, mutual.secondary
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 pub fn parse(text: &str) -> Result<ParsedNetlist, NetlistParseError> {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -128,6 +128,33 @@ Kcouple Lpri Lsec 0.75
 }
 
 #[test]
+fn rejects_mutual_inductor_missing_referenced_inductor() {
+    let error = parse_netlist(
+        r#"
+Lpri p 0 10m
+Kbad Lpri Lmissing 0.75
+"#,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("referenced inductor"));
+}
+
+#[test]
+fn rejects_mutual_inductor_non_finite_coupling() {
+    let error = parse_netlist(
+        r#"
+Lpri p 0 10m
+Lsec s 0 40m
+Kbad Lpri Lsec 1e999
+"#,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("coupling must be finite"));
+}
+
+#[test]
 fn parses_options_analysis_cards() {
     let parsed = parse_netlist(
         r#"

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add AC analysis stamping for `MutualInductor` by coupling referenced
+  inductor pairs through the inverted two-winding inductance matrix.
 - Add a public `MutualInductor` element and `mutualInductor` factory as the
   parser-facing SPICE `K` card foothold; coupled AC/transient stamping follows
   in a later compatibility slice.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -3506,6 +3506,8 @@ function buildAcMatrix(
   const matrix = Array.from({ length: matrixSize }, () =>
     Array.from({ length: matrixSize }, () => complex(0.0, 0.0)),
   );
+  const inductors = inductorByName(circuit);
+  const coupledNames = coupledInductorNames(circuit);
 
   for (const element of circuit.elements()) {
     switch (element.kind) {
@@ -3516,7 +3518,13 @@ function buildAcMatrix(
         stampAcCapacitor(element, omega, nodeIndices, matrix);
         break;
       case "inductor":
+        if (coupledNames.has(element.name)) {
+          break;
+        }
         stampAcInductor(element, omega, nodeIndices, matrix);
+        break;
+      case "mutual-inductor":
+        stampAcMutualInductor(element, inductors, omega, nodeIndices, matrix);
         break;
       case "voltage-source":
         stampAcVoltageSourceMatrix(
@@ -5233,6 +5241,90 @@ function stampAcInductor(
   const n1 = nodeIndex(nodeIndices, element.n1);
   const n2 = nodeIndex(nodeIndices, element.n2);
   stampComplexConductance(matrix, n1, n2, admittance);
+}
+
+function inductorByName(circuit: Circuit): Map<string, Inductor> {
+  const inductors = new Map<string, Inductor>();
+  for (const element of circuit.elements()) {
+    if (element.kind === "inductor") {
+      inductors.set(element.name, element);
+    }
+  }
+  return inductors;
+}
+
+function coupledInductorNames(circuit: Circuit): Set<string> {
+  const names = new Set<string>();
+  for (const element of circuit.elements()) {
+    if (element.kind === "mutual-inductor") {
+      names.add(element.primary);
+      names.add(element.secondary);
+    }
+  }
+  return names;
+}
+
+function validateMutualInductor(
+  element: MutualInductor,
+  inductors: ReadonlyMap<string, Inductor>,
+): { primary: Inductor; secondary: Inductor; mutualInductance: number } {
+  if (!Number.isFinite(element.coupling)) {
+    throw invalidElement(element.name, "coupling must be finite");
+  }
+  if (Math.abs(element.coupling) >= 1.0) {
+    throw invalidElement(element.name, "coupling magnitude must be less than one");
+  }
+  if (element.primary === element.secondary) {
+    throw invalidElement(element.name, "coupled inductors must be distinct");
+  }
+  const primary = inductors.get(element.primary);
+  if (primary === undefined) {
+    throw invalidElement(element.name, `referenced inductor ${JSON.stringify(element.primary)} was not found`);
+  }
+  const secondary = inductors.get(element.secondary);
+  if (secondary === undefined) {
+    throw invalidElement(element.name, `referenced inductor ${JSON.stringify(element.secondary)} was not found`);
+  }
+  validateInductor(primary);
+  validateInductor(secondary);
+  return {
+    primary,
+    secondary,
+    mutualInductance: element.coupling * Math.sqrt(primary.inductanceHenrys * secondary.inductanceHenrys),
+  };
+}
+
+function stampAcMutualInductor(
+  element: MutualInductor,
+  inductors: ReadonlyMap<string, Inductor>,
+  omega: number,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+): void {
+  const { primary, secondary, mutualInductance } = validateMutualInductor(element, inductors);
+  if (omega === 0.0) {
+    stampComplexConductance(matrix, nodeIndex(nodeIndices, primary.n1), nodeIndex(nodeIndices, primary.n2), complex(1.0e12, 0.0));
+    stampComplexConductance(matrix, nodeIndex(nodeIndices, secondary.n1), nodeIndex(nodeIndices, secondary.n2), complex(1.0e12, 0.0));
+    return;
+  }
+
+  const determinant = primary.inductanceHenrys * secondary.inductanceHenrys - mutualInductance ** 2;
+  if (!Number.isFinite(determinant) || determinant <= 0.0) {
+    throw invalidElement(element.name, "coupled inductance matrix is singular");
+  }
+
+  const scale = complex(0.0, -1.0 / (omega * determinant));
+  const y11 = complexScale(scale, secondary.inductanceHenrys);
+  const y12 = complexScale(scale, -mutualInductance);
+  const y22 = complexScale(scale, primary.inductanceHenrys);
+  const p1 = nodeIndex(nodeIndices, primary.n1);
+  const p2 = nodeIndex(nodeIndices, primary.n2);
+  const s1 = nodeIndex(nodeIndices, secondary.n1);
+  const s2 = nodeIndex(nodeIndices, secondary.n2);
+  stampComplexConductance(matrix, p1, p2, y11);
+  stampComplexConductance(matrix, s1, s2, y22);
+  stampComplexTransconductance(matrix, p1, p2, s1, s2, y12);
+  stampComplexTransconductance(matrix, s1, s2, p1, p2, y12);
 }
 
 function stampComplexConductance(

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -13,12 +13,15 @@ import {
   currentSourceWithAc,
   inductor,
   jfet,
+  mutualInductor,
   resistor,
   sParameters,
   vcvs,
   voltageSource,
   voltageSourceWithAc,
 } from "../src/index.js";
+
+const TWO_PI_FOR_TEST = 2.0 * Math.PI;
 
 function expectClose(actual: number | undefined, expected: number): void {
   expect(actual).not.toBeUndefined();
@@ -117,6 +120,51 @@ describe("acSweep", () => {
     expect(out).not.toBeUndefined();
     expectClose(complexAbs(out!), 1.0 / Math.sqrt(2.0));
     expectClose(complexPhase(out!), Math.PI / 4.0);
+  });
+
+  it("stamps mutual-inductor transformer coupling", () => {
+    const primaryL = 1.0e-3;
+    const secondaryL = 4.0e-3;
+    const coupling = 0.9;
+    const load = 1_000.0;
+    const frequency = 1_000.0;
+    const mutualL = coupling * Math.sqrt(primaryL * secondaryL);
+    const denominator = {
+      real: 1.0,
+      imag: (TWO_PI_FOR_TEST * frequency * secondaryL) / load,
+    };
+    const numerator = {
+      real: 0.0,
+      imag: TWO_PI_FOR_TEST * frequency * mutualL,
+    };
+    const scale = denominator.real ** 2 + denominator.imag ** 2;
+    const expected = {
+      real: (numerator.real * denominator.real + numerator.imag * denominator.imag) / scale,
+      imag: (numerator.imag * denominator.real - numerator.real * denominator.imag) / scale,
+    };
+
+    const circuit = new Circuit();
+    circuit.add(currentSourceWithAc("Iin", "0", "pri", 0.0, 1.0));
+    circuit.add(inductor("Lpri", "pri", "0", primaryL));
+    circuit.add(inductor("Lsec", "sec", "0", secondaryL));
+    circuit.add(mutualInductor("K1", "Lpri", "Lsec", coupling));
+    circuit.add(resistor("Rload", "sec", "0", load));
+
+    const points = acSweep(circuit, frequency, frequency, 10);
+
+    const secondary = points[0].voltage("sec");
+    expect(secondary).not.toBeUndefined();
+    expectClose(secondary!.real, expected.real);
+    expectClose(secondary!.imag, expected.imag);
+  });
+
+  it("rejects mutual-inductor missing references", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vin", "pri", "0", 1.0));
+    circuit.add(inductor("Lpri", "pri", "0", 1.0e-3));
+    circuit.add(mutualInductor("Kbad", "Lpri", "Lmissing", 0.9));
+
+    expect(() => acSweep(circuit, 1_000.0, 1_000.0, 10)).toThrowError(SpiceError);
   });
 
   it("injects current-source phasors", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject SPICE `K` mutual-inductor cards that reference missing inductors or
+  use non-finite coupling coefficients.
 - Parse SPICE `K` mutual-inductor cards into `mutualInductor` elements,
   including subcircuit-local inductor reference remapping.
 - Parse SPICE `J` JFET elements via `.model <name> NJF(...)` and

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -305,6 +305,7 @@ export function parseNetlist(text: string): ParsedNetlist {
       throw lineError(statement.lineNumber, error);
     }
   }
+  validateMutualInductors(circuit);
 
   return new ParsedNetlist(circuit, analyses, models, title);
 }
@@ -612,6 +613,35 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
     return ccvs(name, fields[1], fields[2], fields[3], parseValue(fields[4]));
   }
   throw new NetlistParseError(`unsupported element ${JSON.stringify(name)}`);
+}
+
+function validateMutualInductors(circuit: Circuit): void {
+  const inductors = new Set<string>();
+  for (const element of circuit.elements()) {
+    if (element.kind === "inductor") {
+      inductors.add(element.name);
+    }
+  }
+  for (const element of circuit.elements()) {
+    if (element.kind !== "mutual-inductor") {
+      continue;
+    }
+    if (!Number.isFinite(element.coupling)) {
+      throw new NetlistParseError(`${element.name}: coupling must be finite`);
+    }
+    if (Math.abs(element.coupling) >= 1.0) {
+      throw new NetlistParseError(`${element.name}: coupling magnitude must be less than one`);
+    }
+    if (element.primary === element.secondary) {
+      throw new NetlistParseError(`${element.name}: coupled inductors must be distinct`);
+    }
+    if (!inductors.has(element.primary)) {
+      throw new NetlistParseError(`${element.name}: referenced inductor ${JSON.stringify(element.primary)} was not found`);
+    }
+    if (!inductors.has(element.secondary)) {
+      throw new NetlistParseError(`${element.name}: referenced inductor ${JSON.stringify(element.secondary)} was not found`);
+    }
+  }
 }
 
 function startSubckt(

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -77,6 +77,21 @@ Kcouple Lpri Lsec 0.75
     });
   });
 
+  it("rejects mutual-inductor cards with missing referenced inductors", () => {
+    expect(() => parseNetlist(`
+Lpri p 0 10m
+Kbad Lpri Lmissing 0.75
+`)).toThrow(NetlistParseError);
+  });
+
+  it("rejects mutual-inductor cards with non-finite coupling", () => {
+    expect(() => parseNetlist(`
+Lpri p 0 10m
+Lsec s 0 40m
+Kbad Lpri Lsec 1e999
+`)).toThrow(NetlistParseError);
+  });
+
   it("parses .options analysis cards", () => {
     const parsed = parseNetlist(`
 .options reltol=1m abstol=1n gmin=1p method=trap noopiter


### PR DESCRIPTION
## Summary

- add AC analysis stamps for SPICE `K` mutual inductors across Python, TypeScript, and Rust
- validate `K` cards for finite coupling and existing distinct inductor references in all three parsers
- cover coupled-inductor transformer behavior and invalid reference handling with cross-language tests

## Validation

- `sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/python/spice-netlist-parser`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-netlist-parser`
- `cargo test -p spice-engine` in `code/packages/rust`
- `cargo test -p spice-netlist-parser` in `code/packages/rust`
- `git diff --check`

## Notes

This completes the AC stamping slice for Phase 2 mutual inductors. Transient coupled-inductor companion stamping remains the next focused SPICE slice.