### PR TITLE
[codex] Add Board VM input callback transport events

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -149,6 +149,10 @@ queue depth is after the effect.
 transport report kinds, names, labels, queue-depth metadata, and messages, so
 adapters can log or emit callback dispatch, drop, completion, running,
 budget-exhausted, and failure reports without owning that branching.
+`input_callback_transport_event_summary` maps those reports into adapter-facing
+event names, labels, queue-depth metadata, and messages, so language frontends
+can emit dispatch, dropped-callback, completed-callback, running-callback,
+budget-exceeded, and failed-callback events from Rust-owned transport policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -985,6 +985,40 @@ pub struct LanguageInputCallbackTransportReportSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportEventKind {
+    DispatchScheduled,
+    CallbackDropped,
+    CallbackCompleted,
+    CallbackRunning,
+    CallbackBudgetExceeded,
+    CallbackFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportEventSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub event_label: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub dispatch_callback: bool,
+    pub emit_report: bool,
+    pub emit_drop: bool,
+    pub emit_result: bool,
+    pub remove_from_queue: bool,
+    pub keep_dispatch_scheduled: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_event: u8,
+    pub message: String,
+    pub report_summary: LanguageInputCallbackTransportReportSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -1462,6 +1496,21 @@ pub const fn input_callback_transport_report_kind_name(
         LanguageInputCallbackTransportReportKind::Running => "running",
         LanguageInputCallbackTransportReportKind::BudgetExceeded => "budget_exceeded",
         LanguageInputCallbackTransportReportKind::Failure => "failure",
+    }
+}
+
+pub const fn input_callback_transport_event_kind_name(
+    kind: LanguageInputCallbackTransportEventKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportEventKind::DispatchScheduled => "dispatch_scheduled",
+        LanguageInputCallbackTransportEventKind::CallbackDropped => "callback_dropped",
+        LanguageInputCallbackTransportEventKind::CallbackCompleted => "callback_completed",
+        LanguageInputCallbackTransportEventKind::CallbackRunning => "callback_running",
+        LanguageInputCallbackTransportEventKind::CallbackBudgetExceeded => {
+            "callback_budget_exceeded"
+        }
+        LanguageInputCallbackTransportEventKind::CallbackFailed => "callback_failed",
     }
 }
 
@@ -2684,6 +2733,35 @@ pub fn input_callback_transport_report_summary(
     }
 }
 
+pub fn input_callback_transport_event_summary(
+    report_summary: &LanguageInputCallbackTransportReportSummary,
+) -> LanguageInputCallbackTransportEventSummary {
+    let event_kind = input_callback_transport_event_kind(report_summary.report_kind);
+
+    LanguageInputCallbackTransportEventSummary {
+        endpoint: report_summary.endpoint.clone(),
+        connection_label: report_summary.connection_label.clone(),
+        event_label: input_callback_transport_event_label(report_summary, event_kind),
+        event_kind,
+        event_name: input_callback_transport_event_kind_name(event_kind).to_owned(),
+        report_kind: report_summary.report_kind,
+        report_name: report_summary.report_name.clone(),
+        action: report_summary.action,
+        action_name: report_summary.action_name.clone(),
+        dispatch_callback: report_summary.dispatch_callback,
+        emit_report: report_summary.emit_report,
+        emit_drop: report_summary.emit_drop,
+        emit_result: report_summary.emit_result,
+        remove_from_queue: report_summary.remove_from_queue,
+        keep_dispatch_scheduled: report_summary.keep_dispatch_scheduled,
+        terminal: report_summary.terminal,
+        retryable: report_summary.retryable,
+        queue_depth_after_event: report_summary.queue_depth_after_report,
+        message: input_callback_transport_event_message(event_kind).to_owned(),
+        report_summary: report_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -3862,6 +3940,68 @@ fn input_callback_transport_report_message(
         }
         LanguageInputCallbackTransportReportKind::Failure => {
             "Transport should emit a failed-callback report."
+        }
+    }
+}
+
+fn input_callback_transport_event_kind(
+    report_kind: LanguageInputCallbackTransportReportKind,
+) -> LanguageInputCallbackTransportEventKind {
+    match report_kind {
+        LanguageInputCallbackTransportReportKind::Dispatch => {
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        }
+        LanguageInputCallbackTransportReportKind::Drop => {
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        }
+        LanguageInputCallbackTransportReportKind::Completion => {
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        }
+        LanguageInputCallbackTransportReportKind::Running => {
+            LanguageInputCallbackTransportEventKind::CallbackRunning
+        }
+        LanguageInputCallbackTransportReportKind::BudgetExceeded => {
+            LanguageInputCallbackTransportEventKind::CallbackBudgetExceeded
+        }
+        LanguageInputCallbackTransportReportKind::Failure => {
+            LanguageInputCallbackTransportEventKind::CallbackFailed
+        }
+    }
+}
+
+fn input_callback_transport_event_label(
+    report_summary: &LanguageInputCallbackTransportReportSummary,
+    event_kind: LanguageInputCallbackTransportEventKind,
+) -> String {
+    format!(
+        "{} transport_event={} queue_depth_after_event={}",
+        report_summary.report_label,
+        input_callback_transport_event_kind_name(event_kind),
+        report_summary.queue_depth_after_report
+    )
+}
+
+fn input_callback_transport_event_message(
+    event_kind: LanguageInputCallbackTransportEventKind,
+) -> &'static str {
+    match event_kind {
+        LanguageInputCallbackTransportEventKind::DispatchScheduled => {
+            "Adapter should schedule the callback dispatch runner."
+        }
+        LanguageInputCallbackTransportEventKind::CallbackDropped => {
+            "Adapter should emit a dropped input callback event."
+        }
+        LanguageInputCallbackTransportEventKind::CallbackCompleted => {
+            "Adapter should emit a completed input callback event."
+        }
+        LanguageInputCallbackTransportEventKind::CallbackRunning => {
+            "Adapter should emit a running input callback event and keep dispatch scheduled."
+        }
+        LanguageInputCallbackTransportEventKind::CallbackBudgetExceeded => {
+            "Adapter should emit a budget-exceeded input callback event."
+        }
+        LanguageInputCallbackTransportEventKind::CallbackFailed => {
+            "Adapter should emit a failed input callback event."
         }
     }
 }
