### PR TITLE
feat(ui29-4): HostLink + HostTooltip + HostNumberInput kernel rosters

### DIFF
--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -87,7 +87,8 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     // Control flow (§3)
     "If", "Else", "For",
     // Host primitives (§2.1 "Host*" rows + UI29-1's HostDialog +
-    // UI29-2's HostCheckbox/HostRadio).
+    // UI29-2's HostCheckbox/HostRadio + UI29-4's HostLink/HostTooltip/
+    // HostNumberInput).
     // HostDialog was added in UI29-1 after mosaic-pkg-dialog v0.1.0
     // demonstrated that composing a dialog from Box+Column+Text loses
     // modal/focus/top-layer/accessibility semantics that only the
@@ -98,8 +99,18 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     // HostButton wrappers, losing the platform-native a11y role,
     // checked-state visuals (tri-state, focus ring), and keyboard
     // semantics that only the real checkbox/radio widget provides.
+    // HostLink, HostTooltip, HostNumberInput were added in UI29-4
+    // after the post-UI29-2 audit found Breadcrumb and Nav still
+    // faked `<a>` via HostButton (losing role="link", Ctrl-click
+    // open-new-tab, visited-state styling). HostTooltip and
+    // HostNumberInput were promoted in the same batch — the
+    // tooltip's a11y wiring (aria-describedby + hover/long-press
+    // trigger heuristics) and the number-input's mobile-numeric-
+    // keyboard / SpinBox-with-stepper-buttons are not reachable
+    // via composition from existing kernel primitives.
     "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
     "HostCheckbox", "HostRadio",
+    "HostLink", "HostTooltip", "HostNumberInput",
 ];
 
 // ---------------------------------------------------------------------------
