### PR TITLE
spice: route transient method netlist options

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Parse and validate transient integration methods from
+  `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
+  `.options method=<...>`.
 - Parse conservative SPICE `T` transmission-line cards of the form
   `Tname n1 n2 n3 n4 Z0=<ohms> TD=<seconds>`, including subcircuit node
   remapping and validation for unsupported, missing, non-finite, and

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -10,7 +10,7 @@ netlist = parse_netlist("""
 V1 in 0 PULSE(0 1 0 1n 1n 10n 20n)
 R1 in out 1k
 C1 out 0 1u
-.tran 1n 20n
+.tran 1n 20n method=gear2
 .end
 """)
 
@@ -26,4 +26,6 @@ MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 and inductor `IC=<current>` initial conditions, SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
-and `.options` analysis cards.
+and `.options` analysis cards. Transient cards can carry
+`method=euler|trap|gear2`; when omitted, `netlist.transient_method()` falls
+back to `.options method=<...>` if present.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -14,6 +14,7 @@ from spice_netlist_parser.parser import (
     SensAnalysis,
     TfAnalysis,
     TranAnalysis,
+    TransientMethod,
     parse_netlist,
 )
 
@@ -34,6 +35,7 @@ __all__ = [
     "SensAnalysis",
     "TfAnalysis",
     "TranAnalysis",
+    "TransientMethod",
     "__version__",
     "parse",
     "parse_netlist",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -6,6 +6,7 @@ import math
 import re
 from dataclasses import dataclass, field
 from dataclasses import fields as dataclass_fields
+from typing import Literal
 
 from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
 from spice_engine import (
@@ -45,10 +46,11 @@ class OpAnalysis:
 
 @dataclass(frozen=True, slots=True)
 class TranAnalysis:
-    """A `.tran tstep tstop` transient analysis card."""
+    """A `.tran tstep tstop [method=<euler|trap|gear2>]` transient card."""
 
     t_step: float
     t_stop: float
+    method: TransientMethod | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,6 +110,7 @@ class NoiseAnalysis:
 
 
 type OptionValue = float | str | bool
+type TransientMethod = Literal["euler", "trap", "gear2"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -195,6 +198,17 @@ class ParsedNetlist:
 
     def options_cards(self) -> list[OptionsAnalysis]:
         return [analysis for analysis in self.analyses if isinstance(analysis, OptionsAnalysis)]
+
+    def transient_method(self, tran: TranAnalysis | None = None) -> TransientMethod | None:
+        """Return the explicit `.tran` method or fallback `.options method` value."""
+
+        if tran is not None and tran.method is not None:
+            return tran.method
+        for options in self.options_cards():
+            value = options.values.get("method")
+            if isinstance(value, str):
+                return _parse_transient_method(value, ".options method")
+        return None
 
 
 _VALUE_RE = re.compile(
@@ -715,8 +729,12 @@ def _parse_directive(fields: list[str]) -> Analysis:
         _require_fields(fields, 1, ".op")
         return OpAnalysis()
     if directive == ".tran":
-        _require_fields(fields, 3, ".tran")
-        return TranAnalysis(t_step=parse_value(fields[1]), t_stop=parse_value(fields[2]))
+        _require_min_fields(fields, 3, ".tran")
+        return TranAnalysis(
+            t_step=parse_value(fields[1]),
+            t_stop=parse_value(fields[2]),
+            method=_parse_tran_method_options(fields[3:]),
+        )
     if directive == ".dc":
         _require_fields(fields, 5, ".dc")
         return DcAnalysis(
@@ -799,13 +817,41 @@ def _parse_options(tokens: list[str]) -> dict[str, OptionValue]:
                 raise NetlistParseError(f".options contains empty option name in {token!r}")
             if raw_value == "":
                 raise NetlistParseError(f".options {key!r} requires a value")
-            values[key] = _parse_option_value(raw_value)
+            values[key] = (
+                _parse_transient_method(raw_value, ".options method")
+                if key == "method"
+                else _parse_option_value(raw_value)
+            )
         else:
             key = token.strip().lower()
             if not key:
                 raise NetlistParseError(".options contains an empty flag")
             values[key] = True
     return values
+
+
+def _parse_tran_method_options(tokens: list[str]) -> TransientMethod | None:
+    method: TransientMethod | None = None
+    for token in tokens:
+        if "=" not in token:
+            raise NetlistParseError(
+                f".tran unsupported trailing option {token!r}; use method=<euler|trap|gear2>"
+            )
+        key, raw_value = token.split("=", 1)
+        key = key.strip().lower()
+        if key != "method":
+            raise NetlistParseError(f".tran unsupported option {key!r}")
+        if raw_value == "":
+            raise NetlistParseError(".tran method requires a value")
+        method = _parse_transient_method(raw_value, ".tran method")
+    return method
+
+
+def _parse_transient_method(raw_value: str, context: str) -> TransientMethod:
+    method = raw_value.strip().lower()
+    if method in ("euler", "trap", "gear2"):
+        return method
+    raise NetlistParseError(f"{context} must be euler, trap, or gear2, got {raw_value!r}")
 
 
 def _parse_option_value(raw_value: str) -> OptionValue:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -193,6 +193,35 @@ def test_parse_options_analysis_card() -> None:
     assert parsed.options_cards() == parsed.analyses
 
 
+def test_parse_transient_method_from_tran_card() -> None:
+    parsed = parse_netlist(".tran 1n 20n method=gear2")
+
+    assert parsed.tran_cards() == [
+        TranAnalysis(t_step=1.0e-9, t_stop=20.0e-9, method="gear2")
+    ]
+    assert parsed.transient_method(parsed.tran_cards()[0]) == "gear2"
+
+
+def test_transient_method_falls_back_to_options_and_tran_takes_precedence() -> None:
+    parsed = parse_netlist(
+        """
+.options method=trap
+.tran 1n 20n method=euler
+"""
+    )
+
+    assert parsed.options_cards()[0].values["method"] == "trap"
+    assert parsed.transient_method() == "trap"
+    assert parsed.transient_method(parsed.tran_cards()[0]) == "euler"
+
+
+def test_transient_method_rejects_unsupported_values() -> None:
+    with pytest.raises(NetlistParseError, match="must be euler, trap, or gear2"):
+        parse_netlist(".tran 1n 20n method=bogus")
+    with pytest.raises(NetlistParseError, match="must be euler, trap, or gear2"):
+        parse_netlist(".options method=bogus")
+
+
 def test_options_card_rejects_empty_values() -> None:
     with pytest.raises(NetlistParseError, match=r"\.options 'gmin' requires a value"):
         parse_netlist(".options gmin=")

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Parse and validate transient integration methods from
+  `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
+  `.options method=<...>`.
 - Parse conservative SPICE `T` transmission-line cards of the form
   `Tname n1 n2 n3 n4 Z0=<ohms> TD=<seconds>`, including subcircuit node
   remapping and validation for unsupported, missing, non-finite, and

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -10,7 +10,7 @@ let parsed = parse_netlist(r#"
 V1 in 0 PULSE(0 1 0 1n 1n 10n 20n)
 R1 in out 1k
 C1 out 0 1u
-.tran 1n 20n
+.tran 1n 20n method=gear2
 .end
 "#)?;
 
@@ -28,3 +28,6 @@ conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
 and `.options` analysis cards.
+Transient cards can carry `method=euler|trap|gear2`; when omitted,
+`parsed.transient_method(None)?` falls back to `.options method=<...>` if
+present.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, fmt};
 use spice_engine::{
     Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform,
     Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, MutualInductor,
-    PulseWaveform, PwlWaveform, Resistor, SinWaveform, TransmissionLine, Vccs, Vcvs,
-    VoltageSource, Waveform,
+    PulseWaveform, PwlWaveform, Resistor, SinWaveform, TransientMethod, TransmissionLine, Vccs,
+    Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,6 +35,7 @@ pub struct OpAnalysis;
 pub struct TranAnalysis {
     pub time_step: f64,
     pub stop_time: f64,
+    pub method: Option<TransientMethod>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -210,6 +211,21 @@ impl ParsedNetlist {
                 _ => None,
             })
             .collect()
+    }
+
+    pub fn transient_method(
+        &self,
+        tran: Option<&TranAnalysis>,
+    ) -> Result<Option<TransientMethod>, NetlistParseError> {
+        if let Some(method) = tran.and_then(|card| card.method) {
+            return Ok(Some(method));
+        }
+        for options in self.options_cards() {
+            if let Some(OptionValue::Text(value)) = options.values.get("method") {
+                return Ok(Some(parse_transient_method(value, ".options method")?));
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -1199,10 +1215,11 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
             Ok(Analysis::Op(OpAnalysis))
         }
         ".tran" => {
-            require_fields(fields, 3, ".tran")?;
+            require_min_fields(fields, 3, ".tran")?;
             Ok(Analysis::Tran(TranAnalysis {
                 time_step: parse_value(&fields[1])?,
                 stop_time: parse_value(&fields[2])?,
+                method: parse_tran_method_options(&fields[3..])?,
             }))
         }
         ".dc" => {
@@ -1324,7 +1341,13 @@ fn parse_options(tokens: &[String]) -> Result<HashMap<String, OptionValue>, Netl
                     ".options {key:?} requires a value"
                 )));
             }
