### PR TITLE
spice: add trap damping parity

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **Gear-2 damping fixture** — transient tests now cover a coarse LC oscillator
+  where Gear-2 damps numerical ringing more aggressively than trapezoidal
+  integration.
+
 - **Gear-2 transient companions** — transient analysis now accepts
   `method="gear2"` and uses BDF2 capacitor/inductor companion histories after
   bootstrapping with one backward-Euler step.

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -989,6 +989,21 @@ def test_transient_gear2_rl_current_buildup_bootstraps_then_uses_bdf2():
     assert result.points[3].branch_currents["L1"] == pytest.approx(0.94e-3, abs=1e-12)
 
 
+def test_transient_gear2_damps_coarse_lc_oscillator_more_than_trap():
+    c = Circuit()
+    c.add(Capacitor("C1", "tank", "0", 1.0, initial_voltage=1.0))
+    c.add(Inductor("L1", "tank", "0", 1.0))
+
+    trap = transient(c, t_stop=10.0, t_step=1.0, method="trap")
+    gear2 = transient(c, t_stop=10.0, t_step=1.0, method="gear2")
+
+    assert trap.converged
+    assert gear2.converged
+    trap_tail = max(abs(point.node_voltages["tank"]) for point in trap.points[-4:])
+    gear2_tail = max(abs(point.node_voltages["tank"]) for point in gear2.points[-4:])
+    assert gear2_tail < trap_tail * 0.75
+
+
 def test_transient_mutual_inductor_couples_secondary_voltage():
     c = Circuit()
     c.add(CurrentSource("Istep", "0", "pri", 1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add trapezoidal transient integration parity for capacitors and inductors,
+  enabling LC damping comparisons against Gear-2.
 - Add Gear-2 transient integration with BDF2 capacitor/inductor companion
   histories after bootstrapping with one backward-Euler step.
 - Add transient analysis stamping for `TransmissionLine` using a lossless

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1795,6 +1795,7 @@ pub struct TransientPoint {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TransientMethod {
     Euler,
+    Trap,
     Gear2,
 }
 
@@ -3773,6 +3774,7 @@ struct CapacitorState {
     name: String,
     previous_voltage: f64,
     previous_previous_voltage: f64,
+    previous_current: f64,
     time_step: f64,
     method: TransientMethod,
 }
@@ -3782,6 +3784,7 @@ struct InductorState {
     name: String,
     previous_current: f64,
     previous_previous_current: f64,
+    previous_voltage: f64,
     time_step: f64,
     method: TransientMethod,
 }
@@ -4838,21 +4841,23 @@ fn stamp_capacitor(
         return Ok(());
     };
 
-    let conductance = if state.method == TransientMethod::Gear2 {
-        3.0 * capacitor.capacitance_farads / (2.0 * state.time_step)
-    } else {
-        capacitor.capacitance_farads / state.time_step
+    let conductance = match state.method {
+        TransientMethod::Trap => 2.0 * capacitor.capacitance_farads / state.time_step,
+        TransientMethod::Gear2 => 3.0 * capacitor.capacitance_farads / (2.0 * state.time_step),
+        TransientMethod::Euler => capacitor.capacitance_farads / state.time_step,
     };
     let n1 = node_index(node_indices, &capacitor.n1);
     let n2 = node_index(node_indices, &capacitor.n2);
     stamp_conductance(matrix, n1, n2, conductance);
 
-    let history_current = if state.method == TransientMethod::Gear2 {
-        capacitor.capacitance_farads
-            * (4.0 * state.previous_voltage - state.previous_previous_voltage)
-            / (2.0 * state.time_step)
-    } else {
-        conductance * state.previous_voltage
+    let history_current = match state.method {
+        TransientMethod::Trap => conductance * state.previous_voltage + state.previous_current,
+        TransientMethod::Gear2 => {
+            capacitor.capacitance_farads
+                * (4.0 * state.previous_voltage - state.previous_previous_voltage)
+                / (2.0 * state.time_step)
+        }
+        TransientMethod::Euler => conductance * state.previous_voltage,
     };
     if let Some(i) = n1 {
         rhs[i] += history_current;
@@ -4883,16 +4888,18 @@ fn stamp_inductor(
         return Ok(());
     };
 
-    let conductance = if state.method == TransientMethod::Gear2 {
-        2.0 * state.time_step / (3.0 * inductor.inductance_henrys)
-    } else {
-        state.time_step / inductor.inductance_henrys
+    let conductance = match state.method {
+        TransientMethod::Trap => state.time_step / (2.0 * inductor.inductance_henrys),
+        TransientMethod::Gear2 => 2.0 * state.time_step / (3.0 * inductor.inductance_henrys),
+        TransientMethod::Euler => state.time_step / inductor.inductance_henrys,
     };
     stamp_conductance(matrix, n1, n2, conductance);
-    let history_current = if state.method == TransientMethod::Gear2 {
-        (4.0 * state.previous_current - state.previous_previous_current) / 3.0
-    } else {
-        state.previous_current
+    let history_current = match state.method {
+        TransientMethod::Trap => state.previous_current + conductance * state.previous_voltage,
+        TransientMethod::Gear2 => {
+            (4.0 * state.previous_current - state.previous_previous_current) / 3.0
+        }
+        TransientMethod::Euler => state.previous_current,
     };
     if let Some(i) = n1 {
         rhs[i] -= history_current;
@@ -5597,6 +5604,7 @@ fn initial_capacitor_states(
                 name: capacitor.name.clone(),
                 previous_voltage: capacitor.initial_voltage,
                 previous_previous_voltage: capacitor.initial_voltage,
+                previous_current: 0.0,
                 time_step,
                 method,
             }),
@@ -5618,6 +5626,7 @@ fn initial_inductor_states(
                 name: inductor.name.clone(),
                 previous_current: inductor.initial_current,
                 previous_previous_current: inductor.initial_current,
+                previous_voltage: 0.0,
                 time_step,
                 method,
             }),
@@ -5816,8 +5825,24 @@ fn update_capacitor_states(
             continue;
         };
         let previous_voltage = state.previous_voltage;
-        state.previous_voltage =
+        let previous_current = state.previous_current;
+        let voltage =
             voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2);
+        state.previous_current = match state.method {
+            TransientMethod::Trap => {
+                let conductance = 2.0 * capacitor.capacitance_farads / state.time_step;
+                conductance * (voltage - previous_voltage) - previous_current
+            }
+            TransientMethod::Gear2 => {
+                capacitor.capacitance_farads
+                    * (3.0 * voltage - 4.0 * previous_voltage + state.previous_previous_voltage)
+                    / (2.0 * state.time_step)
+            }
+            TransientMethod::Euler => {
+                capacitor.capacitance_farads * (voltage - previous_voltage) / state.time_step
+            }
+        };
+        state.previous_voltage = voltage;
         state.previous_previous_voltage = previous_voltage;
     }
 }
@@ -5839,11 +5864,14 @@ fn update_inductor_states(
             continue;
         };
         let previous_current = state.previous_current;
+        let voltage =
+            voltage_at(node_voltages, &inductor.n1) - voltage_at(node_voltages, &inductor.n2);
         state.previous_current = coupled_currents
             .get(&inductor.name)
             .copied()
             .unwrap_or_else(|| inductor_current(inductor, state, node_voltages));
         state.previous_previous_current = previous_current;
+        state.previous_voltage = voltage;
     }
 }
 
@@ -5880,11 +5908,18 @@ fn inductor_current(
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
     let voltage = voltage_at(node_voltages, &inductor.n1) - voltage_at(node_voltages, &inductor.n2);
-    if state.method == TransientMethod::Gear2 {
-        2.0 * state.time_step * voltage / (3.0 * inductor.inductance_henrys)
-            + (4.0 * state.previous_current - state.previous_previous_current) / 3.0
-    } else {
-        state.previous_current + (state.time_step / inductor.inductance_henrys) * voltage
+    match state.method {
+        TransientMethod::Trap => {
+            let conductance = state.time_step / (2.0 * inductor.inductance_henrys);
+            state.previous_current + conductance * state.previous_voltage + conductance * voltage
+        }
+        TransientMethod::Gear2 => {
+            2.0 * state.time_step * voltage / (3.0 * inductor.inductance_henrys)
+                + (4.0 * state.previous_current - state.previous_previous_current) / 3.0
+        }
+        TransientMethod::Euler => {
+            state.previous_current + (state.time_step / inductor.inductance_henrys) * voltage
+        }
     }
 }
 
@@ -5915,6 +5950,7 @@ fn stamp_transient_mutual_inductor(
         secondary,
         mutual_inductance,
         primary_state.time_step,
+        primary_state.method,
     )?;
     let p1 = node_index(node_indices, &primary.n1);
     let p2 = node_index(node_indices, &primary.n2);
@@ -5924,8 +5960,16 @@ fn stamp_transient_mutual_inductor(
     stamp_conductance(matrix, s1, s2, g22);
     stamp_transconductance(matrix, p1, p2, s1, s2, g12);
     stamp_transconductance(matrix, s1, s2, p1, p2, g12);
-    stamp_equivalent_current_source(rhs, p1, p2, primary_state.previous_current);
-    stamp_equivalent_current_source(rhs, s1, s2, secondary_state.previous_current);
+    let mut primary_history_current = primary_state.previous_current;
+    let mut secondary_history_current = secondary_state.previous_current;
+    if primary_state.method == TransientMethod::Trap {
+        primary_history_current +=
+            g11 * primary_state.previous_voltage + g12 * secondary_state.previous_voltage;
+        secondary_history_current +=
+            g12 * primary_state.previous_voltage + g22 * secondary_state.previous_voltage;
+    }
+    stamp_equivalent_current_source(rhs, p1, p2, primary_history_current);
+    stamp_equivalent_current_source(rhs, s1, s2, secondary_history_current);
     Ok(())
 }
 
@@ -5959,18 +6003,27 @@ fn coupled_transient_inductor_currents(
             secondary,
             mutual_inductance,
             primary_state.time_step,
+            primary_state.method,
         )?;
         let primary_voltage =
             voltage_at(node_voltages, &primary.n1) - voltage_at(node_voltages, &primary.n2);
         let secondary_voltage =
             voltage_at(node_voltages, &secondary.n1) - voltage_at(node_voltages, &secondary.n2);
+        let mut primary_history_current = primary_state.previous_current;
+        let mut secondary_history_current = secondary_state.previous_current;
+        if primary_state.method == TransientMethod::Trap {
+            primary_history_current +=
+                g11 * primary_state.previous_voltage + g12 * secondary_state.previous_voltage;
+            secondary_history_current +=
+                g12 * primary_state.previous_voltage + g22 * secondary_state.previous_voltage;
+        }
         currents.insert(
             primary.name.clone(),
-            primary_state.previous_current + g11 * primary_voltage + g12 * secondary_voltage,
+            primary_history_current + g11 * primary_voltage + g12 * secondary_voltage,
         );
         currents.insert(
             secondary.name.clone(),
-            secondary_state.previous_current + g12 * primary_voltage + g22 * secondary_voltage,
+            secondary_history_current + g12 * primary_voltage + g22 * secondary_voltage,
         );
     }
     Ok(currents)
@@ -5982,6 +6035,7 @@ fn transient_mutual_conductances(
     secondary: &Inductor,
     mutual_inductance: f64,
     time_step: f64,
+    method: TransientMethod,
 ) -> Result<(f64, f64, f64), SpiceError> {
     let determinant =
         primary.inductance_henrys * secondary.inductance_henrys - mutual_inductance.powi(2);
@@ -5991,7 +6045,11 @@ fn transient_mutual_conductances(
             reason: "coupled inductance matrix is singular".to_string(),
         });
     }
-    let scale = time_step / determinant;
+    let scale = if method == TransientMethod::Trap {
+        time_step / (2.0 * determinant)
+    } else {
+        time_step / determinant
+    };
     Ok((
         secondary.inductance_henrys * scale,
         -mutual_inductance * scale,

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -509,6 +509,25 @@ fn transient_gear2_rc_charging_bootstraps_then_uses_bdf2() {
 }
 
 #[test]
+fn transient_trap_rc_charging_uses_trapezoidal_companion() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Capacitor(Capacitor::new("C1", "out", "0", 1.0e-6)));
+
+    let points = transient_with_method(&circuit, 1.0e-3, 3.0e-3, TransientMethod::Trap).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_close(points[0].voltage("out").unwrap(), 1.0 / 3.0);
+    assert_close(points[1].voltage("out").unwrap(), 7.0 / 9.0);
+    assert_close(points[2].voltage("out").unwrap(), 25.0 / 27.0);
+}
+
+#[test]
 fn transient_respects_capacitor_initial_voltage() {
     let mut circuit = Circuit::new();
     circuit.add(Element::Resistor(Resistor::new("R1", "out", "0", 1_000.0)));
@@ -561,6 +580,51 @@ fn transient_gear2_rl_current_buildup_bootstraps_then_uses_bdf2() {
     assert_close(points[0].branch_current("L1").unwrap(), 0.5e-3);
     assert_close(points[1].branch_current("L1").unwrap(), 0.8e-3);
     assert_close(points[2].branch_current("L1").unwrap(), 0.94e-3);
+}
+
+#[test]
+fn transient_trap_rl_current_buildup_uses_trapezoidal_companion() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Inductor(Inductor::new("L1", "out", "0", 1.0)));
+
+    let points = transient_with_method(&circuit, 1.0e-3, 3.0e-3, TransientMethod::Trap).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_close(points[0].branch_current("L1").unwrap(), 1.0e-3 / 3.0);
+    assert_close(points[1].branch_current("L1").unwrap(), 7.0e-3 / 9.0);
+    assert_close(points[2].branch_current("L1").unwrap(), 25.0e-3 / 27.0);
+}
+
+#[test]
+fn transient_gear2_damps_coarse_lc_oscillator_more_than_trap() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Capacitor(Capacitor::with_initial_voltage(
+        "C1", "tank", "0", 1.0, 1.0,
+    )));
+    circuit.add(Element::Inductor(Inductor::new("L1", "tank", "0", 1.0)));
+
+    let trap_points = transient_with_method(&circuit, 1.0, 10.0, TransientMethod::Trap).unwrap();
+    let gear_points = transient_with_method(&circuit, 1.0, 10.0, TransientMethod::Gear2).unwrap();
+    let trap_tail = trap_points
+        .iter()
+        .rev()
+        .take(4)
+        .map(|point| point.voltage("tank").unwrap().abs())
+        .fold(0.0_f64, f64::max);
+    let gear_tail = gear_points
+        .iter()
+        .rev()
+        .take(4)
+        .map(|point| point.voltage("tank").unwrap().abs())
+        .fold(0.0_f64, f64::max);
+
+    assert!(gear_tail < trap_tail * 0.75);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add trapezoidal transient integration parity for capacitors and inductors,
+  enabling LC damping comparisons against Gear-2.
 - Add Gear-2 transient integration with BDF2 capacitor/inductor companion
   histories after bootstrapping with one backward-Euler step.
 - Add transient analysis stamping for `TransmissionLine` using a lossless

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -21,7 +21,7 @@ export type Element =
   | Cccs
   | Ccvs;
 
