### PR TITLE
[codex] Add Board VM input callback transport reports

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -145,6 +145,10 @@ handling without duplicating lifecycle branching.
 transport effects: whether to dispatch a callback, emit a drop notice, emit a
 result, remove a queue item, keep cooperative dispatch scheduled, and what the
 queue depth is after the effect.
+`input_callback_transport_report_summary` turns those effects into stable
+transport report kinds, names, labels, queue-depth metadata, and messages, so
+adapters can log or emit callback dispatch, drop, completion, running,
+budget-exhausted, and failure reports without owning that branching.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -953,6 +953,38 @@ pub struct LanguageInputCallbackTransportEffectSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportReportKind {
+    Dispatch,
+    Drop,
+    Completion,
+    Running,
+    BudgetExceeded,
+    Failure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportReportSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub report_label: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub dispatch_callback: bool,
+    pub emit_report: bool,
+    pub emit_drop: bool,
+    pub emit_result: bool,
+    pub remove_from_queue: bool,
+    pub keep_dispatch_scheduled: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_report: u8,
+    pub message: String,
+    pub effect_summary: LanguageInputCallbackTransportEffectSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -1417,6 +1449,19 @@ pub const fn input_callback_transport_action_name(
             "drop_after_budget_exceeded"
         }
         LanguageInputCallbackTransportAction::DropAfterFailure => "drop_after_failure",
+    }
+}
+
+pub const fn input_callback_transport_report_kind_name(
+    kind: LanguageInputCallbackTransportReportKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportReportKind::Dispatch => "dispatch",
+        LanguageInputCallbackTransportReportKind::Drop => "drop",
+        LanguageInputCallbackTransportReportKind::Completion => "completion",
+        LanguageInputCallbackTransportReportKind::Running => "running",
+        LanguageInputCallbackTransportReportKind::BudgetExceeded => "budget_exceeded",
+        LanguageInputCallbackTransportReportKind::Failure => "failure",
     }
 }
 
@@ -2612,6 +2657,33 @@ pub fn input_callback_transport_effect_summary(
     }
 }
 
+pub fn input_callback_transport_report_summary(
+    effect_summary: &LanguageInputCallbackTransportEffectSummary,
+) -> LanguageInputCallbackTransportReportSummary {
+    let report_kind = input_callback_transport_report_kind(effect_summary.action);
+
+    LanguageInputCallbackTransportReportSummary {
+        endpoint: effect_summary.endpoint.clone(),
+        connection_label: effect_summary.connection_label.clone(),
+        report_label: input_callback_transport_report_label(effect_summary, report_kind),
+        report_kind,
+        report_name: input_callback_transport_report_kind_name(report_kind).to_owned(),
+        action: effect_summary.action,
+        action_name: effect_summary.action_name.clone(),
+        dispatch_callback: effect_summary.dispatch_callback,
+        emit_report: input_callback_transport_report_emits_report(effect_summary),
+        emit_drop: effect_summary.emit_drop,
+        emit_result: effect_summary.emit_result,
+        remove_from_queue: effect_summary.remove_from_queue,
+        keep_dispatch_scheduled: effect_summary.keep_dispatch_scheduled,
+        terminal: effect_summary.terminal,
+        retryable: effect_summary.retryable,
+        queue_depth_after_report: effect_summary.queue_depth_after_effect,
+        message: input_callback_transport_report_message(report_kind).to_owned(),
+        effect_summary: effect_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -3721,6 +3793,75 @@ fn input_callback_transport_effect_message(
         }
         LanguageInputCallbackTransportAction::DropAfterFailure => {
             "Transport should emit the failure result and remove the callback from the queue."
+        }
+    }
+}
+
+fn input_callback_transport_report_kind(
+    action: LanguageInputCallbackTransportAction,
+) -> LanguageInputCallbackTransportReportKind {
+    match action {
+        LanguageInputCallbackTransportAction::DropBeforeDispatch => {
+            LanguageInputCallbackTransportReportKind::Drop
+        }
+        LanguageInputCallbackTransportAction::DispatchCallback => {
+            LanguageInputCallbackTransportReportKind::Dispatch
+        }
+        LanguageInputCallbackTransportAction::CompleteCallback => {
+            LanguageInputCallbackTransportReportKind::Completion
+        }
+        LanguageInputCallbackTransportAction::KeepCallbackRunning => {
+            LanguageInputCallbackTransportReportKind::Running
+        }
+        LanguageInputCallbackTransportAction::DropAfterBudgetExceeded => {
+            LanguageInputCallbackTransportReportKind::BudgetExceeded
+        }
+        LanguageInputCallbackTransportAction::DropAfterFailure => {
+            LanguageInputCallbackTransportReportKind::Failure
+        }
+    }
+}
+
+fn input_callback_transport_report_emits_report(
+    effect_summary: &LanguageInputCallbackTransportEffectSummary,
+) -> bool {
+    effect_summary.emit_drop || effect_summary.emit_result
+}
+
+fn input_callback_transport_report_label(
+    effect_summary: &LanguageInputCallbackTransportEffectSummary,
+    report_kind: LanguageInputCallbackTransportReportKind,
+) -> String {
+    format!(
+        "{} transport_report={} emit_report={} queue_depth_after_report={}",
+        effect_summary.effect_label,
+        input_callback_transport_report_kind_name(report_kind),
+        input_callback_transport_report_emits_report(effect_summary),
+        effect_summary.queue_depth_after_effect
+    )
+}
+
+fn input_callback_transport_report_message(
+    report_kind: LanguageInputCallbackTransportReportKind,
+) -> &'static str {
+    match report_kind {
+        LanguageInputCallbackTransportReportKind::Dispatch => {
+            "Transport should dispatch the callback runner; no report is emitted yet."
+        }
+        LanguageInputCallbackTransportReportKind::Drop => {
+            "Transport should emit a dropped-callback report."
+        }
+        LanguageInputCallbackTransportReportKind::Completion => {
+            "Transport should emit a completed-callback report."
+        }
+        LanguageInputCallbackTransportReportKind::Running => {
+            "Transport should emit a running-callback report and keep dispatch scheduled."
+        }
+        LanguageInputCallbackTransportReportKind::BudgetExceeded => {
+            "Transport should emit a budget-exceeded callback report."
+        }
+        LanguageInputCallbackTransportReportKind::Failure => {
+            "Transport should emit a failed-callback report."
         }
     }
 }
@@ -8945,6 +9086,204 @@ mod tests {
         assert_eq!(
             dropped.message,
             "Transport should emit a drop notice without touching the existing queue."
+        );
+    }
+
+    #[test]
+    fn input_callback_transport_reports_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_action = input_callback_transport_action_summary(&completed_lifecycle);
+        let completed_effect = input_callback_transport_effect_summary(&completed_action);
+        let completed = input_callback_transport_report_summary(&completed_effect);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(completed.report_name, "completion");
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert_eq!(completed.action_name, "complete_callback");
+        assert!(!completed.dispatch_callback);
+        assert!(completed.emit_report);
+        assert!(!completed.emit_drop);
+        assert!(completed.emit_result);
+        assert!(completed.remove_from_queue);
+        assert!(!completed.keep_dispatch_scheduled);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_report, 2);
+        assert_eq!(
+            completed.message,
+            "Transport should emit a completed-callback report."
+        );
+        assert_eq!(completed.effect_summary, completed_effect);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_action = input_callback_transport_action_summary(&pending_lifecycle);
+        let pending_effect = input_callback_transport_effect_summary(&pending_action);
+        let pending = input_callback_transport_report_summary(&pending_effect);
+        assert_eq!(
+            pending.report_kind,
+            LanguageInputCallbackTransportReportKind::Dispatch
+        );
+        assert_eq!(pending.report_name, "dispatch");
+        assert!(pending.dispatch_callback);
+        assert!(!pending.emit_report);
+        assert!(!pending.emit_drop);
+        assert!(!pending.emit_result);
+        assert!(!pending.remove_from_queue);
+        assert!(pending.keep_dispatch_scheduled);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_report, 3);
+        assert_eq!(
+            pending.report_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=42 transport_action=dispatch_callback terminal=false retryable=false dispatch_callback=true emit_drop=false emit_result=false remove_from_queue=false keep_dispatch_scheduled=true queue_depth_after_effect=3 transport_report=dispatch emit_report=false queue_depth_after_report=3"
+        );
+        assert_eq!(
+            pending.message,
+            "Transport should dispatch the callback runner; no report is emitted yet."
+        );
+
+        let running_lifecycle = input_callback_session_lifecycle_summary(
+            &tcp_session,
+            &queue_plan,
+            Some(RunStatus::Running),
+            12,
+            4,
+        );
+        let running_action = input_callback_transport_action_summary(&running_lifecycle);
+        let running_effect = input_callback_transport_effect_summary(&running_action);
+        let running = input_callback_transport_report_summary(&running_effect);
+        assert_eq!(
+            running.report_kind,
+            LanguageInputCallbackTransportReportKind::Running
+        );
+        assert_eq!(running.report_name, "running");
+        assert!(running.emit_report);
+        assert!(running.emit_result);
+        assert!(!running.remove_from_queue);
+        assert!(running.keep_dispatch_scheduled);
+        assert!(running.retryable);
+        assert_eq!(
+            running.message,
+            "Transport should emit a running-callback report and keep dispatch scheduled."
+        );
+
+        let budget_lifecycle = input_callback_session_lifecycle_summary(
+            &tcp_session,
+            &queue_plan,
+            Some(RunStatus::BudgetExceeded),
+            64,
+            9,
+        );
+        let budget_action = input_callback_transport_action_summary(&budget_lifecycle);
+        let budget_effect = input_callback_transport_effect_summary(&budget_action);
+        let budget = input_callback_transport_report_summary(&budget_effect);
+        assert_eq!(
+            budget.report_kind,
+            LanguageInputCallbackTransportReportKind::BudgetExceeded
+        );
+        assert_eq!(budget.report_name, "budget_exceeded");
+        assert!(budget.emit_report);
+        assert!(budget.emit_result);
+        assert!(budget.remove_from_queue);
+        assert!(budget.terminal);
+        assert_eq!(
+            budget.message,
+            "Transport should emit a budget-exceeded callback report."
+        );
+
+        let stopped_lifecycle = input_callback_session_lifecycle_summary(
+            &tcp_session,
+            &queue_plan,
+            Some(RunStatus::Stopped),
+            6,
+            2,
+        );
+        let stopped_action = input_callback_transport_action_summary(&stopped_lifecycle);
+        let stopped_effect = input_callback_transport_effect_summary(&stopped_action);
+        let stopped = input_callback_transport_report_summary(&stopped_effect);
+        assert_eq!(
+            stopped.report_kind,
+            LanguageInputCallbackTransportReportKind::Failure
+        );
+        assert_eq!(stopped.report_name, "failure");
+        assert!(stopped.emit_report);
+        assert!(stopped.emit_result);
+        assert!(stopped.remove_from_queue);
+        assert_eq!(
+            stopped.message,
+            "Transport should emit a failed-callback report."
+        );
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_action = input_callback_transport_action_summary(&dropped_lifecycle);
+        let dropped_effect = input_callback_transport_effect_summary(&dropped_action);
+        let dropped = input_callback_transport_report_summary(&dropped_effect);
+        assert_eq!(
+            dropped.report_kind,
+            LanguageInputCallbackTransportReportKind::Drop
+        );
+        assert_eq!(dropped.report_name, "drop");
+        assert!(!dropped.dispatch_callback);
+        assert!(dropped.emit_report);
+        assert!(dropped.emit_drop);
+        assert!(!dropped.emit_result);
+        assert!(!dropped.remove_from_queue);
+        assert!(!dropped.keep_dispatch_scheduled);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_report, 1);
+        assert_eq!(
+            dropped.report_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=77 transport_action=drop_before_dispatch terminal=true retryable=false dispatch_callback=false emit_drop=true emit_result=false remove_from_queue=false keep_dispatch_scheduled=false queue_depth_after_effect=1 transport_report=drop emit_report=true queue_depth_after_report=1"
+        );
+        assert_eq!(
+            dropped.message,
+            "Transport should emit a dropped-callback report."
         );
     }
 


### PR DESCRIPTION
## Summary
- add Rust-owned input callback transport report kinds, names, labels, and summaries on top of transport effects
- carry dispatch/drop/result/remove/schedule flags plus terminal/retry state through the report summary
- document the report summary API and cover dispatch, drop, completion, running, budget, and failure report cases

## Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-report cargo test -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-report cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Detector validation note: /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool is still unavailable on this machine, so that external helper was not run.