### PR TITLE
feat(toolkit): v0.4 — wire HostLink into Breadcrumb + Nav; add Tooltip + NumberInput

### DIFF
--- a/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,5 +1,96 @@
 # Changelog — mosaic-pkg-toolkit
 
+## [0.4.0] — UI29-4 — HostLink wires Breadcrumb + Nav; Tooltip + NumberInput added
+
+UI29-4 added three new kernel primitives (`HostLink`, `HostTooltip`,
+`HostNumberInput` — positions 19/20/21). v0.4 takes advantage of all
+three: Breadcrumb + Nav move from `HostButton` to `HostLink`
+(internal rewrite — user-facing emits unchanged), and two new
+components (`Tooltip`, `NumberInput`) wrap `HostTooltip` and
+`HostNumberInput` respectively.
+
+### `Breadcrumb` — `HostLink` rewrite
+
+- **Layout:** each crumb now emits `HostLink[breadcrumb-link]`
+  instead of `HostButton[breadcrumb-link]`. The platform-native
+  link semantics — `role="link"` + visited-state styling on web,
+  `Link` widget on SwiftUI/Flutter, rich-text anchor on Qt,
+  `Hyperlink` on XAML — come from the kernel for free now.
+- **Internal change:** The wrapped `HostLink`'s click event is
+  `onActivate` (not `HostButton`'s `onClick`). The toolkit's
+  user-facing `Breadcrumb.onSelect(index)` is unchanged.
+- **`href: "#"` default + `external: false`:** the toolkit
+  doesn't know the host's routing scheme, so each crumb ships
+  with an inert anchor and `external: false` tells the kernel
+  to skip the `window.open`/`launchUrl` shape (host routes via
+  `onSelect`). A follow-up could add a `hrefs: list<text>`
+  slot for hosts that want true per-crumb URLs.
+
+### `Nav` — `HostLink` rewrite (same shape)
+
+- **Layout:** each item now emits `HostLink[nav-link]` instead of
+  `HostButton[nav-link]`. Same rationale + same `href: "#"` +
+  `external: false` choices as Breadcrumb.
+- **Interface:** unchanged — `Nav.onSelect(index)` still fires
+  on activation; internal wiring moved from `onClick` to
+  `onActivate`.
+
+### `Tooltip` — new component
+
+- **Layout:** `HostTooltip[tooltip-wrapper] { Text[tooltip-label] }`.
+  Wraps a visible label `Text` in a `HostTooltip` whose `text`
+  shows on hover (desktop / web) or long-press (mobile).
+- **Interface:** `message: text` (tooltip body — named `message`
+  rather than the kernel-side `text` because `text` is a
+  reserved keyword in the .mil grammar), `label: text` (visible
+  text). No emits — tooltips are display-only.
+- **Scope (v0.4):** plain-text tooltips only, per UI29-4
+  spec §3.2's scoping decision. Rich-content tooltips (icons,
+  multiline, formatted) wait for a follow-up `Popover`
+  component or for the kernel to grow children-pass-through.
+
+### `NumberInput` — new component
+
+- **Layout:** single `HostNumberInput[number-input]` with
+  toolkit-default border / padding chrome (matches `Input`).
+- **Interface:** `value: number`, `placeholder: text`,
+  `disabled: bool`, `onChange(value: number)`. Per spec §3.3,
+  `onChange` fires on commit (Enter / blur), not per-keystroke.
+- **Why a separate component (not just `Input`):** the kernel's
+  `HostNumberInput` lights up the numeric keypad on mobile
+  (iOS/Android), ± stepper buttons on Qt SpinBox / XAML
+  NumberBox, and decimal-format locale awareness — none of
+  which `Input` + manual validation can replicate per-backend.
+- **`min`/`max`/`step` omitted from the toolkit interface:**
+  these are compile-time numeric literals on the kernel
+  primitive rather than runtime slots. Authors who need range
+  constraints compose `HostNumberInput` directly.
+
+### Migration guide
+
+User-facing emits are unchanged across all four touched components:
+
+| Component   | Emit (v0.3) | Emit (v0.4) | Change           |
+|---|---|---|---|
+| Breadcrumb  | `onSelect(index)` | `onSelect(index)` | none (internal rewrite only)  |
+| Nav         | `onSelect(index)` | `onSelect(index)` | none (internal rewrite only)  |
+| Tooltip     | n/a (new)         | (no emits)        | new component                 |
+| NumberInput | n/a (new)         | `onChange(value)` | new component                 |
+
+Hosts using only the documented toolkit-component emits should
+see no behavioural difference beyond platform-native a11y /
+keyboard upgrades on Breadcrumb + Nav (link role, visited-state
+styling, Tab/Enter activation come from the kernel). The only
+breaking surface would be hosts that reached into generated
+artifact internals' `onClick` handlers — those need to migrate
+to `onActivate`.
+
+### Manifest
+
+- `version` bumped 0.3.0 → 0.4.0.
+- `exports` now lists 16 components (was 14): added `NumberInput`
+  and `Tooltip`.
+
 ## [0.3.0] — UI29-2 — Checkbox + Radio rewritten on native primitives
 
 **Breaking change.** `Checkbox` and `Radio` previously composed from

