### PR TITLE
spice: add transmission line ac stamping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Transmission-line AC stamping** — `TransmissionLine` now contributes the
+  lossless two-port admittance matrix in AC analysis, including matched-load
+  phase-delay behavior.
+
 - **Transmission-line element foothold** — `TransmissionLine` now exposes the
   public `T`-card four-terminal delay-line shape for parser and future
   AC/transient stamping work.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -3304,6 +3304,37 @@ def _stamp_ac_mutual_inductor(
     )
 
 
+def _validate_transmission_line(line: TransmissionLine) -> None:
+    if not math.isfinite(line.characteristic_impedance):
+        raise ValueError(f"{line.name}: characteristic impedance must be finite")
+    if line.characteristic_impedance <= 0.0:
+        raise ValueError(f"{line.name}: characteristic impedance must be positive")
+    if not math.isfinite(line.delay):
+        raise ValueError(f"{line.name}: delay must be finite")
+    if line.delay <= 0.0:
+        raise ValueError(f"{line.name}: delay must be positive")
+
+
+def _stamp_ac_transmission_line(
+    line: TransmissionLine,
+    G: list[list[complex]],
+    omega: float,
+    node_to_idx: dict[str, int],
+) -> None:
+    _validate_transmission_line(line)
+    phase = omega * line.delay
+    sin_phase = math.sin(phase)
+    if abs(sin_phase) < 1.0e-12:
+        raise ValueError(f"{line.name}: transmission line phase is singular at this frequency")
+    cos_phase = math.cos(phase)
+    y11 = complex(0.0, -cos_phase / (line.characteristic_impedance * sin_phase))
+    y12 = complex(0.0, 1.0 / (line.characteristic_impedance * sin_phase))
+    _stamp_g_c(G, node_to_idx, line.n1, line.n2, y11)
+    _stamp_g_c(G, node_to_idx, line.n3, line.n4, y11)
+    _stamp_vccs_c(G, node_to_idx, line.n1, line.n2, line.n3, line.n4, y12)
+    _stamp_vccs_c(G, node_to_idx, line.n3, line.n4, line.n1, line.n2, y12)
+
+
 def _has_explicit_ac_sources(circuit: Circuit) -> bool:
     """Return True when at least one independent source has an AC spec."""
 
