### PR TITLE
feat(sql): synthesize sqlite_master / sqlite_schema on in-memory backend

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.89.0] - 2026-05-23
+
+### Added
+
+- ``SELECT ... FROM sqlite_master`` (and its alias ``sqlite_schema``)
+  now works on ``:memory:`` databases.  The in-memory backend
+  synthesizes the catalog rows from current schema state on every
+  scan — no storage, no maintenance, no DDL hook plumbing.  Common
+  migration-tool queries like ``SELECT name FROM sqlite_master WHERE
+  type='table'`` return rows identical to real ``sqlite3``.
+- ``INSERT`` / ``DROP TABLE`` / ``CREATE TABLE`` targeting the
+  reserved names ``sqlite_master`` / ``sqlite_schema`` are rejected
+  with ``IntegrityError``.
+
 ## [1.88.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.88.0"
+version = "1.89.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_sqlite_master.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_sqlite_master.py
@@ -1,0 +1,172 @@
+"""End-to-end tests for ``sqlite_master`` / ``sqlite_schema`` introspection.
+
+SQLite exposes the schema catalog through a virtual table named both
+``sqlite_master`` (legacy) and ``sqlite_schema`` (SQLite 3.33+).  ORMs,
+migration tools, and ``.tables`` shells all rely on it.
+
+Mini-sqlite synthesizes the rows from current backend state on every
+scan — no storage, no maintenance.  These tests verify that the
+synthesized table matches SQLite's structure tightly enough that
+migration-tool queries return identical rows.  We don't oracle-compare
+the literal ``sql`` text (mini-sqlite reconstructs it from ColumnDef
+metadata, so whitespace and keyword casing may differ from the user's
+original) — but ``type``, ``name``, and ``tbl_name`` must match.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import mini_sqlite
+from mini_sqlite import errors as mini_errors
+
+
+def _setup_both(*ddls: str) -> tuple:
+    """Run *ddls* on both engines and return (mini, ref) connections."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for sql in ddls:
+            c.execute(sql)
+    return mini, ref
+
+
+class TestBasicListing:
+    """The migration-tool happy path: list tables and indexes."""
+
+    def test_list_user_tables(self) -> None:
+        mini, ref = _setup_both(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)",
+            "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER)",
+        )
+        q = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall()
+
+    def test_count_tables(self) -> None:
+        mini, ref = _setup_both(
+            "CREATE TABLE a (x INT)",
+            "CREATE TABLE b (x INT)",
+            "CREATE TABLE c (x INT)",
+        )
+        q = "SELECT COUNT(*) FROM sqlite_master WHERE type='table'"
+        assert mini.execute(q).fetchone() == ref.execute(q).fetchone() == (3,)
+
+    def test_empty_database_has_no_rows(self) -> None:
+        mini, ref = _setup_both()
+        q = "SELECT COUNT(*) FROM sqlite_master"
+        assert mini.execute(q).fetchone() == ref.execute(q).fetchone()
+
+    def test_list_indexes(self) -> None:
+        # User-created indexes show up; auto-indexes from PRIMARY KEY do
+        # not (SQLite hides those whose sql is NULL via ORM convention,
+        # but they're still in sqlite_master with sql=NULL).  We filter
+        # to user indexes only by requiring sql IS NOT NULL.
+        mini, ref = _setup_both(
+            "CREATE TABLE t (x INTEGER, y INTEGER)",
+            "CREATE INDEX ix_t_x ON t (x)",
+            "CREATE UNIQUE INDEX ix_t_y ON t (y)",
+        )
+        q = (
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND sql IS NOT NULL ORDER BY name"
+        )
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall()
+
+
+class TestSchemaAlias:
+    """``sqlite_schema`` is the modern alias for ``sqlite_master``."""
+
+    def test_sqlite_schema_returns_same_names(self) -> None:
+        mini, ref = _setup_both(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY)",
+            "CREATE TABLE orders (id INTEGER PRIMARY KEY)",
+        )
+        q1 = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        q2 = "SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name"
+        # Both engines: alias yields identical rows.
+        assert mini.execute(q1).fetchall() == mini.execute(q2).fetchall()
+        assert ref.execute(q1).fetchall() == ref.execute(q2).fetchall()
+
+
+class TestProjection:
+    """Each column projects independently."""
+
+    def test_select_all_columns(self) -> None:
+        mini, ref = _setup_both("CREATE TABLE t (x INTEGER, y TEXT)")
+        # rowid/rootpage value differs between engines (mini returns 0,
+        # sqlite picks a real page number) — exclude rootpage.
+        q = "SELECT type, name, tbl_name FROM sqlite_master WHERE type='table'"
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall()
+
+    def test_tbl_name_equals_name_for_tables(self) -> None:
+        mini, ref = _setup_both("CREATE TABLE foo (x INT)")
+        # SQLite invariant: for ``type='table'`` rows, ``tbl_name == name``.
+        q = "SELECT name, tbl_name FROM sqlite_master WHERE type='table'"
+        m = mini.execute(q).fetchall()
+        r = ref.execute(q).fetchall()
+        assert m == r
+        for name, tbl in m:
+            assert name == tbl
+
+    def test_tbl_name_for_index_points_to_indexed_table(self) -> None:
+        mini, ref = _setup_both(
+            "CREATE TABLE t (x INTEGER)",
+            "CREATE INDEX ix_x ON t (x)",
+        )
+        q = (
+            "SELECT name, tbl_name FROM sqlite_master "
+            "WHERE type='index' AND sql IS NOT NULL"
+        )
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall()
+        m = mini.execute(q).fetchall()
+        assert m == [("ix_x", "t")]
+
+
+class TestReadOnly:
+    """Mini-sqlite rejects modifications to sqlite_master, matching SQLite."""
+
+    def test_insert_rejected(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_errors.Error):
+            mini.execute(
+                "INSERT INTO sqlite_master VALUES "
+                "('table', 'x', 'x', 0, 'CREATE TABLE x(a INT)')"
+            )
+
+    def test_drop_table_rejected(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_errors.Error):
+            mini.execute("DROP TABLE sqlite_master")
+
+    def test_create_table_with_reserved_name_rejected(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_errors.Error):
+            mini.execute("CREATE TABLE sqlite_master (a INT)")
+
+    def test_real_sqlite_also_rejects_modification(self) -> None:
+        # Sanity-check that real SQLite forbids the same writes — if a
+        # future SQLite ever loosens this, the test will start failing
+        # and we'll know to revisit the mini-sqlite policy.
+        ref = sqlite3.connect(":memory:")
+        with pytest.raises(sqlite3.Error):
+            ref.execute("DROP TABLE sqlite_master")
+
+
+class TestWithExistingTier:
+    """The existing ``test_oracle_schema_visible_in_sqlite3`` test
+    (file backend) demonstrates that mini→sqlite3 schema roundtrip works
+    via the on-disk format.  This class targets the *in-memory* path
+    that previously had no sqlite_master at all.
+    """
+
+    def test_orm_style_table_discovery(self) -> None:
+        """The query an ORM uses to enumerate tables works."""
+        mini, ref = _setup_both(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY)",
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)",
+            "CREATE TABLE posts (id INTEGER PRIMARY KEY, body TEXT)",
+        )
+        q = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall()