-export type TransientMethod = "euler" | "gear2";
+export type TransientMethod = "euler" | "trap" | "gear2";
 
 export interface Resistor {
   readonly kind: "resistor";
@@ -1850,8 +1850,8 @@ export function transient(
   if (!Number.isFinite(stopTime) || stopTime < 0.0) {
     throw invalidElement("transient", "stop time must be finite and non-negative");
   }
-  if (method !== "euler" && method !== "gear2") {
-    throw invalidElement("transient", "method must be euler or gear2");
+  if (method !== "euler" && method !== "trap" && method !== "gear2") {
+    throw invalidElement("transient", "method must be euler, trap, or gear2");
   }
 
   validateReactiveElements(circuit);
@@ -2757,6 +2757,7 @@ interface CapacitorState {
   readonly name: string;
   previousVoltage: number;
   previousPreviousVoltage: number;
+  previousCurrent: number;
   readonly timeStep: number;
   method: TransientMethod;
 }
@@ -2765,6 +2766,7 @@ interface InductorState {
   readonly name: string;
   previousCurrent: number;
   previousPreviousCurrent: number;
+  previousVoltage: number;
   readonly timeStep: number;
   method: TransientMethod;
 }
@@ -4157,15 +4159,19 @@ function stampCapacitor(
   }
 
   const conductance =
-    state.method === "gear2"
-      ? (3.0 * element.capacitanceFarads) / (2.0 * state.timeStep)
-      : element.capacitanceFarads / state.timeStep;
+    state.method === "trap"
+      ? (2.0 * element.capacitanceFarads) / state.timeStep
+      : state.method === "gear2"
+        ? (3.0 * element.capacitanceFarads) / (2.0 * state.timeStep)
+        : element.capacitanceFarads / state.timeStep;
   const n1 = nodeIndex(nodeIndices, element.n1);
   const n2 = nodeIndex(nodeIndices, element.n2);
   stampConductance(matrix, n1, n2, conductance);
 
   const historyCurrent =
-    state.method === "gear2"
+    state.method === "trap"
+      ? conductance * state.previousVoltage + state.previousCurrent
+      : state.method === "gear2"
       ? element.capacitanceFarads *
         (4.0 * state.previousVoltage - state.previousPreviousVoltage) /
         (2.0 * state.timeStep)
@@ -4197,12 +4203,16 @@ function stampInductor(
   }
 
   const conductance =
-    state.method === "gear2"
-      ? (2.0 * state.timeStep) / (3.0 * element.inductanceHenrys)
-      : state.timeStep / element.inductanceHenrys;
+    state.method === "trap"
+      ? state.timeStep / (2.0 * element.inductanceHenrys)
+      : state.method === "gear2"
+        ? (2.0 * state.timeStep) / (3.0 * element.inductanceHenrys)
+        : state.timeStep / element.inductanceHenrys;
   stampConductance(matrix, n1, n2, conductance);
   const historyCurrent =
-    state.method === "gear2"
+    state.method === "trap"
+      ? state.previousCurrent + conductance * state.previousVoltage
+      : state.method === "gear2"
       ? (4.0 * state.previousCurrent - state.previousPreviousCurrent) / 3.0
       : state.previousCurrent;
   if (n1 !== undefined) {
@@ -4616,6 +4626,7 @@ function initialCapacitorStates(
         name: element.name,
         previousVoltage: element.initialVoltage,
         previousPreviousVoltage: element.initialVoltage,
+        previousCurrent: 0.0,
         timeStep,
         method,
       });
@@ -4636,6 +4647,7 @@ function initialInductorStates(
         name: element.name,
         previousCurrent: element.initialCurrent,
         previousPreviousCurrent: element.initialCurrent,
+        previousVoltage: 0.0,
         timeStep,
         method,
       });
@@ -4804,8 +4816,22 @@ function updateCapacitorStates(
       continue;
     }
     const previousVoltage = state.previousVoltage;
-    state.previousVoltage =
+    const previousCurrent = state.previousCurrent;
+    const voltage =
       voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
+    if (state.method === "trap") {
+      const conductance = (2.0 * element.capacitanceFarads) / state.timeStep;
+      state.previousCurrent = conductance * (voltage - previousVoltage) - previousCurrent;
+    } else if (state.method === "gear2") {
+      state.previousCurrent =
+        element.capacitanceFarads *
+        (3.0 * voltage - 4.0 * previousVoltage + state.previousPreviousVoltage) /
+        (2.0 * state.timeStep);
+    } else {
+      state.previousCurrent =
+        (element.capacitanceFarads / state.timeStep) * (voltage - previousVoltage);
+    }
+    state.previousVoltage = voltage;
     state.previousPreviousVoltage = previousVoltage;
   }
 }