-            values.insert(key, parse_option_value(raw_value));
+            let value = if key == "method" {
+                let method = parse_transient_method(raw_value, ".options method")?;
+                OptionValue::Text(transient_method_name(method).to_string())
+            } else {
+                parse_option_value(raw_value)
+            };
+            values.insert(key, value);
         } else {
             let key = token.trim().to_ascii_lowercase();
             if key.is_empty() {
@@ -1334,6 +1357,52 @@ fn parse_options(tokens: &[String]) -> Result<HashMap<String, OptionValue>, Netl
         }
     }
     Ok(values)
+}
+
+fn parse_tran_method_options(
+    tokens: &[String],
+) -> Result<Option<TransientMethod>, NetlistParseError> {
+    let mut method = None;
+    for token in tokens {
+        let Some((raw_key, raw_value)) = token.split_once('=') else {
+            return Err(NetlistParseError::new(format!(
+                ".tran unsupported trailing option {token:?}; use method=<euler|trap|gear2>"
+            )));
+        };
+        let key = raw_key.trim().to_ascii_lowercase();
+        if key != "method" {
+            return Err(NetlistParseError::new(format!(
+                ".tran unsupported option {key:?}"
+            )));
+        }
+        if raw_value.is_empty() {
+            return Err(NetlistParseError::new(".tran method requires a value"));
+        }
+        method = Some(parse_transient_method(raw_value, ".tran method")?);
+    }
+    Ok(method)
+}
+
+fn parse_transient_method(
+    raw_value: &str,
+    context: &str,
+) -> Result<TransientMethod, NetlistParseError> {
+    match raw_value.trim().to_ascii_lowercase().as_str() {
+        "euler" => Ok(TransientMethod::Euler),
+        "trap" => Ok(TransientMethod::Trap),
+        "gear2" => Ok(TransientMethod::Gear2),
+        _ => Err(NetlistParseError::new(format!(
+            "{context} must be euler, trap, or gear2, got {raw_value:?}"
+        ))),
+    }
+}
+
+fn transient_method_name(method: TransientMethod) -> &'static str {
+    match method {
+        TransientMethod::Euler => "euler",
+        TransientMethod::Trap => "trap",
+        TransientMethod::Gear2 => "gear2",
+    }
 }
 
 fn parse_option_value(raw_value: &str) -> OptionValue {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
     ac_sweep, dc_op, mc_dc, noise_ac, sens_dc, tf, BjtPolarity, Element, JfetPolarity,
-    McDistribution, McOptions, MosfetType,
+    McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, McAnalysis, NetlistParseError,
@@ -90,6 +90,7 @@ G1 out 0 in 0 2m
             Analysis::Tran(TranAnalysis {
                 time_step: 1.0e-9,
                 stop_time: 20.0e-9,
+                method: None,
             }),
             Analysis::Dc(DcAnalysis {
                 source_name: "Vstep".to_string(),
@@ -224,6 +225,65 @@ fn parses_options_analysis_cards() {
     );
     assert_eq!(card.values.get("noopiter"), Some(&OptionValue::Flag(true)));
     assert!(matches!(parsed.analyses.as_slice(), [Analysis::Options(_)]));
+}
+
+#[test]
+fn parses_transient_methods_from_tran_cards() {
+    let parsed = parse_netlist(".tran 1n 20n method=gear2").unwrap();
+
+    assert_eq!(
+        parsed.tran_cards(),
+        vec![&TranAnalysis {
+            time_step: 1.0e-9,
+            stop_time: 20.0e-9,
+            method: Some(TransientMethod::Gear2),
+        }]
+    );
+    assert_eq!(
+        parsed
+            .transient_method(parsed.tran_cards().first().copied())
+            .unwrap(),
+        Some(TransientMethod::Gear2)
+    );
+}
+
+#[test]
+fn transient_method_falls_back_to_options_and_tran_takes_precedence() {
+    let parsed = parse_netlist(
+        r#"
+.options method=trap
+.tran 1n 20n method=euler
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        parsed.options_cards()[0].values.get("method"),
+        Some(&OptionValue::Text("trap".to_string()))
+    );
+    assert_eq!(
+        parsed.transient_method(None).unwrap(),
+        Some(TransientMethod::Trap)
+    );
+    assert_eq!(
+        parsed
+            .transient_method(parsed.tran_cards().first().copied())
+            .unwrap(),
+        Some(TransientMethod::Euler)
+    );
+}
+
+#[test]
+fn rejects_unsupported_transient_methods() {
+    let tran_error = parse_netlist(".tran 1n 20n method=bogus").unwrap_err();
+    assert!(tran_error
+        .to_string()
+        .contains("must be euler, trap, or gear2"));
+
+    let option_error = parse_netlist(".options method=bogus").unwrap_err();
+    assert!(option_error
+        .to_string()
+        .contains("must be euler, trap, or gear2"));
 }
 
 fn assert_option_number(actual: Option<&OptionValue>, expected: f64) {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Parse and validate transient integration methods from
+  `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
+  `.options method=<...>`.
 - Parse conservative SPICE `T` transmission-line cards of the form
   `Tname n1 n2 n3 n4 Z0=<ohms> TD=<seconds>`, including subcircuit node
   remapping and validation for unsupported, missing, non-finite, and

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -11,7 +11,7 @@ const netlist = parseNetlist(`
 V1 in 0 PULSE(0 1 0 1n 1n 10n 20n)
 R1 in out 1k
 C1 out 0 1u
-.tran 1n 20n
+.tran 1n 20n method=gear2
 .end
 `);
 
@@ -29,4 +29,6 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 initial conditions,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`,
-`.sens`, `.mc`, `.noise`, and `.options` analysis cards.
+`.sens`, `.mc`, `.noise`, and `.options` analysis cards. Transient cards can
+carry `method=euler|trap|gear2`; when omitted, `netlist.transientMethod()`
+falls back to `.options method=<...>` if present.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -27,6 +27,7 @@ import {
   type Element,
   type JfetPolarity,
   type MosfetLevel1Params,
+  type TransientMethod,
   type Waveform,
 } from "@coding-adventures/spice-engine";
 
@@ -45,6 +46,7 @@ export interface TranAnalysis {
   readonly kind: "tran";
   readonly timeStep: number;
   readonly stopTime: number;
+  readonly method?: TransientMethod;
 }
 
 export interface DcAnalysis {
@@ -159,6 +161,19 @@ export class ParsedNetlist {
 
   optionsCards(): OptionsAnalysis[] {
     return this.analyses.filter((analysis): analysis is OptionsAnalysis => analysis.kind === "options");
+  }
+
+  transientMethod(tran?: TranAnalysis): TransientMethod | undefined {
+    if (tran?.method !== undefined) {
+      return tran.method;
+    }
+    for (const options of this.optionsCards()) {
+      const value = options.values.get("method");
+      if (typeof value === "string") {
+        return parseTransientMethod(value, ".options method");
+      }
+    }
+    return undefined;
   }
 }
 
@@ -955,8 +970,14 @@ function parseDirective(fields: readonly string[]): Analysis {
     return { kind: "op" };
   }
   if (directive === ".tran") {
-    requireFields(fields, 3, ".tran");
-    return { kind: "tran", timeStep: parseValue(fields[1]), stopTime: parseValue(fields[2]) };
+    requireMinFields(fields, 3, ".tran");
+    const method = parseTranMethodOptions(fields.slice(3));
+    const card: TranAnalysis = {
+      kind: "tran",
+      timeStep: parseValue(fields[1]),
+      stopTime: parseValue(fields[2]),
+    };
+    return method === undefined ? card : { ...card, method };
   }
   if (directive === ".dc") {
     requireFields(fields, 5, ".dc");
@@ -1062,7 +1083,10 @@ function parseOptions(tokens: readonly string[]): ReadonlyMap<string, OptionValu
       if (rawValue === "") {
         throw new NetlistParseError(`.options ${JSON.stringify(key)} requires a value`);
       }
-      values.set(key, parseOptionValue(rawValue));
+      values.set(
+        key,
+        key === "method" ? parseTransientMethod(rawValue, ".options method") : parseOptionValue(rawValue),
+      );
     } else {
       const key = token.trim().toLowerCase();
       if (key.length === 0) {
@@ -1072,6 +1096,38 @@ function parseOptions(tokens: readonly string[]): ReadonlyMap<string, OptionValu
     }
   }
   return values;
+}
+
+function parseTranMethodOptions(tokens: readonly string[]): TransientMethod | undefined {
+  let method: TransientMethod | undefined;
+  for (const token of tokens) {
+    if (!token.includes("=")) {
+      throw new NetlistParseError(
+        `.tran unsupported trailing option ${JSON.stringify(token)}; use method=<euler|trap|gear2>`,
+      );
+    }
+    const equalsIndex = token.indexOf("=");
+    const key = token.slice(0, equalsIndex).trim().toLowerCase();
+    const rawValue = token.slice(equalsIndex + 1);
+    if (key !== "method") {
+      throw new NetlistParseError(`.tran unsupported option ${JSON.stringify(key)}`);
+    }
+    if (rawValue === "") {
+      throw new NetlistParseError(".tran method requires a value");
+    }
+    method = parseTransientMethod(rawValue, ".tran method");
+  }
+  return method;
+}
+
+function parseTransientMethod(rawValue: string, context: string): TransientMethod {
+  const method = rawValue.trim().toLowerCase();
+  if (method === "euler" || method === "trap" || method === "gear2") {
+    return method;
+  }
+  throw new NetlistParseError(
+    `${context} must be euler, trap, or gear2, got ${JSON.stringify(rawValue)}`,
+  );
 }
 
 function parseOptionValue(rawValue: string): OptionValue {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -147,6 +147,35 @@ Tdelay in 0 out 0 Z0=50 TD=1n
     expect(parsed.optionsCards()).toEqual([card]);
   });
 
+  it("parses transient methods from .tran cards", () => {
+    const parsed = parseNetlist(".tran 1n 20n method=gear2");
+
+    expect(parsed.tranCards()).toEqual([
+      { kind: "tran", timeStep: 1.0e-9, stopTime: 20.0e-9, method: "gear2" },
+    ]);
+    expect(parsed.transientMethod(parsed.tranCards()[0])).toBe("gear2");
+  });
+
+  it("falls back to .options method and lets .tran take precedence", () => {
+    const parsed = parseNetlist(`
+.options method=trap
+.tran 1n 20n method=euler
+`);
+
+    expect(parsed.optionsCards()[0].values.get("method")).toBe("trap");
+    expect(parsed.transientMethod()).toBe("trap");
+    expect(parsed.transientMethod(parsed.tranCards()[0])).toBe("euler");
+  });
+
+  it("rejects unsupported transient method values", () => {
+    expect(() => parseNetlist(".tran 1n 20n method=bogus")).toThrow(
+      /must be euler, trap, or gear2/,
+    );
+    expect(() => parseNetlist(".options method=bogus")).toThrow(
+      /must be euler, trap, or gear2/,
+    );
+  });
+
   it("rejects .options cards with empty values", () => {
     expect(() => parseNetlist(".options gmin=")).toThrow(/\.options "gmin" requires a value/);
   });

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -127,8 +127,7 @@ Scope:
 - `method="gear2"` / equivalent enum support across languages.
 - Capacitor and inductor BDF2 companion histories.
 - Adaptive-step interaction at the same surface as existing trap/euler.
-- Netlist `.options method=gear2` or `.tran ... method=gear2` route if already
-  supported by the parser shape.
+- Netlist `.options method=gear2` or `.tran ... method=gear2` routing.
 
 Acceptance:
 
@@ -143,8 +142,10 @@ Status:
   before two-step history is available. TypeScript and Rust now also expose
   trapezoidal transient companions for parity with Python, and all three
   packages include a coarse LC fixture showing Gear-2 damps ringing more than
-  trapezoidal integration. Adaptive-step interaction and netlist option
-  routing remain follow-up work.
+  trapezoidal integration. The parser packages now validate
+  `.tran ... method=<euler|trap|gear2>`, preserve the method on transient
+  analysis cards, and expose `.options method=<...>` as the fallback route.
+  Adaptive-step interaction remains follow-up work.
 
 ### Phase 5 - Pseudo-Transient DC Continuation
 


### PR DESCRIPTION
## Summary

- parse `.tran ... method=<euler|trap|gear2>` across Python, TypeScript, and Rust netlist parsers
- validate `.options method=<...>` against the engine-supported transient methods and expose fallback helpers
- update parser docs/changelogs and mark Phase 4 netlist option routing as done

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-tran-method-routing sh BUILD` in `code/packages/python/spice-netlist-parser`
- `sh BUILD` in `code/packages/typescript/spice-netlist-parser`
- `cargo test -p spice-netlist-parser` in `code/packages/rust`
- `git diff --check`