--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-05-23
+
+### Added
+
+- ``InMemoryBackend`` now synthesizes ``sqlite_master`` (and its alias
+  ``sqlite_schema``) on demand from current schema state.  The
+  synthesized table exposes the canonical five-column SQLite layout
+  (``type``, ``name``, ``tbl_name``, ``rootpage``, ``sql``) with one row
+  per user table, user-created index, and trigger.  ORMs and migration
+  tools that query ``SELECT name FROM sqlite_master WHERE type='table'``
+  now get correct results against ``:memory:`` databases.
+- ``rootpage`` is always 0 (the on-disk page-number concept is
+  meaningless for the in-memory backend).  Auto-generated indexes
+  (``sqlite_autoindex_*``) get ``NULL`` in the ``sql`` column, matching
+  real SQLite.
+
+### Changed
+
+- ``create_table('sqlite_master', ...)`` and the same for
+  ``sqlite_schema`` raise ``ConstraintViolation`` with the message
+  ``object name reserved for internal use``.  ``insert``,
+  ``drop_table``, and similar mutations also raise — the table is
+  read-only.
+- ``tables()`` listing continues to return *user* tables only;
+  ``sqlite_master`` is visible by name but not in the listing (matches
+  SQLite's ``.tables`` shell command).
+
 ## [0.15.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-backend/pyproject.toml
+++ b/code/packages/python/sql-backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-backend"
-version = "0.15.0"
+version = "0.16.0"
 description = "Pluggable data-source interface for the SQL pipeline — ships the Backend ABC, supporting types, an InMemoryBackend reference, and conformance test helpers."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-backend/src/sql_backend/in_memory.py
+++ b/code/packages/python/sql-backend/src/sql_backend/in_memory.py
@@ -50,6 +50,7 @@ Each case has its own error path. The helper methods ``_apply_defaults`` /
 from __future__ import annotations
 
 import copy
+import re
 from collections.abc import Iterator
 from typing import Final
 
@@ -231,6 +232,201 @@ def _strict_coerce(value: object, declared: str) -> tuple[object, bool]:
     return value, False
 
 
+#: Synthetic table names that expose the schema catalog.  Both names refer
+#: to the same data — SQLite added ``sqlite_schema`` in 3.33 as the
+#: preferred spelling while keeping ``sqlite_master`` for back-compat.
+#: Queries against either name go through the same synthesis path; CREATE
+#: TABLE, DROP TABLE, INSERT, UPDATE, and DELETE on either name raise an
+#: error.
+_MASTER_NAMES: Final[frozenset[str]] = frozenset({"sqlite_master", "sqlite_schema"})
+
+#: Fixed column schema for ``sqlite_master`` (matches SQLite 3).
+#:
+#: =========  =======  =====================================================
+#: name       type     meaning
+#: =========  =======  =====================================================
+#: type       TEXT     'table' | 'index' | 'view' | 'trigger'
+#: name       TEXT     name of the schema object
+#: tbl_name   TEXT     name of the table the object belongs to (= name for
+#:                     tables; the indexed table for indexes; the trigger's
+#:                     target table for triggers)
+#: rootpage   INTEGER  page number — meaningful only on disk; the in-memory
+#:                     backend returns 0
+#: sql        TEXT     the CREATE statement that defined the object;
+#:                     reconstructed from ColumnDef metadata.  NULL for
+#:                     auto-generated indexes (matches SQLite).
+#: =========  =======  =====================================================
+def _master_columns() -> list[ColumnDef]:
+    """Return a fresh copy of the ``sqlite_master`` column schema.
+
+    A fresh list per call keeps callers from accidentally aliasing the
+    same list and mutating the canonical schema.
+    """
+    return [
+        ColumnDef(name="type", type_name="TEXT"),
+        ColumnDef(name="name", type_name="TEXT"),
+        ColumnDef(name="tbl_name", type_name="TEXT"),
+        ColumnDef(name="rootpage", type_name="INTEGER"),
+        ColumnDef(name="sql", type_name="TEXT"),
+    ]
+
+
+#: Pattern that matches a safe bare SQL identifier, optionally followed by
+#: a parenthesized length/precision argument list (e.g. ``VARCHAR(64)`` or
+#: ``DECIMAL(10,2)``).  ``_sanitize_type_name`` uses this to decide whether
+#: a type-name string is safe to interpolate verbatim into the synthesized
+#: ``sqlite_master.sql`` column; anything that doesn't match is replaced
+#: with the SQLite NUMERIC affinity name to neutralize second-order
+#: injection.
+_SAFE_TYPE_NAME = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]*\s*(\(\s*\d+(\s*,\s*\d+)?\s*\))?\s*$"
+)
+
+#: Pattern that matches a safe bare collation name — exactly one
+#: identifier with no parentheses, separators, or punctuation.
+_SAFE_COLLATION_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _sanitize_type_name(s: str) -> str:
+    """Return *s* verbatim if it's a recognisable type name, else NUMERIC.
+
+    SQLite's CREATE TABLE grammar is famously lenient about the column-type
+    slot — it accepts any token sequence and maps via affinity rules.  But
+    when we round-trip the type into the synthesized ``sqlite_master.sql``
+    column, a string like ``"INTEGER); DROP TABLE users;--"`` would inject
+    SQL into a downstream consumer that re-executes our output.
+
+    We accept the standard shape ``IDENT`` or ``IDENT(N)`` or
+    ``IDENT(N,M)`` (case-insensitive).  Anything else is replaced with the
+    NUMERIC affinity name — preserves the table's semantics (NUMERIC is
+    the default affinity for unrecognised types in SQLite) while
+    neutralising the injection vector.
+    """
+    return s if _SAFE_TYPE_NAME.match(s) else "NUMERIC"
+
+
+def _sanitize_collation_name(s: str) -> str:
+    """Return *s* verbatim if it's a bare identifier, else BINARY.
+
+    Collation names in SQLite are bare identifiers (``BINARY``, ``NOCASE``,
+    ``RTRIM``, plus any user-registered ones).  Treating an unsafe name
+    as BINARY (the default) preserves correctness for ill-formed input
+    while preventing SQL injection through the synthesized
+    ``sqlite_master.sql`` column.
+    """
+    return s if _SAFE_COLLATION_NAME.match(s) else "BINARY"
+
+
+def _quote_identifier(name: str) -> str:
+    """Wrap *name* in SQLite-style double quotes, doubling any embedded quotes.
+
+    SQLite's identifier-quoting rule (per the manual): a double-quoted
+    identifier may contain any character except an unescaped ``"``;
+    embedded quotes are doubled.  We always emit quotes — even for
+    well-behaved bare identifiers — so the output is unambiguous when a
+    downstream consumer (ORM, migration tool) re-executes the
+    ``sqlite_master.sql`` column.  Without quoting, an identifier
+    crafted to contain SQL syntax (e.g. a column declared with the name
+    ``x); DROP TABLE users;--``) would render injectable SQL.
+    """
+    escaped = name.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _format_sql_literal(value: object) -> str:
+    """Render *value* as a SQL literal suitable for ``DEFAULT`` clauses.
+
+    Python's ``repr()`` is not a SQL literal serializer — for ``bytes``
+    it produces ``b'...'`` (invalid SQL), and for strings with embedded
+    quotes its escape rules don't match SQL's (which double the quote
+    rather than backslash-escape it).  This helper handles each storage
+    class explicitly so the synthesized ``sql`` column is round-trippable
+    through real SQLite.
+    """
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, float):
+        # ``repr()`` emits ``inf`` / ``-inf`` / ``nan`` for non-finite
+        # floats, which aren't valid SQL literals.  Real SQLite stores
+        # these as NULL when round-tripped through TEXT representation;
+        # NULL is the safest no-op here.
+        import math
+        if not math.isfinite(value):
+            return "NULL"
+        return repr(value)
+    if isinstance(value, int):
+        return repr(value)
+    if isinstance(value, (bytes, bytearray)):
+        # SQLite BLOB literal: X'hexdigits'
+        return "X'" + bytes(value).hex().upper() + "'"
+    # Default: treat as text — escape embedded single quotes by doubling.
+    text = str(value).replace("'", "''")
+    return f"'{text}'"
+
+
+def _reconstruct_create_table(table: str, columns: list[ColumnDef], strict: bool) -> str:
+    """Rebuild a ``CREATE TABLE`` statement from ColumnDef metadata.
+
+    The in-memory backend doesn't preserve the user's literal SQL text, so
+    the ``sql`` column of ``sqlite_master`` is regenerated from the
+    structured schema.  The output is valid SQL but may differ from the
+    user's original byte-for-byte (e.g. whitespace, keyword casing).
+    Tools that only care about ``type`` / ``name`` / ``tbl_name`` (the
+    common case for migration tools) don't notice.
+
+    All identifiers are double-quoted (via :func:`_quote_identifier`) and
+    default values go through :func:`_format_sql_literal` so a downstream
+    consumer that re-executes the synthesized statement (a common ORM
+    pattern) cannot be tricked into running attacker-shaped SQL even if
+    a table or column name contains quoting punctuation.
+    """
+    parts: list[str] = []
+    for col in columns:
+        toks: list[str] = [
+            _quote_identifier(col.name),
+            _sanitize_type_name(col.type_name),
+        ]
+        if col.primary_key:
+            toks.append("PRIMARY KEY")
+            if col.autoincrement:
+                toks.append("AUTOINCREMENT")
+        if col.not_null and not col.primary_key:
+            toks.append("NOT NULL")
+        if col.unique and not col.primary_key:
+            toks.append("UNIQUE")
+        if col.has_default():
+            toks.append(f"DEFAULT {_format_sql_literal(col.default)}")
+        if col.collation:
+            toks.append(f"COLLATE {_sanitize_collation_name(col.collation)}")
+        parts.append(" ".join(toks))
+    out = f"CREATE TABLE {_quote_identifier(table)} ({', '.join(parts)})"
+    if strict:
+        out += " STRICT"
+    return out
+
+
+def _reconstruct_create_index(index: IndexDef) -> str | None:
+    """Rebuild a ``CREATE INDEX`` statement from an IndexDef, or None.
+
+    Returns None for auto-generated indexes (those whose name starts with
+    ``sqlite_autoindex_``) — SQLite stores NULL in the ``sql`` column of
+    ``sqlite_master`` for those, since the user never wrote a literal
+    CREATE INDEX statement.  All identifiers are double-quoted via
+    :func:`_quote_identifier` so attacker-shaped names cannot inject SQL
+    when a downstream consumer re-executes the statement.
+    """
+    if index.name.startswith("sqlite_autoindex_"):
+        return None
+    unique = "UNIQUE " if index.unique else ""
+    cols = ", ".join(_quote_identifier(c) for c in index.columns)
+    return (
+        f"CREATE {unique}INDEX {_quote_identifier(index.name)} "
+        f"ON {_quote_identifier(index.table)} ({cols})"
+    )
+
+
 #: The set of column types SQLite allows in a STRICT table.  When a table
 #: is created with the ``STRICT`` option, every column's declared type must
 #: be one of these (case-insensitive) — anything else raises a
