### PR TITLE
feat(closure-pass-treeshake): scaffold pass (CLOC06 Phase 1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -487,6 +487,7 @@ members = [
     "closure-pass-inline",
     "closure-pass-pipeline",
     "closure-pass-rename",
+    "closure-pass-treeshake",
     "closure-typechecker",
     "compiler-ir",
     "compiler-source-map",

--- a/code/packages/rust/closure-pass-treeshake/BUILD
+++ b/code/packages/rust/closure-pass-treeshake/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-treeshake -- --nocapture

--- a/code/packages/rust/closure-pass-treeshake/BUILD_windows
+++ b/code/packages/rust/closure-pass-treeshake/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-treeshake -- --nocapture

--- a/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closure-pass-treeshake` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-23
+
+### Added
+- New crate per CLOC06 canonical pass set — tree-shaking. Removes `export` declarations and `import` bindings that aren't reachable from any entry point. The whole-program cousin of DCE.
+- `TreeshakePass` zero-sized type implementing `Pass`:
+  - `name = "treeshake"`
+  - `depends_on = &["dce"]` — DCE shrinks intra-module use-sets first, simplifying the cross-module use-chain analysis tree-shake needs.
+  - `iteration_policy = IterationPolicy::FixedPoint` — tree-shake removing an export can make its `import` dead, which DCE can delete, which can leave whole modules unreached, which tree-shake can then remove. Real cascade.
+  - `cost = 3` pass-units — cross-module mark + sweep, same shape as DCE.
+  - `invalidates()` empty in v1 (informational only per CLOC06 Open Question 1).
+- `TreeshakePass::new()` zero-arg constructor.
+- `Pass::run` is **identity** in v1: `javascript-ast` ships only `Program` / `SourceType` today (CLOC02 Phase 1), so there are no `ImportDeclaration` / `ExportDeclaration` nodes to shake. Pass through unchanged, `changed = false`, `nodes_touched = 1`, no contributions emitted (per CLOC03 §"When a pass keeps a node unchanged").
+- 9 tests covering: `name()` value, `iteration_policy == FixedPoint`, `cost == 3`, `depends_on == ["dce"]`, `invalidates` empty, identity run, **two-pass pipeline orders dce before treeshake** even when registered in reverse, solo pipeline run (with the v0.1.0 `pipeline.fixed-point-not-yet-iterated` diagnostic asserted), `Default` + `Clone` impls.
+
+### Notes
+- Dependencies: `coding-adventures-closure-pass-pipeline`, `coding-adventures-javascript-ast`, `coding-adventures-type-sidecar` (future tree-shake reads module-level `external` attributes to seed root set), `coding_adventures_correlation_vector` (per-removal `Contribution` per CLOC03), `serde_json`. Dev-deps: `coding-adventures-javascript-tokens` for `EsVersion`, `coding-adventures-closure-pass-dce` for the two-pass ordering integration test.
+- v1 is scaffolding. The full mark-and-sweep cross-module walk lands once `javascript-ast` grows module syntax. The public surface (name, policy, cost, depends_on) stays put — no churn upstream.

--- a/code/packages/rust/closure-pass-treeshake/Cargo.toml
+++ b/code/packages/rust/closure-pass-treeshake/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "coding-adventures-closure-pass-treeshake"
+version = "0.1.0"
+edition = "2021"
+description = "Tree-shaking pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Removes module exports and imports that aren't reachable from the program's entry points, eliminating whole-module dead weight that intra-module DCE can't see."
+
+[dependencies]
+coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-javascript-ast = { path = "../javascript-ast" }
+coding-adventures-type-sidecar = { path = "../type-sidecar" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
+
+[dev-dependencies]
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+coding-adventures-closure-pass-dce = { path = "../closure-pass-dce" }

--- a/code/packages/rust/closure-pass-treeshake/README.md
+++ b/code/packages/rust/closure-pass-treeshake/README.md
@@ -1,0 +1,91 @@
+# coding-adventures-closure-pass-treeshake
+
+Tree-shaking pass for the Closure Compiler clone. Removes
+`export` declarations and `import` bindings that aren't reachable
+from any entry point. Per
+[CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s
+canonical pass set.
+
+## Why "tree-shake"?
+
+The program is a tree of modules connected by `import` edges.
+Roots = entry-point modules. Hold the tree by its roots, shake
+it — anything not connected to a root falls off.
+
+```text
+entry.js  imports  { a, b }       from utils.js
+utils.js  exports  a, b, c, d
+                           ▲
+                           └─ c and d are unreached;
+                              treeshake removes them
+```
+
+## The difference from DCE
+
+| | DCE | Tree-shake |
+|---|---|---|
+| **Scope** | Within a module/function | Across modules |
+| **Finds** | Locally-unused bindings | Cross-module-unused exports/imports |
+| **Sees `export`s?** | Can't — they're reachable by definition | Yes — that's the point |
+
+That's why CLOC06 pins tree-shake to depend on `dce`: DCE
+shrinks the reachable use-sets first, simplifying the
+cross-module use-chain analysis tree-shake needs. And once
+tree-shake decides an `export` is dead, the next DCE iteration
+can finally delete the underlying definition — a real cascade.
+
+## What's here (v1)
+
+- `TreeshakePass` implementing the `Pass` trait from
+  [`closure-pass-pipeline`](../closure-pass-pipeline).
+- Metadata pinned:
+  - `name = "treeshake"`
+  - `depends_on = ["dce"]` — DCE first so intra-module dead
+    code is gone before cross-module shaking.
+  - `iteration_policy = FixedPoint` — tree-shake → DCE →
+    tree-shake cascade.
+  - `cost = 3` — cross-module mark+sweep, same shape as DCE.
+- `Pass::run` is **identity** in v1: `javascript-ast` ships
+  only `Program` / `SourceType` today, so there are no
+  `ImportDeclaration` / `ExportDeclaration` nodes to shake.
+  The real two-phase walk slots into `Pass::run` once the AST
+  grows module syntax.
+
+## What this PR locks down even as identity
+
+1. The `depends_on("dce")` edge is in the scheduler graph —
+   DCE before tree-shake the moment both passes are in one
+   pipeline.
+2. Two-pass integration test
+   (`pipeline_orders_dce_before_treeshake`) registers
+   `TreeshakePass` first and verifies the scheduler reorders.
+3. Pass metadata drives the future `closurec --disable=treeshake`.
+
+## Where this pass sits
+
+CLOC06 §"Canonical pass set" pins:
+
+```text
+constant-fold → fold-control-flow → dce → inline → rename →
+treeshake → ...
+```
+
+Tree-shake runs late — after DCE has trimmed every module
+internally, after inline has fixed call-site references, after
+rename has settled on the final names.
+
+## Dependency whitelist
+
+- `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
+- `coding-adventures-javascript-ast` — `Program` input/output.
+- `coding-adventures-type-sidecar` — receives sidecar reference;
+  future tree-shake will read module-level `external` attributes
+  to seed the root set.
+- `coding_adventures_correlation_vector` — receives mutable
+  `CVLog` for per-removal `Contribution` emission.
+- `serde_json` — `Contribution.meta` JSON values.
+
+Dev-deps:
+- `coding-adventures-javascript-tokens` for `EsVersion` in tests.
+- `coding-adventures-closure-pass-dce` for the two-pass
+  ordering integration test.

--- a/code/packages/rust/closure-pass-treeshake/required_capabilities.json
+++ b/code/packages/rust/closure-pass-treeshake/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closure-pass-treeshake",
+  "capabilities": [],
+  "justification": "Pure data transformation over an AST. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/closure-pass-treeshake/src/lib.rs
+++ b/code/packages/rust/closure-pass-treeshake/src/lib.rs
@@ -1,0 +1,286 @@
+//! Tree-shaking pass for the Closure Compiler clone.
+//!
+//! Per [CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s
+//! canonical pass set. Removes `export` declarations and `import`
+//! bindings that aren't reachable from any entry point — the
+//! whole-program version of DCE.
+//!
+//! # Why "tree-shake"?
+//!
+//! Imagine the program as a tree of modules connected by
+//! `import` edges. The roots are the entry-point modules. Hold
+//! the tree by its roots, shake it — anything not connected to a
+//! root falls off. That's tree-shaking.
+//!
+//! ```text
+//! entry.js  imports  { a, b }       from utils.js
+//! utils.js  exports  a, b, c, d
+//!                            ▲
+//!                            └─ c and d are unreached;
+//!                               treeshake removes them
+//! ```
+//!
+//! Real bundles often pull in entire modules just because one
+//! function is needed, then bundle the other 47 functions
+//! along for the ride. Tree-shake reads the actual `import`
+//! statements and trims everything else away.
+//!
+//! # The difference from DCE
+//!
+//! - **DCE** operates **within** a module/function. It finds
+//!   bindings that no in-module code uses. It can't tell that
+//!   an `export` is unused because the export is, by definition,
+//!   reachable from the module's outside.
+//! - **Tree-shake** operates **across** modules. It looks at the
+//!   import graph and decides which exports are *actually* used
+//!   by something that's actually used. Once tree-shake decides
+//!   an export is dead, *intra*-module DCE on the next iteration
+//!   can finally delete the underlying definition.
+//!
+//! That's why CLOC06 pins tree-shake to depend on `dce`: DCE
+//! shrinks the reachable use-sets first, which simplifies the
+//! cross-module use-chain analysis tree-shake needs.
+//!
+//! # Why `FixedPoint`?
+//!
+//! Tree-shake → DCE → tree-shake again is a real cascade. If
+//! tree-shake removes module `utils.js` entirely, then DCE
+//! deletes the now-dead `import` statements in `entry.js`,
+//! which can in turn make *more* modules' exports unreferenced.
+//! Bounded by module count in practice; we don't pre-cap it.
+//!
+//! # Scope (v1)
+//!
+//! `javascript-ast` ships only `Program` / `SourceType` today
+//! (CLOC02 Phase 1). With no `ImportDeclaration` /
+//! `ExportDeclaration` / `Identifier` nodes there is nothing to
+//! shake; [`TreeshakePass::run`] is identity in v1. Per CLOC03
+//! §"When a pass keeps a node unchanged" no contributions are
+//! emitted.
+//!
+//! What this PR locks down:
+//!
+//! 1. Pass metadata (`name`, `iteration_policy`, `cost`,
+//!    `depends_on`) — what the scheduler keys on and what the
+//!    future `closurec` CLI surfaces as `--disable=treeshake`.
+//! 2. The `depends_on("dce")` edge so the scheduler forces
+//!    intra-module DCE before cross-module shaking.
+//! 3. The two-pass integration test that proves the ordering.
+
+use coding_adventures_closure_pass_pipeline::{
+    IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
+};
+
+/// `Pass::depends_on` value. CLOC06 canonical order pins DCE
+/// before tree-shake. Kept as a `const` so future tests / sibling
+/// crates can reference the dependency name without retyping.
+const DEPS: &[&str] = &["dce"];
+
+/// Tree-shaking pass. v1 is identity — see crate-level docs.
+///
+/// Zero-sized type: no per-instance state. Pass-internal state
+/// (cross-module import graph, root-set seeded from entry points
+/// and `export` markers that the host declared reachable, the
+/// per-module set of reached identifiers) lives in pass-local
+/// maps constructed inside [`Pass::run`] per CLOC06
+/// §"Pass-internal state."
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TreeshakePass;
+
+impl TreeshakePass {
+    /// Zero-arg constructor for ergonomic
+    /// `PassPipeline::add(Box::new(TreeshakePass::new()))`
+    /// registration.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Pass for TreeshakePass {
+    fn name(&self) -> &'static str {
+        "treeshake"
+    }
+
+    fn depends_on(&self) -> &[&'static str] {
+        // CLOC06 canonical order: DCE first so intra-module dead
+        // code is gone before cross-module use-chains get
+        // analyzed. Shrinks the search space tree-shake walks.
+        DEPS
+    }
+
+    fn iteration_policy(&self) -> IterationPolicy {
+        // Per CLOC06: tree-shake → DCE → tree-shake is a real
+        // cascade. Removing one export can leave its `import`
+        // statement dead, which DCE deletes, which can render a
+        // whole imported module unreached, which tree-shake can
+        // then remove entirely.
+        IterationPolicy::FixedPoint
+    }
+
+    fn cost(&self) -> u32 {
+        // Two-phase per iteration:
+        //   1. Mark — reachability walk from entry points across
+        //      the import graph.
+        //   2. Sweep — remove exports/imports not in the reached
+        //      set.
+        // Similar shape to DCE (also mark+sweep), so similar
+        // cost. The cross-module walk is the main difference;
+        // tree-shake's reachable-set is per-module instead of
+        // per-function, which is comparable in size.
+        3
+    }
+
+    fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        // v1: no ImportDeclaration / ExportDeclaration nodes in
+        // the AST yet, so there's nothing to shake. Pass through
+        // unchanged. The real two-phase walk slots in here once
+        // javascript-ast grows module syntax.
+        Ok(PassOutput {
+            program: ctx.program.clone(),
+            contributions: Vec::new(),
+            changed: false,
+            diagnostics: Vec::new(),
+            stats: PassStats {
+                // Visited the program root; no exports/imports
+                // removed.
+                nodes_touched: 1,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests pin the public contract and lock the DCE ordering
+    //! integration with `PassPipeline`. v1's `run` is identity,
+    //! but the metadata drives the scheduler and outlives the
+    //! v1 body.
+    use super::*;
+    use coding_adventures_closure_pass_dce::DcePass;
+    use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};
+    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_javascript_ast::{Program, SourceType};
+    use coding_adventures_javascript_tokens::EsVersion;
+    use coding_adventures_type_sidecar::Sidecar;
+
+    fn program() -> Program {
+        Program::new("prog.1".to_string(), EsVersion::Es2025, SourceType::Module)
+    }
+
+    #[test]
+    fn name_is_treeshake() {
+        // The handle for `--disable=treeshake` and
+        // `out.stats["treeshake"]`. Public contract.
+        assert_eq!(TreeshakePass::new().name(), "treeshake");
+    }
+
+    #[test]
+    fn iteration_policy_is_fixed_point() {
+        // tree-shake → DCE → tree-shake cascade. FixedPoint
+        // captures the intent even though v1 converges in one
+        // no-op step.
+        assert_eq!(
+            TreeshakePass::new().iteration_policy(),
+            IterationPolicy::FixedPoint
+        );
+    }
+
+    #[test]
+    fn cost_is_three_pass_units() {
+        // Mark + sweep, cross-module. Same shape as DCE.
+        assert_eq!(TreeshakePass::new().cost(), 3);
+    }
+
+    #[test]
+    fn depends_on_dce() {
+        let p = TreeshakePass::new();
+        assert_eq!(p.depends_on(), &["dce"]);
+    }
+
+    #[test]
+    fn invalidates_empty_in_v1() {
+        // CLOC06 Open Question 1: informational only in v0.1.0.
+        assert!(TreeshakePass::new().invalidates().is_empty());
+    }
+
+    #[test]
+    fn run_on_empty_program_returns_unchanged_identity() {
+        // Identity: same CV, version, source_type; no
+        // contributions, no diagnostics, changed=false,
+        // nodes_touched=1.
+        let pass = TreeshakePass::new();
+        let prog = program();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+
+        let ctx = PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        };
+        let out = pass.run(ctx).expect("pass should succeed");
+
+        assert_eq!(out.program.cv, prog.cv);
+        assert_eq!(out.program.version, prog.version);
+        assert_eq!(out.program.source_type, prog.source_type);
+        assert!(!out.changed);
+        assert!(out.contributions.is_empty());
+        assert!(out.diagnostics.is_empty());
+        assert_eq!(out.stats.nodes_touched, 1);
+    }
+
+    #[test]
+    fn pipeline_orders_dce_before_treeshake() {
+        // Register TreeshakePass FIRST. If `depends_on` were
+        // ignored, the pipeline would run them in registration
+        // order: [treeshake, dce]. The scheduler must reorder
+        // them to [dce, treeshake] per CLOC06 canonical order.
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(TreeshakePass::new()));
+        pipeline.add(Box::new(DcePass::new()));
+
+        let mut cv = CVLog::new(true);
+        let out: PipelineOutput = pipeline
+            .run(program(), &Sidecar::new(), &mut cv)
+            .expect("pipeline should run cleanly");
+
+        assert_eq!(
+            out.execution_order,
+            vec!["dce".to_string(), "treeshake".to_string()],
+            "treeshake must run after dce per CLOC06 canonical order"
+        );
+        assert!(out.stats.contains_key("dce"));
+        assert!(out.stats.contains_key("treeshake"));
+    }
+
+    #[test]
+    fn pipeline_runs_treeshake_as_solo_pass() {
+        // TreeshakePass alone (without DCE) still works:
+        // depends_on is "soft" in v1 — the v0.1.0 scheduler
+        // silently drops unknown dependencies.
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(TreeshakePass::new()));
+
+        let mut cv = CVLog::new(true);
+        let out = pipeline.run(program(), &Sidecar::new(), &mut cv).unwrap();
+        assert_eq!(out.execution_order, vec!["treeshake".to_string()]);
+        assert_eq!(out.stats["treeshake"].nodes_touched, 1);
+        // FixedPoint policy → v0.1.0 pipeline emits the
+        // "not yet iterated" informational note.
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|d| d.group.0 == "pipeline.fixed-point-not-yet-iterated"),
+            "expected the pipeline's FixedPoint note; got {:?}",
+            out.diagnostics
+        );
+    }
+
+    #[test]
+    fn pass_is_default_and_clone() {
+        let _a: TreeshakePass = Default::default();
+        let _b: TreeshakePass = TreeshakePass::new();
+        let _c = _b;
+        let _d = _c.clone();
+    }
+}


### PR DESCRIPTION
## Summary

- New crate for **tree-shaking** — removes `export` declarations and `import` bindings that aren't reachable from any entry point. The whole-program cousin of DCE: DCE operates within a module/function; tree-shake operates across modules.
- `TreeshakePass`: `name = "treeshake"`, `depends_on = ["dce"]`, `iteration_policy = FixedPoint`, `cost = 3`.
- `Pass::run` is identity in v1 — `javascript-ast` ships only `Program`/`SourceType` today, so no `ImportDeclaration`/`ExportDeclaration` nodes yet. Real two-phase mark+sweep slots in once the AST grows module syntax.

## Why depends_on = ["dce"]?

DCE shrinks intra-module use-sets first, simplifying the cross-module use-chain analysis tree-shake needs. And the next iteration's DCE can delete underlying definitions whose exports tree-shake just removed — a real cascade, hence `FixedPoint`.

## What this PR locks down

1. `depends_on("dce")` edge — DCE before tree-shake.
2. Two-pass integration test registers TreeshakePass FIRST and verifies scheduler reorders to `dce → treeshake`.
3. Pass metadata drives future `closurec --disable=treeshake`.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-treeshake` passes (9/9).
- [ ] CI green on ubuntu/macos/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)