--- a/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
@@ -7,12 +7,15 @@
 #
 # See `code/specs/mosaic-pkg-toolkit.md` for the design.
 #
-# Phase: v0.3 — Checkbox + Radio rewritten on UI29-2 HostCheckbox /
-# HostRadio kernel primitives. Breaking changes; see CHANGELOG.
+# Phase: v0.4 — UI29-4 host primitives integrated. Breadcrumb + Nav
+# rewritten on HostLink (BREAKING for hosts that wired onClick →
+# now onActivate); new Tooltip and NumberInput components wrap
+# HostTooltip / HostNumberInput. See CHANGELOG for the migration
+# guide.
 
 [package]
 name        = "mosaic-pkg-toolkit"
-version     = "0.3.0"
+version     = "0.4.0"
 description = "Bootstrap-shaped Mosaic UI component library — ready-made components composed purely from UI29 kernel primitives"
 license     = "MIT OR Apache-2.0"
 
@@ -23,12 +26,13 @@ license     = "MIT OR Apache-2.0"
 # v0.1 PR-4: ListGroup, Modal.
 # v0.1 PR-5: Field (label + HostInput + help/error).
 # v0.2 PR-6: Tier-2 batch 1 — Nav, ButtonGroup, Breadcrumb.
+# v0.4 UI29-4: Tooltip, NumberInput (new) + Breadcrumb/Nav rewrites.
 # Remaining Tier-1 (Card, Container) blocked on UI29-2 children
 # pass-through spec; ship when that lands.
 exports = [
   "Alert", "Badge", "Breadcrumb", "Button", "ButtonGroup",
   "Checkbox", "Field", "Input", "ListGroup", "Modal", "Nav",
-  "Radio", "Spinner", "Toast",
+  "NumberInput", "Radio", "Spinner", "Toast", "Tooltip",
 ]
 
 [dependencies]

--- a/code/packages/mosaic-pkg-toolkit/src/Breadcrumb.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Breadcrumb.mll
@@ -1,28 +1,41 @@
-// Breadcrumb.mll — layout for the Breadcrumb.
+// Breadcrumb.mll — layout for the Breadcrumb (v0.4).
 //
 //   Row [ breadcrumb ]
 //     For (each: slot: crumbs, as: crumb, index: i)
-//       HostButton [ breadcrumb-link ] (label: crumb, onClick: emit: onSelect)
+//       HostLink [ breadcrumb-link ] (
+//         href: "#",
+//         label: crumb,
+//         external: false,
+//         onActivate: emit: onSelect
+//       )
 //
-// v0.1: every crumb renders as a HostButton; the .msl styles them
-// uniformly. The "current location" non-clickable distinction
-// (typically the last crumb) needs either a `For` body that
-// branches on `i == crumbs.length - 1` or a separate `current`
-// slot — both are kernel-doable but add complexity. Punting that
-// to a follow-up; v0.1 ships the uniform-clickable form.
+// v0.4 swaps the per-crumb HostButton for HostLink, the UI29-4
+// kernel primitive promoted from the toolkit. The platform-correct
+// a11y semantics (role="link" on web, Link on SwiftUI/Flutter,
+// rich-text anchor on Qt, Hyperlink on XAML) come from the kernel
+// for free now — no per-backend chrome in the toolkit.
 //