@@ -343,9 +539,17 @@ class InMemoryBackend(Backend):
     # --- Schema -----------------------------------------------------------
 
     def tables(self) -> list[str]:
+        # Mirror SQLite: ``.tables`` and ``SELECT name FROM sqlite_master``
+        # both return user tables only.  ``sqlite_master`` / ``sqlite_schema``
+        # are visible *by name* via direct query but don't appear in this
+        # listing.
         return list(self._tables.keys())
 
     def columns(self, table: str) -> list[ColumnDef]:
+        # sqlite_master / sqlite_schema have a fixed five-column schema —
+        # return it directly without touching ``_tables``.
+        if table in _MASTER_NAMES:
+            return _master_columns()
         return list(self._require_table(table).columns)
 
     # --- Header fields (PRAGMA user_version / schema_version) -------------
@@ -374,11 +578,64 @@ class InMemoryBackend(Backend):
     # --- Read -------------------------------------------------------------
 
     def scan(self, table: str) -> RowIterator:
+        # sqlite_master / sqlite_schema are synthesized at scan() time from
+        # the current schema state — no storage, no maintenance.  Both
+        # names route to the same synthesizer.
+        if table in _MASTER_NAMES:
+            return ListRowIterator(self._synthesize_master_rows())
         t = self._require_table(table)
         # Return a snapshot view — hand out shallow copies of rows so the
         # VM can mutate freely without corrupting our state. ListRowIterator
         # handles that copy on each next() call.
         return ListRowIterator(t.rows)
