### PR TITLE
spice: add mutual inductor transient stamps

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Mutual-inductor transient stamping** — `MutualInductor` now couples
+  referenced inductor pairs during transient analysis with a two-winding
+  companion conductance matrix.
+
 - **Mutual-inductor AC stamping** — `MutualInductor` now couples referenced
   inductor pairs in AC analysis using the inverted two-winding inductance
   matrix.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2027,6 +2027,8 @@ def _build_transient_companions(
         G_eq = h/L
         I_eq = I_n                (parallel current source from n+ to n-)
     """
+    coupled_names = _coupled_inductor_names(circuit)
+
     # Build the base element list, substituting time-varying source values.
     # VoltageSource / CurrentSource elements that carry a waveform callable
     # are replaced here with a plain static copy at the current time t.
@@ -2055,6 +2057,80 @@ def _build_transient_companions(
         else:
             base_elements.append(e)
     aug = Circuit(elements=base_elements)
+
+    inductors = _inductor_by_name(circuit)
+    for el in circuit.elements:
+        if isinstance(el, MutualInductor):
+            primary, secondary, mutual_inductance = _validate_mutual_inductor(
+                el,
+                inductors,
+            )
+            determinant = primary.inductance * secondary.inductance - mutual_inductance**2
+            if determinant <= 0.0 or not math.isfinite(determinant):
+                raise ValueError(f"{el.name}: coupled inductance matrix is singular")
+
+            if method == "trap":
+                scale = h / (2.0 * determinant)
+                v_primary_prev = ind_voltages.get(primary.name, 0.0)
+                v_secondary_prev = ind_voltages.get(secondary.name, 0.0)
+            else:
+                scale = h / determinant
+                v_primary_prev = 0.0
+                v_secondary_prev = 0.0
+            g11 = secondary.inductance * scale
+            g12 = -mutual_inductance * scale
+            g22 = primary.inductance * scale
+            i_primary_eq = (
+                ind_currents.get(primary.name, primary.initial_current)
+                + g11 * v_primary_prev
+                + g12 * v_secondary_prev
+            )
+            i_secondary_eq = (
+                ind_currents.get(secondary.name, secondary.initial_current)
+                + g12 * v_primary_prev
+                + g22 * v_secondary_prev
+            )
+
+            aug.elements.append(Resistor(
+                name=f"_K_{el.name}_{primary.name}_R",
+                n_plus=primary.n_plus,
+                n_minus=primary.n_minus,
+                resistance=1.0 / g11,
+            ))
+            aug.elements.append(Resistor(
+                name=f"_K_{el.name}_{secondary.name}_R",
+                n_plus=secondary.n_plus,
+                n_minus=secondary.n_minus,
+                resistance=1.0 / g22,
+            ))
+            aug.elements.append(VCCS(
+                name=f"_K_{el.name}_{primary.name}_from_{secondary.name}",
+                n_plus=primary.n_plus,
+                n_minus=primary.n_minus,
+                ctrl_plus=secondary.n_plus,
+                ctrl_minus=secondary.n_minus,
+                gm=g12,
+            ))
+            aug.elements.append(VCCS(
+                name=f"_K_{el.name}_{secondary.name}_from_{primary.name}",
+                n_plus=secondary.n_plus,
+                n_minus=secondary.n_minus,
+                ctrl_plus=primary.n_plus,
+                ctrl_minus=primary.n_minus,
+                gm=g12,
+            ))
+            aug.elements.append(CurrentSource(
+                name=f"_K_{el.name}_{primary.name}_I",
+                n_plus=primary.n_plus,
+                n_minus=primary.n_minus,
+                current=i_primary_eq,
+            ))
+            aug.elements.append(CurrentSource(
+                name=f"_K_{el.name}_{secondary.name}_I",
+                n_plus=secondary.n_plus,
+                n_minus=secondary.n_minus,
+                current=i_secondary_eq,
+            ))
 
     for el in circuit.elements:
         # ---- Capacitor companion ------------------------------------------
@@ -2086,7 +2162,7 @@ def _build_transient_companions(
             ))
 
         # ---- Inductor companion ------------------------------------------
-        elif isinstance(el, Inductor):
+        elif isinstance(el, Inductor) and el.name not in coupled_names:
             I_prev = ind_currents.get(el.name, 0.0)
             if method == "trap":
                 g_eq = h / (2.0 * el.inductance)
@@ -2142,6 +2218,52 @@ def _update_reactive_state(
     Inductor voltage update (trapezoidal):
         V_{n+1} = V_{n+1,+} - V_{n+1,-}   (for use in the next companion build)
     """
+    coupled_names = _coupled_inductor_names(circuit)
+    inductors = _inductor_by_name(circuit)
+    for el in circuit.elements:
+        if isinstance(el, MutualInductor):
+            primary, secondary, mutual_inductance = _validate_mutual_inductor(
+                el,
+                inductors,
+            )
+            determinant = primary.inductance * secondary.inductance - mutual_inductance**2
+            if determinant <= 0.0 or not math.isfinite(determinant):
+                raise ValueError(f"{el.name}: coupled inductance matrix is singular")
+
+            v_primary = (
+                _node_voltage(primary.n_plus, op.node_voltages)
+                - _node_voltage(primary.n_minus, op.node_voltages)
+            )
+            v_secondary = (
+                _node_voltage(secondary.n_plus, op.node_voltages)
+                - _node_voltage(secondary.n_minus, op.node_voltages)
+            )
+            if method == "trap":
+                scale = h / (2.0 * determinant)
+                v_primary_prev = ind_voltages.get(primary.name, 0.0)
+                v_secondary_prev = ind_voltages.get(secondary.name, 0.0)
+            else:
+                scale = h / determinant
+                v_primary_prev = 0.0
+                v_secondary_prev = 0.0
+            g11 = secondary.inductance * scale
+            g12 = -mutual_inductance * scale
+            g22 = primary.inductance * scale
+            i_primary_eq = (
+                ind_currents.get(primary.name, primary.initial_current)
+                + g11 * v_primary_prev
+                + g12 * v_secondary_prev
+            )
+            i_secondary_eq = (
+                ind_currents.get(secondary.name, secondary.initial_current)
+                + g12 * v_primary_prev
+                + g22 * v_secondary_prev
+            )
+            ind_currents[primary.name] = g11 * v_primary + g12 * v_secondary + i_primary_eq
+            ind_currents[secondary.name] = g12 * v_primary + g22 * v_secondary + i_secondary_eq
+            ind_voltages[primary.name] = v_primary
+            ind_voltages[secondary.name] = v_secondary
+
     for el in circuit.elements:
         if isinstance(el, Capacitor):
             v_plus = _node_voltage(el.n_plus, op.node_voltages)
@@ -2159,7 +2281,7 @@ def _update_reactive_state(
 
             cap_voltages[el.name] = v_new
 
-        elif isinstance(el, Inductor):
+        elif isinstance(el, Inductor) and el.name not in coupled_names:
             v_plus = _node_voltage(el.n_plus, op.node_voltages)
             v_minus = _node_voltage(el.n_minus, op.node_voltages)
             v_new = v_plus - v_minus

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -959,6 +959,21 @@ def test_transient_inductor_respects_initial_current():
     assert isclose(result.points[2].node_voltages["out"], -0.25, abs_tol=1e-9)
 
 
+def test_transient_mutual_inductor_couples_secondary_voltage():
+    c = Circuit()
+    c.add(CurrentSource("Istep", "0", "pri", 1.0))
+    c.add(Inductor("Lpri", "pri", "0", 1.0))
+    c.add(Inductor("Lsec", "sec", "0", 1.0))
+    c.add(MutualInductor("K1", "Lpri", "Lsec", 0.5))
+    c.add(Resistor("Rload", "sec", "0", 10.0))
+
+    result = transient(c, t_stop=0.1, t_step=0.1, method="euler")
+
+    assert result.converged
+    assert isclose(result.points[1].node_voltages["pri"], 8.75, rel_tol=1e-9)
+    assert isclose(result.points[1].node_voltages["sec"], 2.5, rel_tol=1e-9)
+
+
 # ---- Transient: TransientResult metadata ----
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+- Add transient analysis stamping for `MutualInductor` by coupling referenced
+  inductor pairs through a two-winding companion conductance matrix.
 - Add AC analysis stamping for `MutualInductor` by coupling referenced
   inductor pairs through the inverted two-winding inductance matrix.
 - Add a public `MutualInductor` element as the parser-facing SPICE `K` card
-  foothold; coupled AC/transient stamping follows in a later compatibility
-  slice.
+  foothold.
 - Add JFET nonlinear DC operating-point stamping and AC small-signal analysis
   from the solved DC bias point.
 - Add a public `Jfet` element and `JfetPolarity` as the parser-facing

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3919,6 +3919,9 @@ fn solve_linear_circuit_at_operating_point(
 ) -> Result<LinearSolution, SpiceError> {
     let mut matrix = vec![vec![0.0; matrix_size]; matrix_size];
     let mut rhs = vec![0.0; matrix_size];
+    let inductors = inductor_by_name(circuit);
+    let coupled_names = coupled_inductor_names(circuit);
+    let has_transient_inductor_states = !inductor_states.is_empty();
 
     for element in circuit.elements() {
         match element {
@@ -3930,16 +3933,31 @@ fn solve_linear_circuit_at_operating_point(
                 &mut matrix,
                 &mut rhs,
             )?,
-            Element::Inductor(inductor) => stamp_inductor(
-                inductor,
-                inductor_states,
-                node_indices,
-                &voltage_sources,
-                node_count,
-                &mut matrix,
-                &mut rhs,
-            )?,
-            Element::MutualInductor(_) => {}
+            Element::Inductor(inductor) => {
+                if !has_transient_inductor_states || !coupled_names.contains(&inductor.name) {
+                    stamp_inductor(
+                        inductor,
+                        inductor_states,
+                        node_indices,
+                        &voltage_sources,
+                        node_count,
+                        &mut matrix,
+                        &mut rhs,
+                    )?
+                }
+            }
+            Element::MutualInductor(mutual) => {
+                if has_transient_inductor_states {
+                    stamp_transient_mutual_inductor(
+                        mutual,
+                        &inductors,
+                        inductor_states,
+                        node_indices,
+                        &mut matrix,
+                        &mut rhs,
+                    )?
+                }
+            }
             Element::VoltageSource(source) => stamp_voltage_source(
                 source,
                 node_indices,
@@ -5444,6 +5462,10 @@ fn update_inductor_states(
     node_voltages: &BTreeMap<String, f64>,
     inductor_states: &mut [InductorState],
 ) {
+    let inductors = inductor_by_name(circuit);
+    let coupled_currents =
+        coupled_transient_inductor_currents(circuit, &inductors, inductor_states, node_voltages)
+            .unwrap_or_default();
     for state in inductor_states {
         let Some(inductor) = circuit.elements().iter().find_map(|element| match element {
             Element::Inductor(inductor) if inductor.name == state.name => Some(inductor),
@@ -5451,7 +5473,10 @@ fn update_inductor_states(
         }) else {
             continue;
         };
-        state.previous_current = inductor_current(inductor, state, node_voltages);
+        state.previous_current = coupled_currents
+            .get(&inductor.name)
+            .copied()
+            .unwrap_or_else(|| inductor_current(inductor, state, node_voltages));
     }
 }
 
@@ -5461,6 +5486,10 @@ fn insert_transient_inductor_currents(
     node_voltages: &BTreeMap<String, f64>,
     branch_currents: &mut BTreeMap<String, f64>,
 ) {
+    let inductors = inductor_by_name(circuit);
+    let coupled_currents =
+        coupled_transient_inductor_currents(circuit, &inductors, inductor_states, node_voltages)
+            .unwrap_or_default();
     for state in inductor_states {
         let Some(inductor) = circuit.elements().iter().find_map(|element| match element {
             Element::Inductor(inductor) if inductor.name == state.name => Some(inductor),
@@ -5470,7 +5499,10 @@ fn insert_transient_inductor_currents(
         };
         branch_currents.insert(
             format!("I({})", inductor.name),
-            inductor_current(inductor, state, node_voltages),
+            coupled_currents
+                .get(&inductor.name)
+                .copied()
+                .unwrap_or_else(|| inductor_current(inductor, state, node_voltages)),
         );
     }
 }
@@ -5483,6 +5515,117 @@ fn inductor_current(
     let conductance = state.time_step / inductor.inductance_henrys;
     let voltage = voltage_at(node_voltages, &inductor.n1) - voltage_at(node_voltages, &inductor.n2);
     state.previous_current + conductance * voltage
+}
+
+fn stamp_transient_mutual_inductor(
+    mutual: &MutualInductor,
+    inductors: &HashMap<String, &Inductor>,
+    inductor_states: &[InductorState],
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) -> Result<(), SpiceError> {
+    let (primary, secondary, mutual_inductance) = validate_mutual_inductor(mutual, inductors)?;
+    let Some(primary_state) = inductor_states
+        .iter()
+        .find(|state| state.name == primary.name)
+    else {
+        return Ok(());
+    };
+    let Some(secondary_state) = inductor_states
+        .iter()
+        .find(|state| state.name == secondary.name)
+    else {
+        return Ok(());
+    };
+    let (g11, g12, g22) = transient_mutual_conductances(
+        mutual,
+        primary,
+        secondary,
+        mutual_inductance,
+        primary_state.time_step,
+    )?;
+    let p1 = node_index(node_indices, &primary.n1);
+    let p2 = node_index(node_indices, &primary.n2);
+    let s1 = node_index(node_indices, &secondary.n1);
+    let s2 = node_index(node_indices, &secondary.n2);
+    stamp_conductance(matrix, p1, p2, g11);
+    stamp_conductance(matrix, s1, s2, g22);
+    stamp_transconductance(matrix, p1, p2, s1, s2, g12);
+    stamp_transconductance(matrix, s1, s2, p1, p2, g12);
+    stamp_equivalent_current_source(rhs, p1, p2, primary_state.previous_current);
+    stamp_equivalent_current_source(rhs, s1, s2, secondary_state.previous_current);
+    Ok(())
+}
+
+fn coupled_transient_inductor_currents(
+    circuit: &Circuit,
+    inductors: &HashMap<String, &Inductor>,
+    inductor_states: &[InductorState],
+    node_voltages: &BTreeMap<String, f64>,
+) -> Result<HashMap<String, f64>, SpiceError> {
+    let mut currents = HashMap::new();
+    for element in circuit.elements() {
+        let Element::MutualInductor(mutual) = element else {
+            continue;
+        };
+        let (primary, secondary, mutual_inductance) = validate_mutual_inductor(mutual, inductors)?;
+        let Some(primary_state) = inductor_states
+            .iter()
+            .find(|state| state.name == primary.name)
+        else {
+            continue;
+        };
+        let Some(secondary_state) = inductor_states
+            .iter()
+            .find(|state| state.name == secondary.name)
+        else {
+            continue;
+        };
+        let (g11, g12, g22) = transient_mutual_conductances(
+            mutual,
+            primary,
+            secondary,
+            mutual_inductance,
+            primary_state.time_step,
+        )?;
+        let primary_voltage =
+            voltage_at(node_voltages, &primary.n1) - voltage_at(node_voltages, &primary.n2);
+        let secondary_voltage =
+            voltage_at(node_voltages, &secondary.n1) - voltage_at(node_voltages, &secondary.n2);
+        currents.insert(
+            primary.name.clone(),
+            primary_state.previous_current + g11 * primary_voltage + g12 * secondary_voltage,
+        );
+        currents.insert(
+            secondary.name.clone(),
+            secondary_state.previous_current + g12 * primary_voltage + g22 * secondary_voltage,
+        );
+    }
+    Ok(currents)
+}
+
+fn transient_mutual_conductances(
+    mutual: &MutualInductor,
+    primary: &Inductor,
+    secondary: &Inductor,
+    mutual_inductance: f64,
+    time_step: f64,
+) -> Result<(f64, f64, f64), SpiceError> {
+    let determinant =
+        primary.inductance_henrys * secondary.inductance_henrys - mutual_inductance.powi(2);
+    if !determinant.is_finite() || determinant <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mutual.name.clone(),
+            reason: "coupled inductance matrix is singular".to_string(),
+        });
+    }
+    let scale = time_step / determinant;
+    Ok((
+        secondary.inductance_henrys * scale,
+        -mutual_inductance * scale,
+        primary.inductance_henrys * scale,
+    ))
 }
 
 fn voltage_at(node_voltages: &BTreeMap<String, f64>, node: &str) -> f64 {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -3,7 +3,7 @@ use spice_engine::{
     pss_newton_solve_with_tolerance, pss_newton_update, pss_newton_update_with_tolerance,
     pss_residual, pss_residual_jacobian_with_tolerance, pss_residual_with_tolerance,
     pss_with_tolerance, transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element,
-    ExpWaveform, Inductor, PssNewtonCandidateResult, PssNewtonIterationResult,
+    ExpWaveform, Inductor, MutualInductor, PssNewtonCandidateResult, PssNewtonIterationResult,
     PssNewtonSolveResult, PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult,
     PssResult, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource,
     Waveform,
@@ -539,6 +539,26 @@ fn transient_respects_inductor_initial_current() {
     assert_close(points[0].branch_current("L1").unwrap(), 0.5e-3);
     assert_close(points[1].voltage("out").unwrap(), -0.25);
     assert_close(points[1].branch_current("L1").unwrap(), 0.25e-3);
+}
+
+#[test]
+fn transient_mutual_inductor_couples_secondary_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::CurrentSource(CurrentSource::new(
+        "Istep", "0", "pri", 1.0,
+    )));
+    circuit.add(Element::Inductor(Inductor::new("Lpri", "pri", "0", 1.0)));
+    circuit.add(Element::Inductor(Inductor::new("Lsec", "sec", "0", 1.0)));
+    circuit.add(Element::MutualInductor(MutualInductor::new(
+        "K1", "Lpri", "Lsec", 0.5,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rload", "sec", "0", 10.0)));
+
+    let points = transient(&circuit, 0.1, 0.1).unwrap();
+
+    assert_close(points[0].voltage("pri").unwrap(), 8.75);
+    assert_close(points[0].voltage("sec").unwrap(), 2.5);
+    assert_close(points[0].branch_current("Lsec").unwrap(), -0.25);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+- Add transient analysis stamping for `MutualInductor` by coupling referenced
+  inductor pairs through a two-winding companion conductance matrix.
 - Add AC analysis stamping for `MutualInductor` by coupling referenced
   inductor pairs through the inverted two-winding inductance matrix.
 - Add a public `MutualInductor` element and `mutualInductor` factory as the
-  parser-facing SPICE `K` card foothold; coupled AC/transient stamping follows
-  in a later compatibility slice.
+  parser-facing SPICE `K` card foothold.
 - Add JFET nonlinear DC operating-point stamping and AC small-signal analysis
   from the solved DC bias point.
 - Add a public `Jfet` element and `jfet` factory as the parser-facing

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -3188,6 +3188,9 @@ function solveLinearCircuitAtOperatingPoint(
     Array.from({ length: matrixSize }, () => 0.0),
   );
   const rhs = Array.from({ length: matrixSize }, () => 0.0);
+  const inductors = inductorByName(circuit);
+  const coupledNames = coupledInductorNames(circuit);
+  const hasTransientInductorStates = inductorStates.length > 0;
 
   for (const element of circuit.elements()) {
     switch (element.kind) {
@@ -3198,15 +3201,29 @@ function solveLinearCircuitAtOperatingPoint(
         stampCapacitor(element, capacitorStates, nodeIndices, matrix, rhs);
         break;
       case "inductor":
-        stampInductor(
-          element,
-          inductorStates,
-          nodeIndices,
-          voltageSources,
-          nodeCount,
-          matrix,
-          rhs,
-        );
+        if (!hasTransientInductorStates || !coupledNames.has(element.name)) {
+          stampInductor(
+            element,
+            inductorStates,
+            nodeIndices,
+            voltageSources,
+            nodeCount,
+            matrix,
+            rhs,
+          );
+        }
+        break;
+      case "mutual-inductor":
+        if (hasTransientInductorStates) {
+          stampTransientMutualInductor(
+            element,
+            inductors,
+            inductorStates,
+            nodeIndices,
+            matrix,
+            rhs,
+          );
+        }
         break;
       case "voltage-source":
         stampVoltageSource(
@@ -4531,6 +4548,13 @@ function updateInductorStates(
   nodeVoltages: ReadonlyMap<string, number>,
   inductorStates: InductorState[],
 ): void {
+  const inductors = inductorByName(circuit);
+  const coupledCurrents = coupledTransientInductorCurrents(
+    circuit,
+    inductors,
+    inductorStates,
+    nodeVoltages,
+  );
   for (const state of inductorStates) {
     const element = circuit
       .elements()
@@ -4541,7 +4565,8 @@ function updateInductorStates(
     if (element === undefined) {
       continue;
     }
-    state.previousCurrent = inductorCurrent(element, state, nodeVoltages);
+    state.previousCurrent =
+      coupledCurrents.get(element.name) ?? inductorCurrent(element, state, nodeVoltages);
   }
 }
 
@@ -4551,6 +4576,13 @@ function insertTransientInductorCurrents(
   nodeVoltages: ReadonlyMap<string, number>,
   branchCurrents: Map<string, number>,
 ): void {
+  const inductors = inductorByName(circuit);
+  const coupledCurrents = coupledTransientInductorCurrents(
+    circuit,
+    inductors,
+    inductorStates,
+    nodeVoltages,
+  );
   for (const state of inductorStates) {
     const element = circuit
       .elements()
@@ -4563,7 +4595,7 @@ function insertTransientInductorCurrents(
     }
     branchCurrents.set(
       `I(${element.name})`,
-      inductorCurrent(element, state, nodeVoltages),
+      coupledCurrents.get(element.name) ?? inductorCurrent(element, state, nodeVoltages),
     );
   }
 }
@@ -4576,6 +4608,96 @@ function inductorCurrent(
   const conductance = state.timeStep / element.inductanceHenrys;
   const voltage = voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
   return state.previousCurrent + conductance * voltage;
+}
+
+function stampTransientMutualInductor(
+  element: MutualInductor,
+  inductors: ReadonlyMap<string, Inductor>,
+  inductorStates: readonly InductorState[],
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  const { primary, secondary, mutualInductance } = validateMutualInductor(element, inductors);
+  const primaryState = inductorStates.find((state) => state.name === primary.name);
+  const secondaryState = inductorStates.find((state) => state.name === secondary.name);
+  if (primaryState === undefined || secondaryState === undefined) {
+    return;
+  }
+  const { g11, g12, g22 } = transientMutualConductances(
+    element,
+    primary,
+    secondary,
+    mutualInductance,
+    primaryState.timeStep,
+  );
+  const p1 = nodeIndex(nodeIndices, primary.n1);
+  const p2 = nodeIndex(nodeIndices, primary.n2);
+  const s1 = nodeIndex(nodeIndices, secondary.n1);
+  const s2 = nodeIndex(nodeIndices, secondary.n2);
+  stampConductance(matrix, p1, p2, g11);
+  stampConductance(matrix, s1, s2, g22);
+  stampTransconductance(matrix, p1, p2, s1, s2, g12);
+  stampTransconductance(matrix, s1, s2, p1, p2, g12);
+  stampCurrentSourceEquivalent(rhs, p1, p2, primaryState.previousCurrent);
+  stampCurrentSourceEquivalent(rhs, s1, s2, secondaryState.previousCurrent);
+}
+
+function coupledTransientInductorCurrents(
+  circuit: Circuit,
+  inductors: ReadonlyMap<string, Inductor>,
+  inductorStates: readonly InductorState[],
+  nodeVoltages: ReadonlyMap<string, number>,
+): Map<string, number> {
+  const currents = new Map<string, number>();
+  for (const element of circuit.elements()) {
+    if (element.kind !== "mutual-inductor") {
+      continue;
+    }
+    const { primary, secondary, mutualInductance } = validateMutualInductor(element, inductors);
+    const primaryState = inductorStates.find((state) => state.name === primary.name);
+    const secondaryState = inductorStates.find((state) => state.name === secondary.name);
+    if (primaryState === undefined || secondaryState === undefined) {
+      continue;
+    }
+    const { g11, g12, g22 } = transientMutualConductances(
+      element,
+      primary,
+      secondary,
+      mutualInductance,
+      primaryState.timeStep,
+    );
+    const primaryVoltage = voltageAt(nodeVoltages, primary.n1) - voltageAt(nodeVoltages, primary.n2);
+    const secondaryVoltage = voltageAt(nodeVoltages, secondary.n1) - voltageAt(nodeVoltages, secondary.n2);
+    currents.set(
+      primary.name,
+      primaryState.previousCurrent + g11 * primaryVoltage + g12 * secondaryVoltage,
+    );
+    currents.set(
+      secondary.name,
+      secondaryState.previousCurrent + g12 * primaryVoltage + g22 * secondaryVoltage,
+    );
+  }
+  return currents;
+}
+
+function transientMutualConductances(
+  element: MutualInductor,
+  primary: Inductor,
+  secondary: Inductor,
+  mutualInductance: number,
+  timeStep: number,
+): { g11: number; g12: number; g22: number } {
+  const determinant = primary.inductanceHenrys * secondary.inductanceHenrys - mutualInductance ** 2;
+  if (!Number.isFinite(determinant) || determinant <= 0.0) {
+    throw invalidElement(element.name, "coupled inductance matrix is singular");
+  }
+  const scale = timeStep / determinant;
+  return {
+    g11: secondary.inductanceHenrys * scale,
+    g12: -mutualInductance * scale,
+    g22: primary.inductanceHenrys * scale,
+  };
 }
 
 function voltageAt(

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -10,10 +10,12 @@ import {
   capacitorWithInitialVoltage,
   cccs,
   ccvs,
+  currentSource,
   currentSourceWithWaveform,
   estimatePeriod,
   inductor,
   inductorWithInitialCurrent,
+  mutualInductor,
   pss,
   pssNewtonCandidate,
   pssNewtonIteration,
@@ -461,6 +463,21 @@ describe("transient", () => {
     expectClose(points[0].branchCurrent("L1"), 0.5e-3);
     expectClose(points[1].voltage("out"), -0.25);
     expectClose(points[1].branchCurrent("L1"), 0.25e-3);
+  });
+
+  it("couples secondary voltage through a mutual inductor", () => {
+    const circuit = new Circuit();
+    circuit.add(currentSource("Istep", "0", "pri", 1.0));
+    circuit.add(inductor("Lpri", "pri", "0", 1.0));
+    circuit.add(inductor("Lsec", "sec", "0", 1.0));
+    circuit.add(mutualInductor("K1", "Lpri", "Lsec", 0.5));
+    circuit.add(resistor("Rload", "sec", "0", 10.0));
+
+    const points = transient(circuit, 0.1, 0.1);
+
+    expectClose(points[0].voltage("pri"), 8.75);
+    expectClose(points[0].voltage("sec"), 2.5);
+    expectClose(points[0].branchCurrent("Lsec"), -0.25);
   });
 
   it("rejects non-positive capacitance", () => {


### PR DESCRIPTION
## Summary

- add transient companion stamping for SPICE `K` mutual inductors across Python, TypeScript, and Rust
- skip ordinary uncoupled inductor stamps only when transient state is active so DC/AC operating points keep their existing inductor behavior
- cover coupled secondary transient response and inductor branch-current reporting with cross-language tests

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-mutual-inductor-transient sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This completes the transient stamping acceptance slice for Phase 2 mutual inductors. The next SPICE phase in `spice-1970s-compatibility.md` is ideal transmission-line `T` cards.