-// Separators (the `/` or `>` between crumbs) are intentionally
-// NOT in the .mll for v0.1 either — they'd require a similar
-// branching-on-index pattern. The .msl can simulate separators
-// via per-link right-margin + a `::after` pseudo-element on
-// platforms that support it.
+// href default `"#"`: the toolkit doesn't know the host's routing
+// scheme, so we ship an inert anchor and let the host's
+// `onActivate` handler resolve the destination from the crumb
+// index. A follow-up could add an `hrefs: list<text>` slot for
+// hosts that want true per-crumb URLs (enabling right-click
+// → Copy Link, middle-click → open-in-new-tab, etc.); v0.4 keeps
+// the interface backwards-compatible.
+//
+// `external: false` tells the kernel this is in-app navigation
+// (no browser-window opening) so the React/Flutter emitters skip
+// the `window.open` / `launchUrl` hint and route through
+// onActivate instead.
 
 layout Breadcrumb {
   Row [ breadcrumb ] {
     For ( each: slot: crumbs , as: crumb , index: i ) {
-      HostButton [ breadcrumb-link ] (
+      HostLink [ breadcrumb-link ] (
+        href : "#" ,
         label : crumb ,
-        onClick : emit: onSelect
+        external : false ,
+        onActivate : emit: onSelect
       )
     }
   }

--- a/code/packages/mosaic-pkg-toolkit/src/Nav.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Nav.mll
@@ -1,20 +1,35 @@
-// Nav.mll — layout for the horizontal nav.
+// Nav.mll — layout for the horizontal nav (v0.4).
 //
 //   Row [ nav ]
 //     For (each: slot: items, as: item, index: i)
-//       HostButton [ nav-link ] (label: item, onClick: emit: onSelect)
+//       HostLink [ nav-link ] (
+//         href: "#",
+//         label: item,
+//         external: false,
+//         onActivate: emit: onSelect
+//       )
 //
-// Structurally identical to ListGroup but laid out horizontally
-// via Row. Each item is a HostButton so a11y wiring (focus,
-// keyboard activation) comes from the kernel for free; .msl
-// flat-styles the chrome.
+// v0.4 swaps the per-item HostButton for HostLink — same rationale
+// as Breadcrumb's rewrite. The "nav as a row of links" idiom is
+// what the DOM `<nav>` semantic element wraps in real-world HTML,
+// and the cross-platform native widgets (SwiftUI's `Link`, XAML's
+// `Hyperlink`, etc.) all model the same shape. Switching to
+// HostLink also brings free keyboard semantics (Tab + Enter to
+// activate) the prior HostButton lowering depended on a per-
+// backend onClick spelling for.
+//
+// `external: false` + `href: "#"` is the same pattern as
+// Breadcrumb — toolkit owns the layout, host owns routing via
+// `onActivate(index)`.
 
 layout Nav {
   Row [ nav ] {
     For ( each: slot: items , as: item , index: i ) {
-      HostButton [ nav-link ] (
+      HostLink [ nav-link ] (
+        href : "#" ,
         label : item ,
-        onClick : emit: onSelect
+        external : false ,
+        onActivate : emit: onSelect
       )
     }
   }

--- a/code/packages/mosaic-pkg-toolkit/src/NumberInput.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/NumberInput.dark.msl
@@ -1,0 +1,13 @@
+// NumberInput.dark.msl — dark-theme styling for NumberInput.
+
+style NumberInput {
+  part number-input {
+    padding       : 8 ;
+    border-radius : 4 ;
+    background    : "#1e293b" ;
+    color         : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#475569" ;
+    font-size     : 14 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/NumberInput.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/NumberInput.light.msl
@@ -1,0 +1,18 @@
+// NumberInput.light.msl — default light-theme styling for NumberInput.
+//
+// Mirrors Input.light.msl exactly — numeric inputs share text
+// inputs' visual chrome on every platform. The only material
+// difference is the keyboard surface (numeric keypad on mobile),
+// which the kernel emits without any per-backend styling.
+
+style NumberInput {
+  part number-input {
+    padding       : 8 ;
+    border-radius : 4 ;
+    background    : "#ffffff" ;
+    color         : "#212529" ;
+    border-width  : 1 ;
+    border-color  : "#ced4da" ;
+    font-size     : 14 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/NumberInput.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/NumberInput.mil
@@ -1,0 +1,29 @@
+// NumberInput.mil — interface for the toolkit NumberInput (v0.4).
+//
+// A styled single-line numeric input. Thin wrapper around the
+// UI29-4 HostNumberInput kernel primitive with toolkit-default
+// theming (border, focus, padding — mirrors the Input wrapper).
+//
+// The numeric-keyboard surfacing (mobile keypads), ± stepper
+// affordances (Qt SpinBox, XAML NumberBox), and range validation
+// all come from the kernel for free. The toolkit's job is just
+// the visual chrome.
+
+component NumberInput {
+  // Current numeric value. Required. Two-way: host's onChange
+  // handler typically updates the slot.
+  slot value : number ;
+
+  // Placeholder text shown when the input is empty.
+  slot placeholder : text ;
+
+  // Disabled flag. When true, the input renders disabled and
+  // stops firing onChange.
+  slot disabled : bool ;
+
+  // Fired on commit (Enter / blur). Payload is the new numeric
+  // value. Per UI29-4 spec §3.3, numeric fields explicitly do
+  // NOT fire per-keystroke — intermediate states like "12"
+  // while typing "12.5" aren't meaningful values.
+  emit onChange ( value : number ) ;
+}

--- a/code/packages/mosaic-pkg-toolkit/src/NumberInput.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/NumberInput.mll
@@ -1,0 +1,20 @@
+// NumberInput.mll — layout for the toolkit NumberInput (v0.4).
+//
+// Single HostNumberInput wrapped with `part_name: number-input` so
+// the .msl can style border, focus, and padding consistently
+// across every backend.
+//
+// `min`/`max`/`step` are deliberately omitted from the toolkit
+// wrapper's interface — they're per-use compile-time literals
+// rather than runtime slots, so authors who need range constraints
+// should compose `HostNumberInput` directly. A follow-up could
+// add toolkit `min`/`max` if a recurring pattern emerges.
+
+layout NumberInput {
+  HostNumberInput [ number-input ] (
+    value : slot: value ,
+    placeholder : slot: placeholder ,
+    disabled : slot: disabled ,
+    onChange : emit: onChange
+  )
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Tooltip.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Tooltip.dark.msl
@@ -1,0 +1,11 @@
+// Tooltip.dark.msl — dark-theme styling for Tooltip.
+
+style Tooltip {
+  part tooltip-label {
+    color     : "#f1f5f9" ;
+    font-size : 14 ;
+  }
+  part tooltip-wrapper {
+    padding : 0 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Tooltip.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Tooltip.light.msl
@@ -1,0 +1,16 @@
+// Tooltip.light.msl — default light-theme styling for Tooltip.
+//
+// Most backends render tooltips via stock OS chrome (DOM `title=`
+// is browser-styled and uncustomisable; SwiftUI `.help` uses the
+// platform tooltip; Qt/XAML/Flutter expose limited custom chrome).
+// The label .msl is what we can safely customise.
+
+style Tooltip {
+  part tooltip-label {
+    color     : "#212529" ;
+    font-size : 14 ;
+  }
+  part tooltip-wrapper {
+    padding : 0 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Tooltip.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Tooltip.mil
@@ -1,0 +1,37 @@
+// Tooltip.mil — interface for the toolkit Tooltip (v0.4).
+//
+// Plain-text hover-help annotation wrapped around a visible label.
+// Thin wrapper around the UI29-4 HostTooltip kernel primitive plus
+// a Text — the toolkit's contribution is the "tooltip-wrapped text"
+// convenience shape that covers the most common toolkit usage.
+//
+// Why a `label` slot and not a node-typed children slot?
+// -----------------------------------------------------
+// Same reason as Modal: arbitrary children pass-through is a
+// kernel feature that v0.4 doesn't yet have. The "tooltip a
+// piece of text" shape covers a clean majority of toolkit
+// tooltips (info-icon hovers, abbreviation expansions, key-bind
+// hints). Hosts that need to tooltip arbitrary widgets can use
+// the kernel `HostTooltip` directly with their own children.
+//
+// Rich-content tooltips (icons, multiline, formatted) are out
+// of scope for v0.4 per UI29-4 spec §3.2's plain-text-only
+// scope. A follow-up `Popover` toolkit component handles the
+// rich case.
+
+component Tooltip {
+  // The tooltip body text shown on hover / long-press. Plain
+  // text only in v0.4. Named `message` (not `text`) because
+  // `text` is a reserved keyword in the .mil grammar — it's the
+  // type name for textual slots, so it can't double as a slot
+  // identifier. The kernel HostTooltip's slot IS called `text`
+  // since the kernel-side .mosmodel parsing has a smaller
+  // keyword footprint; the toolkit wraps it with a non-keyword
+  // alias.
+  slot message : text ;
+
+  // The visible label the tooltip annotates.
+  slot label : text ;
+
+  // (no emits — tooltips are display-only.)
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Tooltip.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Tooltip.mll
@@ -1,0 +1,28 @@
+// Tooltip.mll — layout for the toolkit Tooltip (v0.4).
+//
+//   HostTooltip [ tooltip-wrapper ] ( text: slot: message ) {
+//     Text [ tooltip-label ] ( content: slot: label )
+//   }
+//
+// HostTooltip wraps its single child (the spec's `target`); we
+// wrap a `Text` widget so the visible label inherits toolkit
+// font-family / size defaults. Each backend then maps to its
+// native tooltip chrome (DOM `title=` attribute, SwiftUI `.help`,
+// Qt `ToolTip.text`, XAML `ToolTipService.ToolTip`, Flutter
+// `Tooltip(message:, child:)`).
+//
+// The kernel HostTooltip prop is `text` (per UI29-4 spec §3.2);
+// the toolkit slot is `message` because `text` is a grammar
+// keyword in .mil files. The mapping `text: slot: message`
+// connects the kernel-side `text` prop to the toolkit-side
+// `message` slot.
+
+layout Tooltip {
+  HostTooltip [ tooltip-wrapper ] (
+    text : slot: message
+  ) {
+    Text [ tooltip-label ] (
+      content : slot: label
+    )
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -37,7 +37,7 @@ use std::path::PathBuf;
 const COMPONENTS: &[&str] = &[
     "Alert", "Badge", "Breadcrumb", "Button", "ButtonGroup",
     "Checkbox", "Field", "Input", "ListGroup", "Modal", "Nav",
-    "Radio", "Spinner", "Toast",
+    "NumberInput", "Radio", "Spinner", "Toast", "Tooltip",
 ];
 
 /// Themes shipped per component. Both must compile.
@@ -82,8 +82,8 @@ fn manifest_declares_expected_exports() {
         .and_then(|v| v.as_str())
         .expect("[package].version must be set");
     assert_eq!(
-        version, "0.3.0",
-        "[package].version must be 0.3.0 for the UI29-2 Checkbox/Radio rewrite"
+        version, "0.4.0",
+        "[package].version must be 0.4.0 for the UI29-4 HostLink + Tooltip + NumberInput release"
     );
 
     let exports = value


### PR DESCRIPTION
## Summary

Closes plan item [I] in the UI29-4 cycle. mosaic-pkg-toolkit v0.4 exploits all three new kernel primitives (HostLink/HostTooltip/HostNumberInput):

- **Breadcrumb** & **Nav** rewritten on `HostLink` (was `HostButton`). Platform-native link semantics — `role=\"link\"`, visited-state, `Link` widget on SwiftUI/Flutter, rich-text anchor on Qt, `Hyperlink` on XAML — flow from the kernel for free. `href: \"#\"` + `external: false` keeps routing under host control via `onActivate`. User-facing `onSelect(index)` emit unchanged.
- **Tooltip** (new): `HostTooltip` wrapping a `Text` label. Slot named `message` (not the kernel-side `text`) because `text` is a reserved keyword in the .mil grammar.
- **NumberInput** (new): single `HostNumberInput` with toolkit border/padding chrome (mirrors `Input`). `onChange` fires on commit (Enter/blur) per spec §3.3 rejection of per-keystroke dispatch for numeric fields.

Manifest: version 0.3.0 → 0.4.0; `exports` grows 14 → 16.

## Test plan

- [x] `cargo test` in mosaic-pkg-toolkit passing (16 tests, all components round-trip through mosmodel/moslayout/mosstyle compilers)
- [x] Manifest version assertion updated to \"0.4.0\"
- [x] Security review passed (declarative .mil/.mll/.msl files; no new injection paths beyond already-vetted kernel primitives)
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)