+
+    def _synthesize_master_rows(self) -> list[Row]:
+        """Build the ``sqlite_master`` row list from current schema state.
+
+        Layout matches SQLite::
+
+            type      | name        | tbl_name    | rootpage | sql
+            ----------+-------------+-------------+----------+------------------
+            'table'   | <user-name> | <user-name> | 0        | CREATE TABLE ...
+            'index'   | <idx-name>  | <tbl-name>  | 0        | CREATE INDEX ...
+            'trigger' | <trg-name>  | <tbl-name>  | 0        | CREATE TRIGGER ...
+
+        Auto-generated indexes (``sqlite_autoindex_*``) get NULL in the
+        ``sql`` column, matching real SQLite.  ``rootpage`` is meaningful
+        only on disk; the in-memory backend returns 0 for every row.
+        """
+        rows: list[Row] = []
+        # Tables in insertion order.
+        for name, tbl in self._tables.items():
+            rows.append({
+                "type": "table",
+                "name": name,
+                "tbl_name": name,
+                "rootpage": 0,
+                "sql": _reconstruct_create_table(name, tbl.columns, tbl.strict),
+            })
+        # Indexes in insertion order.
+        for idx_name, idx in self._indexes.items():
+            rows.append({
+                "type": "index",
+                "name": idx_name,
+                "tbl_name": idx.table,
+                "rootpage": 0,
+                "sql": _reconstruct_create_index(idx),
+            })
+        # Triggers in creation order (per table).  ``_triggers`` is keyed
+        # by name; iterate ``_triggers_by_table`` to preserve per-table
+        # creation order (matches SQLite's ordering inside sqlite_master).
+        for tbl_name, trigs in self._triggers_by_table.items():
+            for trg in trigs:
+                rows.append({
+                    "type": "trigger",
+                    "name": trg.name,
+                    "tbl_name": tbl_name,
+                    "rootpage": 0,
+                    "sql": getattr(trg, "sql", None),
+                })
+        return rows
 
     def _open_cursor(self, table: str) -> ListCursor:
         """Internal helper: produce a ListCursor the VM can use for UPDATE/DELETE.
@@ -388,13 +645,29 @@ class InMemoryBackend(Backend):
         flow is: open a scan, iterate with next(), then pass the iterator
         to ``update`` or ``delete`` — so in practice the VM never needs
         this helper. Tests do.
+
+        ``sqlite_master`` / ``sqlite_schema`` are special-cased: the
+        synthesized rows are wrapped in a ListCursor on the fly.  Cursors
+        opened against the master table cannot be used for UPDATE/DELETE
+        because the underlying rows are recomputed on every call —
+        positional mutation would have no persistent target.  The
+        existing TableNotFound from ``_require_table`` inside ``update``
+        / ``delete`` is what fires in that case.
         """
