### PR TITLE
feat(closure-pass-collapse-properties): scaffold pass (CLOC06 Phase 1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -481,6 +481,7 @@ members = [
     "irc-server",
     "irc-net-stdlib",
     "url-parser",
+    "closure-pass-collapse-properties",
     "closure-pass-constant-fold",
     "closure-pass-dce",
     "closure-pass-fold-control-flow",

--- a/code/packages/rust/closure-pass-collapse-properties/BUILD
+++ b/code/packages/rust/closure-pass-collapse-properties/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-collapse-properties -- --nocapture

--- a/code/packages/rust/closure-pass-collapse-properties/BUILD_windows
+++ b/code/packages/rust/closure-pass-collapse-properties/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closure-pass-collapse-properties -- --nocapture

--- a/code/packages/rust/closure-pass-collapse-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-collapse-properties/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closure-pass-collapse-properties` crate will be documented in this file.
+
+## [0.1.0] - 2026-05-23
+
+### Added
+- New crate per CLOC06 canonical pass set — property-collapse. Collapses repeated nested property-access chains on stable namespace-style objects into shorter local bindings (`ns.utils.format.x`, `ns.utils.format.y`, `ns.utils.format.z` → `const $f = ns.utils.format; $f.x; $f.y; $f.z`).
+- `CollapsePropertiesPass` zero-sized type implementing `Pass`:
+  - `name = "collapse-properties"`
+  - `depends_on = &["constant-fold"]` — folded constants resolve into recognisable property-access shapes the collapse pass can spot (e.g. `ns[KEY]` where `KEY = "utils"`).
+  - `iteration_policy = IterationPolicy::FixedPoint` — collapsing one chain can expose new shared prefixes; bounded in practice by chain depth.
+  - `cost = 3` pass-units — gather chain frequencies + emit binding + rewrite uses. Same shape as DCE.
+  - `invalidates()` empty in v1 (informational only per CLOC06 Open Question 1).
+- `CollapsePropertiesPass::new()` zero-arg constructor.
+- `Pass::run` is **identity** in v1: `javascript-ast` ships only `Program` / `SourceType` today (CLOC02 Phase 1), so there are no `MemberExpression` / `Identifier` / `VariableDeclaration` nodes to collapse. Pass through unchanged, `changed = false`, `nodes_touched = 1`, no contributions emitted (per CLOC03 §"When a pass keeps a node unchanged").
+- 9 tests covering: `name()` value, `iteration_policy == FixedPoint`, `cost == 3`, `depends_on == ["constant-fold"]`, `invalidates` empty, identity run, **two-pass pipeline orders constant-fold before collapse-properties** even when registered in reverse, solo pipeline run (with the v0.1.0 `pipeline.fixed-point-not-yet-iterated` diagnostic asserted), `Default` + `Clone` impls.
+
+### Notes
+- Safety prerequisite: collapse is only valid when the intermediate object is genuinely stable. The implementation will read the type sidecar's `stable` / `pure` / `frozen` attributes plus a local mutation analysis. CLOC04 left the exact attribute name open; the implementation will pin it once the sidecar grows the namespace-stability marker.
+- Dependencies: `coding-adventures-closure-pass-pipeline`, `coding-adventures-javascript-ast`, `coding-adventures-type-sidecar`, `coding_adventures_correlation_vector` (per-collapse `Contribution` per CLOC03), `serde_json`. Dev-deps: `coding-adventures-javascript-tokens` for `EsVersion`, `coding-adventures-closure-pass-constant-fold` for the two-pass ordering integration test.
+- v1 is scaffolding. The full gather + rewrite lands once `javascript-ast` grows the needed variants. The public surface (name, policy, cost, depends_on) stays put — no churn upstream.

--- a/code/packages/rust/closure-pass-collapse-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-collapse-properties/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "coding-adventures-closure-pass-collapse-properties"
+version = "0.1.0"
+edition = "2021"
+description = "Property-collapse pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Collapses repeated property-access chains on stable namespace objects into shorter local bindings to shrink output and avoid redundant lookups."
+
+[dependencies]
+coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-javascript-ast = { path = "../javascript-ast" }
+coding-adventures-type-sidecar = { path = "../type-sidecar" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
+
+[dev-dependencies]
+coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
+coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constant-fold" }

--- a/code/packages/rust/closure-pass-collapse-properties/README.md
+++ b/code/packages/rust/closure-pass-collapse-properties/README.md
@@ -1,0 +1,85 @@
+# coding-adventures-closure-pass-collapse-properties
+
+Property-collapse pass for the Closure Compiler clone. Collapses
+repeated nested property-access chains on stable namespace-style
+objects into shorter local bindings. Per
+[CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s
+canonical pass set.
+
+## What it does (once the AST grows the needed variants)
+
+```js
+// before
+ns.utils.format.currency(1);
+ns.utils.format.percent(0.5);
+ns.utils.format.date(now);
+
+// after collapse-properties
+const $f = ns.utils.format;
+$f.currency(1);
+$f.percent(0.5);
+$f.date(now);
+```
+
+Two wins: shorter source and fewer property lookups at runtime.
+
+## Why "stable" matters
+
+Collapsing is only safe when the intermediate is genuinely
+stable — neither the chain nor any function in between can
+mutate the namespace object. The pass reads the type sidecar's
+`stable` / `pure` / `frozen` attributes plus a local mutation
+analysis; without evidence, it bails.
+
+## What's here (v1)
+
+- `CollapsePropertiesPass` implementing the `Pass` trait from
+  [`closure-pass-pipeline`](../closure-pass-pipeline).
+- Metadata pinned:
+  - `name = "collapse-properties"`
+  - `depends_on = ["constant-fold"]` — folded constants resolve
+    into recognisable property-access shapes that collapse can
+    spot.
+  - `iteration_policy = FixedPoint` — collapsing one chain can
+    expose new shared prefixes (`$c.theme.x`, `$c.theme.y` → `$t.x`,
+    `$t.y`).
+  - `cost = 3` — gather chain frequencies + emit binding +
+    rewrite uses. Same shape as DCE.
+- `Pass::run` is **identity** in v1: `javascript-ast` ships
+  only `Program` / `SourceType` today, so there are no
+  `MemberExpression` / `Identifier` / `VariableDeclaration`
+  nodes to collapse. The real gather + rewrite slots into
+  `Pass::run` once the AST grows variants.
+
+## What this PR locks down even as identity
+
+1. The `depends_on("constant-fold")` edge is in the scheduler
+   graph — folded constants before chain collapse.
+2. The two-pass integration test
+   (`pipeline_orders_constant_fold_before_collapse_properties`)
+   registers `CollapsePropertiesPass` first and verifies the
+   scheduler reorders.
+3. Pass metadata drives the future
+   `closurec --disable=collapse-properties`.
+
+## Where this pass sits
+
+CLOC06 §"Canonical pass set" pins this after the value-folding
+group and before `rename` — so the pass sees folded names
+(meaningful chain prefixes) but operates before renaming
+flattens identifiers.
+
+## Dependency whitelist
+
+- `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
+- `coding-adventures-javascript-ast` — `Program` input/output.
+- `coding-adventures-type-sidecar` — `stable` / `pure` / `frozen`
+  attributes inform collapse safety.
+- `coding_adventures_correlation_vector` — receives mutable
+  `CVLog` for per-collapse `Contribution` emission.
+- `serde_json` — `Contribution.meta` JSON values.
+
+Dev-deps:
+- `coding-adventures-javascript-tokens` for `EsVersion` in tests.
+- `coding-adventures-closure-pass-constant-fold` for the
+  two-pass ordering integration test.

--- a/code/packages/rust/closure-pass-collapse-properties/required_capabilities.json
+++ b/code/packages/rust/closure-pass-collapse-properties/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closure-pass-collapse-properties",
+  "capabilities": [],
+  "justification": "Pure data transformation over an AST. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/closure-pass-collapse-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-collapse-properties/src/lib.rs
@@ -1,0 +1,326 @@
+//! Property-collapse pass for the Closure Compiler clone.
+//!
+//! Per [CLOC06](../../../specs/CLOC06-pass-interface-contract.md)'s
+//! canonical pass set. Collapses repeated nested property-access
+//! chains on stable namespace-style objects into shorter local
+//! bindings:
+//!
+//! ```js
+//! // before
+//! ns.utils.format.currency(1);
+//! ns.utils.format.percent(0.5);
+//! ns.utils.format.date(now);
+//!
+//! // after collapse-properties
+//! const $f = ns.utils.format;     // bound once
+//! $f.currency(1);
+//! $f.percent(0.5);
+//! $f.date(now);
+//! ```
+//!
+//! Two wins:
+//!
+//! 1. **Smaller output.** `ns.utils.format` is repeated thrice
+//!    in the original; once after collapse.
+//! 2. **Faster runtime.** Each `.foo.bar.baz` is a chain of
+//!    property lookups. Caching the intermediate object in a
+//!    local skips the lookups on the hot path.
+//!
+//! # Why "stable" matters
+//!
+//! Collapsing is only safe when the intermediate object is
+//! genuinely stable — i.e., neither the property chain nor any
+//! visible function can mutate it between accesses:
+//!
+//! ```js
+//! // UNSAFE: mutate() could replace ns.utils.format mid-chain
+//! ns.utils.format.currency(1);
+//! mutate();
+//! ns.utils.format.percent(0.5);    // might be a different object now
+//! ```
+//!
+//! The pass reads the type sidecar's `stable` / `pure` / `frozen`
+//! attributes plus a local mutation analysis. Without that
+//! evidence it bails. (CLOC04 left the exact attribute name
+//! open; the implementation will pick once the sidecar grows
+//! the namespace-stability marker.)
+//!
+//! # Why depends_on = ["constant-fold"]?
+//!
+//! Folded constant expressions can resolve into recognisable
+//! property-access shapes. Without fold, the pass would miss
+//! collapsing in expressions like:
+//!
+//! ```js
+//! const KEY = "utils";              // fold can prove this
+//! ns[KEY].format.x(...)             // → ns.utils.format.x(...)
+//! ns[KEY].format.y(...)             // collapse can now see the
+//! ns[KEY].format.z(...)             //   shared `ns.utils.format`
+//! ```
+//!
+//! # Why `FixedPoint`?
+//!
+//! Collapsing one chain can rewrite call sites in ways that
+//! expose *new* chains:
+//!
+//! ```js
+//! // before
+//! lib.feature.config.theme.color;
+//! lib.feature.config.theme.font;
+//!
+//! // first iteration collapses lib.feature.config:
+//! const $c = lib.feature.config;
+//! $c.theme.color;
+//! $c.theme.font;
+//!
+//! // second iteration spots the new shared `$c.theme`:
+//! const $c = lib.feature.config;
+//! const $t = $c.theme;
+//! $t.color;
+//! $t.font;
+//! ```
+//!
+//! Bounded in practice by the depth of the chains; we don't
+//! pre-cap.
+//!
+//! # Scope (v1)
+//!
+//! `javascript-ast` ships only `Program` / `SourceType` today
+//! (CLOC02 Phase 1). With no `MemberExpression` / `Identifier` /
+//! `VariableDeclaration` nodes there is nothing to collapse;
+//! [`CollapsePropertiesPass::run`] is identity in v1. Per CLOC03
+//! §"When a pass keeps a node unchanged" no contributions are
+//! emitted.
+//!
+//! What this PR locks down:
+//!
+//! 1. Pass metadata (`name`, `iteration_policy`, `cost`,
+//!    `depends_on`) — what the scheduler keys on and what the
+//!    future `closurec` CLI surfaces as
+//!    `--disable=collapse-properties`.
+//! 2. The `depends_on("constant-fold")` edge so the scheduler
+//!    forces fold-before-collapse as soon as both passes are
+//!    in one pipeline.
+//! 3. The two-pass integration test that proves the ordering.
+
+use coding_adventures_closure_pass_pipeline::{
+    IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
+};
+
+/// `Pass::depends_on` value. Kept as a `const` so future tests
+/// and sibling crates can reference the dependency name without
+/// retyping it.
+const DEPS: &[&str] = &["constant-fold"];
+
+/// Property-collapse pass. v1 is identity — see crate-level docs.
+///
+/// Zero-sized type: no per-instance state. Pass-internal state
+/// (per-scope chain frequency tables, the "do-not-collapse" set
+/// seeded from mutated namespaces) lives in pass-local maps
+/// constructed inside [`Pass::run`] per CLOC06 §"Pass-internal
+/// state."
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CollapsePropertiesPass;
+
+impl CollapsePropertiesPass {
+    /// Zero-arg constructor for ergonomic
+    /// `PassPipeline::add(Box::new(CollapsePropertiesPass::new()))`
+    /// registration.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Pass for CollapsePropertiesPass {
+    fn name(&self) -> &'static str {
+        "collapse-properties"
+    }
+
+    fn depends_on(&self) -> &[&'static str] {
+        // CLOC06 canonical order: constant-fold first so folded
+        // constants resolve into recognisable property-access
+        // shapes that collapse can spot.
+        DEPS
+    }
+
+    fn iteration_policy(&self) -> IterationPolicy {
+        // Per CLOC06: collapsing one chain can expose new
+        // shared prefixes in the now-rewritten call sites.
+        // Bounded in practice by chain depth.
+        IterationPolicy::FixedPoint
+    }
+
+    fn cost(&self) -> u32 {
+        // Per scope:
+        //   1. Walk the scope to gather property-chain frequencies.
+        //   2. For each chain whose frequency × length passes the
+        //      threshold, emit a binding + rewrite uses.
+        // Same shape and weight as DCE's mark+sweep.
+        3
+    }
+
+    fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        // v1: no MemberExpression / Identifier /
+        // VariableDeclaration nodes in the AST yet, so there's
+        // nothing to collapse. Pass through unchanged. The real
+        // gather + rewrite slots in here once javascript-ast
+        // grows the variants.
+        Ok(PassOutput {
+            program: ctx.program.clone(),
+            contributions: Vec::new(),
+            changed: false,
+            diagnostics: Vec::new(),
+            stats: PassStats {
+                // Visited the program root; no chains collapsed.
+                nodes_touched: 1,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests pin the public contract and lock the ordering
+    //! integration with `PassPipeline`. v1's `run` is identity,
+    //! but the metadata drives the scheduler and outlives the
+    //! v1 body.
+    use super::*;
+    use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
+    use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};
+    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_javascript_ast::{Program, SourceType};
+    use coding_adventures_javascript_tokens::EsVersion;
+    use coding_adventures_type_sidecar::Sidecar;
+
+    fn program() -> Program {
+        Program::new("prog.1".to_string(), EsVersion::Es2025, SourceType::Module)
+    }
+
+    #[test]
+    fn name_is_collapse_properties() {
+        // `--disable=collapse-properties` and
+        // `out.stats["collapse-properties"]` key on this.
+        // Public contract.
+        assert_eq!(
+            CollapsePropertiesPass::new().name(),
+            "collapse-properties"
+        );
+    }
+
+    #[test]
+    fn iteration_policy_is_fixed_point() {
+        // Collapse one chain → expose new shared prefix →
+        // collapse again. FixedPoint captures intent.
+        assert_eq!(
+            CollapsePropertiesPass::new().iteration_policy(),
+            IterationPolicy::FixedPoint
+        );
+    }
+
+    #[test]
+    fn cost_is_three_pass_units() {
+        // Gather + rewrite. Same shape as DCE.
+        assert_eq!(CollapsePropertiesPass::new().cost(), 3);
+    }
+
+    #[test]
+    fn depends_on_constant_fold() {
+        let p = CollapsePropertiesPass::new();
+        assert_eq!(p.depends_on(), &["constant-fold"]);
+    }
+
+    #[test]
+    fn invalidates_empty_in_v1() {
+        // CLOC06 Open Question 1: informational only in v0.1.0.
+        assert!(CollapsePropertiesPass::new().invalidates().is_empty());
+    }
+
+    #[test]
+    fn run_on_empty_program_returns_unchanged_identity() {
+        // Identity: same CV, version, source_type; no
+        // contributions, no diagnostics, changed=false,
+        // nodes_touched=1.
+        let pass = CollapsePropertiesPass::new();
+        let prog = program();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+
+        let ctx = PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        };
+        let out = pass.run(ctx).expect("pass should succeed");
+
+        assert_eq!(out.program.cv, prog.cv);
+        assert_eq!(out.program.version, prog.version);
+        assert_eq!(out.program.source_type, prog.source_type);
+        assert!(!out.changed);
+        assert!(out.contributions.is_empty());
+        assert!(out.diagnostics.is_empty());
+        assert_eq!(out.stats.nodes_touched, 1);
+    }
+
+    #[test]
+    fn pipeline_orders_constant_fold_before_collapse_properties() {
+        // Register CollapsePropertiesPass FIRST. If
+        // `depends_on` were ignored, the pipeline would run them
+        // in registration order: [collapse-properties,
+        // constant-fold]. The scheduler must reorder them to
+        // [constant-fold, collapse-properties] per CLOC06
+        // canonical order.
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(CollapsePropertiesPass::new()));
+        pipeline.add(Box::new(ConstantFoldPass::new()));
+
+        let mut cv = CVLog::new(true);
+        let out: PipelineOutput = pipeline
+            .run(program(), &Sidecar::new(), &mut cv)
+            .expect("pipeline should run cleanly");
+
+        assert_eq!(
+            out.execution_order,
+            vec![
+                "constant-fold".to_string(),
+                "collapse-properties".to_string(),
+            ],
+            "collapse-properties must run after constant-fold per CLOC06 canonical order"
+        );
+        assert!(out.stats.contains_key("constant-fold"));
+        assert!(out.stats.contains_key("collapse-properties"));
+    }
+
+    #[test]
+    fn pipeline_runs_collapse_properties_as_solo_pass() {
+        // CollapsePropertiesPass alone (without constant-fold)
+        // still works: depends_on is "soft" in v1 — the v0.1.0
+        // scheduler silently drops unknown dependencies.
+        let mut pipeline = PassPipeline::new();
+        pipeline.add(Box::new(CollapsePropertiesPass::new()));
+
+        let mut cv = CVLog::new(true);
+        let out = pipeline.run(program(), &Sidecar::new(), &mut cv).unwrap();
+        assert_eq!(
+            out.execution_order,
+            vec!["collapse-properties".to_string()]
+        );
+        assert_eq!(out.stats["collapse-properties"].nodes_touched, 1);
+        // FixedPoint policy → v0.1.0 pipeline emits the
+        // "not yet iterated" informational note.
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|d| d.group.0 == "pipeline.fixed-point-not-yet-iterated"),
+            "expected the pipeline's FixedPoint note; got {:?}",
+            out.diagnostics
+        );
+    }
+
+    #[test]
+    fn pass_is_default_and_clone() {
+        let _a: CollapsePropertiesPass = Default::default();
+        let _b: CollapsePropertiesPass = CollapsePropertiesPass::new();
+        let _c = _b;
+        let _d = _c.clone();
+    }
+}


