### PR TITLE
spice: add gear2 transient companions

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Gear-2 transient companions** — transient analysis now accepts
+  `method="gear2"` and uses BDF2 capacitor/inductor companion histories after
+  bootstrapping with one backward-Euler step.
+
 - **Transmission-line transient stamping** — `TransmissionLine` now participates
   in transient analysis with a lossless Bergeron delay-line companion model,
   including matched-load delayed step behavior.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -12,7 +12,7 @@ reactive elements with complex admittances (Y_C = jωC, Y_L = 1/jωL);
 solve the resulting complex linear system at each frequency.  See
 :func:`ac_sweep` and the Section 3 comment block below.
 
-For transient: two integration methods are supported:
+For transient: three integration methods are supported:
 
 1. **Backward Euler** (``method="euler"``):
    Simple first-order method.  For a capacitor::
@@ -32,6 +32,11 @@ For transient: two integration methods are supported:
 
        Companion: G_eq = h/(2L), I_eq = I_n + G_eq * V_n  (parallel current)
        Post-step update:  I_{n+1} = G_eq * (V_{n+1} - V_n_... ) + I_eq
+
+3. **Gear-2 / BDF2** (``method="gear2"``):
+   Second-order, numerically damped method.  The first step bootstraps with
+   backward Euler, then capacitor and inductor companions use two-step
+   history.
 
 **Adaptive timestep** (``adaptive=True``):
    After each trapezoidal step the Local Truncation Error (LTE) is
@@ -317,7 +322,8 @@ class TransientResult:
     converged:
         ``False`` if any DC solve diverged (integration stopped early).
     method:
-        Integration method that was used: ``"trap"`` or ``"euler"``.
+        Integration method that was used: ``"trap"``, ``"euler"``, or
+        ``"gear2"``.
     steps_rejected:
         Number of timesteps rejected by the LTE adaptive controller.
         Always 0 when ``adaptive=False``.
@@ -2101,8 +2107,10 @@ def _build_transient_companions(
     h: float,
     method: str,
     cap_voltages: dict[str, float],
+    cap_voltages_older: dict[str, float],
     cap_currents: dict[str, float],
     ind_currents: dict[str, float],
+    ind_currents_older: dict[str, float],
     ind_voltages: dict[str, float],
     line_history: dict[str, list[TransmissionLineSample]],
     t: float = 0.0,
@@ -2121,7 +2129,8 @@ def _build_transient_companions(
     h:
         Current timestep size (seconds).
     method:
-        ``"trap"`` (trapezoidal) or ``"euler"`` (backward Euler).
+        ``"trap"`` (trapezoidal), ``"euler"`` (backward Euler), or
+        ``"gear2"`` (BDF2).
     cap_voltages, cap_currents, ind_currents, ind_voltages:
         Reactive-element history dictionaries from the previous timestep.
     t:
@@ -2289,6 +2298,10 @@ def _build_transient_companions(
             if method == "trap":
                 g_eq = 2.0 * el.capacitance / h
                 I_eq = g_eq * v_prev + cap_currents.get(el.name, 0.0)
+            elif method == "gear2":
+                v_older = cap_voltages_older.get(el.name, el.initial_voltage)
+                g_eq = 3.0 * el.capacitance / (2.0 * h)
+                I_eq = el.capacitance * (4.0 * v_prev - v_older) / (2.0 * h)
             else:  # backward Euler
                 g_eq = el.capacitance / h
                 I_eq = g_eq * v_prev
@@ -2318,6 +2331,10 @@ def _build_transient_companions(
                 g_eq = h / (2.0 * el.inductance)
                 V_prev = ind_voltages.get(el.name, 0.0)
                 I_eq = I_prev + g_eq * V_prev
+            elif method == "gear2":
+                I_older = ind_currents_older.get(el.name, el.initial_current)
+                g_eq = 2.0 * h / (3.0 * el.inductance)
+                I_eq = (4.0 * I_prev - I_older) / 3.0
             else:  # backward Euler
                 g_eq = h / el.inductance
                 I_eq = I_prev
@@ -2346,8 +2363,10 @@ def _update_reactive_state(
     method: str,
     op: DcResult,
     cap_voltages: dict[str, float],
+    cap_voltages_older: dict[str, float],
     cap_currents: dict[str, float],
     ind_currents: dict[str, float],
+    ind_currents_older: dict[str, float],
     ind_voltages: dict[str, float],
 ) -> None:
     """Update capacitor and inductor history in-place after a successful step.
@@ -2420,15 +2439,22 @@ def _update_reactive_state(
             v_minus = _node_voltage(el.n_minus, op.node_voltages)
             v_new = v_plus - v_minus
             v_prev = cap_voltages.get(el.name, el.initial_voltage)
+            v_older = cap_voltages_older.get(el.name, el.initial_voltage)
 
             if method == "trap":
                 g_eq = 2.0 * el.capacitance / h
                 I_prev = cap_currents.get(el.name, 0.0)
                 cap_currents[el.name] = g_eq * (v_new - v_prev) - I_prev
+            elif method == "gear2":
+                cap_currents[el.name] = (
+                    el.capacitance * (3.0 * v_new - 4.0 * v_prev + v_older)
+                    / (2.0 * h)
+                )
             else:
                 g_eq = el.capacitance / h
                 cap_currents[el.name] = g_eq * (v_new - v_prev)
 
+            cap_voltages_older[el.name] = v_prev
             cap_voltages[el.name] = v_new
 
         elif isinstance(el, Inductor) and el.name not in coupled_names:
@@ -2436,16 +2462,23 @@ def _update_reactive_state(
             v_minus = _node_voltage(el.n_minus, op.node_voltages)
             v_new = v_plus - v_minus
             I_prev = ind_currents.get(el.name, 0.0)
+            I_older = ind_currents_older.get(el.name, el.initial_current)
             V_prev = ind_voltages.get(el.name, 0.0)
 
             if method == "trap":
                 g_eq = h / (2.0 * el.inductance)
                 I_eq = I_prev + g_eq * V_prev
                 ind_currents[el.name] = g_eq * v_new + I_eq
+            elif method == "gear2":
+                ind_currents[el.name] = (
+                    2.0 * h * v_new / (3.0 * el.inductance)
+                    + (4.0 * I_prev - I_older) / 3.0
+                )
             else:
                 g_eq = h / el.inductance
                 ind_currents[el.name] = g_eq * v_new + I_prev
 
+            ind_currents_older[el.name] = I_prev
             ind_voltages[el.name] = v_new
 
 
@@ -2501,7 +2534,7 @@ def transient(
     max_iterations: int = 50,
     tol: float = 1e-6,
 ) -> TransientResult:
-    """Transient (time-domain) analysis with trapezoidal or backward-Euler integration.
+    """Transient (time-domain) analysis with trapezoidal, backward-Euler, or Gear-2 integration.
 
     Replaces each reactive element (capacitor, inductor) with its Norton
     companion model at every timestep and solves the resulting DC problem
@@ -2517,7 +2550,8 @@ def transient(
         Initial (or fixed) timestep (seconds).  Must be > 0.
     method:
         ``"trap"`` (trapezoidal, default — 2nd-order accurate) or
-        ``"euler"`` (backward Euler — 1st-order, unconditionally stable).
+        ``"euler"`` (backward Euler — 1st-order, unconditionally stable), or
+        ``"gear2"`` (BDF2 after one backward-Euler bootstrap step).
     adaptive:
         When ``True``, enable LTE-based adaptive timestepping.  Only
         meaningful with ``method="trap"``.
@@ -2623,6 +2657,9 @@ def transient(
     )
     initial_branch_currents = dict(op.branch_currents)
     initial_branch_currents.update(line_branch_currents)
+    for el in circuit.elements:
+        if isinstance(el, Inductor):
+            initial_branch_currents[el.name] = el.initial_current
     points: list[TransientPoint] = [
         TransientPoint(
             time=0.0,
@@ -2640,10 +2677,12 @@ def transient(
         el.name: 0.0
         for el in circuit.elements if isinstance(el, Capacitor)
     }
+    cap_voltages_older: dict[str, float] = dict(cap_voltages)
     ind_currents: dict[str, float] = {
         el.name: el.initial_current
         for el in circuit.elements if isinstance(el, Inductor)
     }
+    ind_currents_older: dict[str, float] = dict(ind_currents)
     ind_voltages: dict[str, float] = {
         el.name: 0.0
         for el in circuit.elements if isinstance(el, Inductor)
@@ -2675,15 +2714,16 @@ def transient(
     t = t_step
     h = t_step  # current step size
     while t <= t_stop + 1e-12 * t_stop:
+        step_method = "euler" if method == "gear2" and len(points) < 2 else method
         # Clamp last step to land exactly on t_stop.
         h = min(h, t_stop - (t - h) + 1e-12 * t_stop)
         if h < _min_step:
             h = _min_step  # floor; stop shrinking
 
         aug = _build_transient_companions(
-            circuit, h, method,
-            cap_voltages, cap_currents,
-            ind_currents, ind_voltages,
+            circuit, h, step_method,
+            cap_voltages, cap_voltages_older, cap_currents,
+            ind_currents, ind_currents_older, ind_voltages,
             line_history,
             t=t,
         )
@@ -2714,8 +2754,9 @@ def transient(
             # Accept step; consider doubling h for the next step.
             t_actual = t  # the time we are committing to
             _update_reactive_state(
-                circuit, h, method, op,
-                cap_voltages, cap_currents, ind_currents, ind_voltages,
+                circuit, h, step_method, op,
+                cap_voltages, cap_voltages_older, cap_currents,
+                ind_currents, ind_currents_older, ind_voltages,
             )
             line_branch_currents = _append_transmission_line_history(
                 circuit,
@@ -2725,6 +2766,7 @@ def transient(
             )
             branch_currents = dict(op.branch_currents)
             branch_currents.update(line_branch_currents)
+            branch_currents.update(ind_currents)
             cap_voltages_prev = dict(cap_voltages)
             points.append(TransientPoint(
                 time=t_actual,
@@ -2737,8 +2779,9 @@ def transient(
         else:
             # Non-adaptive or backward Euler or not enough history yet.
             _update_reactive_state(
-                circuit, h, method, op,
-                cap_voltages, cap_currents, ind_currents, ind_voltages,
+                circuit, h, step_method, op,
+                cap_voltages, cap_voltages_older, cap_currents,
+                ind_currents, ind_currents_older, ind_voltages,
             )
             line_branch_currents = _append_transmission_line_history(
                 circuit,
@@ -2748,6 +2791,7 @@ def transient(
             )
             branch_currents = dict(op.branch_currents)
             branch_currents.update(line_branch_currents)
+            branch_currents.update(ind_currents)
             cap_voltages_prev = dict(cap_voltages)
             points.append(TransientPoint(
                 time=t,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -960,6 +960,35 @@ def test_transient_inductor_respects_initial_current():
     assert isclose(result.points[2].node_voltages["out"], -0.25, abs_tol=1e-9)
 
 
+def test_transient_gear2_rc_charging_bootstraps_then_uses_bdf2():
+    c = Circuit()
+    c.add(VoltageSource("V1", "in", "0", 1.0))
+    c.add(Resistor("R1", "in", "vc", 1000.0))
+    c.add(Capacitor("C1", "vc", "0", 1.0e-6))
+
+    result = transient(c, t_stop=3.0e-3, t_step=1.0e-3, method="gear2")
+
+    assert result.converged
+    assert result.method == "gear2"
+    assert result.points[1].node_voltages["vc"] == pytest.approx(0.5, abs=1e-12)
+    assert result.points[2].node_voltages["vc"] == pytest.approx(0.8, abs=1e-12)
+    assert result.points[3].node_voltages["vc"] == pytest.approx(0.94, abs=1e-12)
+
+
+def test_transient_gear2_rl_current_buildup_bootstraps_then_uses_bdf2():
+    c = Circuit()
+    c.add(VoltageSource("V1", "in", "0", 1.0))
+    c.add(Resistor("R1", "in", "out", 1000.0))
+    c.add(Inductor("L1", "out", "0", 1.0))
+
+    result = transient(c, t_stop=3.0e-3, t_step=1.0e-3, method="gear2")
+
+    assert result.converged
+    assert result.points[1].branch_currents["L1"] == pytest.approx(0.5e-3, abs=1e-12)
+    assert result.points[2].branch_currents["L1"] == pytest.approx(0.8e-3, abs=1e-12)
+    assert result.points[3].branch_currents["L1"] == pytest.approx(0.94e-3, abs=1e-12)
+
+
 def test_transient_mutual_inductor_couples_secondary_voltage():
     c = Circuit()
     c.add(CurrentSource("Istep", "0", "pri", 1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add Gear-2 transient integration with BDF2 capacitor/inductor companion
+  histories after bootstrapping with one backward-Euler step.
 - Add transient analysis stamping for `TransmissionLine` using a lossless
   Bergeron delay-line companion model, including matched-load delayed step
   behavior.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1792,6 +1792,12 @@ pub struct TransientPoint {
     pub branch_currents: BTreeMap<String, f64>,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TransientMethod {
+    Euler,
+    Gear2,
+}
+
 impl TransientPoint {
     pub fn voltage(&self, node: &str) -> Option<f64> {
         if is_ground(node) {
@@ -2829,6 +2835,15 @@ pub fn transient(
     time_step: f64,
     stop_time: f64,
 ) -> Result<Vec<TransientPoint>, SpiceError> {
+    transient_with_method(circuit, time_step, stop_time, TransientMethod::Euler)
+}
+
+pub fn transient_with_method(
+    circuit: &Circuit,
+    time_step: f64,
+    stop_time: f64,
+    method: TransientMethod,
+) -> Result<Vec<TransientPoint>, SpiceError> {
     if !time_step.is_finite() || time_step <= 0.0 {
         return Err(SpiceError::InvalidElement {
             name: "transient".to_string(),
@@ -2844,8 +2859,8 @@ pub fn transient(
 
     validate_reactive_elements(circuit)?;
 
-    let mut capacitor_states = initial_capacitor_states(circuit, time_step);
-    let mut inductor_states = initial_inductor_states(circuit, time_step);
+    let mut capacitor_states = initial_capacitor_states(circuit, time_step, method);
+    let mut inductor_states = initial_inductor_states(circuit, time_step, method);
     let mut line_states = initial_transmission_line_states(circuit);
     let initial_circuit = circuit_with_transmission_line_companions(circuit, &line_states, 0.0)?;
     let initial_solution = solve_linear_circuit(
@@ -2863,6 +2878,12 @@ pub fn transient(
     let mut points = Vec::new();
     let mut time = time_step;
     while time <= stop_time + time_step * 1.0e-9 {
+        let step_method = if method == TransientMethod::Gear2 && points.is_empty() {
+            TransientMethod::Euler
+        } else {
+            method
+        };
+        set_reactive_state_method(&mut capacitor_states, &mut inductor_states, step_method);
         let companion_circuit =
             circuit_with_transmission_line_companions(circuit, &line_states, time)?;
         let linear_solution = solve_linear_circuit(
@@ -2931,8 +2952,8 @@ pub fn pss_residual_with_tolerance(
     validate_reactive_elements(circuit)?;
     let initial_solution = solve_linear_circuit(
         circuit,
-        &initial_capacitor_states(circuit, time_step),
-        &initial_inductor_states(circuit, time_step),
+        &initial_capacitor_states(circuit, time_step, TransientMethod::Euler),
+        &initial_inductor_states(circuit, time_step, TransientMethod::Euler),
         Some(0.0),
     )?;
     let points = transient(circuit, time_step, period)?;
@@ -3751,14 +3772,18 @@ fn sample_std_dev(values: &[f64]) -> f64 {
 struct CapacitorState {
     name: String,
     previous_voltage: f64,
+    previous_previous_voltage: f64,
     time_step: f64,
+    method: TransientMethod,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 struct InductorState {
     name: String,
     previous_current: f64,
+    previous_previous_current: f64,
     time_step: f64,
+    method: TransientMethod,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -4813,12 +4838,22 @@ fn stamp_capacitor(
         return Ok(());
     };
 
-    let conductance = capacitor.capacitance_farads / state.time_step;
+    let conductance = if state.method == TransientMethod::Gear2 {
+        3.0 * capacitor.capacitance_farads / (2.0 * state.time_step)
+    } else {
+        capacitor.capacitance_farads / state.time_step
+    };
     let n1 = node_index(node_indices, &capacitor.n1);
     let n2 = node_index(node_indices, &capacitor.n2);
     stamp_conductance(matrix, n1, n2, conductance);
 
-    let history_current = conductance * state.previous_voltage;
+    let history_current = if state.method == TransientMethod::Gear2 {
+        capacitor.capacitance_farads
+            * (4.0 * state.previous_voltage - state.previous_previous_voltage)
+            / (2.0 * state.time_step)
+    } else {
+        conductance * state.previous_voltage
+    };
     if let Some(i) = n1 {
         rhs[i] += history_current;
     }
@@ -4848,13 +4883,22 @@ fn stamp_inductor(
         return Ok(());
     };
 
-    let conductance = state.time_step / inductor.inductance_henrys;
+    let conductance = if state.method == TransientMethod::Gear2 {
+        2.0 * state.time_step / (3.0 * inductor.inductance_henrys)
+    } else {
+        state.time_step / inductor.inductance_henrys
+    };
     stamp_conductance(matrix, n1, n2, conductance);
+    let history_current = if state.method == TransientMethod::Gear2 {
+        (4.0 * state.previous_current - state.previous_previous_current) / 3.0
+    } else {
+        state.previous_current
+    };
     if let Some(i) = n1 {
-        rhs[i] -= state.previous_current;
+        rhs[i] -= history_current;
     }
     if let Some(j) = n2 {
-        rhs[j] += state.previous_current;
+        rhs[j] += history_current;
     }
     Ok(())
 }
@@ -5540,7 +5584,11 @@ fn validate_transmission_line(line: &TransmissionLine) -> Result<(), SpiceError>
     Ok(())
 }
 
-fn initial_capacitor_states(circuit: &Circuit, time_step: f64) -> Vec<CapacitorState> {
+fn initial_capacitor_states(
+    circuit: &Circuit,
+    time_step: f64,
+    method: TransientMethod,
+) -> Vec<CapacitorState> {
     circuit
         .elements()
         .iter()
@@ -5548,14 +5596,20 @@ fn initial_capacitor_states(circuit: &Circuit, time_step: f64) -> Vec<CapacitorS
             Element::Capacitor(capacitor) => Some(CapacitorState {
                 name: capacitor.name.clone(),
                 previous_voltage: capacitor.initial_voltage,
+                previous_previous_voltage: capacitor.initial_voltage,
                 time_step,
+                method,
             }),
             _ => None,
         })
         .collect()
 }
 
-fn initial_inductor_states(circuit: &Circuit, time_step: f64) -> Vec<InductorState> {
+fn initial_inductor_states(
+    circuit: &Circuit,
+    time_step: f64,
+    method: TransientMethod,
+) -> Vec<InductorState> {
     circuit
         .elements()
         .iter()
@@ -5563,11 +5617,26 @@ fn initial_inductor_states(circuit: &Circuit, time_step: f64) -> Vec<InductorSta
             Element::Inductor(inductor) => Some(InductorState {
                 name: inductor.name.clone(),
                 previous_current: inductor.initial_current,
+                previous_previous_current: inductor.initial_current,
                 time_step,
+                method,
             }),
             _ => None,
         })
         .collect()
+}
+
+fn set_reactive_state_method(
+    capacitor_states: &mut [CapacitorState],
+    inductor_states: &mut [InductorState],
+    method: TransientMethod,
+) {
+    for state in capacitor_states {
+        state.method = method;
+    }
+    for state in inductor_states {
+        state.method = method;
+    }
 }
 
 fn initial_transmission_line_states(circuit: &Circuit) -> Vec<TransmissionLineState> {
@@ -5746,8 +5815,10 @@ fn update_capacitor_states(
         }) else {
             continue;
         };
+        let previous_voltage = state.previous_voltage;
         state.previous_voltage =
             voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2);
+        state.previous_previous_voltage = previous_voltage;
     }
 }
 
@@ -5767,10 +5838,12 @@ fn update_inductor_states(
         }) else {
             continue;
         };
+        let previous_current = state.previous_current;
         state.previous_current = coupled_currents
             .get(&inductor.name)
             .copied()
             .unwrap_or_else(|| inductor_current(inductor, state, node_voltages));
+        state.previous_previous_current = previous_current;
     }
 }
 
@@ -5806,9 +5879,13 @@ fn inductor_current(
     state: &InductorState,
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
-    let conductance = state.time_step / inductor.inductance_henrys;
     let voltage = voltage_at(node_voltages, &inductor.n1) - voltage_at(node_voltages, &inductor.n2);
-    state.previous_current + conductance * voltage
+    if state.method == TransientMethod::Gear2 {
+        2.0 * state.time_step * voltage / (3.0 * inductor.inductance_henrys)
+            + (4.0 * state.previous_current - state.previous_previous_current) / 3.0
+    } else {
+        state.previous_current + (state.time_step / inductor.inductance_henrys) * voltage
+    }
 }
 
 fn stamp_transient_mutual_inductor(

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2,11 +2,11 @@ use spice_engine::{
     estimate_period, pss_newton_candidate_with_tolerance, pss_newton_iteration_with_tolerance,
     pss_newton_solve_with_tolerance, pss_newton_update, pss_newton_update_with_tolerance,
     pss_residual, pss_residual_jacobian_with_tolerance, pss_residual_with_tolerance,
-    pss_with_tolerance, transient, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Element,
-    ExpWaveform, Inductor, MutualInductor, PssNewtonCandidateResult, PssNewtonIterationResult,
-    PssNewtonSolveResult, PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult,
-    PssResult, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, TransmissionLine,
-    VoltageSource, Waveform,
+    pss_with_tolerance, transient, transient_with_method, Capacitor, Cccs, Ccvs, Circuit,
+    CurrentSource, Element, ExpWaveform, Inductor, MutualInductor, PssNewtonCandidateResult,
+    PssNewtonIterationResult, PssNewtonSolveResult, PssNewtonUpdateResult,
+    PssResidualJacobianResult, PssResidualResult, PssResult, PulseWaveform, PwlWaveform, Resistor,
+    SinWaveform, SpiceError, TransientMethod, TransmissionLine, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -490,6 +490,25 @@ fn transient_rc_step_uses_backward_euler_capacitor_companion() {
 }
 
 #[test]
+fn transient_gear2_rc_charging_bootstraps_then_uses_bdf2() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Capacitor(Capacitor::new("C1", "out", "0", 1.0e-6)));
+
+    let points = transient_with_method(&circuit, 1.0e-3, 3.0e-3, TransientMethod::Gear2).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_close(points[0].voltage("out").unwrap(), 0.5);
+    assert_close(points[1].voltage("out").unwrap(), 0.8);
+    assert_close(points[2].voltage("out").unwrap(), 0.94);
+}
+
+#[test]
 fn transient_respects_capacitor_initial_voltage() {
     let mut circuit = Circuit::new();
     circuit.add(Element::Resistor(Resistor::new("R1", "out", "0", 1_000.0)));
@@ -523,6 +542,25 @@ fn transient_rl_step_uses_backward_euler_inductor_companion() {
     assert_close(points[1].branch_current("L1").unwrap(), 0.75e-3);
     assert_close(points[2].voltage("out").unwrap(), 0.125);
     assert_close(points[2].branch_current("L1").unwrap(), 0.875e-3);
+}
+
+#[test]
+fn transient_gear2_rl_current_buildup_bootstraps_then_uses_bdf2() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Inductor(Inductor::new("L1", "out", "0", 1.0)));
+
+    let points = transient_with_method(&circuit, 1.0e-3, 3.0e-3, TransientMethod::Gear2).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_close(points[0].branch_current("L1").unwrap(), 0.5e-3);
+    assert_close(points[1].branch_current("L1").unwrap(), 0.8e-3);
+    assert_close(points[2].branch_current("L1").unwrap(), 0.94e-3);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add Gear-2 transient integration with BDF2 capacitor/inductor companion
+  histories after bootstrapping with one backward-Euler step.
 - Add transient analysis stamping for `TransmissionLine` using a lossless
   Bergeron delay-line companion model, including matched-load delayed step
   behavior.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -21,6 +21,8 @@ export type Element =
   | Cccs
   | Ccvs;
 
+export type TransientMethod = "euler" | "gear2";
+
 export interface Resistor {
   readonly kind: "resistor";
   readonly name: string;
@@ -1840,6 +1842,7 @@ export function transient(
   circuit: Circuit,
   timeStep: number,
   stopTime: number,
+  method: TransientMethod = "euler",
 ): TransientPoint[] {
   if (!Number.isFinite(timeStep) || timeStep <= 0.0) {
     throw invalidElement("transient", "time step must be finite and positive");
@@ -1847,11 +1850,14 @@ export function transient(
   if (!Number.isFinite(stopTime) || stopTime < 0.0) {
     throw invalidElement("transient", "stop time must be finite and non-negative");
   }
+  if (method !== "euler" && method !== "gear2") {
+    throw invalidElement("transient", "method must be euler or gear2");
+  }
 
   validateReactiveElements(circuit);
 
-  const capacitorStates = initialCapacitorStates(circuit, timeStep);
-  const inductorStates = initialInductorStates(circuit, timeStep);
+  const capacitorStates = initialCapacitorStates(circuit, timeStep, method);
+  const inductorStates = initialInductorStates(circuit, timeStep, method);
   const lineStates = initialTransmissionLineStates(circuit);
   const initialCircuit = circuitWithTransmissionLineCompanions(circuit, lineStates, 0.0);
   const initialSolution = solveLinearCircuit(
@@ -1863,6 +1869,8 @@ export function transient(
   updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
   const points: TransientPoint[] = [];
   for (let time = timeStep; time <= stopTime + timeStep * 1.0e-9; time += timeStep) {
+    const stepMethod = method === "gear2" && points.length === 0 ? "euler" : method;
+    setReactiveStateMethod(capacitorStates, inductorStates, stepMethod);
     const companionCircuit = circuitWithTransmissionLineCompanions(circuit, lineStates, time);
     const solution = solveLinearCircuit(
       companionCircuit,
@@ -1915,8 +1923,8 @@ export function pssResidual(
   validateReactiveElements(circuit);
   const initialSolution = solveLinearCircuit(
     circuit,
-    initialCapacitorStates(circuit, timeStep),
-    initialInductorStates(circuit, timeStep),
+    initialCapacitorStates(circuit, timeStep, "euler"),
+    initialInductorStates(circuit, timeStep, "euler"),
     0.0,
   );
   const points = transient(circuit, timeStep, period);
@@ -2748,13 +2756,17 @@ function sampleStdDev(values: readonly number[]): number {
 interface CapacitorState {
   readonly name: string;
   previousVoltage: number;
+  previousPreviousVoltage: number;
   readonly timeStep: number;
+  method: TransientMethod;
 }
 
 interface InductorState {
   readonly name: string;
   previousCurrent: number;
+  previousPreviousCurrent: number;
   readonly timeStep: number;
+  method: TransientMethod;
 }
 
 interface TransmissionLineState {
@@ -4144,12 +4156,20 @@ function stampCapacitor(
     return;
   }
 
-  const conductance = element.capacitanceFarads / state.timeStep;
+  const conductance =
+    state.method === "gear2"
+      ? (3.0 * element.capacitanceFarads) / (2.0 * state.timeStep)
+      : element.capacitanceFarads / state.timeStep;
   const n1 = nodeIndex(nodeIndices, element.n1);
   const n2 = nodeIndex(nodeIndices, element.n2);
   stampConductance(matrix, n1, n2, conductance);
 
-  const historyCurrent = conductance * state.previousVoltage;
+  const historyCurrent =
+    state.method === "gear2"
+      ? element.capacitanceFarads *
+        (4.0 * state.previousVoltage - state.previousPreviousVoltage) /
+        (2.0 * state.timeStep)
+      : conductance * state.previousVoltage;
   if (n1 !== undefined) {
     rhs[n1] += historyCurrent;
   }
@@ -4176,13 +4196,20 @@ function stampInductor(
     return;
   }
 
-  const conductance = state.timeStep / element.inductanceHenrys;
+  const conductance =
+    state.method === "gear2"
+      ? (2.0 * state.timeStep) / (3.0 * element.inductanceHenrys)
+      : state.timeStep / element.inductanceHenrys;
   stampConductance(matrix, n1, n2, conductance);
+  const historyCurrent =
+    state.method === "gear2"
+      ? (4.0 * state.previousCurrent - state.previousPreviousCurrent) / 3.0
+      : state.previousCurrent;
   if (n1 !== undefined) {
-    rhs[n1] -= state.previousCurrent;
+    rhs[n1] -= historyCurrent;
   }
   if (n2 !== undefined) {
-    rhs[n2] += state.previousCurrent;
+    rhs[n2] += historyCurrent;
   }
 }
 
@@ -4580,6 +4607,7 @@ function validateInductor(element: Inductor): void {
 function initialCapacitorStates(
   circuit: Circuit,
   timeStep: number,
+  method: TransientMethod,
 ): CapacitorState[] {
   const states: CapacitorState[] = [];
   for (const element of circuit.elements()) {
@@ -4587,7 +4615,9 @@ function initialCapacitorStates(
       states.push({
         name: element.name,
         previousVoltage: element.initialVoltage,
+        previousPreviousVoltage: element.initialVoltage,
         timeStep,
+        method,
       });
     }
   }
@@ -4597,6 +4627,7 @@ function initialCapacitorStates(
 function initialInductorStates(
   circuit: Circuit,
   timeStep: number,
+  method: TransientMethod,
 ): InductorState[] {
   const states: InductorState[] = [];
   for (const element of circuit.elements()) {
@@ -4604,11 +4635,26 @@ function initialInductorStates(
       states.push({
         name: element.name,
         previousCurrent: element.initialCurrent,
+        previousPreviousCurrent: element.initialCurrent,
         timeStep,
+        method,
       });
     }
   }
   return states;
+}
+
+function setReactiveStateMethod(
+  capacitorStates: CapacitorState[],
+  inductorStates: InductorState[],
+  method: TransientMethod,
+): void {
+  for (const state of capacitorStates) {
+    state.method = method;
+  }
+  for (const state of inductorStates) {
+    state.method = method;
+  }
 }
 
 function initialTransmissionLineStates(circuit: Circuit): TransmissionLineState[] {
@@ -4757,8 +4803,10 @@ function updateCapacitorStates(
     if (element === undefined) {
       continue;
     }
+    const previousVoltage = state.previousVoltage;
     state.previousVoltage =
       voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
+    state.previousPreviousVoltage = previousVoltage;
   }
 }
 
@@ -4784,8 +4832,10 @@ function updateInductorStates(
     if (element === undefined) {
       continue;
     }
+    const previousCurrent = state.previousCurrent;
     state.previousCurrent =
       coupledCurrents.get(element.name) ?? inductorCurrent(element, state, nodeVoltages);
+    state.previousPreviousCurrent = previousCurrent;
   }
 }
 
@@ -4824,9 +4874,14 @@ function inductorCurrent(
   state: InductorState,
   nodeVoltages: ReadonlyMap<string, number>,
 ): number {
-  const conductance = state.timeStep / element.inductanceHenrys;
   const voltage = voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
-  return state.previousCurrent + conductance * voltage;
+  if (state.method === "gear2") {
+    return (
+      (2.0 * state.timeStep * voltage) / (3.0 * element.inductanceHenrys) +
+      (4.0 * state.previousCurrent - state.previousPreviousCurrent) / 3.0
+    );
+  }
+  return state.previousCurrent + (state.timeStep / element.inductanceHenrys) * voltage;
 }
 
 function stampTransientMutualInductor(

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -466,6 +466,32 @@ describe("transient", () => {
     expectClose(points[1].branchCurrent("L1"), 0.25e-3);
   });
 
+  it("uses Gear-2 BDF2 capacitor companions after an Euler bootstrap step", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "vc", 1_000.0));
+    circuit.add(capacitor("C1", "vc", "0", 1.0e-6));
+
+    const points = transient(circuit, 1.0e-3, 3.0e-3, "gear2");
+
+    expectClose(points[0].voltage("vc"), 0.5);
+    expectClose(points[1].voltage("vc"), 0.8);
+    expectClose(points[2].voltage("vc"), 0.94);
+  });
+
+  it("uses Gear-2 BDF2 inductor companions after an Euler bootstrap step", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "out", 1_000.0));
+    circuit.add(inductor("L1", "out", "0", 1.0));
+
+    const points = transient(circuit, 1.0e-3, 3.0e-3, "gear2");
+
+    expectClose(points[0].branchCurrent("L1"), 0.5e-3);
+    expectClose(points[1].branchCurrent("L1"), 0.8e-3);
+    expectClose(points[2].branchCurrent("L1"), 0.94e-3);
+  });
+
   it("couples secondary voltage through a mutual inductor", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("Istep", "0", "pri", 1.0));

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -136,6 +136,13 @@ Acceptance:
 - LC damped fixture showing Gear-2 suppresses trapezoidal ringing better than
   trap at the same coarse step.
 
+Status:
+
+- Fixed-step Gear-2 / BDF2 capacitor and inductor companions are implemented
+  across Python, TypeScript, and Rust, with one backward-Euler bootstrap step
+  before two-step history is available. Adaptive-step interaction, netlist
+  option routing, and LC damping comparison remain follow-up work.
+
 ### Phase 5 - Pseudo-Transient DC Continuation
 
 Finish the convergence-aid chain named in `spice-engine.md`.


### PR DESCRIPTION
## Summary

- add fixed-step Gear-2 / BDF2 transient companion support for capacitors and inductors across Python, TypeScript, and Rust
- bootstrap Gear-2 with one backward-Euler step before using two-step history
- add cross-language RC and RL fixtures for the Gear-2 update sequence
- record Python transient inductor branch currents and update the 1970s compatibility plan with remaining Phase 4 follow-up scope

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-gear2-transient sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This is the fixed-step Gear-2 companion slice. Adaptive-step Gear-2 interaction, parser/options routing, and LC damping comparison remain follow-ups.