+        if table in _MASTER_NAMES:
+            return ListCursor(self._synthesize_master_rows())
         t = self._require_table(table)
         return ListCursor(t.rows)
 
     # --- Write ------------------------------------------------------------
 
     def insert(self, table: str, row: Row) -> None:
+        if table in _MASTER_NAMES:
+            raise ConstraintViolation(
+                table=table,
+                column=None,
+                message=f"table {table} may not be modified",
+            )
         t = self._require_table(table)
         full_row = self._apply_defaults(t, row)
         self._check_unknown_columns(table, t, full_row)
@@ -472,6 +745,16 @@ class InMemoryBackend(Backend):
         *,
         strict: bool = False,
     ) -> None:
+        if table in _MASTER_NAMES:
+            # SQLite reserves the ``sqlite_*`` prefix; the master/schema
+            # names in particular cannot be redeclared.  Surface a clear
+            # ConstraintViolation rather than letting a row get inserted
+            # into a fictitious table.
+            raise ConstraintViolation(
+                table=table,
+                column=None,
+                message=f"object name reserved for internal use: {table}",
+            )
         if table in self._tables:
             if if_not_exists:
                 return
@@ -495,6 +778,16 @@ class InMemoryBackend(Backend):
         self._schema_version += 1
 
     def drop_table(self, table: str, if_exists: bool) -> None:
