### PR TITLE
feat(sql): implement EXPLAIN QUERY PLAN + non-zero sqlite_master.rootpage

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.90.0] - 2026-05-23
+
+### Added
+
+- ``EXPLAIN QUERY PLAN <stmt>`` is now implemented end-to-end.  The
+  engine parses and plans the inner statement (without executing it),
+  walks the optimised ``LogicalPlan``, and emits a four-column row set
+  (``id``, ``parent``, ``notused``, ``detail``) that mirrors SQLite's
+  output shape.  Detail strings cover the common plan shapes:
+  ``SCAN <table>``, ``SEARCH <table> USING INDEX <name>``, ``USE TEMP
+  B-TREE FOR ORDER BY / GROUP BY / DISTINCT / WINDOW FUNCTION``, and
+  ``SCAN SUBQUERY <alias>``.  Pure transforms (Filter, Project, Limit,
+  Having, Join) are elided so children reparent to the elided node's
+  parent — matching SQLite's output topology.
+- Bare ``EXPLAIN`` (without ``QUERY PLAN``) continues to return an
+  empty result — mini-sqlite does not expose its internal IR as VDBE
+  bytecode.
+
+### Changed
+
+- ``sqlite_master.rootpage`` now reports a stable non-zero monotonic
+  integer for tables and indexes (matching SQLite's convention) instead
+  of always returning 0.  Triggers still report 0 (not a b-tree
+  object).  See ``sql-backend`` 0.17 for the underlying change.
+
 ## [1.89.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.89.0"
+version = "1.90.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -62,6 +62,9 @@ from sql_planner.plan import (
 from sql_planner.plan import (
     Limit as PlanLimit,
 )
+from sql_planner.plan import (
+    children as _plan_children,
+)
 from sql_vm import QueryEvent, QueryResult, execute  # noqa: F401 — QueryEvent re-exported
 
 from .adapter import to_statement
@@ -114,13 +117,28 @@ def run(
         # metadata and return formatted rows without going through the planner.
         if re.match(r"\s*PRAGMA\b", bound, re.IGNORECASE):
             return _run_pragma(backend, bound, fk_child=fk_child)
+        # EXPLAIN QUERY PLAN <stmt>: parse + plan the inner statement and
+        # return a four-column row set (id, parent, notused, detail) that
+        # mirrors SQLite's output format.  Walked here instead of inside
+        # the normal pipeline so we never code-generate or execute the
+        # underlying statement.
+        if re.match(r"\s*EXPLAIN\s+QUERY\s+PLAN\b", bound, re.IGNORECASE):
+            inner = re.sub(
+                r"^\s*EXPLAIN\s+QUERY\s+PLAN\s+",
+                "",
+                bound,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+            return _run_explain_query_plan(backend, inner, view_defs=view_defs)
         # VACUUM / ANALYZE / REINDEX are no-ops in mini-sqlite.  SQLite uses
         # VACUUM to rebuild the database file and ANALYZE to collect statistics
         # for the query planner; neither concept applies to our in-memory /
         # file-backed stack.  We silently succeed so migration scripts and ORM
         # setup routines that call these statements don't crash.
-        # EXPLAIN / EXPLAIN QUERY PLAN are similarly intercepted — we return an
-        # empty result rather than trying to expose our internal IR.
+        # Bare EXPLAIN (without QUERY PLAN) emits SQLite's VDBE bytecode —
+        # we don't expose our internal IR, so we silently return an empty
+        # result rather than crash.
         if re.match(
             r"\s*(VACUUM|ANALYZE|REINDEX|EXPLAIN\b)\b",
             bound,
@@ -480,6 +498,139 @@ _PRAGMA_RE = re.compile(
     """,
     re.IGNORECASE | re.VERBOSE,
 )
+
+
+# ---------------------------------------------------------------------------
+# EXPLAIN QUERY PLAN — walk the optimised LogicalPlan and emit one row per
+# "interesting" plan node.  The output mirrors SQLite's four-column layout:
+#
+#   id      | parent  | notused | detail
+#   --------+---------+---------+--------------------------------
+#   integer | integer | always  | human-readable description, e.g.
+#           |         | 0       | "SCAN t" or "SEARCH t USING INDEX ix"
+#
+# We deliberately do NOT emit a row for every plan node — SQLite skips
+# pure transforms (Filter, Project) and only surfaces the data-source and
+# big algorithmic choices (sorts, group-by, distinct).  Our detail-string
+# generator returns ``None`` for nodes we want to elide; the walker then
+# passes the elided node's parent_id down to its children.
+# ---------------------------------------------------------------------------
+
+
+def _explain_detail(node: LogicalPlan) -> str | None:
+    """Return SQLite-style EXPLAIN QUERY PLAN detail text for *node*, or None.
+
+    Returning None means the node is a pure transform (e.g. Filter,
+    Project, Limit, Having) that doesn't appear as its own row in
+    SQLite's output; its children are reparented to the elided node's
+    parent so the id/parent topology still matches.
+    """
+    # Late-imported to avoid a top-level cycle with the planner module.
+    from sql_planner.plan import (
+        Aggregate as _Agg,
+    )
+    from sql_planner.plan import (
+        Delete as _Del,
+    )
+    from sql_planner.plan import (
+        Distinct as _Dist,
+    )
+    from sql_planner.plan import (
+        IndexScan as _Ix,
+    )
+    from sql_planner.plan import (
+        Insert as _Ins,
+    )
+    from sql_planner.plan import (
+        Scan as _Scan,
+    )
+    from sql_planner.plan import (
+        Sort as _Sort,
+    )
+    from sql_planner.plan import (
+        Update as _Upd,
+    )
+    from sql_planner.plan import (
+        WindowAgg as _Win,
+    )
+
+    if isinstance(node, _Scan):
+        # ``SCAN <table>`` or ``SCAN <table> AS <alias>`` — the alias is
+        # included when distinct from the table name so the user can tell
+        # apart self-joins.
+        if node.alias and node.alias != node.table:
+            return f"SCAN {node.table} AS {node.alias}"
+        return f"SCAN {node.table}"
+    if isinstance(node, _Ix):
+        # ``SEARCH <table> [AS <alias>] USING INDEX <name>`` — SQLite
+        # also appends ``(<col>=?)`` for each equality bound, but we keep
+        # the form minimal here.  Future work can expand the bound shape.
+        base = f"SEARCH {node.table}"
+        if node.alias and node.alias != node.table:
+            base += f" AS {node.alias}"
+        return base + f" USING INDEX {node.index_name}"
+    if isinstance(node, _Agg):
+        return "USE TEMP B-TREE FOR GROUP BY"
+    if isinstance(node, _Sort):
+        return "USE TEMP B-TREE FOR ORDER BY"
+    if isinstance(node, _Dist):
+        return "USE TEMP B-TREE FOR DISTINCT"
+    if isinstance(node, _Win):
+        return "USE TEMP B-TREE FOR WINDOW FUNCTION"
+    if isinstance(node, DerivedTable):
+        alias = node.alias or "subq"
+        return f"SCAN SUBQUERY {alias}"
+    if isinstance(node, (_Ins, _Upd, _Del)):
+        # DML uses the target table directly; SQLite shows the table
+        # name (no row for the action itself, but we approximate).
+        return f"SCAN {node.table}"
+    # All other nodes (Filter, Project, Join, Having, Limit, Union/Intersect/
+    # Except, Begin/Commit/Rollback, CreateTable, etc.) elided.
+    return None
+
+
+def _run_explain_query_plan(
+    backend: Backend,
+    sql: str,
+    *,
+    view_defs: dict | None = None,
+) -> QueryResult:
+    """Plan *sql* and return a ``(id, parent, notused, detail)`` row set.
+
+    The inner statement is parsed and planned but never executed.  No
+    side effects on the backend.  Designed for the ``EXPLAIN QUERY PLAN``
+    diagnostic path, not for general query handling.
+    """
+    ast = parse_sql(sql)
+    stmt = to_statement(ast, view_defs=view_defs)
+    logical = plan(stmt, backend_as_schema_provider(backend))
+    optimized = optimize(logical)
+
+    rows: list[tuple[int, int, int, str]] = []
+    counter = [0]  # mutable in closure — pre-increment to get the next id
+
+    def walk(node: LogicalPlan, parent_id: int) -> None:
+        detail = _explain_detail(node)
+        if detail is not None:
+            counter[0] += 1
+            my_id = counter[0]
+            rows.append((my_id, parent_id, 0, detail))
+            child_parent = my_id
+        else:
+            # Elided node: children inherit this node's parent.
+            child_parent = parent_id
+        for child in _plan_children(node):
+            walk(child, child_parent)
+
+    walk(optimized, 0)
+
+    return QueryResult(
+        columns=("id", "parent", "notused", "detail"),
+        rows=tuple(rows),
+    )
+
+
+# ---------------------------------------------------------------------------
 
 
 # Boolean PRAGMA value parser.  SQLite accepts a wide range of representations

--- a/code/packages/python/mini-sqlite/tests/test_tier3_explain_query_plan.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_explain_query_plan.py
@@ -1,0 +1,160 @@
+"""Tests for ``EXPLAIN QUERY PLAN <stmt>``.
+
+SQLite's EXPLAIN QUERY PLAN walks a parsed/optimised query plan and
+emits a four-column row set (``id``, ``parent``, ``notused``,
+``detail``) describing the algorithmic choices it made — which table
+got a sequential scan, which got an index search, whether a temp
+b-tree was used for sorting / grouping, etc.
+
+Mini-sqlite implements this by walking its own LogicalPlan tree and
+mapping each "interesting" node to a SQLite-compatible detail string.
+Pure transforms (Filter, Project, Limit, Having, Join) are elided so
+their children re-parent to the elided node's parent — matching
+SQLite's output topology.
+
+Test strategy:
+
+* Verify the four-column shape (id, parent, notused, detail).
+* Pin the detail strings produced for the common plan shapes:
+  scan, index search, sort, group by, distinct, join, subquery.
+* Verify ``EXPLAIN`` without ``QUERY PLAN`` still returns an empty
+  result (mini-sqlite doesn't emit VDBE bytecode).
+* Verify EXPLAIN QUERY PLAN does NOT execute the inner statement
+  (no side effects on the backend).
+"""
+
+from __future__ import annotations
+
+import mini_sqlite
+
+
+class TestSchema:
+    """The four-column output shape matches SQLite."""
+
+    def test_column_order(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        cur = c.execute("EXPLAIN QUERY PLAN SELECT * FROM t")
+        # Description is sqlite3-style: tuple-of-tuples per column.
+        # mini-sqlite mirrors that — but we mainly care about the
+        # column names being present in order.
+        assert cur.description is not None
+        names = [d[0] for d in cur.description]
+        assert names == ["id", "parent", "notused", "detail"]
+
+    def test_notused_is_always_zero(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        rows = c.execute(
+            "EXPLAIN QUERY PLAN SELECT * FROM t WHERE x > 1 ORDER BY x"
+        ).fetchall()
+        assert rows
+        for r in rows:
+            assert r[2] == 0  # notused column
+
+
+class TestSimpleScan:
+    """Plain ``SELECT * FROM t`` emits one ``SCAN t`` row."""
+
+    def test_select_star_emits_scan(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        rows = c.execute("EXPLAIN QUERY PLAN SELECT * FROM t").fetchall()
+        assert rows == [(1, 0, 0, "SCAN t")]
+
+    def test_aliased_table_includes_alias(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        rows = c.execute("EXPLAIN QUERY PLAN SELECT * FROM t AS u").fetchall()
+        assert rows == [(1, 0, 0, "SCAN t AS u")]
+
+
+class TestIndexSearch:
+    """Predicates matched by an index produce ``SEARCH ... USING INDEX``."""
+
+    def test_index_search_on_equality_predicate(self) -> None:
+        # auto_index=False so the advisor doesn't add its own index;
+        # we want to verify the plan we explicitly built.
+        c = mini_sqlite.connect(":memory:", auto_index=False)
+        c.execute("CREATE TABLE t (x INTEGER, y INTEGER)")
+        c.execute("CREATE INDEX ix_x ON t (x)")
+        rows = c.execute(
+            "EXPLAIN QUERY PLAN SELECT * FROM t WHERE x = 5"
+        ).fetchall()
+        # One row; detail names the index.
+        assert rows == [(1, 0, 0, "SEARCH t USING INDEX ix_x")]
+
+
+class TestTempBTreeNodes:
+    """Sort / group by / distinct each emit a 'USE TEMP B-TREE' row."""
+
+    def test_order_by_emits_temp_btree(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        rows = c.execute(
+            "EXPLAIN QUERY PLAN SELECT * FROM t ORDER BY x"
+        ).fetchall()
+        # Sort wraps the scan: id=1 is the sort, id=2 is the child scan.
+        assert rows == [
+            (1, 0, 0, "USE TEMP B-TREE FOR ORDER BY"),
+            (2, 1, 0, "SCAN t"),
+        ]
+
+    def test_group_by_emits_temp_btree(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        rows = c.execute(
+            "EXPLAIN QUERY PLAN SELECT x, COUNT(*) FROM t GROUP BY x"
+        ).fetchall()
+        # Aggregate wraps the scan.
+        assert (1, 0, 0, "USE TEMP B-TREE FOR GROUP BY") in rows
+
+    def test_distinct_emits_temp_btree(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        rows = c.execute(
+            "EXPLAIN QUERY PLAN SELECT DISTINCT x FROM t"
+        ).fetchall()
+        assert (1, 0, 0, "USE TEMP B-TREE FOR DISTINCT") in rows
+
+
+class TestJoinShape:
+    """A two-table join emits two sibling rows under the same parent."""
+
+    def test_join_emits_two_scans(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE a (x INTEGER)")
+        c.execute("CREATE TABLE b (x INTEGER)")
+        rows = c.execute(
+            "EXPLAIN QUERY PLAN SELECT * FROM a JOIN b ON a.x = b.x"
+        ).fetchall()
+        # The Join plan node is elided, so both scans are siblings
+        # under the implicit root (parent=0).
+        assert rows == [
+            (1, 0, 0, "SCAN a"),
+            (2, 0, 0, "SCAN b"),
+        ]
+
+
+class TestSideEffects:
+    """EXPLAIN QUERY PLAN must NOT execute the inner statement."""
+
+    def test_explain_query_plan_does_not_insert(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        # If EXPLAIN ran the INSERT we'd see a row in t afterwards.
+        c.execute("EXPLAIN QUERY PLAN INSERT INTO t VALUES (1)")
+        assert c.execute("SELECT COUNT(*) FROM t").fetchone() == (0,)
+
+
+class TestBareExplain:
+    """Bare EXPLAIN (no QUERY PLAN) returns no rows — mini-sqlite has no VDBE."""
+
+    def test_bare_explain_returns_empty(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE t (x INTEGER)")
+        # We don't oracle-compare against sqlite3 here — bare EXPLAIN
+        # produces VDBE bytecode in real SQLite, but mini-sqlite uses a
+        # different IR.  Returning empty is the documented behaviour.
+        result = c.execute("EXPLAIN SELECT * FROM t").fetchall()
+        assert result == []

--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-05-23
+
+### Changed
+
+- ``InMemoryBackend._synthesize_master_rows`` now assigns stable
+  monotonic positive integers to the ``rootpage`` column for tables
+  and indexes (matching SQLite's convention that ``rootpage > 0``
+  means the object exists in the b-tree).  Triggers continue to get
+  ``rootpage = 0`` since they're not b-tree objects.  Page numbers
+  are assigned in iteration order at synthesis time and are not
+  stable across schema mutations (matches SQLite's documented
+  behaviour for fresh databases).
+
 ## [0.16.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-backend/pyproject.toml
+++ b/code/packages/python/sql-backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-backend"
-version = "0.16.0"
+version = "0.17.0"
 description = "Pluggable data-source interface for the SQL pipeline — ships the Backend ABC, supporting types, an InMemoryBackend reference, and conformance test helpers."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-backend/src/sql_backend/in_memory.py
+++ b/code/packages/python/sql-backend/src/sql_backend/in_memory.py
@@ -596,36 +596,45 @@ class InMemoryBackend(Backend):
 
             type      | name        | tbl_name    | rootpage | sql
             ----------+-------------+-------------+----------+------------------
-            'table'   | <user-name> | <user-name> | 0        | CREATE TABLE ...
-            'index'   | <idx-name>  | <tbl-name>  | 0        | CREATE INDEX ...
+            'table'   | <user-name> | <user-name> | <n>      | CREATE TABLE ...
+            'index'   | <idx-name>  | <tbl-name>  | <n>      | CREATE INDEX ...
             'trigger' | <trg-name>  | <tbl-name>  | 0        | CREATE TRIGGER ...
 
         Auto-generated indexes (``sqlite_autoindex_*``) get NULL in the
         ``sql`` column, matching real SQLite.  ``rootpage`` is meaningful
-        only on disk; the in-memory backend returns 0 for every row.
+        only on disk; the in-memory backend assigns a stable monotonic
+        positive integer per table/index (matching SQLite's convention
+        that ``rootpage > 0`` means "exists in the b-tree").  Triggers
+        and views have ``rootpage = 0`` — they're not b-tree objects.
+        Page numbers are not stable across schema mutations: they're
+        assigned in iteration order at synthesis time.
         """
         rows: list[Row] = []
+        next_page = 1  # tables and indexes start at 1; triggers stay at 0
         # Tables in insertion order.
         for name, tbl in self._tables.items():
             rows.append({
                 "type": "table",
                 "name": name,
                 "tbl_name": name,
-                "rootpage": 0,
+                "rootpage": next_page,
                 "sql": _reconstruct_create_table(name, tbl.columns, tbl.strict),
             })
+            next_page += 1
         # Indexes in insertion order.
         for idx_name, idx in self._indexes.items():
             rows.append({
                 "type": "index",
                 "name": idx_name,
                 "tbl_name": idx.table,
-                "rootpage": 0,
+                "rootpage": next_page,
                 "sql": _reconstruct_create_index(idx),
             })
+            next_page += 1
         # Triggers in creation order (per table).  ``_triggers`` is keyed
         # by name; iterate ``_triggers_by_table`` to preserve per-table
         # creation order (matches SQLite's ordering inside sqlite_master).
+        # Triggers do not have a b-tree root; ``rootpage`` is always 0.
         for tbl_name, trigs in self._triggers_by_table.items():
             for trg in trigs:
                 rows.append({

--- a/code/packages/python/sql-backend/tests/test_sqlite_master.py
+++ b/code/packages/python/sql-backend/tests/test_sqlite_master.py
@@ -78,7 +78,9 @@ class TestMasterRows:
         assert r["type"] == "table"
         assert r["name"] == "t"
         assert r["tbl_name"] == "t"
-        assert r["rootpage"] == 0
+        # The first b-tree object gets rootpage 1; non-zero is SQLite's
+        # convention for "exists in the b-tree".
+        assert r["rootpage"] == 1
         # Identifiers are quoted to prevent second-order SQL injection
         # when a downstream consumer re-executes sqlite_master.sql.
         assert 'CREATE TABLE "t"' in r["sql"]
@@ -339,6 +341,34 @@ class TestReadOnly:
                 "rootpage": 0,
                 "sql": "CREATE TABLE fake (x INT)",
             })
+
+
+class TestRootpage:
+    """Non-zero rootpage for tables and indexes; 0 for triggers."""
+
+    def test_first_table_gets_rootpage_1(self) -> None:
+        b = InMemoryBackend()
+        b.create_table(
+            "t", [ColumnDef(name="x", type_name="INTEGER")], if_not_exists=False
+        )
+        r = _collect(b.scan("sqlite_master"))[0]
+        assert r["rootpage"] == 1
+
+    def test_pages_monotonic_in_creation_order(self) -> None:
+        # SQLite assigns page numbers in creation order for fresh tables;
+        # we mirror that by enumerating tables then indexes in dict order.
+        b = _make_backend()
+        rows = _collect(b.scan("sqlite_master"))
+        pages = [r["rootpage"] for r in rows]
+        assert pages == sorted(pages)  # monotonic
+        assert all(p > 0 for p in pages)  # all positive (b-tree objects)
+
+    def test_index_gets_distinct_page_from_table(self) -> None:
+        b = _make_backend()  # users (table) + ix_name (index)
+        rows = _collect(b.scan("sqlite_master"))
+        table_pages = {r["rootpage"] for r in rows if r["type"] == "table"}
+        index_pages = {r["rootpage"] for r in rows if r["type"] == "index"}
+        assert not (table_pages & index_pages)
 
 
 class TestTablesListingIsClean:


### PR DESCRIPTION
## Summary

Two complementary diagnostic improvements that bring mini-sqlite closer to byte-compat with sqlite3 for ORM/tooling consumers:

1. **EXPLAIN QUERY PLAN**: previously a silent no-op. Now walks the optimised ``LogicalPlan`` and emits a four-column row set (``id``, ``parent``, ``notused``, ``detail``) mirroring SQLite's output. Covers SCAN, SEARCH ... USING INDEX, USE TEMP B-TREE FOR ORDER BY / GROUP BY / DISTINCT / WINDOW FUNCTION, and SCAN SUBQUERY.
2. **sqlite_master.rootpage**: previously always 0. Now stable monotonic positive integers for tables/indexes (matching SQLite's convention that rootpage > 0 means "exists in the b-tree"). Triggers still get 0.

## Test plan

- [x] sql-backend: 186 tests (3 new rootpage tests), 82.91% coverage
- [x] mini-sqlite: 2135 tests (11 new EXPLAIN QUERY PLAN tests), 91.39% coverage  
- [x] sql-planner / sql-codegen / sql-vm / storage-sqlite: regression check, no changes
- [x] ruff clean
- [x] /security-review passed (verified injection paths, regex prefix-strip soundness, recursion DoS, detail-string interpolation)

Versions: sql-backend 0.16→0.17, mini-sqlite 1.89→1.90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)