@@ -4833,9 +4859,11 @@ function updateInductorStates(
       continue;
     }
     const previousCurrent = state.previousCurrent;
+    const voltage = voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
     state.previousCurrent =
       coupledCurrents.get(element.name) ?? inductorCurrent(element, state, nodeVoltages);
     state.previousPreviousCurrent = previousCurrent;
+    state.previousVoltage = voltage;
   }
 }
 
@@ -4875,6 +4903,10 @@ function inductorCurrent(
   nodeVoltages: ReadonlyMap<string, number>,
 ): number {
   const voltage = voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
+  if (state.method === "trap") {
+    const conductance = state.timeStep / (2.0 * element.inductanceHenrys);
+    return state.previousCurrent + conductance * state.previousVoltage + conductance * voltage;
+  }
   if (state.method === "gear2") {
     return (
       (2.0 * state.timeStep * voltage) / (3.0 * element.inductanceHenrys) +
@@ -4904,6 +4936,7 @@ function stampTransientMutualInductor(
     secondary,
     mutualInductance,
     primaryState.timeStep,
+    primaryState.method,
   );
   const p1 = nodeIndex(nodeIndices, primary.n1);
   const p2 = nodeIndex(nodeIndices, primary.n2);
@@ -4913,8 +4946,16 @@ function stampTransientMutualInductor(
   stampConductance(matrix, s1, s2, g22);
   stampTransconductance(matrix, p1, p2, s1, s2, g12);
   stampTransconductance(matrix, s1, s2, p1, p2, g12);
-  stampCurrentSourceEquivalent(rhs, p1, p2, primaryState.previousCurrent);
-  stampCurrentSourceEquivalent(rhs, s1, s2, secondaryState.previousCurrent);
+  let primaryHistoryCurrent = primaryState.previousCurrent;
+  let secondaryHistoryCurrent = secondaryState.previousCurrent;
+  if (primaryState.method === "trap") {
+    primaryHistoryCurrent +=
+      g11 * primaryState.previousVoltage + g12 * secondaryState.previousVoltage;
+    secondaryHistoryCurrent +=
+      g12 * primaryState.previousVoltage + g22 * secondaryState.previousVoltage;
+  }
+  stampCurrentSourceEquivalent(rhs, p1, p2, primaryHistoryCurrent);
+  stampCurrentSourceEquivalent(rhs, s1, s2, secondaryHistoryCurrent);
 }
 
 function coupledTransientInductorCurrents(
@@ -4940,16 +4981,25 @@ function coupledTransientInductorCurrents(
       secondary,
       mutualInductance,
       primaryState.timeStep,
+      primaryState.method,
     );
     const primaryVoltage = voltageAt(nodeVoltages, primary.n1) - voltageAt(nodeVoltages, primary.n2);
     const secondaryVoltage = voltageAt(nodeVoltages, secondary.n1) - voltageAt(nodeVoltages, secondary.n2);
+    let primaryHistoryCurrent = primaryState.previousCurrent;
+    let secondaryHistoryCurrent = secondaryState.previousCurrent;
+    if (primaryState.method === "trap") {
+      primaryHistoryCurrent +=
+        g11 * primaryState.previousVoltage + g12 * secondaryState.previousVoltage;
+      secondaryHistoryCurrent +=
+        g12 * primaryState.previousVoltage + g22 * secondaryState.previousVoltage;
+    }
     currents.set(
       primary.name,
-      primaryState.previousCurrent + g11 * primaryVoltage + g12 * secondaryVoltage,
+      primaryHistoryCurrent + g11 * primaryVoltage + g12 * secondaryVoltage,
     );
     currents.set(
       secondary.name,
-      secondaryState.previousCurrent + g12 * primaryVoltage + g22 * secondaryVoltage,
+      secondaryHistoryCurrent + g12 * primaryVoltage + g22 * secondaryVoltage,
     );
   }
   return currents;
@@ -4961,12 +5011,13 @@ function transientMutualConductances(
   secondary: Inductor,
   mutualInductance: number,
   timeStep: number,
+  method: TransientMethod,
 ): { g11: number; g12: number; g22: number } {
   const determinant = primary.inductanceHenrys * secondary.inductanceHenrys - mutualInductance ** 2;
   if (!Number.isFinite(determinant) || determinant <= 0.0) {
     throw invalidElement(element.name, "coupled inductance matrix is singular");
   }
-  const scale = timeStep / determinant;
+  const scale = method === "trap" ? timeStep / (2.0 * determinant) : timeStep / determinant;
   return {
     g11: secondary.inductanceHenrys * scale,
     g12: -mutualInductance * scale,

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -479,6 +479,19 @@ describe("transient", () => {
     expectClose(points[2].voltage("vc"), 0.94);
   });
 
+  it("uses trapezoidal capacitor companions", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "vc", 1_000.0));
+    circuit.add(capacitor("C1", "vc", "0", 1.0e-6));
+
+    const points = transient(circuit, 1.0e-3, 3.0e-3, "trap");
+
+    expectClose(points[0].voltage("vc"), 1.0 / 3.0);
+    expectClose(points[1].voltage("vc"), 7.0 / 9.0);
+    expectClose(points[2].voltage("vc"), 25.0 / 27.0);
+  });
+
   it("uses Gear-2 BDF2 inductor companions after an Euler bootstrap step", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("V1", "in", "0", 1.0));
@@ -490,6 +503,32 @@ describe("transient", () => {
     expectClose(points[0].branchCurrent("L1"), 0.5e-3);
     expectClose(points[1].branchCurrent("L1"), 0.8e-3);
     expectClose(points[2].branchCurrent("L1"), 0.94e-3);
+  });
+
+  it("uses trapezoidal inductor companions", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "out", 1_000.0));
+    circuit.add(inductor("L1", "out", "0", 1.0));
+
+    const points = transient(circuit, 1.0e-3, 3.0e-3, "trap");
+
+    expectClose(points[0].branchCurrent("L1"), 1.0e-3 / 3.0);
+    expectClose(points[1].branchCurrent("L1"), 7.0e-3 / 9.0);
+    expectClose(points[2].branchCurrent("L1"), 25.0e-3 / 27.0);
+  });
+
+  it("shows Gear-2 damping a coarse LC oscillator more than trap", () => {
+    const circuit = new Circuit();
+    circuit.add(capacitorWithInitialVoltage("C1", "tank", "0", 1.0, 1.0));
+    circuit.add(inductor("L1", "tank", "0", 1.0));
+
+    const trapPoints = transient(circuit, 1.0, 10.0, "trap");
+    const gearPoints = transient(circuit, 1.0, 10.0, "gear2");
+    const trapTail = Math.max(...trapPoints.slice(-4).map((point) => Math.abs(point.voltage("tank") ?? 0.0)));
+    const gearTail = Math.max(...gearPoints.slice(-4).map((point) => Math.abs(point.voltage("tank") ?? 0.0)));
+
+    expect(gearTail).toBeLessThan(trapTail * 0.75);
   });
 
   it("couples secondary voltage through a mutual inductor", () => {

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -140,8 +140,11 @@ Status:
 
 - Fixed-step Gear-2 / BDF2 capacitor and inductor companions are implemented
   across Python, TypeScript, and Rust, with one backward-Euler bootstrap step
-  before two-step history is available. Adaptive-step interaction, netlist
-  option routing, and LC damping comparison remain follow-up work.
+  before two-step history is available. TypeScript and Rust now also expose
+  trapezoidal transient companions for parity with Python, and all three
+  packages include a coarse LC fixture showing Gear-2 damps ringing more than
+  trapezoidal integration. Adaptive-step interaction and netlist option
+  routing remain follow-up work.
 
 ### Phase 5 - Pseudo-Transient DC Continuation
 


### PR DESCRIPTION
## Summary

- add TypeScript and Rust transient `trap` method support for capacitor and inductor companions
- carry capacitor current and inductor voltage history for trapezoidal updates, including coupled-inductor history terms
- add cross-language coarse LC fixtures showing Gear-2 damps ringing more than trap
- update the 1970s compatibility plan to mark the LC damping acceptance item done

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-trap-gear2-damping sh BUILD` in `code/packages/python/spice-engine`
- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`

## Notes

This completes the Phase 4 LC damping comparison. Adaptive-step Gear-2 interaction and netlist option routing remain follow-up work.