### PR TITLE
Expand HTML parser browser resource extraction

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -218,14 +218,84 @@ def check_browser_readiness_case(
 
     require_optional_nullable_string(case_path, expected, "title", errors)
     require_optional_nullable_string(case_path, expected, "base_href", errors)
+    require_optional_nullable_string(case_path, expected, "base_target", errors)
     require_string(f"{case_path}.expected", expected, "body_text", errors)
+    require_object_list(f"{case_path}.expected", expected, "metas", errors)
+    require_object_list(f"{case_path}.expected", expected, "resources", errors)
+    require_object_list(f"{case_path}.expected", expected, "anchors", errors)
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_object_list(f"{case_path}.expected", expected, "forms", errors)
     require_object_list(f"{case_path}.expected", expected, "tables", errors)
+    check_browser_expected_lists(case_path, expected, errors)
 
     return errors
+
+
+def check_browser_expected_lists(
+    case_path: str,
+    expected: dict[str, Any],
+    errors: list[str],
+) -> None:
+    for index, meta in enumerate(object_list_items(expected, "metas")):
+        meta_path = f"{case_path}.expected.metas[{index}]"
+        for field in ("name", "http_equiv", "property", "charset", "content"):
+            require_optional_nullable_string(meta_path, meta, field, errors)
+
+    for index, resource in enumerate(object_list_items(expected, "resources")):
+        resource_path = f"{case_path}.expected.resources[{index}]"
+        require_string(resource_path, resource, "kind", errors)
+        require_string(resource_path, resource, "url", errors)
+        for field in ("rel", "type_hint", "media", "title"):
+            require_optional_nullable_string(resource_path, resource, field, errors)
+        require_boolean(resource_path, resource, "async_script", errors)
+        require_boolean(resource_path, resource, "defer_script", errors)
+
+    for index, anchor in enumerate(object_list_items(expected, "anchors")):
+        anchor_path = f"{case_path}.expected.anchors[{index}]"
+        for field in ("id", "name"):
+            require_optional_nullable_string(anchor_path, anchor, field, errors)
+        require_string(anchor_path, anchor, "text", errors)
+
+    for index, heading in enumerate(object_list_items(expected, "headings")):
+        heading_path = f"{case_path}.expected.headings[{index}]"
+        require_integer(heading_path, heading, "level", errors)
+        require_string(heading_path, heading, "text", errors)
+
+    for index, link in enumerate(object_list_items(expected, "links")):
+        link_path = f"{case_path}.expected.links[{index}]"
+        for field in ("href", "name", "target", "rel", "title"):
+            require_optional_nullable_string(link_path, link, field, errors)
+        require_string(link_path, link, "text", errors)
+
+    for index, image in enumerate(object_list_items(expected, "images")):
+        image_path = f"{case_path}.expected.images[{index}]"
+        for field in ("src", "alt", "width", "height"):
+            require_optional_nullable_string(image_path, image, field, errors)
+
+    for index, form in enumerate(object_list_items(expected, "forms")):
+        form_path = f"{case_path}.expected.forms[{index}]"
+        require_optional_nullable_string(form_path, form, "action", errors)
+        require_string(form_path, form, "method", errors)
+        require_optional_nullable_string(form_path, form, "enctype", errors)
+        require_optional_nullable_string(form_path, form, "target", errors)
+        require_object_list(form_path, form, "controls", errors)
+        for control_index, control in enumerate(object_list_items(form, "controls")):
+            control_path = f"{form_path}.controls[{control_index}]"
+            require_string(control_path, control, "control_type", errors)
+            require_optional_nullable_string(control_path, control, "name", errors)
+            require_optional_nullable_string(control_path, control, "value", errors)
+            require_boolean(control_path, control, "disabled", errors)
+            require_boolean(control_path, control, "checked", errors)
+            require_string(control_path, control, "text", errors)
+            require_string_list(control_path, control, "options", errors)
+
+    for index, table in enumerate(object_list_items(expected, "tables")):
+        table_path = f"{case_path}.expected.tables[{index}]"
+        require_optional_nullable_string(table_path, table, "caption", errors)
+        for field in ("row_count", "cell_count", "header_cell_count"):
+            require_integer(table_path, table, field, errors)
 
 
 def check_split_points(
@@ -312,6 +382,16 @@ def require_integer(
         errors.append(f"{path}.{field} must be an integer")
 
 
+def require_boolean(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(data.get(field), bool):
+        errors.append(f"{path}.{field} must be a boolean")
+
+
 def require_string_list(
     path: str,
     data: dict[str, Any],
@@ -332,6 +412,13 @@ def require_object_list(
     value = data.get(field)
     if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
         errors.append(f"{path}.{field} must be a list of objects")
+
+
+def object_list_items(data: dict[str, Any], field: str) -> list[dict[str, Any]]:
+    value = data.get(field)
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        return []
+    return value
 
 
 def require_optional_string_list(

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
@@ -41,7 +41,11 @@ class HtmlFixtureSchemasTest(unittest.TestCase):
                 "expected": {
                     "title": "x",
                     "base_href": None,
+                    "base_target": None,
                     "body_text": "body",
+                    "metas": [],
+                    "resources": [],
+                    "anchors": [],
                     "headings": [],
                     "links": [],
                     "images": [],

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -178,6 +178,10 @@ documented in this file.
 - Self-closing flags on non-void HTML start tags are now ignored with a parser
   diagnostic, keeping elements such as `div`, `script`, `textarea`, and table
   cells open for their real content.
+- Browser-facing document extraction now includes base targets, head metadata,
+  loadable resources, anchor targets, richer link attributes, form encodings,
+  form targets, and basic control disabled/checked state for browser pipeline
+  consumers.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -58,8 +58,9 @@ The current parser surface includes:
 - parser diagnostics for unmatched end tags
 - body-fragment parsing that returns DOM nodes without the implied
   `html/head/body` shell while preserving lexer/parser diagnostics
-- browser-facing document extraction for title, base URL, body text, headings,
-  links, image attributes, form controls, and table summaries
+- browser-facing document extraction for title, base URL/target, head metadata,
+  resource inventory, anchor targets, body text, headings, richer links, image
+  attributes, form controls, and table summaries
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources
@@ -333,6 +334,7 @@ let browser_document = parse_browser_document(
 
 assert_eq!(browser_document.title.as_deref(), Some("Example"));
 assert_eq!(browser_document.links[0].href.as_deref(), Some("next.html"));
+assert!(browser_document.resources.is_empty());
 
 match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -797,12 +797,44 @@ pub fn parse_html_fragment_for_context_with_diagnostics_and_options(
 pub struct BrowserDocument {
     pub title: Option<String>,
     pub base_href: Option<String>,
+    pub base_target: Option<String>,
     pub body_text: String,
+    pub metas: Vec<BrowserMeta>,
+    pub resources: Vec<BrowserResource>,
+    pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub forms: Vec<BrowserForm>,
     pub tables: Vec<BrowserTable>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMeta {
+    pub name: Option<String>,
+    pub http_equiv: Option<String>,
+    pub property: Option<String>,
+    pub charset: Option<String>,
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserResource {
+    pub kind: String,
+    pub url: String,
+    pub rel: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+    pub title: Option<String>,
+    pub async_script: bool,
+    pub defer_script: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAnchor {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -815,6 +847,9 @@ pub struct BrowserHeading {
 pub struct BrowserLink {
     pub href: Option<String>,
     pub name: Option<String>,
+    pub target: Option<String>,
+    pub rel: Option<String>,
+    pub title: Option<String>,
     pub text: String,
 }
 
@@ -830,6 +865,8 @@ pub struct BrowserImage {
 pub struct BrowserForm {
     pub action: Option<String>,
     pub method: String,
+    pub enctype: Option<String>,
+    pub target: Option<String>,
     pub controls: Vec<BrowserFormControl>,
 }
 
@@ -838,6 +875,8 @@ pub struct BrowserFormControl {
     pub control_type: String,
     pub name: Option<String>,
     pub value: Option<String>,
+    pub disabled: bool,
+    pub checked: bool,
     pub text: String,
     pub options: Vec<String>,
 }
@@ -866,10 +905,17 @@ impl BrowserDocument {
                 .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
                 .and_then(|element| element.attribute("href"))
                 .map(ToOwned::to_owned),
+            base_target: head
+                .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
+                .and_then(|element| element.attribute("target"))
+                .map(ToOwned::to_owned),
             body_text: visible_text_for_nodes(body_children),
             ..Self::default()
         };
 
+        if let Some(head) = head {
+            collect_head_browser_facts(&head.children, &mut summary);
+        }
         collect_browser_facts(body_children, &mut summary);
         summary
     }
@@ -7785,10 +7831,16 @@ fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             continue;
         };
 
+        collect_anchor_target(element, summary);
+        collect_body_resource(element, summary);
+
         match element.name.as_str() {
             "a" => summary.links.push(BrowserLink {
                 href: element.attribute("href").map(ToOwned::to_owned),
                 name: element.attribute("name").map(ToOwned::to_owned),
+                target: element.attribute("target").map(ToOwned::to_owned),
+                rel: element.attribute("rel").map(ToOwned::to_owned),
+                title: element.attribute("title").map(ToOwned::to_owned),
                 text: visible_text_for_nodes(&element.children),
             }),
             "img" => summary.images.push(BrowserImage {
@@ -7803,6 +7855,8 @@ fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                     .attribute("method")
                     .map(|method| method.to_ascii_lowercase())
                     .unwrap_or_else(|| "get".to_string()),
+                enctype: element.attribute("enctype").map(ToOwned::to_owned),
+                target: element.attribute("target").map(ToOwned::to_owned),
                 controls: collect_form_controls(&element.children),
             }),
             "table" => summary.tables.push(BrowserTable {
@@ -7825,6 +7879,132 @@ fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
     }
 }
 
+fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+
+        match element.name.as_str() {
+            "meta" => summary.metas.push(BrowserMeta {
+                name: element.attribute("name").map(ToOwned::to_owned),
+                http_equiv: element.attribute("http-equiv").map(ToOwned::to_owned),
+                property: element.attribute("property").map(ToOwned::to_owned),
+                charset: element.attribute("charset").map(ToOwned::to_owned),
+                content: element.attribute("content").map(ToOwned::to_owned),
+            }),
+            "link" => {
+                if let Some(href) = element.attribute("href") {
+                    summary.resources.push(BrowserResource {
+                        kind: link_resource_kind(element.attribute("rel")),
+                        url: href.to_string(),
+                        rel: element.attribute("rel").map(ToOwned::to_owned),
+                        type_hint: element.attribute("type").map(ToOwned::to_owned),
+                        media: element.attribute("media").map(ToOwned::to_owned),
+                        title: element.attribute("title").map(ToOwned::to_owned),
+                        async_script: false,
+                        defer_script: false,
+                    });
+                }
+            }
+            "script" => {
+                if let Some(src) = element.attribute("src") {
+                    summary.resources.push(BrowserResource {
+                        kind: "script".to_string(),
+                        url: src.to_string(),
+                        rel: None,
+                        type_hint: element.attribute("type").map(ToOwned::to_owned),
+                        media: None,
+                        title: None,
+                        async_script: element.attribute("async").is_some(),
+                        defer_script: element.attribute("defer").is_some(),
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        collect_head_browser_facts(&element.children, summary);
+    }
+}
+
+fn collect_anchor_target(element: &Element, summary: &mut BrowserDocument) {
+    let id = element.attribute("id");
+    let name = element.attribute("name").filter(|_| element.name == "a");
+    if id.is_none() && name.is_none() {
+        return;
+    }
+
+    summary.anchors.push(BrowserAnchor {
+        id: id.map(ToOwned::to_owned),
+        name: name.map(ToOwned::to_owned),
+        text: visible_text_for_nodes(&element.children),
+    });
+}
+
+fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
+    let Some((kind, url)) = body_resource(element) else {
+        return;
+    };
+
+    summary.resources.push(BrowserResource {
+        kind,
+        url,
+        rel: None,
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        async_script: element.name == "script" && element.attribute("async").is_some(),
+        defer_script: element.name == "script" && element.attribute("defer").is_some(),
+    });
+}
+
+fn body_resource(element: &Element) -> Option<(String, String)> {
+    match element.name.as_str() {
+        "img" => element
+            .attribute("src")
+            .map(|src| ("image".to_string(), src.to_string())),
+        "script" => element
+            .attribute("src")
+            .map(|src| ("script".to_string(), src.to_string())),
+        "iframe" | "frame" => element
+            .attribute("src")
+            .map(|src| ("frame".to_string(), src.to_string())),
+        "embed" => element
+            .attribute("src")
+            .map(|src| ("embed".to_string(), src.to_string())),
+        "object" => element
+            .attribute("data")
+            .map(|data| ("object".to_string(), data.to_string())),
+        "audio" | "video" => element
+            .attribute("src")
+            .map(|src| (element.name.clone(), src.to_string())),
+        "source" | "track" => element
+            .attribute("src")
+            .map(|src| (element.name.clone(), src.to_string())),
+        _ => None,
+    }
+}
+
+fn link_resource_kind(rel: Option<&str>) -> String {
+    let Some(rel) = rel else {
+        return "link".to_string();
+    };
+    let rel_tokens = rel.split_ascii_whitespace().map(str::to_ascii_lowercase);
+    for token in rel_tokens {
+        match token.as_str() {
+            "stylesheet" => return "stylesheet".to_string(),
+            "icon" | "shortcut" => return "icon".to_string(),
+            "preload" => return "preload".to_string(),
+            "modulepreload" => return "modulepreload".to_string(),
+            "manifest" => return "manifest".to_string(),
+            "alternate" => return "alternate".to_string(),
+            _ => {}
+        }
+    }
+    "link".to_string()
+}
+
 fn collect_form_controls(nodes: &[Node]) -> Vec<BrowserFormControl> {
     let mut controls = Vec::new();
     collect_form_controls_into(nodes, &mut controls);
@@ -7845,6 +8025,8 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
                     .unwrap_or_else(|| "text".to_string()),
                 name: element.attribute("name").map(ToOwned::to_owned),
                 value: element.attribute("value").map(ToOwned::to_owned),
+                disabled: element.attribute("disabled").is_some(),
+                checked: element.attribute("checked").is_some(),
                 text: String::new(),
                 options: Vec::new(),
             }),
@@ -7855,6 +8037,8 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
                     .unwrap_or_else(|| "submit".to_string()),
                 name: element.attribute("name").map(ToOwned::to_owned),
                 value: element.attribute("value").map(ToOwned::to_owned),
+                disabled: element.attribute("disabled").is_some(),
+                checked: false,
                 text: visible_text_for_nodes(&element.children),
                 options: Vec::new(),
             }),
@@ -7862,6 +8046,8 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
                 control_type: "select".to_string(),
                 name: element.attribute("name").map(ToOwned::to_owned),
                 value: None,
+                disabled: element.attribute("disabled").is_some(),
+                checked: false,
                 text: visible_text_for_nodes(&element.children),
                 options: collect_select_options(&element.children),
             }),
@@ -7869,6 +8055,8 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
                 control_type: "textarea".to_string(),
                 name: element.attribute("name").map(ToOwned::to_owned),
                 value: None,
+                disabled: element.attribute("disabled").is_some(),
+                checked: false,
                 text: element_text(element),
                 options: Vec::new(),
             }),

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,6 +1,6 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserDocument, BrowserForm, BrowserFormControl, BrowserHeading,
-    BrowserImage, BrowserLink, BrowserTable,
+    parse_browser_document, BrowserAnchor, BrowserDocument, BrowserForm, BrowserFormControl,
+    BrowserHeading, BrowserImage, BrowserLink, BrowserMeta, BrowserResource, BrowserTable,
 };
 use serde::Deserialize;
 
@@ -24,12 +24,44 @@ struct BrowserReadinessCase {
 struct ExpectedBrowserDocument {
     title: Option<String>,
     base_href: Option<String>,
+    base_target: Option<String>,
     body_text: String,
+    metas: Vec<ExpectedMeta>,
+    resources: Vec<ExpectedResource>,
+    anchors: Vec<ExpectedAnchor>,
     headings: Vec<ExpectedHeading>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     forms: Vec<ExpectedForm>,
     tables: Vec<ExpectedTable>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMeta {
+    name: Option<String>,
+    http_equiv: Option<String>,
+    property: Option<String>,
+    charset: Option<String>,
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedResource {
+    kind: String,
+    url: String,
+    rel: Option<String>,
+    type_hint: Option<String>,
+    media: Option<String>,
+    title: Option<String>,
+    async_script: bool,
+    defer_script: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAnchor {
+    id: Option<String>,
+    name: Option<String>,
+    text: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -42,6 +74,9 @@ struct ExpectedHeading {
 struct ExpectedLink {
     href: Option<String>,
     name: Option<String>,
+    target: Option<String>,
+    rel: Option<String>,
+    title: Option<String>,
     text: String,
 }
 
@@ -57,6 +92,8 @@ struct ExpectedImage {
 struct ExpectedForm {
     action: Option<String>,
     method: String,
+    enctype: Option<String>,
+    target: Option<String>,
     controls: Vec<ExpectedFormControl>,
 }
 
@@ -65,6 +102,8 @@ struct ExpectedFormControl {
     control_type: String,
     name: Option<String>,
     value: Option<String>,
+    disabled: bool,
+    checked: bool,
     text: String,
     options: Vec<String>,
 }
@@ -104,7 +143,23 @@ impl ExpectedBrowserDocument {
         BrowserDocument {
             title: self.title,
             base_href: self.base_href,
+            base_target: self.base_target,
             body_text: self.body_text,
+            metas: self
+                .metas
+                .into_iter()
+                .map(ExpectedMeta::into_browser_meta)
+                .collect(),
+            resources: self
+                .resources
+                .into_iter()
+                .map(ExpectedResource::into_browser_resource)
+                .collect(),
+            anchors: self
+                .anchors
+                .into_iter()
+                .map(ExpectedAnchor::into_browser_anchor)
+                .collect(),
             headings: self
                 .headings
                 .into_iter()
@@ -134,6 +189,43 @@ impl ExpectedBrowserDocument {
     }
 }
 
+impl ExpectedMeta {
+    fn into_browser_meta(self) -> BrowserMeta {
+        BrowserMeta {
+            name: self.name,
+            http_equiv: self.http_equiv,
+            property: self.property,
+            charset: self.charset,
+            content: self.content,
+        }
+    }
+}
+
+impl ExpectedResource {
+    fn into_browser_resource(self) -> BrowserResource {
+        BrowserResource {
+            kind: self.kind,
+            url: self.url,
+            rel: self.rel,
+            type_hint: self.type_hint,
+            media: self.media,
+            title: self.title,
+            async_script: self.async_script,
+            defer_script: self.defer_script,
+        }
+    }
+}
+
+impl ExpectedAnchor {
+    fn into_browser_anchor(self) -> BrowserAnchor {
+        BrowserAnchor {
+            id: self.id,
+            name: self.name,
+            text: self.text,
+        }
+    }
+}
+
 impl ExpectedHeading {
     fn into_browser_heading(self) -> BrowserHeading {
         BrowserHeading {
@@ -148,6 +240,9 @@ impl ExpectedLink {
         BrowserLink {
             href: self.href,
             name: self.name,
+            target: self.target,
+            rel: self.rel,
+            title: self.title,
             text: self.text,
         }
     }
@@ -169,6 +264,8 @@ impl ExpectedForm {
         BrowserForm {
             action: self.action,
             method: self.method,
+            enctype: self.enctype,
+            target: self.target,
             controls: self
                 .controls
                 .into_iter()
@@ -184,6 +281,8 @@ impl ExpectedFormControl {
             control_type: self.control_type,
             name: self.name,
             value: self.value,
+            disabled: self.disabled,
+            checked: self.checked,
             text: self.text,
             options: self.options,
         }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -11,8 +11,9 @@ without inventing a Rust-only test schema.
 
 `html-browser-readiness.json` is a checked parser acceptance corpus for
 browser-facing extraction. It verifies that broad HTML documents produce stable
-title, base URL, body text, heading, link, image, form, and table facts that a
-browser pipeline can consume before layout and Paint VM rendering.
+title, base URL/target, metadata, resource, anchor, body text, heading, link,
+image, form, and table facts that a browser pipeline can consume before layout
+and Paint VM rendering.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -6,16 +6,27 @@
     {
       "id": "legacy-directory-page",
       "description": "Omitted shell, title/base metadata, anchors, image attributes, and implied list-item endings.",
-      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\"><h1>Example Directory</h1><p>Welcome to <a href=\"intro.html\">Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
+      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=next title=\"Intro\">Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
       "expected": {
         "title": "Example & Links",
         "base_href": "https://example.test/docs/",
+        "base_target": "_top",
         "body_text": "Example Directory Welcome to Venture HTML. One Two",
+        "metas": [
+          { "name": null, "http_equiv": null, "property": null, "charset": "utf-8", "content": null }
+        ],
+        "resources": [
+          { "kind": "stylesheet", "url": "style.css", "rel": "stylesheet", "type_hint": null, "media": "screen", "title": "default", "async_script": false, "defer_script": false },
+          { "kind": "image", "url": "logo.gif", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false }
+        ],
+        "anchors": [
+          { "id": "index", "name": null, "text": "Example Directory" }
+        ],
         "headings": [
           { "level": 1, "text": "Example Directory" }
         ],
         "links": [
-          { "href": "intro.html", "name": null, "text": "Venture HTML" }
+          { "href": "intro.html", "name": null, "target": "main", "rel": "next", "title": "Intro", "text": "Venture HTML" }
         ],
         "images": [
           { "src": "logo.gif", "alt": "Logo", "width": "88", "height": "31" }
@@ -27,11 +38,17 @@
     {
       "id": "catalog-form-table-page",
       "description": "Form controls, select options, textarea text, button text, and table summaries.",
-      "input": "<html><head><title>Search</title></head><body><h2>Catalog</h2><form action=\"/search\" method=POST><input name=q value=\"rust html\"><input type=hidden name=page value=1><select name=section><option>Books<option>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
+      "input": "<html><head><title>Search</title><meta http-equiv=refresh content=\"30; url=/next\"></head><body><h2>Catalog</h2><form action=\"/search\" method=POST enctype=\"multipart/form-data\" target=results><input name=q value=\"rust html\"><input type=hidden name=page value=1><input type=checkbox name=in_stock value=yes checked><input type=text name=disabled value=no disabled><select name=section><option>Books<option>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
       "expected": {
         "title": "Search",
         "base_href": null,
+        "base_target": null,
         "body_text": "Catalog Books Manuals Line one Line two Search Results Name Kind Mosaic Browser",
+        "metas": [
+          { "name": null, "http_equiv": "refresh", "property": null, "charset": null, "content": "30; url=/next" }
+        ],
+        "resources": [],
+        "anchors": [],
         "headings": [
           { "level": 2, "text": "Catalog" }
         ],
@@ -41,12 +58,16 @@
           {
             "action": "/search",
             "method": "post",
+            "enctype": "multipart/form-data",
+            "target": "results",
             "controls": [
-              { "control_type": "text", "name": "q", "value": "rust html", "text": "", "options": [] },
-              { "control_type": "hidden", "name": "page", "value": "1", "text": "", "options": [] },
-              { "control_type": "select", "name": "section", "value": null, "text": "Books Manuals", "options": ["Books", "Manuals"] },
-              { "control_type": "textarea", "name": "notes", "value": null, "text": "Line one Line two", "options": [] },
-              { "control_type": "submit", "name": "go", "value": null, "text": "Search", "options": [] }
+              { "control_type": "text", "name": "q", "value": "rust html", "disabled": false, "checked": false, "text": "", "options": [] },
+              { "control_type": "hidden", "name": "page", "value": "1", "disabled": false, "checked": false, "text": "", "options": [] },
+              { "control_type": "checkbox", "name": "in_stock", "value": "yes", "disabled": false, "checked": true, "text": "", "options": [] },
+              { "control_type": "text", "name": "disabled", "value": "no", "disabled": true, "checked": false, "text": "", "options": [] },
+              { "control_type": "select", "name": "section", "value": null, "disabled": false, "checked": false, "text": "Books Manuals", "options": ["Books", "Manuals"] },
+              { "control_type": "textarea", "name": "notes", "value": null, "disabled": false, "checked": false, "text": "Line one Line two", "options": [] },
+              { "control_type": "submit", "name": "go", "value": null, "disabled": false, "checked": false, "text": "Search", "options": [] }
             ]
           }
         ],
@@ -58,17 +79,25 @@
     {
       "id": "tag-soup-formatting-page",
       "description": "Bad nesting, formatting reconstruction, named anchors, same-page links, pre text, and invisible script/style contents.",
-      "input": "<body><p>Alpha <b>bold<p>Beta <i>italic</b> tail</i><center><h3>Archive</h3><a name=top></a><a href=\"#top\">Back</a></center><pre>  spaced\n text</pre><script>document.write(\"x\")</script><style>p{color:red}</style>",
+      "input": "<body><p>Alpha <b>bold<p>Beta <i>italic</b> tail</i><center><h3>Archive</h3><a name=top></a><a href=\"#top\">Back</a></center><pre>  spaced\n text</pre><script src=app.js async defer>document.write(\"x\")</script><style>p{color:red}</style>",
       "expected": {
         "title": null,
         "base_href": null,
+        "base_target": null,
         "body_text": "Alpha bold Beta italic tail Archive Back spaced text",
+        "metas": [],
+        "resources": [
+          { "kind": "script", "url": "app.js", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": true, "defer_script": true }
+        ],
+        "anchors": [
+          { "id": null, "name": "top", "text": "" }
+        ],
         "headings": [
           { "level": 3, "text": "Archive" }
         ],
         "links": [
-          { "href": null, "name": "top", "text": "" },
-          { "href": "#top", "name": null, "text": "Back" }
+          { "href": null, "name": "top", "target": null, "rel": null, "title": null, "text": "" },
+          { "href": "#top", "name": null, "target": null, "rel": null, "title": null, "text": "Back" }
         ],
         "images": [],
         "forms": [],


### PR DESCRIPTION
## Summary
- expand BrowserDocument with base target, head metadata, loadable resource inventory, and anchor targets
- carry richer browser-facing link/form/control facts through the extraction API
- broaden browser-readiness fixtures, schema validation, and docs around the new browser pipeline surface

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser