### PR TITLE
feat(sql): INTEGER PRIMARY KEY auto-rowid assignment on INSERT

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.93.0] - 2026-05-23
+
+### Added
+
+- ``INSERT INTO t(other_col) VALUES (...)`` and ``INSERT INTO t
+  VALUES (NULL, ...)`` now work end-to-end on a table with an
+  ``INTEGER PRIMARY KEY`` column.  The id auto-assigns to the next
+  rowid — SQLite's "INTEGER PRIMARY KEY is an alias for rowid"
+  semantics.  Previously these forms failed with a NOT NULL
+  violation, blocking ORM patterns.
+- The rowid pseudo-column now aliases the INTEGER PRIMARY KEY
+  column when one exists: ``SELECT rowid, id FROM t`` returns
+  identical values per row.
+- ``last_insert_rowid()`` correctly reports the auto-assigned id
+  (or the explicit id when one was supplied).
+
+### Changed
+
+- ``SELECT *`` on a table with a partially-omitted INSERT now
+  returns columns in declaration order rather than insertion order
+  (where the omitted columns previously moved to the end).  See
+  ``sql-backend`` 0.18 for the underlying ``_apply_defaults`` fix.
+
 ## [1.92.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.92.0"
+version = "1.93.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_integer_pk_autoassign.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_integer_pk_autoassign.py
@@ -1,0 +1,141 @@
+"""End-to-end tests for ``INTEGER PRIMARY KEY`` auto-rowid assignment.
+
+SQLite treats ``INTEGER PRIMARY KEY`` as an alias for the rowid: when
+INSERT omits the column or passes ``NULL``, SQLite assigns the next
+rowid; when the user supplies an explicit integer, the rowid counter
+bumps past it so subsequent auto-assigns don't collide.
+
+Mini-sqlite previously rejected the omit/NULL forms with a NOT NULL
+violation — making ORM-style ``INSERT INTO t(name) VALUES ('alice')``
+fail.  These tests verify the new auto-assign behaviour is
+SQLite-compatible and oracle-tested against the stdlib driver.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import mini_sqlite
+from mini_sqlite import errors as mini_errors
+
+
+def _both_match(ddl: str, *dml: str, query: str) -> None:
+    """Both engines must produce identical results for *query* after *ddl* + *dml*."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        c.execute(ddl)
+        for d in dml:
+            c.execute(d)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestOmitColumn:
+    """``INSERT INTO t(other_col) VALUES (...)`` auto-assigns the id."""
+
+    def test_single_insert(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t(v) VALUES ('a')",
+            query="SELECT * FROM t",
+        )
+
+    def test_multiple_inserts_get_sequential_ids(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t(v) VALUES ('a'), ('b'), ('c')",
+            query="SELECT id, v FROM t ORDER BY id",
+        )
+
+
+class TestExplicitNull:
+    """``INSERT INTO t VALUES (NULL, ...)`` auto-assigns the id."""
+
+    def test_null_id(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (NULL, 'a')",
+            query="SELECT * FROM t",
+        )
+
+
+class TestExplicitValue:
+    """An explicit integer id is stored verbatim and bumps the counter."""
+
+    def test_explicit_id_stored_verbatim(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (42, 'a')",
+            query="SELECT * FROM t",
+        )
+
+    def test_explicit_then_auto_bumps_counter(self) -> None:
+        # The auto-assign after an explicit 100 must yield 101 — matching
+        # SQLite's ``_next_rowid = max(_next_rowid, supplied_id + 1)`` rule.
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (100, 'a')",
+            "INSERT INTO t(v) VALUES ('b')",
+            query="SELECT id, v FROM t ORDER BY id",
+        )
+
+
+class TestRowidAlias:
+    """``rowid`` and the INTEGER PRIMARY KEY column return identical values."""
+
+    def test_rowid_equals_id(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t(v) VALUES ('a'), ('b'), ('c')",
+            query="SELECT rowid, id FROM t ORDER BY id",
+        )
+
+
+class TestLastInsertRowid:
+    """``last_insert_rowid()`` reflects the auto-assigned value."""
+
+    def test_after_omit_returns_assigned_id(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t(v) VALUES ('a')",
+            query="SELECT last_insert_rowid()",
+        )
+
+    def test_after_explicit_returns_explicit_id(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (50, 'a')",
+            query="SELECT last_insert_rowid()",
+        )
+
+
+class TestNonIntegerPkNoAutoAssign:
+    """Only INTEGER PRIMARY KEY gets rowid-alias treatment — TEXT PK doesn't."""
+
+    def test_text_pk_null_still_violates(self) -> None:
+        # TEXT PRIMARY KEY is *not* a rowid alias.  NULL on a TEXT PK
+        # must continue to violate the implicit NOT NULL.
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t (name TEXT PRIMARY KEY, v TEXT)")
+        with pytest.raises(mini_errors.IntegrityError):
+            mini.execute("INSERT INTO t VALUES (NULL, 'x')")
+
+
+class TestColumnOrderPreserved:
+    """Auto-assigned id appears in the correct column position.
+
+    Regression guard: the original implementation accidentally built the
+    row dict in caller-insertion order, putting the auto-assigned id at
+    the END of the dict.  ``SELECT *`` walks the dict in insertion
+    order, so the user saw ``(v, id)`` instead of ``(id, v)``.  The
+    fix builds the row dict in column-declaration order regardless of
+    which columns the caller supplied.
+    """
+
+    def test_select_star_returns_id_first(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        mini.execute("INSERT INTO t(v) VALUES ('a')")
+        assert mini.execute("SELECT * FROM t").fetchall() == [(1, "a")]

--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-05-23
+
+### Added
+
+- ``InMemoryBackend.insert`` now auto-assigns the next rowid to an
+  ``INTEGER PRIMARY KEY`` column when the supplied value is ``None``
+  or the column is missing from the input row — mirrors SQLite's
+  "INTEGER PRIMARY KEY is an alias for rowid" semantics.  Unblocks
+  ORM-style ``INSERT INTO t(name) VALUES ('alice')`` patterns that
+  previously failed with a NOT NULL violation.
+- When the user supplies an explicit integer id, ``_next_rowid``
+  advances past it so a subsequent auto-assign doesn't collide
+  (SQLite's ``_next_rowid = max(_next_rowid, supplied_id + 1)``).
+- The hidden ``_ROWID_KEY`` stamp is now sourced from the IPK
+  column's value when one exists, so ``SELECT rowid`` and ``SELECT
+  id`` return identical results — required for SQLite compat.
+
+### Changed
+
+- ``_apply_defaults`` now builds the row dict in *column-declaration
+  order* rather than caller-supplied order.  Previously a user
+  insert that omitted a column (now common with IPK auto-assign)
+  would yield a row dict ordered ``(supplied_cols, then_defaults)``,
+  which surfaced as wrong-order ``SELECT *`` output.  Existing
+  callers that supplied all columns are unaffected — only the
+  iteration order of the returned dict changed.
+- ``test_not_null_from_primary_key`` renamed to
+  ``test_not_null_from_primary_key_text_type`` and changed to use a
+  ``TEXT PRIMARY KEY`` column (which still violates NOT NULL on
+  explicit NULL — only ``INTEGER PRIMARY KEY`` gets the rowid-alias
+  exemption).  Added three new tests covering the new auto-assign
+  paths.
+
 ## [0.17.0] - 2026-05-23
 
 ### Changed

--- a/code/packages/python/sql-backend/pyproject.toml
+++ b/code/packages/python/sql-backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-backend"
-version = "0.17.0"
+version = "0.18.0"
 description = "Pluggable data-source interface for the SQL pipeline — ships the Backend ABC, supporting types, an InMemoryBackend reference, and conformance test helpers."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-backend/src/sql_backend/in_memory.py
+++ b/code/packages/python/sql-backend/src/sql_backend/in_memory.py
@@ -134,6 +134,22 @@ def _sql_sort_key(v: SqlValue) -> tuple[int, object]:
 _ROWID_KEY: Final[str] = "\x00rowid"
 
 
+def _find_ipk_column(t: _Table) -> ColumnDef | None:
+    """Return the table's INTEGER PRIMARY KEY column, or None.
+
+    In SQLite an INTEGER PRIMARY KEY column is an alias for the rowid.
+    We recognise it as ``primary_key=True`` plus a type-name in
+    ``{INT, INTEGER}`` (case-insensitive).  Composite primary keys
+    (which currently can't be expressed in the in-memory backend
+    because each column has its own ``primary_key`` flag) do not get
+    rowid-alias treatment — the user must supply explicit values.
+    """
+    for col in t.columns:
+        if col.primary_key and col.type_name.upper() in ("INT", "INTEGER"):
+            return col
+    return None
+
+
 def _strict_type_label(value: object) -> str:
     """Return the SQLite type-name for *value*, used in STRICT-mode error messages.
 
@@ -680,6 +696,13 @@ class InMemoryBackend(Backend):
         t = self._require_table(table)
         full_row = self._apply_defaults(t, row)
         self._check_unknown_columns(table, t, full_row)
+        # INTEGER PRIMARY KEY auto-assign: SQLite treats an INTEGER PRIMARY
+        # KEY column as an alias for the rowid.  When the user omits the
+        # column or passes NULL, SQLite assigns the next rowid; when the
+        # user supplies an explicit value, ``_next_rowid`` is bumped past
+        # it so a subsequent auto-assign doesn't collide.  Done before
+        # ``_check_not_null`` because PRIMARY KEY implies NOT NULL.
+        self._autoassign_ipk(t, full_row)
         self._check_not_null(table, t, full_row)
         if t.strict:
             self._check_strict_types(table, t, full_row)
@@ -687,11 +710,42 @@ class InMemoryBackend(Backend):
         # Stamp the row with its stable integer rowid AFTER constraint
         # checks pass.  The key ``_ROWID_KEY`` (null-prefixed, not a valid
         # SQL identifier) is invisible to normal column resolution and is
-        # skipped by ScanAllColumns.  The counter starts at 1 and is never
-        # reused, matching real-SQLite behaviour.
-        full_row[_ROWID_KEY] = t._next_rowid
-        t._next_rowid += 1
+        # skipped by ScanAllColumns.  When an INTEGER PRIMARY KEY column
+        # exists, the stamp matches that column's value (rowid is the IPK)
+        # so ``SELECT rowid`` and ``SELECT id`` return identical results.
+        ipk_col = _find_ipk_column(t)
+        if ipk_col is not None and full_row.get(ipk_col.name) is not None:
+            full_row[_ROWID_KEY] = full_row[ipk_col.name]
+        else:
+            full_row[_ROWID_KEY] = t._next_rowid
+            t._next_rowid += 1
         t.rows.append(full_row)
+
+    def _autoassign_ipk(self, t: _Table, row: Row) -> None:
+        """Fill in the INTEGER PRIMARY KEY column with the next rowid.
+
+        Three cases:
+
+        * Column absent or value is ``None`` → assign ``t._next_rowid``
+          and bump the counter.
+        * Column value is an explicit integer → bump the counter past
+          that value so subsequent auto-assigns don't collide.
+        * No INTEGER PRIMARY KEY column on the table → no-op (the
+          ``_ROWID_KEY`` stamp still uses ``_next_rowid``).
+        """
+        ipk_col = _find_ipk_column(t)
+        if ipk_col is None:
+            return
+        val = row.get(ipk_col.name)
+        if val is None:
+            row[ipk_col.name] = t._next_rowid
+            t._next_rowid += 1
+        elif isinstance(val, int) and not isinstance(val, bool):
+            # User supplied an explicit id; bump the counter so the next
+            # auto-assigned rowid doesn't collide.  SQLite's behaviour:
+            # ``_next_rowid = max(_next_rowid, supplied_id + 1)``.
+            if val >= t._next_rowid:
+                t._next_rowid = val + 1
 
     def update(
         self,
@@ -1213,16 +1267,31 @@ class InMemoryBackend(Backend):
         the default value. If the column is absent and has no default, we
         leave it absent — NOT NULL / UNIQUE checks downstream will decide
         whether that's an error. (Absent columns produce NULL on read.)
+
+        Column ordering: the returned dict's iteration order matches the
+        table's declared column order, NOT the caller-supplied dict's
+        order.  This matters because ``SELECT *`` walks the row dict in
+        insertion order — if a user INSERT omitted a column (common with
+        INTEGER PRIMARY KEY auto-assign), that column would otherwise
+        end up at the END of the dict and surface in the wrong position.
         """
-        out: Row = dict(row)
+        out: Row = {}
         for col in t.columns:
-            if col.name not in out and col.has_default():
+            if col.name in row:
+                out[col.name] = row[col.name]
+            elif col.has_default():
                 # col.default is ColumnDefault = SqlValue | _NoDefault.
                 # has_default() ruled out the sentinel, so this cast is safe.
                 out[col.name] = col.default  # type: ignore[assignment]
-            elif col.name not in out:
+            else:
                 # Missing + no default → NULL, so NOT NULL checks can see it.
                 out[col.name] = None
+        # Preserve any extra keys the caller passed (typically only the
+        # hidden ``_ROWID_KEY``; unknown column names are rejected by
+        # ``_check_unknown_columns`` immediately after this returns).
+        for key, value in row.items():
+            if key not in out:
+                out[key] = value
         return out
 
     def _check_unknown_columns(self, table: str, t: _Table, row: Row) -> None:

--- a/code/packages/python/sql-backend/tests/test_in_memory.py
+++ b/code/packages/python/sql-backend/tests/test_in_memory.py
@@ -134,10 +134,59 @@ class TestInsert:
         b = make_backend()
         b.insert("t", {"id": 3, "val": None})
 
-    def test_not_null_from_primary_key(self) -> None:
-        b = make_backend()
+    def test_not_null_from_primary_key_text_type(self) -> None:
+        # NOT NULL is implied by PRIMARY KEY.  For NON-integer PK types,
+        # the auto-rowid-assign path doesn't fire (only INTEGER PRIMARY
+        # KEY is an alias for rowid), so explicit NULL still violates.
+        b = InMemoryBackend()
+        b.create_table(
+            "u",
+            [
+                ColumnDef(name="name", type_name="TEXT", primary_key=True),
+                ColumnDef(name="val", type_name="TEXT"),
+            ],
+            if_not_exists=False,
+        )
         with pytest.raises(ConstraintViolation):
-            b.insert("t", {"id": None, "val": "x"})
+            b.insert("u", {"name": None, "val": "x"})
+
+    def test_integer_pk_auto_assigns_when_null(self) -> None:
+        # The complement of the test above: an INTEGER PRIMARY KEY column
+        # auto-assigns the next rowid when the supplied value is NULL —
+        # mirrors SQLite's "INTEGER PRIMARY KEY is an alias for rowid"
+        # semantics.  No ConstraintViolation here.
+        b = make_backend()
+        b.insert("t", {"id": None, "val": "x"})
+        # The next rowid after the make_backend preloads (id=1, id=2) is 3.
+        rows = []
+        it = b.scan("t")
+        while (r := it.next()) is not None:
+            rows.append(r)
+        assert any(r.get("id") == 3 and r.get("val") == "x" for r in rows)
+
+    def test_integer_pk_auto_assigns_when_omitted(self) -> None:
+        # Same behaviour when the column is omitted entirely from the
+        # INSERT row dict — the common ORM pattern.
+        b = make_backend()
+        b.insert("t", {"val": "y"})
+        rows = []
+        it = b.scan("t")
+        while (r := it.next()) is not None:
+            rows.append(r)
+        assert any(r.get("id") == 3 and r.get("val") == "y" for r in rows)
+
+    def test_integer_pk_explicit_value_bumps_next_rowid(self) -> None:
+        # When the user supplies an explicit id, ``_next_rowid`` should
+        # advance past it so a subsequent auto-assign doesn't collide.
+        b = make_backend()  # preloads id=1, id=2 → _next_rowid is now 3
+        b.insert("t", {"id": 100, "val": "explicit"})
+        b.insert("t", {"val": "auto"})
+        rows = []
+        it = b.scan("t")
+        while (r := it.next()) is not None:
+            rows.append(r)
+        ids = sorted(r["id"] for r in rows)
+        assert ids == [1, 2, 100, 101]
 
     def test_unique_violation(self) -> None:
         b = InMemoryBackend()

--- a/code/packages/python/sql-vm/tests/test_rowid.py
+++ b/code/packages/python/sql-vm/tests/test_rowid.py
@@ -98,7 +98,13 @@ class TestRowIdSelect:
         assert rows == [{"rowid": 1}]
 
     def test_select_rowid_multiple_rows(self) -> None:
-        """Rowids are sequential 1-based integers in insertion order."""
+        """``rowid`` aliases the INTEGER PRIMARY KEY column when one exists.
+
+        SQLite invariant: ``INTEGER PRIMARY KEY`` IS the rowid, not a
+        separate column.  When the user inserts explicit id values 0..4,
+        the rowids match those values rather than running a parallel
+        1..5 counter.
+        """
         be = InMemoryBackend()
         _make_table("t", [("id", "INTEGER", True)], be)
         for i in range(5):
@@ -109,7 +115,7 @@ class TestRowIdSelect:
             items=(ProjectionItem(expr=RowIdRef(table="t"), alias="rowid"),),
         )
         rows = _select(be, plan)
-        assert [r["rowid"] for r in rows] == [1, 2, 3, 4, 5]
+        assert [r["rowid"] for r in rows] == [0, 1, 2, 3, 4]
 
     def test_select_rowid_with_real_column(self) -> None:
         """Rowid emitted alongside a real column."""


### PR DESCRIPTION
## Summary

SQLite treats ``INTEGER PRIMARY KEY`` as an alias for the rowid: when INSERT omits the column or passes ``NULL``, the engine assigns the next rowid; when the user supplies an explicit integer, the rowid counter bumps past it.

Mini-sqlite previously rejected the omit/NULL forms with a NOT NULL violation, blocking pretty much every ORM pattern like:

```sql
CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
INSERT INTO users(name) VALUES ('alice');  -- ❌ NOT NULL violation
```

This change wires it end-to-end:

1. Backend auto-assigns rowid when IPK column is missing/NULL.
2. Explicit user-supplied id bumps ``_next_rowid`` past it so subsequent auto-assigns don't collide.
3. Rowid IS the IPK — ``SELECT rowid`` and ``SELECT id`` return identical values.

## Bonus column-ordering fix

``_apply_defaults`` previously built the row dict in caller-insertion order. Combined with the new auto-assign path filling in a missing IPK column, ``SELECT *`` was showing ``(v, id)`` instead of ``(id, v)``. Rewrote ``_apply_defaults`` to build the dict in column-declaration order.

## Test plan

- [x] sql-backend: 189 tests pass, 83.35% coverage (one test renamed, 3 new auto-assign tests)
- [x] sql-vm: 921 tests pass, 80.34% coverage (1 test updated for rowid-alias behaviour)
- [x] sql-planner / sql-codegen / storage-sqlite: regression-only, no failures
- [x] mini-sqlite: 2149 tests pass, 91.48% coverage (10 new oracle tests vs sqlite3)
- [x] ruff clean
- [x] /security-review passed

Versions: sql-backend 0.17→0.18, mini-sqlite 1.92→1.93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)