### PR DESCRIPTION
## Summary

- New crate for **property-collapse** — collapses repeated nested property-access chains on stable namespace-style objects into shorter local bindings (`ns.utils.format.x/y/z` → `const $f = ns.utils.format; $f.x/y/z`).
- `CollapsePropertiesPass`: `name = "collapse-properties"`, `depends_on = ["constant-fold"]`, `iteration_policy = FixedPoint`, `cost = 3`.
- `Pass::run` is identity in v1 — `javascript-ast` ships only `Program`/`SourceType` today, so no `MemberExpression`/`Identifier`/`VariableDeclaration` nodes yet. Real gather+rewrite slots in once the AST grows variants.

## Why depends_on = ["constant-fold"]?

Folded constants resolve into recognisable property-access shapes (`ns[KEY]` where `KEY = "utils"` is folded → `ns.utils`), which collapse can then spot.

## Safety prerequisite

Only valid when the intermediate is genuinely stable. Will read the sidecar's `stable`/`pure`/`frozen` attributes plus a local mutation analysis (exact attribute name pinned once CLOC04 sidecar grows the namespace-stability marker).

## What this PR locks down

1. `depends_on("constant-fold")` edge — folded constants before chain collapse.
2. Two-pass integration test registers CollapsePropertiesPass FIRST and verifies scheduler reorders to `constant-fold → collapse-properties`.
3. Pass metadata drives future `closurec --disable=collapse-properties`.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-collapse-properties` passes (9/9).
- [ ] CI green on ubuntu/macos/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)