@@ -9284,6 +9424,223 @@ mod tests {
         assert_eq!(
             dropped.message,
             "Transport should emit a dropped-callback report."
+        );
+    }
+
+    #[test]
+    fn input_callback_transport_events_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_action = input_callback_transport_action_summary(&completed_lifecycle);
+        let completed_effect = input_callback_transport_effect_summary(&completed_action);
+        let completed_report = input_callback_transport_report_summary(&completed_effect);
+        let completed = input_callback_transport_event_summary(&completed_report);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(completed.event_name, "callback_completed");
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(completed.report_name, "completion");
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert_eq!(completed.action_name, "complete_callback");
+        assert!(!completed.dispatch_callback);
+        assert!(completed.emit_report);
+        assert!(!completed.emit_drop);
+        assert!(completed.emit_result);
+        assert!(completed.remove_from_queue);
+        assert!(!completed.keep_dispatch_scheduled);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_event, 2);
+        assert_eq!(
+            completed.message,
+            "Adapter should emit a completed input callback event."
+        );
+        assert_eq!(completed.report_summary, completed_report);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_action = input_callback_transport_action_summary(&pending_lifecycle);
+        let pending_effect = input_callback_transport_effect_summary(&pending_action);
+        let pending_report = input_callback_transport_report_summary(&pending_effect);
+        let pending = input_callback_transport_event_summary(&pending_report);
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert_eq!(pending.event_name, "dispatch_scheduled");
+        assert_eq!(
+            pending.report_kind,
+            LanguageInputCallbackTransportReportKind::Dispatch
+        );
+        assert!(pending.dispatch_callback);
+        assert!(!pending.emit_report);
+        assert!(!pending.emit_drop);
+        assert!(!pending.emit_result);
+        assert!(!pending.remove_from_queue);
+        assert!(pending.keep_dispatch_scheduled);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_event, 3);
+        assert_eq!(
+            pending.event_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=42 transport_action=dispatch_callback terminal=false retryable=false dispatch_callback=true emit_drop=false emit_result=false remove_from_queue=false keep_dispatch_scheduled=true queue_depth_after_effect=3 transport_report=dispatch emit_report=false queue_depth_after_report=3 transport_event=dispatch_scheduled queue_depth_after_event=3"
+        );
+        assert_eq!(
+            pending.message,
+            "Adapter should schedule the callback dispatch runner."
+        );
+
+        let running_lifecycle = input_callback_session_lifecycle_summary(
+            &tcp_session,
+            &queue_plan,
+            Some(RunStatus::Running),
+            12,
+            4,
+        );
+        let running_action = input_callback_transport_action_summary(&running_lifecycle);
+        let running_effect = input_callback_transport_effect_summary(&running_action);
+        let running_report = input_callback_transport_report_summary(&running_effect);
+        let running = input_callback_transport_event_summary(&running_report);
+        assert_eq!(
+            running.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackRunning
+        );
+        assert_eq!(running.event_name, "callback_running");
+        assert!(running.emit_report);
+        assert!(running.emit_result);
+        assert!(!running.remove_from_queue);
+        assert!(running.keep_dispatch_scheduled);
+        assert!(running.retryable);
+        assert_eq!(
+            running.message,
+            "Adapter should emit a running input callback event and keep dispatch scheduled."
+        );
+
+        let budget_lifecycle = input_callback_session_lifecycle_summary(
+            &tcp_session,
+            &queue_plan,
+            Some(RunStatus::BudgetExceeded),
+            64,
+            9,
+        );
+        let budget_action = input_callback_transport_action_summary(&budget_lifecycle);
+        let budget_effect = input_callback_transport_effect_summary(&budget_action);
+        let budget_report = input_callback_transport_report_summary(&budget_effect);
+        let budget = input_callback_transport_event_summary(&budget_report);
+        assert_eq!(
+            budget.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackBudgetExceeded
+        );
+        assert_eq!(budget.event_name, "callback_budget_exceeded");
+        assert!(budget.emit_report);
+        assert!(budget.emit_result);
+        assert!(budget.remove_from_queue);
+        assert!(budget.terminal);
+        assert_eq!(
+            budget.message,
+            "Adapter should emit a budget-exceeded input callback event."
+        );
+
+        let stopped_lifecycle = input_callback_session_lifecycle_summary(
+            &tcp_session,
+            &queue_plan,
+            Some(RunStatus::Stopped),
+            6,
+            2,
+        );
+        let stopped_action = input_callback_transport_action_summary(&stopped_lifecycle);
+        let stopped_effect = input_callback_transport_effect_summary(&stopped_action);
+        let stopped_report = input_callback_transport_report_summary(&stopped_effect);
+        let stopped = input_callback_transport_event_summary(&stopped_report);
+        assert_eq!(
+            stopped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackFailed
+        );
+        assert_eq!(stopped.event_name, "callback_failed");
+        assert!(stopped.emit_report);
+        assert!(stopped.emit_result);
+        assert!(stopped.remove_from_queue);
+        assert_eq!(
+            stopped.message,
+            "Adapter should emit a failed input callback event."
+        );
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_action = input_callback_transport_action_summary(&dropped_lifecycle);
+        let dropped_effect = input_callback_transport_effect_summary(&dropped_action);
+        let dropped_report = input_callback_transport_report_summary(&dropped_effect);
+        let dropped = input_callback_transport_event_summary(&dropped_report);
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(dropped.event_name, "callback_dropped");
+        assert_eq!(
+            dropped.report_kind,
+            LanguageInputCallbackTransportReportKind::Drop
+        );
+        assert!(!dropped.dispatch_callback);
+        assert!(dropped.emit_report);
+        assert!(dropped.emit_drop);
+        assert!(!dropped.emit_result);
+        assert!(!dropped.remove_from_queue);
+        assert!(!dropped.keep_dispatch_scheduled);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_event, 1);
+        assert_eq!(
+            dropped.event_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=77 transport_action=drop_before_dispatch terminal=true retryable=false dispatch_callback=false emit_drop=true emit_result=false remove_from_queue=false keep_dispatch_scheduled=false queue_depth_after_effect=1 transport_report=drop emit_report=true queue_depth_after_report=1 transport_event=callback_dropped queue_depth_after_event=1"
+        );
+        assert_eq!(
+            dropped.message,
+            "Adapter should emit a dropped input callback event."
         );
     }
 


### PR DESCRIPTION
## Summary
- add Rust-owned input callback transport event kinds, names, labels, and summaries on top of transport reports
- carry report/action/effect booleans plus terminal, retry, and queue-depth state into adapter-facing event summaries
- document the event summary API and cover dispatch, dropped, completed, running, budget-exceeded, and failed callback events

## Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-events cargo test -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-events cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Detector validation note: /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool is still unavailable on this machine, so that external helper was not run.