@@ -657,18 +668,21 @@ version = "1"
 
     #[test]
     fn kernel_set_covers_ui29_section_2_1() {
-        // The eighteen primitives — fifteen from UI29 §2.1, plus
+        // The twenty-one primitives — fifteen from UI29 §2.1, plus
         // HostDialog added in UI29-1 (#3846), plus HostCheckbox and
-        // HostRadio added in UI29-2 (#3978).
-        let expected_18 = [
+        // HostRadio added in UI29-2 (#3978), plus HostLink,
+        // HostTooltip, and HostNumberInput added in UI29-4 (this
+        // batch).
+        let expected_21 = [
             "Box", "Row", "Column", "Stack", "Text", "Image",
             "Spacer", "Divider", "Icon",
             "If", "For",
             "HostInput", "HostButton", "HostTable", "HostScroll",
             "HostDialog",
             "HostCheckbox", "HostRadio",
+            "HostLink", "HostTooltip", "HostNumberInput",
         ];
-        for name in &expected_18 {
+        for name in &expected_21 {
             assert!(
                 KERNEL_PRIMITIVES.contains(name),
                 "kernel must include `{name}`"

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -100,19 +100,32 @@ const PRIMITIVES: &[&str] = &[
     // (currently both nodes coexist as siblings in `children`).
     "If",
     "Else",
-    // UI29 §2.1 / UI29-1 / UI29-2 — host primitives. Each lowers to the
-    // host platform's native widget (DOM <input>, SwiftUI TextField, Qt
-    // TextInput, etc.). HostDialog (UI29-1) is the 16th kernel
-    // primitive, added after mosaic-pkg-dialog v0.1.0 exposed the need
-    // for a native dialog primitive with modal/focus/top-layer/
-    // accessibility semantics that composition cannot provide.
-    // HostCheckbox and HostRadio (UI29-2) are the 17th and 18th, added
-    // after mosaic-pkg-toolkit's Checkbox/Radio were found to be fake
-    // HostButton wrappers — losing native a11y role, checked-state
-    // visuals (tri-state, focus ring), and keyboard semantics that
-    // only the platform's real checkbox/radio widget provides.
+    // UI29 §2.1 / UI29-1 / UI29-2 / UI29-4 — host primitives. Each
+    // lowers to the host platform's native widget (DOM <input>,
+    // SwiftUI TextField, Qt TextInput, etc.). HostDialog (UI29-1) is
+    // the 16th kernel primitive, added after mosaic-pkg-dialog v0.1.0
+    // exposed the need for a native dialog primitive with modal/focus/
+    // top-layer/accessibility semantics that composition cannot
+    // provide.
+    // HostCheckbox and HostRadio (UI29-2) are the 17th and 18th,
+    // added after mosaic-pkg-toolkit's Checkbox/Radio were found to
+    // be fake HostButton wrappers — losing native a11y role,
+    // checked-state visuals (tri-state, focus ring), and keyboard
+    // semantics that only the platform's real checkbox/radio widget
+    // provides.
+    // HostLink, HostTooltip, and HostNumberInput (UI29-4) are the
+    // 19th, 20th, and 21st. HostLink closes the only remaining fake-
+    // X pattern in the toolkit (Breadcrumb + Nav fake `<a>` via
+    // HostButton, losing role="link", Ctrl-click new-tab, visited-
+    // state). HostTooltip wraps a single child with a platform-native
+    // hover/long-press tooltip with proper aria-describedby wiring.
+    // HostNumberInput exposes numeric-only entry with mobile numeric
+    // keyboard, ± stepper buttons (Qt SpinBox / WinUI NumberBox), and
+    // min/max validation. See code/specs/UI29-4-form-and-nav-
+    // candidates-survey.md for the full inclusion-criteria audit.
     "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
     "HostCheckbox", "HostRadio",
+    "HostLink", "HostTooltip", "HostNumberInput",
 ];
 
 fn is_primitive(tag: &str) -> bool {
@@ -2086,10 +2099,17 @@ mod tests {
     ///
     /// UI29-2 — `HostCheckbox` and `HostRadio` joined as primitives 17 and
     /// 18 after `mosaic-pkg-toolkit`'s Checkbox/Radio were found to be
-    /// fake `HostButton` wrappers. They lose the platform-native a11y
-    /// role, checked-state visuals, and keyboard semantics that only the
-    /// real checkbox/radio widget provides — composition can't recover
-    /// them. The kernel now stands at 18 primitives.
+    /// fake `HostButton` wrappers.
+    ///
+    /// UI29-4 — `HostLink`, `HostTooltip`, and `HostNumberInput` joined as
+    /// primitives 19, 20, and 21 after the post-UI29-2 toolkit audit
+    /// identified Breadcrumb and Nav as the only remaining fake-X
+    /// patterns (both faking `<a>` via `HostButton`). HostTooltip and
+    /// HostNumberInput were promoted in the same batch because their
+    /// per-backend native-widget shape varies enough (e.g. Qt's `SpinBox`
+    /// with built-in ± buttons, mobile platforms' `inputmode="numeric"`
+    /// keyboard) that userland composition couldn't reach parity.
+    /// The kernel now stands at 21 primitives.
     #[test]
     fn host_dialog_and_friends_in_primitives() {
         assert!(PRIMITIVES.contains(&"HostInput"));
@@ -2107,6 +2127,18 @@ mod tests {
         assert!(
             PRIMITIVES.contains(&"HostRadio"),
             "UI29-2 added HostRadio as the 18th kernel primitive"
+        );
+        assert!(
+            PRIMITIVES.contains(&"HostLink"),
+            "UI29-4 added HostLink as the 19th kernel primitive"
+        );
+        assert!(
+            PRIMITIVES.contains(&"HostTooltip"),
+            "UI29-4 added HostTooltip as the 20th kernel primitive"
+        );
+        assert!(
+            PRIMITIVES.contains(&"HostNumberInput"),
+            "UI29-4 added HostNumberInput as the 21st kernel primitive"
         );
     }
 


### PR DESCRIPTION
## Summary

**Plan item [A]** in the overnight loop. Promotes \`HostLink\`, \`HostTooltip\`, and \`HostNumberInput\` to the kernel as the 19th, 20th, and 21st primitives, per the UI29-4 survey (#4027).

- Adds the three names to \`moslayout-compiler::PRIMITIVES\` and \`mosaic-package-resolver::KERNEL_PRIMITIVES\`.
- Extends \`host_dialog_and_friends_in_primitives\` and renames \`expected_18\` → \`expected_21\` in the resolver test.
- Backends fall through to no-op until U29-4-K-* PRs land; \`cargo build\` clean across all 7 emit crates.

## Rationale (from the survey doc)

- **HostLink** closes the only remaining fake-X pattern in mosaic-pkg-toolkit (Breadcrumb + Nav both fake \`<a>\` via HostButton).
- **HostTooltip** wraps a single child with platform-native hover/long-press tooltip + aria-describedby wiring.
- **HostNumberInput** exposes numeric-only entry with mobile numeric keyboard, ± stepper buttons (Qt SpinBox / WinUI NumberBox), and min/max validation.

## Test plan

- [x] \`cargo test -p moslayout-compiler -p mosaic-package-resolver\` — 13 + 55 passing
- [x] \`cargo build\` across all 7 emit crates — clean
- [ ] CI green
- [ ] Reviewer sign-off (no auto-merge per overnight loop instruction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)