@@ -3404,6 +3435,9 @@ def _stamp_ac(
 
     elif isinstance(el, MutualInductor):
         _stamp_ac_mutual_inductor(el, inductors, G, omega, node_to_idx)
+
+    elif isinstance(el, TransmissionLine):
+        _stamp_ac_transmission_line(el, G, omega, node_to_idx)
 
     elif isinstance(el, VoltageSource):
         # Ideal voltage source stamp: adds branch current as an unknown.

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -125,6 +125,7 @@ from spice_engine import (
     SParameterResult,
     SubcircuitDefinition,
     TfResult,
+    TransmissionLine,
     VoltageSource,
     XInstance,
     ac_sweep,
@@ -1823,6 +1824,31 @@ def test_ac_mutual_inductor_rejects_missing_reference():
     c.add(MutualInductor("Kbad", "Lpri", "Lmissing", 0.9))
 
     with pytest.raises(ValueError, match="referenced inductor"):
+        ac_sweep(c, f_start=1_000.0, f_stop=1_000.0, n_points=1, sweep="lin")
+
+
+def test_ac_transmission_line_matched_load_phase_delay():
+    freq = 1_000_000.0
+    delay = 1.0 / (4.0 * freq)
+
+    c = Circuit()
+    c.add(VoltageSource("Vin", "src", "0", 0.0, ac=AcSource(1.0)))
+    c.add(Resistor("Rsrc", "src", "in", 50.0))
+    c.add(TransmissionLine("T1", "in", "0", "out", "0", 50.0, delay))
+    c.add(Resistor("Rload", "out", "0", 50.0))
+
+    point = ac_sweep(c, f_start=freq, f_stop=freq, n_points=1, sweep="lin").points[0]
+
+    assert point.node_voltages["out"] == pytest.approx(-0.5j)
+
+
+def test_ac_transmission_line_rejects_invalid_parameters():
+    c = Circuit()
+    c.add(VoltageSource("Vin", "src", "0", 0.0, ac=AcSource(1.0)))
+    c.add(TransmissionLine("Tbad", "src", "0", "out", "0", 0.0, 1.0e-9))
+    c.add(Resistor("Rload", "out", "0", 50.0))
+
+    with pytest.raises(ValueError, match="characteristic impedance must be positive"):
         ac_sweep(c, f_start=1_000.0, f_stop=1_000.0, n_points=1, sweep="lin")
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add AC analysis stamping for `TransmissionLine` using the lossless two-port
+  admittance matrix, including matched-load phase-delay behavior.
 - Add a public `TransmissionLine` element as the parser-facing SPICE `T` card
   foothold for future AC/transient delay-line stamping.
 - Add transient analysis stamping for `MutualInductor` by coupling referenced

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4212,7 +4212,9 @@ fn build_ac_matrix(
             Element::MutualInductor(mutual) => {
                 stamp_ac_mutual_inductor(mutual, &inductors, omega, node_indices, &mut matrix)?
             }
-            Element::TransmissionLine(_) => {}
+            Element::TransmissionLine(line) => {
+                stamp_ac_transmission_line(line, omega, node_indices, &mut matrix)?
+            }
             Element::VoltageSource(source) => stamp_ac_voltage_source_matrix(
                 source,
                 node_indices,
@@ -6573,6 +6575,61 @@ fn stamp_ac_mutual_inductor(
     stamp_complex_conductance(matrix, s1, s2, y22);
     stamp_complex_transconductance(matrix, p1, p2, s1, s2, y12);
     stamp_complex_transconductance(matrix, s1, s2, p1, p2, y12);
+    Ok(())
+}
+
+fn stamp_ac_transmission_line(
+    line: &TransmissionLine,
+    omega: f64,
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<Complex>],
+) -> Result<(), SpiceError> {
+    if !line.characteristic_impedance_ohms.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "characteristic impedance must be finite".to_string(),
+        });
+    }
+    if line.characteristic_impedance_ohms <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "characteristic impedance must be positive".to_string(),
+        });
+    }
+    if !line.delay_seconds.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "delay must be finite".to_string(),
+        });
+    }
+    if line.delay_seconds <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "delay must be positive".to_string(),
+        });
+    }
+    let phase = omega * line.delay_seconds;
+    let sin_phase = phase.sin();
+    if sin_phase.abs() < 1.0e-12 {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "transmission line phase is singular at this frequency".to_string(),
+        });
+    }
+    let cos_phase = phase.cos();
+    let y11 = Complex::new(
+        0.0,
+        -cos_phase / (line.characteristic_impedance_ohms * sin_phase),
+    );
+    let y12 = Complex::new(0.0, 1.0 / (line.characteristic_impedance_ohms * sin_phase));
+    let n1 = node_index(node_indices, &line.n1);
+    let n2 = node_index(node_indices, &line.n2);
+    let n3 = node_index(node_indices, &line.n3);
+    let n4 = node_index(node_indices, &line.n4);
+    stamp_complex_conductance(matrix, n1, n2, y11);
+    stamp_complex_conductance(matrix, n3, n4, y11);
+    stamp_complex_transconductance(matrix, n1, n2, n3, n4, y12);
+    stamp_complex_transconductance(matrix, n3, n4, n1, n2, y12);
     Ok(())
 }
 

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,7 +1,8 @@
 use spice_engine::{
     ac_sweep, ac_sweep_corners, s_parameters, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit,
     CornerOverride, CornerSpec, CurrentSource, Element, Inductor, Jfet, JfetPolarity, Mosfet,
-    MosfetLevel1Params, MosfetType, MutualInductor, Resistor, SpiceError, Vcvs, VoltageSource,
+    MosfetLevel1Params, MosfetType, MutualInductor, Resistor, SpiceError, TransmissionLine, Vcvs,
+    VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -189,6 +190,44 @@ fn ac_mutual_inductor_rejects_missing_reference() {
     assert!(matches!(
         ac_sweep(&circuit, 1_000.0, 1_000.0, 10),
         Err(SpiceError::InvalidElement { name, .. }) if name == "Kbad"
+    ));
+}
+
+#[test]
+fn ac_transmission_line_matched_load_phase_delay() {
+    let frequency: f64 = 1_000_000.0;
+    let delay = 1.0 / (4.0 * frequency);
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+        "Vin", "src", "0", 0.0, 1.0, 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rsrc", "src", "in", 50.0)));
+    circuit.add(Element::TransmissionLine(TransmissionLine::new(
+        "T1", "in", "0", "out", "0", 50.0, delay,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rload", "out", "0", 50.0)));
+
+    let points = ac_sweep(&circuit, frequency, frequency, 10).unwrap();
+
+    let out = points[0].voltage("out").unwrap();
+    assert_close(out.real, 0.0);
+    assert_close(out.imag, -0.5);
+}
+
+#[test]
+fn ac_transmission_line_rejects_invalid_parameters() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+        "Vin", "src", "0", 0.0, 1.0, 0.0,
+    )));
+    circuit.add(Element::TransmissionLine(TransmissionLine::new(
+        "Tbad", "src", "0", "out", "0", 0.0, 1.0e-9,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rload", "out", "0", 50.0)));
+
+    assert!(matches!(
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 10),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Tbad"
     ));
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add AC analysis stamping for `TransmissionLine` using the lossless two-port
+  admittance matrix, including matched-load phase-delay behavior.
 - Add a public `TransmissionLine` element and `transmissionLine` factory as
   the parser-facing SPICE `T` card foothold for future AC/transient delay-line
   stamping.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -3588,6 +3588,7 @@ function buildAcMatrix(
         stampAcMutualInductor(element, inductors, omega, nodeIndices, matrix);
         break;
       case "transmission-line":
+        stampAcTransmissionLine(element, omega, nodeIndices, matrix);
         break;
       case "voltage-source":
         stampAcVoltageSourceMatrix(
@@ -5501,6 +5502,42 @@ function stampAcMutualInductor(
   stampComplexConductance(matrix, s1, s2, y22);
   stampComplexTransconductance(matrix, p1, p2, s1, s2, y12);
   stampComplexTransconductance(matrix, s1, s2, p1, p2, y12);
+}
+
+function stampAcTransmissionLine(
+  element: TransmissionLine,
+  omega: number,
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: Complex[][],
+): void {
+  if (!Number.isFinite(element.characteristicImpedanceOhms)) {
+    throw invalidElement(element.name, "characteristic impedance must be finite");
+  }
+  if (element.characteristicImpedanceOhms <= 0.0) {
+    throw invalidElement(element.name, "characteristic impedance must be positive");
+  }
+  if (!Number.isFinite(element.delaySeconds)) {
+    throw invalidElement(element.name, "delay must be finite");
+  }
+  if (element.delaySeconds <= 0.0) {
+    throw invalidElement(element.name, "delay must be positive");
+  }
+  const phase = omega * element.delaySeconds;
+  const sinPhase = Math.sin(phase);
+  if (Math.abs(sinPhase) < 1.0e-12) {
+    throw invalidElement(element.name, "transmission line phase is singular at this frequency");
+  }
+  const cosPhase = Math.cos(phase);
+  const y11 = complex(0.0, -cosPhase / (element.characteristicImpedanceOhms * sinPhase));
+  const y12 = complex(0.0, 1.0 / (element.characteristicImpedanceOhms * sinPhase));
+  const n1 = nodeIndex(nodeIndices, element.n1);
+  const n2 = nodeIndex(nodeIndices, element.n2);
+  const n3 = nodeIndex(nodeIndices, element.n3);
+  const n4 = nodeIndex(nodeIndices, element.n4);
+  stampComplexConductance(matrix, n1, n2, y11);
+  stampComplexConductance(matrix, n3, n4, y11);
+  stampComplexTransconductance(matrix, n1, n2, n3, n4, y12);
+  stampComplexTransconductance(matrix, n3, n4, n1, n2, y12);
 }
 
 function stampComplexConductance(

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -16,6 +16,7 @@ import {
   mutualInductor,
   resistor,
   sParameters,
+  transmissionLine,
   vcvs,
   voltageSource,
   voltageSourceWithAc,
@@ -163,6 +164,32 @@ describe("acSweep", () => {
     circuit.add(voltageSource("Vin", "pri", "0", 1.0));
     circuit.add(inductor("Lpri", "pri", "0", 1.0e-3));
     circuit.add(mutualInductor("Kbad", "Lpri", "Lmissing", 0.9));
+
+    expect(() => acSweep(circuit, 1_000.0, 1_000.0, 10)).toThrowError(SpiceError);
+  });
+
+  it("applies transmission-line matched-load phase delay", () => {
+    const frequency = 1_000_000.0;
+    const delay = 1.0 / (4.0 * frequency);
+    const circuit = new Circuit();
+    circuit.add(voltageSourceWithAc("Vin", "src", "0", 0.0, 1.0));
+    circuit.add(resistor("Rsrc", "src", "in", 50.0));
+    circuit.add(transmissionLine("T1", "in", "0", "out", "0", 50.0, delay));
+    circuit.add(resistor("Rload", "out", "0", 50.0));
+
+    const points = acSweep(circuit, frequency, frequency, 10);
+    const out = points[0].voltage("out");
+
+    expect(out).not.toBeUndefined();
+    expectClose(out!.real, 0.0);
+    expectClose(out!.imag, -0.5);
+  });
+
+  it("rejects invalid transmission-line AC parameters", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSourceWithAc("Vin", "src", "0", 0.0, 1.0));
+    circuit.add(transmissionLine("Tbad", "src", "0", "out", "0", 0.0, 1.0e-9));
+    circuit.add(resistor("Rload", "out", "0", 50.0));
 
     expect(() => acSweep(circuit, 1_000.0, 1_000.0, 10)).toThrowError(SpiceError);
   });


### PR DESCRIPTION
## Summary

- stamp `TransmissionLine` in AC analysis using the lossless two-port admittance matrix across Python, TypeScript, and Rust
- validate finite/positive line impedance and delay during AC stamping
- add matched-load phase-delay fixtures and invalid-parameter coverage across all three engine test suites

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-transmission-line-ac sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This completes the AC phase-shift slice for Phase 3 ideal transmission lines. Transient delay-line behavior remains the next focused SPICE slice.