+        if table in _MASTER_NAMES:
+            # ``DROP TABLE [IF EXISTS] sqlite_master`` is always wrong; the
+            # IF EXISTS branch would otherwise silently succeed because the
+            # name isn't in ``_tables``.  Explicit guard surfaces a clear
+            # error matching SQLite's behaviour.
+            raise ConstraintViolation(
+                table=table,
+                column=None,
+                message=f"table {table} may not be dropped",
+            )
         if table not in self._tables:
             if if_exists:
                 return

--- a/code/packages/python/sql-backend/tests/test_sqlite_master.py
+++ b/code/packages/python/sql-backend/tests/test_sqlite_master.py
@@ -1,0 +1,366 @@
+"""Tests for the synthesized ``sqlite_master`` / ``sqlite_schema`` table.
+
+The in-memory backend exposes a virtual ``sqlite_master`` (and its alias
+``sqlite_schema``) that lists tables, indexes, and triggers.  The rows
+are synthesized on demand from the backend's current state — no
+storage, no maintenance.  These tests pin:
+
+* the fixed five-column schema
+* row content for tables / indexes
+* read-only enforcement (no INSERT/UPDATE/DROP/CREATE on the master name)
+* both names route to the same data
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sql_backend.errors import ConstraintViolation
+from sql_backend.in_memory import InMemoryBackend
+from sql_backend.index import IndexDef
+from sql_backend.schema import ColumnDef
+
+
+def _make_backend() -> InMemoryBackend:
+    """Backend with one table and one user-created index."""
+    b = InMemoryBackend()
+    b.create_table(
+        "users",
+        [
+            ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+            ColumnDef(name="name", type_name="TEXT", not_null=True),
+        ],
+        if_not_exists=False,
+    )
+    b.create_index(IndexDef(name="ix_name", table="users", columns=("name",), unique=False))
+    return b
+
+
+class TestMasterSchema:
+    """``columns('sqlite_master')`` and ``columns('sqlite_schema')`` return
+    the fixed five-column schema regardless of backend state."""
+
+    def test_columns_returns_fixed_schema(self) -> None:
+        b = InMemoryBackend()
+        cols = b.columns("sqlite_master")
+        assert [c.name for c in cols] == ["type", "name", "tbl_name", "rootpage", "sql"]
+        assert [c.type_name for c in cols] == ["TEXT", "TEXT", "TEXT", "INTEGER", "TEXT"]
+
+    def test_sqlite_schema_is_alias(self) -> None:
+        # Both names yield identical column lists.
+        b = InMemoryBackend()
+        assert b.columns("sqlite_master") == b.columns("sqlite_schema")
+
+    def test_columns_independent_of_user_tables(self) -> None:
+        b = _make_backend()
+        # User tables exist but the master schema is fixed.
+        assert [c.name for c in b.columns("sqlite_master")] == [
+            "type", "name", "tbl_name", "rootpage", "sql"
+        ]
+
+
+class TestMasterRows:
+    """``scan('sqlite_master')`` synthesizes one row per object."""
+
+    def test_empty_backend_has_no_master_rows(self) -> None:
+        b = InMemoryBackend()
+        it = b.scan("sqlite_master")
+        assert it.next() is None
+
+    def test_one_table_one_row(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t", [ColumnDef(name="x", type_name="INTEGER")], if_not_exists=False
+        )
+        rows = _collect(b.scan("sqlite_master"))
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["type"] == "table"
+        assert r["name"] == "t"
+        assert r["tbl_name"] == "t"
+        assert r["rootpage"] == 0
+        # Identifiers are quoted to prevent second-order SQL injection
+        # when a downstream consumer re-executes sqlite_master.sql.
+        assert 'CREATE TABLE "t"' in r["sql"]
+        assert '"x" INTEGER' in r["sql"]
+
+    def test_index_appears_after_table(self) -> None:
+        b = _make_backend()
+        rows = _collect(b.scan("sqlite_master"))
+        types = [r["type"] for r in rows]
+        assert "table" in types
+        assert "index" in types
+        # Tables come before indexes (matches SQLite's insertion order).
+        assert types.index("table") < types.index("index")
+
+    def test_index_row_contents(self) -> None:
+        b = _make_backend()
+        rows = _collect(b.scan("sqlite_master"))
+        idx_rows = [r for r in rows if r["type"] == "index"]
+        assert len(idx_rows) == 1
+        r = idx_rows[0]
+        assert r["name"] == "ix_name"
+        assert r["tbl_name"] == "users"
+        assert r["sql"] == 'CREATE INDEX "ix_name" ON "users" ("name")'
+
+    def test_unique_index_in_sql_text(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t", [ColumnDef(name="x", type_name="INTEGER")], if_not_exists=False
+        )
+        b.create_index(IndexDef(name="ix_x", table="t", columns=("x",), unique=True))
+        r = next(r for r in _collect(b.scan("sqlite_master")) if r["type"] == "index")
+        assert "UNIQUE" in r["sql"]
+
+    def test_autoindex_has_null_sql(self) -> None:
+        # ``sqlite_autoindex_*`` names indicate engine-managed indexes —
+        # their sql column should be NULL, matching real SQLite.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [
+                ColumnDef(name="id", type_name="INTEGER", primary_key=True),
+                ColumnDef(name="email", type_name="TEXT", unique=True),
+            ],
+            if_not_exists=False,
+        )
+        b.create_index(IndexDef(
+            name="sqlite_autoindex_t_1", table="t", columns=("email",), unique=True,
+        ))
+        idx_rows = [r for r in _collect(b.scan("sqlite_master")) if r["type"] == "index"]
+        assert idx_rows[0]["sql"] is None
+
+    def test_strict_keyword_appears_in_sql(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="INTEGER")],
+            if_not_exists=False,
+            strict=True,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        # Trailing STRICT keyword, after the column-list closing paren.
+        assert r["sql"].endswith(") STRICT")
+
+
+class TestInjectionMitigation:
+    """Identifier quoting in the synthesized ``sql`` column.
+
+    The ``sql`` column of ``sqlite_master`` is data, not directly
+    re-executed by mini-sqlite — but a common consumer pattern (ORMs,
+    migration tools, schema-diff utilities) is to read the sql column
+    and feed it back to ``execute()``.  If we emitted unquoted
+    identifiers, a maliciously-named column could carry SQL syntax
+    across that boundary.  These tests pin the mitigation: every
+    identifier in the synthesized output is wrapped in double quotes
+    with embedded ``"`` doubled.
+    """
+
+    def test_table_name_with_quote_doubled(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            'weird"name',
+            [ColumnDef(name="x", type_name="INTEGER")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        # The embedded `"` must be doubled inside the quoted identifier.
+        assert '"weird""name"' in r["sql"]
+
+    def test_column_name_with_quote_doubled(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name='col"with"quotes', type_name="TEXT")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert '"col""with""quotes" TEXT' in r["sql"]
+
+    def test_column_name_with_injection_attempt_neutralized(self) -> None:
+        # A column name crafted to look like SQL must end up as a
+        # quoted identifier, not as executable syntax.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name='x); DROP TABLE users;--', type_name="INTEGER")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        # The entire payload is inside one quoted identifier — the
+        # outer parentheses we generate for the column list are still
+        # the only `(` / `)` in the surrounding structure.
+        assert '"x); DROP TABLE users;--" INTEGER' in r["sql"]
+
+    def test_default_string_with_quotes_escaped(self) -> None:
+        # Defaults are formatted as SQL literals with single-quote
+        # doubling (SQLite's rule), not Python repr.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="TEXT", default="he said 'hi'")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert "DEFAULT 'he said ''hi'''" in r["sql"]
+
+    def test_default_bytes_as_blob_literal(self) -> None:
+        # bytes defaults serialise as X'hex...' (SQLite BLOB literal),
+        # not Python's b'...' repr.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="BLOB", default=b"\x00\xff")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert "DEFAULT X'00FF'" in r["sql"]
+
+    def test_unsafe_type_name_neutralized_to_numeric(self) -> None:
+        # SQLite's CREATE TABLE grammar accepts almost any token sequence
+        # in the column-type slot.  A programmatic caller could construct
+        # a ColumnDef with a type that contains SQL syntax; the
+        # synthesized sql column must NOT echo that verbatim.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="INTEGER); DROP TABLE u;--")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        # The unsafe text is replaced with NUMERIC affinity; the
+        # injection payload never reaches the synthesized sql.
+        assert "DROP TABLE" not in r["sql"]
+        assert " NUMERIC" in r["sql"]
+
+    def test_unsafe_collation_neutralized_to_binary(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="TEXT", collation="X; DROP TABLE u;--")],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert "DROP TABLE" not in r["sql"]
+        assert "COLLATE BINARY" in r["sql"]
+
+    def test_parameterized_type_name_preserved(self) -> None:
+        # ``VARCHAR(64)`` and ``DECIMAL(10,2)`` are common legacy types;
+        # they must pass through the sanitizer unchanged.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [
+                ColumnDef(name="a", type_name="VARCHAR(64)"),
+                ColumnDef(name="b", type_name="DECIMAL(10,2)"),
+            ],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert "VARCHAR(64)" in r["sql"]
+        assert "DECIMAL(10,2)" in r["sql"]
+
+    def test_non_finite_float_default_as_null(self) -> None:
+        # ``inf`` / ``nan`` are not valid SQL literals; emit NULL instead
+        # of letting Python's ``repr()`` produce ``inf``.
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="REAL", default=float("inf"))],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert "DEFAULT NULL" in r["sql"]
+        assert "inf" not in r["sql"]
+
+    def test_default_none_as_null(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t",
+            [ColumnDef(name="x", type_name="INTEGER", default=None)],
+            if_not_exists=False,
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert "DEFAULT NULL" in r["sql"]
+
+
+class TestSchemaAlias:
+    """``sqlite_schema`` returns identical rows to ``sqlite_master``."""
+
+    def test_both_names_yield_same_rows(self) -> None:
+        b = _make_backend()
+        rows_master = _collect(b.scan("sqlite_master"))
+        rows_schema = _collect(b.scan("sqlite_schema"))
+        assert rows_master == rows_schema
+
+
+class TestReadOnly:
+    """The master / schema table cannot be mutated or redefined."""
+
+    def test_cannot_create_table_named_sqlite_master(self) -> None:
+        b = InMemoryBackend()
+        with pytest.raises(ConstraintViolation) as exc:
+            b.create_table(
+                "sqlite_master",
+                [ColumnDef(name="x", type_name="TEXT")],
+                if_not_exists=False,
+            )
+        assert "reserved" in str(exc.value).lower()
+
+    def test_cannot_create_table_named_sqlite_schema(self) -> None:
+        b = InMemoryBackend()
+        with pytest.raises(ConstraintViolation):
+            b.create_table(
+                "sqlite_schema",
+                [ColumnDef(name="x", type_name="TEXT")],
+                if_not_exists=False,
+            )
+
+    def test_cannot_drop_sqlite_master(self) -> None:
+        # The IF EXISTS branch would otherwise silently succeed because
+        # ``sqlite_master`` isn't in ``_tables`` — the explicit guard
+        # surfaces a clear error.
+        b = InMemoryBackend()
+        with pytest.raises(ConstraintViolation):
+            b.drop_table("sqlite_master", if_exists=True)
+
+    def test_cannot_drop_sqlite_master_no_if_exists(self) -> None:
+        b = InMemoryBackend()
+        with pytest.raises(ConstraintViolation):
+            b.drop_table("sqlite_master", if_exists=False)
+
+    def test_cannot_insert_into_sqlite_master(self) -> None:
+        b = InMemoryBackend()
+        with pytest.raises(ConstraintViolation):
+            b.insert("sqlite_master", {
+                "type": "table",
+                "name": "fake",
+                "tbl_name": "fake",
+                "rootpage": 0,
+                "sql": "CREATE TABLE fake (x INT)",
+            })
+
+
+class TestTablesListingIsClean:
+    """``backend.tables()`` lists user tables only — system tables are
+    hidden from the listing (matching SQLite's ``.tables`` behaviour)."""
+
+    def test_tables_does_not_include_sqlite_master(self) -> None:
+        b = InMemoryBackend()
+        assert "sqlite_master" not in b.tables()
+        assert "sqlite_schema" not in b.tables()
+
+    def test_tables_lists_user_tables_after_create(self) -> None:
+        b = _make_backend()
+        assert b.tables() == ["users"]
+
+
+def _collect(it: object) -> list[dict]:
+    """Drain an iterator's rows into a plain list (for ergonomic assertions)."""
+    rows = []
+    while True:
+        r = it.next()
+        if r is None:
+            break
+        rows.append(r)
+    return rows


### PR DESCRIPTION
## Summary

- ORMs and migration tools (Django, Alembic, .tables shell, etc.) all discover schema by querying ``sqlite_master``. Previously this failed on mini-sqlite's ``:memory:`` databases. This change makes the in-memory backend synthesize the standard five-column catalog on demand.
- Both ``sqlite_master`` and the modern alias ``sqlite_schema`` route to the same synthesizer.
- Reserved-name guards: CREATE TABLE / DROP TABLE / INSERT on either name raise ``IntegrityError``.

## Security

The synthesized ``sql`` column would be a second-order SQL injection vector if downstream consumers (ORMs typically) re-execute it. Mitigated by four sanitization helpers:

- ``_quote_identifier`` — double-quotes identifiers, doubles embedded ``\"``
- ``_format_sql_literal`` — types-aware SQL literal formatter (NULL/bool/int/float-with-finite-check/BLOB ``X'hex'``/TEXT with doubled ``'``)
- ``_sanitize_type_name`` — allowlist of safe column-type shapes; falls back to ``NUMERIC`` for anything outside
- ``_sanitize_collation_name`` — bare-identifier allowlist; falls back to ``BINARY``

Three rounds of /security-review with full remediation between rounds; final round passed.

## Test plan

- [x] sql-backend: 183 tests pass (28 new), 82.86% coverage — new tests cover injection-mitigation matrix
- [x] sql-planner / sql-codegen / sql-vm: regression check, no changes
- [x] mini-sqlite: 2124 tests pass (13 new oracle tests vs real ``sqlite3``), 91.38% coverage
- [x] storage-sqlite: 646 tests, 95.23% coverage — unchanged
- [x] ruff clean on all touched packages
- [x] /security-review passed (3 rounds)

Versions: sql-backend 0.15→0.16, mini-sqlite 1.88→1.89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)