### PR TITLE
Add HTML parser browser content tree

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
@@ -131,6 +131,11 @@ FORMAT_REGISTRY: tuple[FixtureFormat, ...] = (
         "parser-browser-readiness",
     ),
     FixtureFormat(
+        "html-parser/tests/fixtures/html-browser-content-tree.json",
+        "venture-html-browser-content-tree/v1",
+        "parser-browser-content-tree",
+    ),
+    FixtureFormat(
         "html-parser/tests/fixtures/whatwg-block-boundary-audit.json",
         "whatwg-html-block-boundary-audit/v1",
         "parser-audit",
@@ -370,6 +375,10 @@ def check_category_contract(
         require_top_level(relative_path, data, "source_fixture", str, errors)
         require_top_level(relative_path, data, "case_count", int, errors)
     elif category == "parser-browser-readiness":
+        require_cases(relative_path, data, errors)
+        require_top_level(relative_path, data, "suite", str, errors)
+        require_case_field(relative_path, data, "expected", dict, errors)
+    elif category == "parser-browser-content-tree":
         require_cases(relative_path, data, errors)
         require_top_level(relative_path, data, "suite", str, errors)
         require_case_field(relative_path, data, "expected", dict, errors)

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -16,6 +16,7 @@ RUST_DIR = FIXTURE_DIR.parents[2]
 PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
 PARSER_SOURCE_FIXTURE = "html5lib-tree-construction-smoke.dat"
 BROWSER_READINESS_FORMAT = "venture-html-browser-readiness/v1"
+BROWSER_CONTENT_TREE_FORMAT = "venture-html-browser-content-tree/v1"
 NUMERIC_REFERENCE_FIXTURE = "whatwg-numeric-references.json"
 INPUT_STREAM_FIXTURE = "whatwg-input-stream.json"
 CHUNK_BOUNDARY_FIXTURE = "whatwg-chunk-boundaries.json"
@@ -81,6 +82,8 @@ def check_fixture_schemas() -> tuple[list[str], FixtureStats]:
                 continue
             if data.get("format") == BROWSER_READINESS_FORMAT:
                 errors.extend(check_browser_readiness_case(relative_path, index, case))
+            elif data.get("format") == BROWSER_CONTENT_TREE_FORMAT:
+                errors.extend(check_browser_content_tree_case(relative_path, index, case))
             elif fixture_path.parent == PARSER_FIXTURE_DIR:
                 errors.extend(check_parser_audit_case(relative_path, index, case))
             else:
@@ -118,7 +121,7 @@ def check_top_level_schema(relative_path: str, data: dict[str, Any]) -> list[str
     require_non_empty_string(relative_path, data, "format", errors)
     require_non_empty_string(relative_path, data, "description", errors)
 
-    if data.get("format") == BROWSER_READINESS_FORMAT:
+    if data.get("format") in (BROWSER_READINESS_FORMAT, BROWSER_CONTENT_TREE_FORMAT):
         require_non_empty_string(relative_path, data, "suite", errors)
     elif relative_path.startswith("html-parser/"):
         if data.get("source_fixture") != PARSER_SOURCE_FIXTURE:
@@ -296,6 +299,50 @@ def check_browser_expected_lists(
         require_optional_nullable_string(table_path, table, "caption", errors)
         for field in ("row_count", "cell_count", "header_cell_count"):
             require_integer(table_path, table, field, errors)
+
+
+def check_browser_content_tree_case(
+    relative_path: str,
+    index: int,
+    case: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    case_path = f"{relative_path}: cases[{index}]"
+
+    require_non_empty_string(case_path, case, "id", errors)
+    require_optional_non_empty_string(case_path, case, "description", errors)
+    require_string(case_path, case, "input", errors)
+
+    expected = case.get("expected")
+    if not isinstance(expected, dict):
+        errors.append(f"{case_path}.expected must be an object")
+        return errors
+    require_object_list(f"{case_path}.expected", expected, "children", errors)
+    for node_index, node in enumerate(object_list_items(expected, "children")):
+        check_browser_content_node(
+            f"{case_path}.expected.children[{node_index}]",
+            node,
+            errors,
+        )
+
+    return errors
+
+
+def check_browser_content_node(
+    node_path: str,
+    node: dict[str, Any],
+    errors: list[str],
+) -> None:
+    require_string(node_path, node, "role", errors)
+    for field in ("name", "text", "href", "src", "alt", "control_type"):
+        require_optional_nullable_string(node_path, node, field, errors)
+    require_object_list(node_path, node, "children", errors)
+    for child_index, child in enumerate(object_list_items(node, "children")):
+        check_browser_content_node(
+            f"{node_path}.children[{child_index}]",
+            child,
+            errors,
+        )
 
 
 def check_split_points(

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
@@ -34,6 +34,7 @@ class HtmlFixtureFormatRegistryTest(unittest.TestCase):
                 "lexer-numeric-reference",
                 "lexer-token",
                 "parser-audit",
+                "parser-browser-content-tree",
                 "parser-browser-readiness",
             },
         )

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
@@ -57,6 +57,43 @@ class HtmlFixtureSchemasTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_browser_content_tree_cases_require_recursive_node_shape(self) -> None:
+        errors = schema_check.check_browser_content_tree_case(
+            "html-parser/tests/fixtures/html-browser-content-tree.json",
+            0,
+            {
+                "id": "example",
+                "input": "<p>body",
+                "expected": {
+                    "children": [
+                        {
+                            "role": "block",
+                            "name": "p",
+                            "text": None,
+                            "href": None,
+                            "src": None,
+                            "alt": None,
+                            "control_type": None,
+                            "children": [
+                                {
+                                    "role": "text",
+                                    "name": None,
+                                    "text": "body",
+                                    "href": None,
+                                    "src": None,
+                                    "alt": None,
+                                    "control_type": None,
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
+
+        self.assertEqual(errors, [])
+
     def test_chunk_split_points_must_stay_inside_input(self) -> None:
         errors = schema_check.check_lexer_case(
             "html-lexer/tests/fixtures/whatwg-chunk-boundaries.json",

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -182,6 +182,8 @@ documented in this file.
   loadable resources, anchor targets, richer link attributes, form encodings,
   form targets, and basic control disabled/checked state for browser pipeline
   consumers.
+- Browser-facing content tree extraction now projects parsed body content into
+  CSS-independent structural nodes for early browser rendering pipelines.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -61,6 +61,8 @@ The current parser surface includes:
 - browser-facing document extraction for title, base URL/target, head metadata,
   resource inventory, anchor targets, body text, headings, richer links, image
   attributes, form controls, and table summaries
+- browser-facing content tree extraction that filters parser-only shell and
+  invisible nodes into a CSS-independent body structure for early rendering
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources
@@ -322,8 +324,8 @@ audit report and pinned-count checks into the same local guard.
 ```rust
 use coding_adventures_html_lexer::HtmlScriptingMode;
 use coding_adventures_html_parser::{
-    parse_browser_document, parse_html, parse_html_fragment, parse_html_with_options,
-    HtmlInitialTokenizerContext, HtmlParseOptions,
+    parse_browser_content_tree, parse_browser_document, parse_html, parse_html_fragment,
+    parse_html_with_options, HtmlInitialTokenizerContext, HtmlParseOptions,
 };
 use dom_core::Node;
 
@@ -335,6 +337,10 @@ let browser_document = parse_browser_document(
 assert_eq!(browser_document.title.as_deref(), Some("Example"));
 assert_eq!(browser_document.links[0].href.as_deref(), Some("next.html"));
 assert!(browser_document.resources.is_empty());
+
+let content_tree = parse_browser_content_tree("<h1>Example</h1><p>Hello <b>there</b>").unwrap();
+assert_eq!(content_tree.children[0].role, "heading");
+assert_eq!(content_tree.children[1].role, "block");
 
 match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -631,6 +631,16 @@ pub fn extract_browser_document(document: &Document) -> BrowserDocument {
     BrowserDocument::from_document(document)
 }
 
+/// Parse a complete HTML string and extract a browser-facing content tree.
+pub fn parse_browser_content_tree(source: &str) -> Result<BrowserContentTree, ParseError> {
+    parse_html(source).map(|document| extract_browser_content_tree(&document))
+}
+
+/// Extract a browser-facing content tree from a parsed DOM document.
+pub fn extract_browser_content_tree(document: &Document) -> BrowserContentTree {
+    BrowserContentTree::from_document(document)
+}
+
 /// Parse a complete HTML string into a DOM document plus lexer/parser diagnostics.
 pub fn parse_html_with_diagnostics(source: &str) -> Result<ParseOutput, ParseError> {
     parse_html_with_diagnostics_and_options(source, HtmlParseOptions::default())
@@ -837,6 +847,23 @@ pub struct BrowserAnchor {
     pub text: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BrowserContentTree {
+    pub children: Vec<BrowserContentNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserContentNode {
+    pub role: String,
+    pub name: Option<String>,
+    pub text: Option<String>,
+    pub href: Option<String>,
+    pub src: Option<String>,
+    pub alt: Option<String>,
+    pub control_type: Option<String>,
+    pub children: Vec<BrowserContentNode>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserHeading {
     pub level: u8,
@@ -918,6 +945,22 @@ impl BrowserDocument {
         }
         collect_browser_facts(body_children, &mut summary);
         summary
+    }
+}
+
+impl BrowserContentTree {
+    pub fn from_document(document: &Document) -> Self {
+        let body = find_first_element_in_nodes(&document.children, "body");
+        let body_children = body
+            .map(|element| element.children.as_slice())
+            .unwrap_or(document.children.as_slice());
+        Self::from_nodes(body_children)
+    }
+
+    pub fn from_nodes(nodes: &[Node]) -> Self {
+        let mut children = Vec::new();
+        collect_browser_content_nodes(nodes, &mut children);
+        Self { children }
     }
 }
 
@@ -8003,6 +8046,178 @@ fn link_resource_kind(rel: Option<&str>) -> String {
         }
     }
     "link".to_string()
+}
+
+fn collect_browser_content_nodes(nodes: &[Node], output: &mut Vec<BrowserContentNode>) {
+    for node in nodes {
+        match node {
+            Node::Text(value) => {
+                let text = collapse_html_whitespace(&value.data);
+                if !text.is_empty() {
+                    output.push(BrowserContentNode {
+                        role: "text".to_string(),
+                        name: None,
+                        text: Some(text),
+                        href: None,
+                        src: None,
+                        alt: None,
+                        control_type: None,
+                        children: Vec::new(),
+                    });
+                }
+            }
+            Node::Element(element) => {
+                if let Some(content_node) = browser_content_node_for_element(element) {
+                    output.push(content_node);
+                }
+            }
+            Node::DocumentType(_) | Node::Comment(_) => {}
+        }
+    }
+}
+
+fn browser_content_node_for_element(element: &Element) -> Option<BrowserContentNode> {
+    if is_browser_invisible_element(&element.name) {
+        return None;
+    }
+
+    let role = browser_content_role(&element.name)?;
+    let mut children = Vec::new();
+    if should_collect_browser_content_children(&element.name) {
+        collect_browser_content_nodes(&element.children, &mut children);
+    }
+
+    let text = browser_content_text(element, role);
+    if role == "inline" && text.is_none() && children.is_empty() {
+        return None;
+    }
+
+    Some(BrowserContentNode {
+        role: role.to_string(),
+        name: Some(element.name.clone()),
+        text,
+        href: element.attribute("href").map(ToOwned::to_owned),
+        src: browser_content_src(element),
+        alt: element.attribute("alt").map(ToOwned::to_owned),
+        control_type: browser_content_control_type(element),
+        children,
+    })
+}
+
+fn browser_content_role(name: &str) -> Option<&'static str> {
+    match name {
+        "area" | "base" | "link" | "meta" | "param" | "script" | "style" | "template" | "title" => {
+            None
+        }
+        "a" => Some("link"),
+        "img" => Some("image"),
+        "br" | "wbr" => Some("line_break"),
+        "form" => Some("form"),
+        "input" | "button" | "select" | "textarea" => Some("control"),
+        "ul" | "ol" | "menu" | "dir" => Some("list"),
+        "li" | "dt" | "dd" => Some("list_item"),
+        "table" => Some("table"),
+        "caption" => Some("table_caption"),
+        "tbody" | "thead" | "tfoot" => Some("table_section"),
+        "tr" => Some("table_row"),
+        "td" | "th" => Some("table_cell"),
+        name if heading_level(name).is_some() => Some("heading"),
+        name if is_browser_block_element(name) => Some("block"),
+        _ => Some("inline"),
+    }
+}
+
+fn should_collect_browser_content_children(name: &str) -> bool {
+    !matches!(
+        name,
+        "area"
+            | "base"
+            | "br"
+            | "button"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "select"
+            | "textarea"
+            | "wbr"
+    )
+}
+
+fn browser_content_text(element: &Element, role: &str) -> Option<String> {
+    let text = match role {
+        "control" if element.name == "input" => {
+            element.attribute("value").unwrap_or_default().to_string()
+        }
+        "control" | "heading" | "link" | "table_caption" => {
+            visible_text_for_nodes(&element.children)
+        }
+        _ => String::new(),
+    };
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn browser_content_src(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "object" => element.attribute("data").map(ToOwned::to_owned),
+        _ => element.attribute("src").map(ToOwned::to_owned),
+    }
+}
+
+fn browser_content_control_type(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "input" => Some(
+            element
+                .attribute("type")
+                .map(|input_type| input_type.to_ascii_lowercase())
+                .unwrap_or_else(|| "text".to_string()),
+        ),
+        "button" => Some(
+            element
+                .attribute("type")
+                .map(|button_type| button_type.to_ascii_lowercase())
+                .unwrap_or_else(|| "submit".to_string()),
+        ),
+        "select" | "textarea" => Some(element.name.clone()),
+        _ => None,
+    }
+}
+
+fn is_browser_block_element(name: &str) -> bool {
+    matches!(
+        name,
+        "address"
+            | "article"
+            | "aside"
+            | "blockquote"
+            | "body"
+            | "center"
+            | "details"
+            | "dialog"
+            | "div"
+            | "fieldset"
+            | "figcaption"
+            | "figure"
+            | "footer"
+            | "header"
+            | "hgroup"
+            | "hr"
+            | "html"
+            | "legend"
+            | "main"
+            | "nav"
+            | "p"
+            | "plaintext"
+            | "pre"
+            | "section"
+            | "summary"
+            | "xmp"
+    )
 }
 
 fn collect_form_controls(nodes: &[Node]) -> Vec<BrowserFormControl> {

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -1,0 +1,90 @@
+use coding_adventures_html_parser::{
+    parse_browser_content_tree, BrowserContentNode, BrowserContentTree,
+};
+use serde::Deserialize;
+
+const BROWSER_CONTENT_TREE_FIXTURE: &str = include_str!("fixtures/html-browser-content-tree.json");
+
+#[derive(Debug, Deserialize)]
+struct BrowserContentTreeSuite {
+    format: String,
+    suite: String,
+    cases: Vec<BrowserContentTreeCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BrowserContentTreeCase {
+    id: String,
+    input: String,
+    expected: ExpectedContentTree,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedContentTree {
+    children: Vec<ExpectedContentNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedContentNode {
+    role: String,
+    name: Option<String>,
+    text: Option<String>,
+    href: Option<String>,
+    src: Option<String>,
+    alt: Option<String>,
+    control_type: Option<String>,
+    children: Vec<ExpectedContentNode>,
+}
+
+#[test]
+fn browser_content_tree_cases_extract_renderable_body_structure() {
+    let suite: BrowserContentTreeSuite = serde_json::from_str(BROWSER_CONTENT_TREE_FIXTURE)
+        .expect("browser content tree fixture should parse");
+
+    assert_eq!(suite.format, "venture-html-browser-content-tree/v1");
+    assert_eq!(suite.suite, "browser-content-tree");
+    assert!(!suite.cases.is_empty(), "fixture should contain cases");
+
+    for case in suite.cases {
+        let actual = parse_browser_content_tree(&case.input)
+            .unwrap_or_else(|error| panic!("{} should parse: {error}", case.id));
+
+        assert_eq!(
+            actual,
+            case.expected.into_browser_content_tree(),
+            "{} extracted browser content tree should match",
+            case.id
+        );
+    }
+}
+
+impl ExpectedContentTree {
+    fn into_browser_content_tree(self) -> BrowserContentTree {
+        BrowserContentTree {
+            children: self
+                .children
+                .into_iter()
+                .map(ExpectedContentNode::into_browser_content_node)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedContentNode {
+    fn into_browser_content_node(self) -> BrowserContentNode {
+        BrowserContentNode {
+            role: self.role,
+            name: self.name,
+            text: self.text,
+            href: self.href,
+            src: self.src,
+            alt: self.alt,
+            control_type: self.control_type,
+            children: self
+                .children
+                .into_iter()
+                .map(ExpectedContentNode::into_browser_content_node)
+                .collect(),
+        }
+    }
+}

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -15,6 +15,12 @@ title, base URL/target, metadata, resource, anchor, body text, heading, link,
 image, form, and table facts that a browser pipeline can consume before layout
 and Paint VM rendering.
 
+`html-browser-content-tree.json` is a checked parser acceptance corpus for the
+browser-facing content-tree projection. It verifies that broad HTML body
+content can be filtered into renderable structural nodes such as headings,
+blocks, inline runs, links, images, form controls, lists, and tables while
+skipping parser shell, head metadata, comments, scripts, styles, and templates.
+
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 
 ```bash

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -1,0 +1,209 @@
+{
+  "format": "venture-html-browser-content-tree/v1",
+  "suite": "browser-content-tree",
+  "description": "Browser-facing parser acceptance cases for extracting a renderable, CSS-independent body content tree.",
+  "cases": [
+    {
+      "id": "classic-document-flow",
+      "description": "Head metadata is skipped while headings, paragraphs, links, images, line breaks, and lists stay renderable.",
+      "input": "<!doctype html><title>Example</title><link rel=stylesheet href=style.css><h1 id=top>Example Directory</h1><p>Welcome to <a href=intro.html>Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
+      "expected": {
+        "children": [
+          {
+            "role": "heading",
+            "name": "h1",
+            "text": "Example Directory",
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "Example Directory", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          },
+          {
+            "role": "block",
+            "name": "p",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "Welcome to", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              {
+                "role": "link",
+                "name": "a",
+                "text": "Venture HTML",
+                "href": "intro.html",
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "text", "name": null, "text": "Venture HTML", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              },
+              { "role": "text", "name": null, "text": ".", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "alt": "Logo", "control_type": null, "children": [] }
+            ]
+          },
+          {
+            "role": "list",
+            "name": "ul",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              {
+                "role": "list_item",
+                "name": "li",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "text", "name": null, "text": "One", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              },
+              {
+                "role": "list_item",
+                "name": "li",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "text", "name": null, "text": "Two", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "forms-and-tables",
+      "description": "Forms and tables are preserved as browser-facing structural nodes without exposing raw parser shell nodes.",
+      "input": "<body><h2>Catalog</h2><form action=/search><input name=q value=html><select name=section><option>Books<option>Manuals</select><button>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
+      "expected": {
+        "children": [
+          {
+            "role": "heading",
+            "name": "h2",
+            "text": "Catalog",
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "Catalog", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          },
+          {
+            "role": "form",
+            "name": "form",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "role": "control", "name": "input", "text": "html", "href": null, "src": null, "alt": null, "control_type": "text", "children": [] },
+              { "role": "control", "name": "select", "text": "Books Manuals", "href": null, "src": null, "alt": null, "control_type": "select", "children": [] },
+              { "role": "control", "name": "button", "text": "Search", "href": null, "src": null, "alt": null, "control_type": "submit", "children": [] }
+            ]
+          },
+          {
+            "role": "table",
+            "name": "table",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              {
+                "role": "table_caption",
+                "name": "caption",
+                "text": "Results",
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "text", "name": null, "text": "Results", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              },
+              {
+                "role": "table_section",
+                "name": "tbody",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  {
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "role": "table_cell", "name": "th", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Name", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "role": "table_cell", "name": "th", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Kind", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  },
+                  {
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Mosaic", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Browser", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "invisible-and-inline-content",
+      "description": "Script, style, template, comments, and head metadata disappear while inline formatting keeps its rendered text.",
+      "input": "<title>Skip</title><p>Alpha <b>bold</b> <i>italic</i><script>bad()</script><style>p{}</style><template><p>hidden</p></template><!--comment--> tail",
+      "expected": {
+        "children": [
+          {
+            "role": "block",
+            "name": "p",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "Alpha", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "role": "inline", "name": "b", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "bold", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+              { "role": "inline", "name": "i", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "italic", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+              { "role": "text", "name": null, "text": "tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add parse_browser_content_tree/extract_browser_content_tree APIs for a CSS-independent body content projection
- model renderable browser content nodes for text, blocks, inline runs, links, images, form controls, lists, and table structure
- add a browser content-tree fixture, Rust acceptance test, schema/registry governance, and parser docs

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser