### PR TITLE
feat(visicalc): migrate FormulaBar from legacy Input to HostInput (Phase 1)

### DIFF
--- a/demo/visicalc/mosaic/FormulaBar.desktop.mll
+++ b/demo/visicalc/mosaic/FormulaBar.desktop.mll
@@ -1,15 +1,22 @@
 // FormulaBar.desktop.mll — desktop layout for the formula bar.
 //
-// Row containing the cell address label and the editable Input field.
-// The Input primitive (UI25) handles onChange / onCommit / onCancel
-// natively: onChange wraps `e.target.value` as the payload, and
-// onCommit + onCancel merge into a single onKeyDown handler keyed on
-// Enter / Escape.
+// Row containing the cell address label and the editable HostInput
+// field. Migrated from the legacy `Input` primitive (UI25) to
+// `HostInput` (UI29 §2.1, kernel primitive #4) per the VisiCalc
+// Phase 1 plan — same value/readOnly/placeholder/event wiring, just
+// the kernel-canonical name.
+//
+// HostInput handles onChange / onCommit / onCancel natively:
+// onChange wraps `e.target.value` as the payload, and onCommit +
+// onCancel merge into a single onKeyDown handler keyed on Enter /
+// Escape — identical generated React shape to the legacy `Input`
+// primitive (per the UI29 §2.1 migration note in the React
+// emitter docs).
 
 layout FormulaBar {
   Row [bar] {
     Text [address-label] (content: slot: cell-address)
-    Input [formula-field] (
+    HostInput [formula-field] (
       value:       slot: formula,
       read-only:   slot: read-only,
       placeholder: "Enter formula",


### PR DESCRIPTION
## Summary

Closes plan item [J] — the final item in the UI29-4 cycle.

- One-token rename in `demo/visicalc/mosaic/FormulaBar.desktop.mll`: `Input` → `HostInput`.
- The legacy `Input` primitive (UI25) is slated for retirement under U29-X1. `HostInput` (UI29 §2.1, kernel primitive #4) is the kernel-canonical replacement and accepts the SAME prop names (`value`, `read-only`, `placeholder`, `onChange`, `onCommit`, `onCancel`).
- **Verification:** regenerated `FormulaBar.tsx` via `demo/visicalc/scripts/build.sh`; diff against pre-migration output is empty. Discriminated union (`formulaChange`/`commit`/`cancel`), dispatch wiring, JSX shape, and inline styles are all byte-identical. Confirms the spec's migration guarantee that swapping `Input` → `HostInput` is invisible at the React-artifact layer.
- Grid demo continues to use `Input` directly — Phase 2 of VisiCalc tackles Grid + its hand-written `GridEvent` shim.

## Test plan

- [x] `bash demo/visicalc/scripts/build.sh` succeeds
- [x] `diff <pre-migration FormulaBar.tsx> <post-migration FormulaBar.tsx>` is empty
- [x] Generated tsx still exports the same `FormulaBarEvent` discriminated union
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)