### PR TITLE
spice: add transmission line transient stamping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Transmission-line transient stamping** — `TransmissionLine` now participates
+  in transient analysis with a lossless Bergeron delay-line companion model,
+  including matched-load delayed step behavior.
+
 - **Transmission-line AC stamping** — `TransmissionLine` now contributes the
   lossless two-port admittance matrix in AC analysis, including matched-load
   phase-delay behavior.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -1960,6 +1960,142 @@ def _node_voltage(name: str, node_voltages: dict[str, float]) -> float:
     return 0.0 if _is_ground(name) else node_voltages.get(name, 0.0)
 
 
+TransmissionLineSample = tuple[float, float, float, float, float]
+
+
+def _transmission_line_port_voltage(
+    line: TransmissionLine,
+    node_voltages: dict[str, float],
+    first_port: bool,
+) -> float:
+    if first_port:
+        return (
+            _node_voltage(line.n1, node_voltages)
+            - _node_voltage(line.n2, node_voltages)
+        )
+    return (
+        _node_voltage(line.n3, node_voltages)
+        - _node_voltage(line.n4, node_voltages)
+    )
+
+
+def _transmission_line_sample_at(
+    samples: list[TransmissionLineSample],
+    target_time: float,
+) -> tuple[float, float, float, float]:
+    if not samples or target_time < samples[0][0] - 1.0e-18:
+        return (0.0, 0.0, 0.0, 0.0)
+    if target_time <= samples[0][0]:
+        _, v1, i1, v2, i2 = samples[0]
+        return (v1, i1, v2, i2)
+    for left, right in zip(samples, samples[1:]):
+        if target_time <= right[0]:
+            t0, v10, i10, v20, i20 = left
+            t1, v11, i11, v21, i21 = right
+            if t1 <= t0:
+                return (v11, i11, v21, i21)
+            alpha = (target_time - t0) / (t1 - t0)
+            return (
+                v10 + alpha * (v11 - v10),
+                i10 + alpha * (i11 - i10),
+                v20 + alpha * (v21 - v20),
+                i20 + alpha * (i21 - i20),
+            )
+    _, v1, i1, v2, i2 = samples[-1]
+    return (v1, i1, v2, i2)
+
+
+def _transmission_line_history_terms(
+    line: TransmissionLine,
+    line_history: dict[str, list[TransmissionLineSample]],
+    time: float,
+) -> tuple[float, float]:
+    _validate_transmission_line(line)
+    v1_d, i1_d, v2_d, i2_d = _transmission_line_sample_at(
+        line_history.get(line.name, []),
+        time - line.delay,
+    )
+    z0 = line.characteristic_impedance
+    return (v2_d / z0 + i2_d, v1_d / z0 + i1_d)
+
+
+def _add_transmission_line_companion(
+    circuit: Circuit,
+    line: TransmissionLine,
+    history_1: float,
+    history_2: float,
+) -> None:
+    _validate_transmission_line(line)
+    circuit.add(Resistor(
+        name=f"_T_{line.name}_P1_R",
+        n_plus=line.n1,
+        n_minus=line.n2,
+        resistance=line.characteristic_impedance,
+    ))
+    circuit.add(Resistor(
+        name=f"_T_{line.name}_P2_R",
+        n_plus=line.n3,
+        n_minus=line.n4,
+        resistance=line.characteristic_impedance,
+    ))
+    circuit.add(CurrentSource(
+        name=f"_T_{line.name}_P1_I",
+        n_plus=line.n1,
+        n_minus=line.n2,
+        current=-history_1,
+    ))
+    circuit.add(CurrentSource(
+        name=f"_T_{line.name}_P2_I",
+        n_plus=line.n3,
+        n_minus=line.n4,
+        current=-history_2,
+    ))
+
+
+def _transmission_line_branch_currents(
+    circuit: Circuit,
+    line_history: dict[str, list[TransmissionLineSample]],
+    time: float,
+    node_voltages: dict[str, float],
+) -> dict[str, float]:
+    currents: dict[str, float] = {}
+    for el in circuit.elements:
+        if not isinstance(el, TransmissionLine):
+            continue
+        history_1, history_2 = _transmission_line_history_terms(el, line_history, time)
+        v1 = _transmission_line_port_voltage(el, node_voltages, True)
+        v2 = _transmission_line_port_voltage(el, node_voltages, False)
+        currents[f"I({el.name}:1)"] = v1 / el.characteristic_impedance - history_1
+        currents[f"I({el.name}:2)"] = v2 / el.characteristic_impedance - history_2
+    return currents
+
+
+def _append_transmission_line_history(
+    circuit: Circuit,
+    line_history: dict[str, list[TransmissionLineSample]],
+    time: float,
+    node_voltages: dict[str, float],
+) -> dict[str, float]:
+    currents = _transmission_line_branch_currents(
+        circuit,
+        line_history,
+        time,
+        node_voltages,
+    )
+    for el in circuit.elements:
+        if isinstance(el, TransmissionLine):
+            v1 = _transmission_line_port_voltage(el, node_voltages, True)
+            v2 = _transmission_line_port_voltage(el, node_voltages, False)
+            line_history.setdefault(el.name, []).append((
+                time,
+                v1,
+                currents[f"I({el.name}:1)"],
+                v2,
+                currents[f"I({el.name}:2)"],
+            ))
+    return currents
+
+
 def _build_transient_companions(
     circuit: Circuit,
     h: float,
@@ -1968,6 +2104,7 @@ def _build_transient_companions(
     cap_currents: dict[str, float],
     ind_currents: dict[str, float],
     ind_voltages: dict[str, float],
+    line_history: dict[str, list[TransmissionLineSample]],
     t: float = 0.0,
 ) -> Circuit:
     """Build the linearised companion circuit for one timestep.
@@ -2040,7 +2177,7 @@ def _build_transient_companions(
     # Capacitors and Inductors are always excluded (they get companion models).
     base_elements: list = []
     for e in circuit.elements:
-        if isinstance(e, (Capacitor, Inductor)):
+        if isinstance(e, (Capacitor, Inductor, TransmissionLine)):
             continue
         if isinstance(e, VoltageSource) and e.waveform is not None:
             # Evaluate the waveform at the current simulation time.
@@ -2062,6 +2199,14 @@ def _build_transient_companions(
         else:
             base_elements.append(e)
     aug = Circuit(elements=base_elements)
+    for el in circuit.elements:
+        if isinstance(el, TransmissionLine):
+            history_1, history_2 = _transmission_line_history_terms(
+                el,
+                line_history,
+                t,
+            )
+            _add_transmission_line_companion(aug, el, history_1, history_2)
 
     inductors = _inductor_by_name(circuit)
     for el in circuit.elements:
@@ -2415,7 +2560,7 @@ def transient(
     # are evaluated at t = 0 to obtain the correct initial bias.
     init_elements: list = []
     for e in circuit.elements:
-        if isinstance(e, (Capacitor, Inductor)):
+        if isinstance(e, (Capacitor, Inductor, TransmissionLine)):
             continue
         if isinstance(e, VoltageSource) and e.waveform is not None:
             init_elements.append(VoltageSource(
@@ -2463,15 +2608,26 @@ def transient(
                     n_minus=el.n_minus,
                     current=el.initial_current,
                 ))
+        elif isinstance(el, TransmissionLine):
+            _add_transmission_line_companion(init_circuit, el, 0.0, 0.0)
     op = dc_op(init_circuit, max_iterations=max_iterations, tol=tol)
     if not op.converged:
         return TransientResult(points=[], converged=False, method=method)
 
+    line_history: dict[str, list[TransmissionLineSample]] = {}
+    line_branch_currents = _append_transmission_line_history(
+        circuit,
+        line_history,
+        0.0,
+        op.node_voltages,
+    )
+    initial_branch_currents = dict(op.branch_currents)
+    initial_branch_currents.update(line_branch_currents)
     points: list[TransientPoint] = [
         TransientPoint(
             time=0.0,
             node_voltages=dict(op.node_voltages),
-            branch_currents=dict(op.branch_currents),
+            branch_currents=initial_branch_currents,
         )
     ]
 
@@ -2528,6 +2684,7 @@ def transient(
             circuit, h, method,
             cap_voltages, cap_currents,
             ind_currents, ind_voltages,
+            line_history,
             t=t,
         )
         op = dc_op(aug, max_iterations=max_iterations, tol=tol)
@@ -2560,11 +2717,19 @@ def transient(
                 circuit, h, method, op,
                 cap_voltages, cap_currents, ind_currents, ind_voltages,
             )
+            line_branch_currents = _append_transmission_line_history(
+                circuit,
+                line_history,
+                t_actual,
+                op.node_voltages,
+            )
+            branch_currents = dict(op.branch_currents)
+            branch_currents.update(line_branch_currents)
             cap_voltages_prev = dict(cap_voltages)
             points.append(TransientPoint(
                 time=t_actual,
                 node_voltages=dict(op.node_voltages),
-                branch_currents=dict(op.branch_currents),
+                branch_currents=branch_currents,
             ))
 
             if lte < tol_lte / 8.0:
@@ -2575,11 +2740,19 @@ def transient(
                 circuit, h, method, op,
                 cap_voltages, cap_currents, ind_currents, ind_voltages,
             )
+            line_branch_currents = _append_transmission_line_history(
+                circuit,
+                line_history,
+                t,
+                op.node_voltages,
+            )
+            branch_currents = dict(op.branch_currents)
+            branch_currents.update(line_branch_currents)
             cap_voltages_prev = dict(cap_voltages)
             points.append(TransientPoint(
                 time=t,
                 node_voltages=dict(op.node_voltages),
-                branch_currents=dict(op.branch_currents),
+                branch_currents=branch_currents,
             ))
 
         t += h

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -975,6 +975,32 @@ def test_transient_mutual_inductor_couples_secondary_voltage():
     assert isclose(result.points[1].node_voltages["sec"], 2.5, rel_tol=1e-9)
 
 
+def test_transient_transmission_line_delays_matched_step():
+    delay = 1.0e-9
+    c = Circuit()
+    c.add(VoltageSource("VIN", "in", "0", 1.0))
+    c.add(TransmissionLine("T1", "in", "0", "out", "0", 50.0, delay))
+    c.add(Resistor("RL", "out", "0", 50.0))
+
+    result = transient(c, t_stop=2.0 * delay, t_step=delay / 2.0, method="euler")
+
+    assert result.converged
+    assert result.points[0].node_voltages.get("out", 0.0) == pytest.approx(0.0, abs=1e-12)
+    assert result.points[1].node_voltages.get("out", 0.0) == pytest.approx(0.0, abs=1e-12)
+    assert result.points[2].node_voltages["out"] == pytest.approx(1.0, rel=1e-9, abs=1e-9)
+    assert result.points[2].branch_currents["I(T1:2)"] == pytest.approx(-0.02, rel=1e-9)
+
+
+def test_transient_transmission_line_rejects_invalid_parameters():
+    c = Circuit()
+    c.add(VoltageSource("VIN", "in", "0", 1.0))
+    c.add(TransmissionLine("Tbad", "in", "0", "out", "0", 50.0, 0.0))
+    c.add(Resistor("RL", "out", "0", 50.0))
+
+    with pytest.raises(ValueError, match="delay must be positive"):
+        transient(c, t_stop=1.0e-9, t_step=1.0e-9, method="euler")
+
+
 # ---- Transient: TransientResult metadata ----
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add transient analysis stamping for `TransmissionLine` using a lossless
+  Bergeron delay-line companion model, including matched-load delayed step
+  behavior.
 - Add AC analysis stamping for `TransmissionLine` using the lossless two-port
   admittance matrix, including matched-load phase-delay behavior.
 - Add a public `TransmissionLine` element as the parser-facing SPICE `T` card

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2846,11 +2846,31 @@ pub fn transient(
 
     let mut capacitor_states = initial_capacitor_states(circuit, time_step);
     let mut inductor_states = initial_inductor_states(circuit, time_step);
+    let mut line_states = initial_transmission_line_states(circuit);
+    let initial_circuit = circuit_with_transmission_line_companions(circuit, &line_states, 0.0)?;
+    let initial_solution = solve_linear_circuit(
+        &initial_circuit,
+        &capacitor_states,
+        &inductor_states,
+        Some(0.0),
+    )?;
+    update_transmission_line_states(
+        circuit,
+        &initial_solution.node_voltages,
+        &mut line_states,
+        0.0,
+    )?;
     let mut points = Vec::new();
     let mut time = time_step;
     while time <= stop_time + time_step * 1.0e-9 {
-        let linear_solution =
-            solve_linear_circuit(circuit, &capacitor_states, &inductor_states, Some(time))?;
+        let companion_circuit =
+            circuit_with_transmission_line_companions(circuit, &line_states, time)?;
+        let linear_solution = solve_linear_circuit(
+            &companion_circuit,
+            &capacitor_states,
+            &inductor_states,
+            Some(time),
+        )?;
         update_capacitor_states(
             circuit,
             &linear_solution.node_voltages,
@@ -2861,10 +2881,18 @@ pub fn transient(
             &linear_solution.node_voltages,
             &mut inductor_states,
         );
+        let line_currents = update_transmission_line_states(
+            circuit,
+            &linear_solution.node_voltages,
+            &mut line_states,
+            time,
+        )?;
+        let mut branch_currents = linear_solution.branch_currents;
+        branch_currents.extend(line_currents);
         points.push(TransientPoint {
             time,
             node_voltages: linear_solution.node_voltages,
-            branch_currents: linear_solution.branch_currents,
+            branch_currents,
         });
         time += time_step;
     }
@@ -3731,6 +3759,21 @@ struct InductorState {
     name: String,
     previous_current: f64,
     time_step: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct TransmissionLineSample {
+    time: f64,
+    port1_voltage: f64,
+    port1_current: f64,
+    port2_voltage: f64,
+    port2_current: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct TransmissionLineState {
+    name: String,
+    samples: Vec<TransmissionLineSample>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -5322,6 +5365,7 @@ fn validate_reactive_elements(circuit: &Circuit) -> Result<(), SpiceError> {
         match element {
             Element::Capacitor(capacitor) => validate_capacitor(capacitor)?,
             Element::Inductor(inductor) => validate_inductor(inductor)?,
+            Element::TransmissionLine(line) => validate_transmission_line(line)?,
             _ => {}
         }
     }
@@ -5468,6 +5512,34 @@ fn validate_inductor(inductor: &Inductor) -> Result<(), SpiceError> {
     Ok(())
 }
 
+fn validate_transmission_line(line: &TransmissionLine) -> Result<(), SpiceError> {
+    if !line.characteristic_impedance_ohms.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "characteristic impedance must be finite".to_string(),
+        });
+    }
+    if line.characteristic_impedance_ohms <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "characteristic impedance must be positive".to_string(),
+        });
+    }
+    if !line.delay_seconds.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "delay must be finite".to_string(),
+        });
+    }
+    if line.delay_seconds <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: line.name.clone(),
+            reason: "delay must be positive".to_string(),
+        });
+    }
+    Ok(())
+}
+
 fn initial_capacitor_states(circuit: &Circuit, time_step: f64) -> Vec<CapacitorState> {
     circuit
         .elements()
@@ -5496,6 +5568,170 @@ fn initial_inductor_states(circuit: &Circuit, time_step: f64) -> Vec<InductorSta
             _ => None,
         })
         .collect()
+}
+
+fn initial_transmission_line_states(circuit: &Circuit) -> Vec<TransmissionLineState> {
+    circuit
+        .elements()
+        .iter()
+        .filter_map(|element| match element {
+            Element::TransmissionLine(line) => Some(TransmissionLineState {
+                name: line.name.clone(),
+                samples: Vec::new(),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn transmission_line_state_at(
+    state: Option<&TransmissionLineState>,
+    target_time: f64,
+) -> TransmissionLineSample {
+    let Some(state) = state else {
+        return TransmissionLineSample {
+            time: target_time,
+            port1_voltage: 0.0,
+            port1_current: 0.0,
+            port2_voltage: 0.0,
+            port2_current: 0.0,
+        };
+    };
+    if state.samples.is_empty() || target_time < state.samples[0].time - 1.0e-18 {
+        return TransmissionLineSample {
+            time: target_time,
+            port1_voltage: 0.0,
+            port1_current: 0.0,
+            port2_voltage: 0.0,
+            port2_current: 0.0,
+        };
+    }
+    if target_time <= state.samples[0].time {
+        return state.samples[0].clone();
+    }
+    for window in state.samples.windows(2) {
+        let left = &window[0];
+        let right = &window[1];
+        if target_time <= right.time {
+            let span = right.time - left.time;
+            if span <= 0.0 {
+                return right.clone();
+            }
+            let alpha = (target_time - left.time) / span;
+            return TransmissionLineSample {
+                time: target_time,
+                port1_voltage: left.port1_voltage
+                    + alpha * (right.port1_voltage - left.port1_voltage),
+                port1_current: left.port1_current
+                    + alpha * (right.port1_current - left.port1_current),
+                port2_voltage: left.port2_voltage
+                    + alpha * (right.port2_voltage - left.port2_voltage),
+                port2_current: left.port2_current
+                    + alpha * (right.port2_current - left.port2_current),
+            };
+        }
+    }
+    state.samples[state.samples.len() - 1].clone()
+}
+
+fn transmission_line_history_terms(
+    line: &TransmissionLine,
+    line_states: &[TransmissionLineState],
+    time: f64,
+) -> Result<(f64, f64), SpiceError> {
+    validate_transmission_line(line)?;
+    let delayed = transmission_line_state_at(
+        line_states.iter().find(|state| state.name == line.name),
+        time - line.delay_seconds,
+    );
+    Ok((
+        delayed.port2_voltage / line.characteristic_impedance_ohms + delayed.port2_current,
+        delayed.port1_voltage / line.characteristic_impedance_ohms + delayed.port1_current,
+    ))
+}
+
+fn circuit_with_transmission_line_companions(
+    circuit: &Circuit,
+    line_states: &[TransmissionLineState],
+    time: f64,
+) -> Result<Circuit, SpiceError> {
+    let mut companion = Circuit::new();
+    for element in circuit.elements() {
+        match element {
+            Element::TransmissionLine(line) => {
+                let (history1, history2) =
+                    transmission_line_history_terms(line, line_states, time)?;
+                companion.add(Element::Resistor(Resistor::new(
+                    format!("_T_{}_P1_R", line.name),
+                    line.n1.clone(),
+                    line.n2.clone(),
+                    line.characteristic_impedance_ohms,
+                )));
+                companion.add(Element::Resistor(Resistor::new(
+                    format!("_T_{}_P2_R", line.name),
+                    line.n3.clone(),
+                    line.n4.clone(),
+                    line.characteristic_impedance_ohms,
+                )));
+                companion.add(Element::CurrentSource(CurrentSource::new(
+                    format!("_T_{}_P1_I", line.name),
+                    line.n1.clone(),
+                    line.n2.clone(),
+                    -history1,
+                )));
+                companion.add(Element::CurrentSource(CurrentSource::new(
+                    format!("_T_{}_P2_I", line.name),
+                    line.n3.clone(),
+                    line.n4.clone(),
+                    -history2,
+                )));
+            }
+            _ => companion.add(element.clone()),
+        }
+    }
+    Ok(companion)
+}
+
+fn transmission_line_port_voltage(
+    line: &TransmissionLine,
+    node_voltages: &BTreeMap<String, f64>,
+    first_port: bool,
+) -> f64 {
+    if first_port {
+        return voltage_at(node_voltages, &line.n1) - voltage_at(node_voltages, &line.n2);
+    }
+    voltage_at(node_voltages, &line.n3) - voltage_at(node_voltages, &line.n4)
+}
+
+fn update_transmission_line_states(
+    circuit: &Circuit,
+    node_voltages: &BTreeMap<String, f64>,
+    line_states: &mut [TransmissionLineState],
+    time: f64,
+) -> Result<BTreeMap<String, f64>, SpiceError> {
+    let mut currents = BTreeMap::new();
+    for element in circuit.elements() {
+        let Element::TransmissionLine(line) = element else {
+            continue;
+        };
+        let (history1, history2) = transmission_line_history_terms(line, line_states, time)?;
+        let port1_voltage = transmission_line_port_voltage(line, node_voltages, true);
+        let port2_voltage = transmission_line_port_voltage(line, node_voltages, false);
+        let port1_current = port1_voltage / line.characteristic_impedance_ohms - history1;
+        let port2_current = port2_voltage / line.characteristic_impedance_ohms - history2;
+        currents.insert(format!("I({}:1)", line.name), port1_current);
+        currents.insert(format!("I({}:2)", line.name), port2_current);
+        if let Some(state) = line_states.iter_mut().find(|state| state.name == line.name) {
+            state.samples.push(TransmissionLineSample {
+                time,
+                port1_voltage,
+                port1_current,
+                port2_voltage,
+                port2_current,
+            });
+        }
+    }
+    Ok(currents)
 }
 
 fn update_capacitor_states(

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -5,8 +5,8 @@ use spice_engine::{
     pss_with_tolerance, transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element,
     ExpWaveform, Inductor, MutualInductor, PssNewtonCandidateResult, PssNewtonIterationResult,
     PssNewtonSolveResult, PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult,
-    PssResult, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, VoltageSource,
-    Waveform,
+    PssResult, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, TransmissionLine,
+    VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -559,6 +559,42 @@ fn transient_mutual_inductor_couples_secondary_voltage() {
     assert_close(points[0].voltage("pri").unwrap(), 8.75);
     assert_close(points[0].voltage("sec").unwrap(), 2.5);
     assert_close(points[0].branch_current("Lsec").unwrap(), -0.25);
+}
+
+#[test]
+fn transient_transmission_line_delays_matched_step() {
+    let delay = 1.0e-9;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "VIN", "in", "0", 1.0,
+    )));
+    circuit.add(Element::TransmissionLine(TransmissionLine::new(
+        "T1", "in", "0", "out", "0", 50.0, delay,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("RL", "out", "0", 50.0)));
+
+    let points = transient(&circuit, delay / 2.0, 2.0 * delay).unwrap();
+
+    assert_close(points[0].voltage("out").unwrap_or(0.0), 0.0);
+    assert_close(points[1].voltage("out").unwrap(), 1.0);
+    assert_close(points[1].branch_current("T1:2").unwrap(), -0.02);
+}
+
+#[test]
+fn transient_transmission_line_rejects_invalid_parameters() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "VIN", "in", "0", 1.0,
+    )));
+    circuit.add(Element::TransmissionLine(TransmissionLine::new(
+        "Tbad", "in", "0", "out", "0", 50.0, 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("RL", "out", "0", 50.0)));
+
+    assert!(matches!(
+        transient(&circuit, 1.0e-9, 1.0e-9),
+        Err(SpiceError::InvalidElement { name, .. }) if name == "Tbad"
+    ));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add transient analysis stamping for `TransmissionLine` using a lossless
+  Bergeron delay-line companion model, including matched-load delayed step
+  behavior.
 - Add AC analysis stamping for `TransmissionLine` using the lossless two-port
   admittance matrix, including matched-load phase-delay behavior.
 - Add a public `TransmissionLine` element and `transmissionLine` factory as

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1852,18 +1852,38 @@ export function transient(
 
   const capacitorStates = initialCapacitorStates(circuit, timeStep);
   const inductorStates = initialInductorStates(circuit, timeStep);
+  const lineStates = initialTransmissionLineStates(circuit);
+  const initialCircuit = circuitWithTransmissionLineCompanions(circuit, lineStates, 0.0);
+  const initialSolution = solveLinearCircuit(
+    initialCircuit,
+    capacitorStates,
+    inductorStates,
+    0.0,
+  );
+  updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
   const points: TransientPoint[] = [];
   for (let time = timeStep; time <= stopTime + timeStep * 1.0e-9; time += timeStep) {
+    const companionCircuit = circuitWithTransmissionLineCompanions(circuit, lineStates, time);
     const solution = solveLinearCircuit(
-      circuit,
+      companionCircuit,
       capacitorStates,
       inductorStates,
       time,
     );
     updateCapacitorStates(circuit, solution.nodeVoltages, capacitorStates);
     updateInductorStates(circuit, solution.nodeVoltages, inductorStates);
+    const lineCurrents = updateTransmissionLineStates(
+      circuit,
+      solution.nodeVoltages,
+      lineStates,
+      time,
+    );
+    const branchCurrents = new Map(solution.branchCurrents);
+    for (const [name, current] of lineCurrents) {
+      branchCurrents.set(name, current);
+    }
     points.push(
-      makeTransientPoint(time, solution.nodeVoltages, solution.branchCurrents),
+      makeTransientPoint(time, solution.nodeVoltages, branchCurrents),
     );
   }
   return points;
@@ -2735,6 +2755,17 @@ interface InductorState {
   readonly name: string;
   previousCurrent: number;
   readonly timeStep: number;
+}
+
+interface TransmissionLineState {
+  readonly name: string;
+  samples: Array<{
+    readonly time: number;
+    readonly port1Voltage: number;
+    readonly port1Current: number;
+    readonly port2Voltage: number;
+    readonly port2Current: number;
+  }>;
 }
 
 interface LinearSolution {
@@ -4474,6 +4505,8 @@ function validateReactiveElements(circuit: Circuit): void {
       validateCapacitor(element);
     } else if (element.kind === "inductor") {
       validateInductor(element);
+    } else if (element.kind === "transmission-line") {
+      validateTransmissionLine(element);
     }
   }
 }
@@ -4576,6 +4609,137 @@ function initialInductorStates(
     }
   }
   return states;
+}
+
+function initialTransmissionLineStates(circuit: Circuit): TransmissionLineState[] {
+  return circuit
+    .elements()
+    .filter((element): element is TransmissionLine => element.kind === "transmission-line")
+    .map((element) => ({ name: element.name, samples: [] }));
+}
+
+function validateTransmissionLine(element: TransmissionLine): void {
+  if (!Number.isFinite(element.characteristicImpedanceOhms)) {
+    throw invalidElement(element.name, "characteristic impedance must be finite");
+  }
+  if (element.characteristicImpedanceOhms <= 0.0) {
+    throw invalidElement(element.name, "characteristic impedance must be positive");
+  }
+  if (!Number.isFinite(element.delaySeconds)) {
+    throw invalidElement(element.name, "delay must be finite");
+  }
+  if (element.delaySeconds <= 0.0) {
+    throw invalidElement(element.name, "delay must be positive");
+  }
+}
+
+function transmissionLineStateAt(
+  state: TransmissionLineState | undefined,
+  targetTime: number,
+): {
+  readonly port1Voltage: number;
+  readonly port1Current: number;
+  readonly port2Voltage: number;
+  readonly port2Current: number;
+} {
+  const samples = state?.samples ?? [];
+  if (samples.length === 0 || targetTime < samples[0].time - 1.0e-18) {
+    return { port1Voltage: 0.0, port1Current: 0.0, port2Voltage: 0.0, port2Current: 0.0 };
+  }
+  if (targetTime <= samples[0].time) {
+    return samples[0];
+  }
+  for (let index = 0; index + 1 < samples.length; index += 1) {
+    const left = samples[index];
+    const right = samples[index + 1];
+    if (targetTime <= right.time) {
+      const span = right.time - left.time;
+      if (span <= 0.0) {
+        return right;
+      }
+      const alpha = (targetTime - left.time) / span;
+      return {
+        port1Voltage: left.port1Voltage + alpha * (right.port1Voltage - left.port1Voltage),
+        port1Current: left.port1Current + alpha * (right.port1Current - left.port1Current),
+        port2Voltage: left.port2Voltage + alpha * (right.port2Voltage - left.port2Voltage),
+        port2Current: left.port2Current + alpha * (right.port2Current - left.port2Current),
+      };
+    }
+  }
+  return samples[samples.length - 1];
+}
+
+function transmissionLineHistoryTerms(
+  element: TransmissionLine,
+  lineStates: readonly TransmissionLineState[],
+  time: number,
+): readonly [number, number] {
+  validateTransmissionLine(element);
+  const delayed = transmissionLineStateAt(
+    lineStates.find((state) => state.name === element.name),
+    time - element.delaySeconds,
+  );
+  return [
+    delayed.port2Voltage / element.characteristicImpedanceOhms + delayed.port2Current,
+    delayed.port1Voltage / element.characteristicImpedanceOhms + delayed.port1Current,
+  ];
+}
+
+function circuitWithTransmissionLineCompanions(
+  circuit: Circuit,
+  lineStates: readonly TransmissionLineState[],
+  time: number,
+): Circuit {
+  const companion = new Circuit();
+  for (const element of circuit.elements()) {
+    if (element.kind !== "transmission-line") {
+      companion.add(element);
+      continue;
+    }
+    const [history1, history2] = transmissionLineHistoryTerms(element, lineStates, time);
+    companion.add(resistor(`_T_${element.name}_P1_R`, element.n1, element.n2, element.characteristicImpedanceOhms));
+    companion.add(resistor(`_T_${element.name}_P2_R`, element.n3, element.n4, element.characteristicImpedanceOhms));
+    companion.add(currentSource(`_T_${element.name}_P1_I`, element.n1, element.n2, -history1));
+    companion.add(currentSource(`_T_${element.name}_P2_I`, element.n3, element.n4, -history2));
+  }
+  return companion;
+}
+
+function transmissionLinePortVoltage(
+  element: TransmissionLine,
+  nodeVoltages: ReadonlyMap<string, number>,
+  firstPort: boolean,
+): number {
+  if (firstPort) {
+    return voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
+  }
+  return voltageAt(nodeVoltages, element.n3) - voltageAt(nodeVoltages, element.n4);
+}
+
+function updateTransmissionLineStates(
+  circuit: Circuit,
+  nodeVoltages: ReadonlyMap<string, number>,
+  lineStates: TransmissionLineState[],
+  time: number,
+): Map<string, number> {
+  const currents = new Map<string, number>();
+  for (const element of circuit.elements()) {
+    if (element.kind !== "transmission-line") {
+      continue;
+    }
+    const [history1, history2] = transmissionLineHistoryTerms(element, lineStates, time);
+    const port1Voltage = transmissionLinePortVoltage(element, nodeVoltages, true);
+    const port2Voltage = transmissionLinePortVoltage(element, nodeVoltages, false);
+    const port1Current = port1Voltage / element.characteristicImpedanceOhms - history1;
+    const port2Current = port2Voltage / element.characteristicImpedanceOhms - history2;
+    currents.set(`I(${element.name}:1)`, port1Current);
+    currents.set(`I(${element.name}:2)`, port2Current);
+    const state = lineStates.find((candidate) => candidate.name === element.name);
+    if (state !== undefined) {
+      state.samples.push({ time, port1Voltage, port1Current, port2Voltage, port2Current });
+    }
+  }
+  return currents;
 }
 
 function updateCapacitorStates(

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -25,6 +25,7 @@ import {
   pssResidual,
   resistor,
   transient,
+  transmissionLine,
   voltageSource,
   voltageSourceWithWaveform,
   waveformPeriod,
@@ -478,6 +479,32 @@ describe("transient", () => {
     expectClose(points[0].voltage("pri"), 8.75);
     expectClose(points[0].voltage("sec"), 2.5);
     expectClose(points[0].branchCurrent("Lsec"), -0.25);
+  });
+
+  it("delays a matched transmission-line step", () => {
+    const delay = 1.0e-9;
+    const circuit = new Circuit();
+    circuit.add(voltageSource("VIN", "in", "0", 1.0));
+    circuit.add(transmissionLine("T1", "in", "0", "out", "0", 50.0, delay));
+    circuit.add(resistor("RL", "out", "0", 50.0));
+
+    const points = transient(circuit, delay / 2.0, 2.0 * delay);
+
+    expectClose(points[0].voltage("out"), 0.0);
+    expectClose(points[1].voltage("out"), 1.0);
+    expectClose(points[1].branchCurrent("T1:2"), -0.02);
+  });
+
+  it("rejects invalid transmission-line transient parameters", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("VIN", "in", "0", 1.0));
+    circuit.add(transmissionLine("Tbad", "in", "0", "out", "0", 50.0, 0.0));
+    circuit.add(resistor("RL", "out", "0", 50.0));
+
+    expect(() => transient(circuit, 1.0e-9, 1.0e-9)).toThrowError(SpiceError);
+    expect(() => transient(circuit, 1.0e-9, 1.0e-9)).toThrowError(
+      "invalid element Tbad",
+    );
   });
 
   it("rejects non-positive capacitance", () => {

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -113,6 +113,11 @@ Acceptance:
 - AC phase-delay fixture.
 - Parser tests for supported and unsupported line parameter forms.
 
+Status:
+
+- Parser support and AC phase-shift behavior are on `main`; this slice adds
+  transient delayed-step behavior across Python, TypeScript, and Rust.
+
 ### Phase 4 - Gear-2 / BDF2 Transient Integration
 
 Complete the integration-method set expected by the spec.


### PR DESCRIPTION
## Summary

- stamp `TransmissionLine` during transient analysis with a lossless Bergeron delay-line companion model across Python, TypeScript, and Rust
- record transmission-line port branch currents and validate finite/positive impedance and delay for transient runs
- add matched-load delayed-step fixtures plus invalid-parameter coverage across the three transient test suites
- update the 1970s compatibility plan to mark the transient delayed-step slice

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-transmission-line-transient sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This closes the remaining Phase 3 ideal transmission-line engine behavior. The next focused SPICE slice is Phase 4 Gear-2 / BDF2 transient integration.