### PR TITLE
spice: add adaptive transient parity

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `transient_adaptive`, an LTE-controlled transient surface with bounded
+  step growth/shrinkage and `Euler` / `Trap` / `Gear2` method routing.
 - Add trapezoidal transient integration parity for capacitors and inductors,
   enabling LC damping comparisons against Gear-2.
 - Add Gear-2 transient integration with BDF2 capacitor/inductor companion

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -18,7 +18,8 @@ The initial slices implement:
 - AC small-signal frequency sweeps for linear RC/RL circuits and explicit AC
   source phasors with DC-bias operating-point linearization for nonlinear
   devices.
-- Backward-Euler transient analysis for linear RC/RL circuits.
+- Backward-Euler, trapezoidal, Gear-2, and adaptive transient analysis for
+  linear RC/RL circuits.
 - Time-varying transient source waveforms: PWL, SIN, PULSE, and EXP.
 
 The package supports resistors, capacitors, inductors, diodes, BJTs,
@@ -27,7 +28,10 @@ current sources, optional AC source phasors, optional source waveforms, ground
 aliases, node voltages, and voltage source branch currents.
 
 ```rust
-use spice_engine::{Circuit, Element, PwlWaveform, Resistor, VoltageSource, Waveform};
+use spice_engine::{
+    transient_adaptive, AdaptiveTransientOptions, Circuit, Element, PwlWaveform, Resistor,
+    TransientMethod, VoltageSource, Waveform,
+};
 
 let mut circuit = Circuit::new();
 circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
@@ -38,4 +42,13 @@ circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
     Waveform::Pwl(PwlWaveform::new(vec![(0.0, 0.0), (1.0e-9, 1.8)])),
 )));
 circuit.add(Element::Resistor(Resistor::new("Rload", "in", "0", 1_000.0)));
+let result = transient_adaptive(
+    &circuit,
+    0.5e-9,
+    1.0e-9,
+    AdaptiveTransientOptions {
+        method: TransientMethod::Gear2,
+        ..Default::default()
+    },
+)?;
 ```

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1799,6 +1799,33 @@ pub enum TransientMethod {
     Gear2,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct AdaptiveTransientOptions {
+    pub method: TransientMethod,
+    pub tolerance: f64,
+    pub min_step: Option<f64>,
+    pub max_step: Option<f64>,
+}
+
+impl Default for AdaptiveTransientOptions {
+    fn default() -> Self {
+        Self {
+            method: TransientMethod::Trap,
+            tolerance: 1.0e-4,
+            min_step: None,
+            max_step: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdaptiveTransientResult {
+    pub points: Vec<TransientPoint>,
+    pub method: TransientMethod,
+    pub steps_rejected: usize,
+    pub converged: bool,
+}
+
 impl TransientPoint {
     pub fn voltage(&self, node: &str) -> Option<f64> {
         if is_ground(node) {
@@ -2919,6 +2946,153 @@ pub fn transient_with_method(
         time += time_step;
     }
     Ok(points)
+}
+
+pub fn transient_adaptive(
+    circuit: &Circuit,
+    time_step: f64,
+    stop_time: f64,
+    options: AdaptiveTransientOptions,
+) -> Result<AdaptiveTransientResult, SpiceError> {
+    if !time_step.is_finite() || time_step <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "transient".to_string(),
+            reason: "time step must be finite and positive".to_string(),
+        });
+    }
+    if !stop_time.is_finite() || stop_time < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "transient".to_string(),
+            reason: "stop time must be finite and non-negative".to_string(),
+        });
+    }
+    if !options.tolerance.is_finite() || options.tolerance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "transient".to_string(),
+            reason: "adaptive tolerance must be finite and non-negative".to_string(),
+        });
+    }
+    let min_step = options.min_step.unwrap_or(time_step / 1_000.0);
+    let max_step = options.max_step.unwrap_or(time_step * 10.0);
+    if !min_step.is_finite() || min_step <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: "transient".to_string(),
+            reason: "minimum step must be finite and positive".to_string(),
+        });
+    }
+    if !max_step.is_finite() || max_step < min_step {
+        return Err(SpiceError::InvalidElement {
+            name: "transient".to_string(),
+            reason: "maximum step must be finite and at least the minimum step".to_string(),
+        });
+    }
+
+    validate_reactive_elements(circuit)?;
+
+    let mut capacitor_states = initial_capacitor_states(circuit, time_step, options.method);
+    let mut inductor_states = initial_inductor_states(circuit, time_step, options.method);
+    let mut line_states = initial_transmission_line_states(circuit);
+    let initial_circuit = circuit_with_transmission_line_companions(circuit, &line_states, 0.0)?;
+    let initial_solution = solve_linear_circuit(
+        &initial_circuit,
+        &capacitor_states,
+        &inductor_states,
+        Some(0.0),
+    )?;
+    update_transmission_line_states(
+        circuit,
+        &initial_solution.node_voltages,
+        &mut line_states,
+        0.0,
+    )?;
+
+    let mut points = Vec::new();
+    let mut steps_rejected = 0;
+    let mut current_time = 0.0;
+    let mut step = time_step.min(max_step);
+    let mut previous_cap_voltages = capacitor_voltages(circuit, &initial_solution.node_voltages);
+    let mut previous_previous_cap_voltages = previous_cap_voltages.clone();
+
+    while current_time < stop_time - time_step * 1.0e-12 {
+        let remaining = stop_time - current_time;
+        let proposed_step = if remaining <= min_step {
+            remaining
+        } else {
+            step.min(remaining).max(min_step)
+        };
+        let proposed_time = current_time + proposed_step;
+        let step_method = if options.method == TransientMethod::Gear2 && points.is_empty() {
+            TransientMethod::Euler
+        } else {
+            options.method
+        };
+        set_reactive_state_method(&mut capacitor_states, &mut inductor_states, step_method);
+        set_reactive_state_step(&mut capacitor_states, &mut inductor_states, proposed_step);
+        let companion_circuit =
+            circuit_with_transmission_line_companions(circuit, &line_states, proposed_time)?;
+        let linear_solution = solve_linear_circuit(
+            &companion_circuit,
+            &capacitor_states,
+            &inductor_states,
+            Some(proposed_time),
+        )?;
+        let proposed_cap_voltages = capacitor_voltages(circuit, &linear_solution.node_voltages);
+        let can_estimate_lte = options.method != TransientMethod::Euler && !points.is_empty();
+        let lte = if can_estimate_lte {
+            transient_lte_estimate(
+                circuit,
+                &proposed_cap_voltages,
+                &previous_cap_voltages,
+                &previous_previous_cap_voltages,
+            )
+        } else {
+            0.0
+        };
+        if can_estimate_lte && lte > options.tolerance && proposed_step > min_step + 1.0e-20 {
+            step = (proposed_step / 2.0).max(min_step);
+            steps_rejected += 1;
+            continue;
+        }
+
+        update_capacitor_states(
+            circuit,
+            &linear_solution.node_voltages,
+            &mut capacitor_states,
+        );
+        update_inductor_states(
+            circuit,
+            &linear_solution.node_voltages,
+            &mut inductor_states,
+        );
+        let line_currents = update_transmission_line_states(
+            circuit,
+            &linear_solution.node_voltages,
+            &mut line_states,
+            proposed_time,
+        )?;
+        let mut branch_currents = linear_solution.branch_currents;
+        branch_currents.extend(line_currents);
+        points.push(TransientPoint {
+            time: proposed_time,
+            node_voltages: linear_solution.node_voltages,
+            branch_currents,
+        });
+        current_time = proposed_time;
+        previous_previous_cap_voltages = previous_cap_voltages;
+        previous_cap_voltages = proposed_cap_voltages;
+        step = if can_estimate_lte && lte < options.tolerance / 8.0 {
+            (proposed_step * 2.0).min(max_step)
+        } else {
+            proposed_step
+        };
+    }
+
+    Ok(AdaptiveTransientResult {
+        points,
+        method: options.method,
+        steps_rejected,
+        converged: true,
+    })
 }
 
 pub fn pss_residual(
@@ -5646,6 +5820,66 @@ fn set_reactive_state_method(
     for state in inductor_states {
         state.method = method;
     }
+}
+
+fn set_reactive_state_step(
+    capacitor_states: &mut [CapacitorState],
+    inductor_states: &mut [InductorState],
+    time_step: f64,
+) {
+    for state in capacitor_states {
+        state.time_step = time_step;
+    }
+    for state in inductor_states {
+        state.time_step = time_step;
+    }
+}
+
+fn capacitor_voltages(
+    circuit: &Circuit,
+    node_voltages: &BTreeMap<String, f64>,
+) -> BTreeMap<String, f64> {
+    circuit
+        .elements()
+        .iter()
+        .filter_map(|element| match element {
+            Element::Capacitor(capacitor) => Some((
+                capacitor.name.clone(),
+                voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+fn transient_lte_estimate(
+    circuit: &Circuit,
+    current_voltages: &BTreeMap<String, f64>,
+    previous_voltages: &BTreeMap<String, f64>,
+    previous_previous_voltages: &BTreeMap<String, f64>,
+) -> f64 {
+    circuit
+        .elements()
+        .iter()
+        .filter_map(|element| match element {
+            Element::Capacitor(capacitor) => {
+                let current = current_voltages
+                    .get(&capacitor.name)
+                    .copied()
+                    .unwrap_or(capacitor.initial_voltage);
+                let previous = previous_voltages
+                    .get(&capacitor.name)
+                    .copied()
+                    .unwrap_or(capacitor.initial_voltage);
+                let previous_previous = previous_previous_voltages
+                    .get(&capacitor.name)
+                    .copied()
+                    .unwrap_or(capacitor.initial_voltage);
+                Some((current - 2.0 * previous + previous_previous).abs() / 2.0)
+            }
+            _ => None,
+        })
+        .fold(0.0, f64::max)
 }
 
 fn initial_transmission_line_states(circuit: &Circuit) -> Vec<TransmissionLineState> {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2,7 +2,8 @@ use spice_engine::{
     estimate_period, pss_newton_candidate_with_tolerance, pss_newton_iteration_with_tolerance,
     pss_newton_solve_with_tolerance, pss_newton_update, pss_newton_update_with_tolerance,
     pss_residual, pss_residual_jacobian_with_tolerance, pss_residual_with_tolerance,
-    pss_with_tolerance, transient, transient_with_method, Capacitor, Cccs, Ccvs, Circuit,
+    pss_with_tolerance, transient, transient_adaptive, transient_with_method,
+    AdaptiveTransientOptions, AdaptiveTransientResult, Capacitor, Cccs, Ccvs, Circuit,
     CurrentSource, Element, ExpWaveform, Inductor, MutualInductor, PssNewtonCandidateResult,
     PssNewtonIterationResult, PssNewtonSolveResult, PssNewtonUpdateResult,
     PssResidualJacobianResult, PssResidualResult, PssResult, PulseWaveform, PwlWaveform, Resistor,
@@ -625,6 +626,75 @@ fn transient_gear2_damps_coarse_lc_oscillator_more_than_trap() {
         .fold(0.0_f64, f64::max);
 
     assert!(gear_tail < trap_tail * 0.75);
+}
+
+#[test]
+fn adaptive_transient_matches_fixed_trap_when_bounds_pin_step() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Capacitor(Capacitor::new("C1", "out", "0", 1.0e-6)));
+
+    let fixed = transient_with_method(&circuit, 1.0e-3, 3.0e-3, TransientMethod::Trap).unwrap();
+    let adaptive = transient_adaptive(
+        &circuit,
+        1.0e-3,
+        3.0e-3,
+        AdaptiveTransientOptions {
+            method: TransientMethod::Trap,
+            tolerance: 1.0,
+            min_step: Some(1.0e-3),
+            max_step: Some(1.0e-3),
+        },
+    )
+    .unwrap();
+
+    let _: AdaptiveTransientResult = adaptive.clone();
+    assert!(adaptive.converged);
+    assert_eq!(adaptive.steps_rejected, 0);
+    assert_eq!(adaptive.points.len(), fixed.len());
+    assert_close(adaptive.points[0].time, fixed[0].time);
+    assert_close(
+        adaptive.points.last().unwrap().voltage("out").unwrap(),
+        fixed.last().unwrap().voltage("out").unwrap(),
+    );
+}
+
+#[test]
+fn adaptive_transient_uses_variable_steps_with_gear2_after_bootstrap() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "vin", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Capacitor(Capacitor::new("C1", "out", "0", 1.0e-6)));
+
+    let fixed = transient_with_method(&circuit, 1.0e-4, 1.0e-3, TransientMethod::Gear2).unwrap();
+    let adaptive = transient_adaptive(
+        &circuit,
+        1.0e-4,
+        1.0e-3,
+        AdaptiveTransientOptions {
+            method: TransientMethod::Gear2,
+            tolerance: 1.0,
+            min_step: None,
+            max_step: Some(5.0e-4),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(adaptive.method, TransientMethod::Gear2);
+    assert!(adaptive.converged);
+    assert_eq!(adaptive.steps_rejected, 0);
+    assert!(adaptive.points.len() < fixed.len());
+    assert_close(adaptive.points.last().unwrap().time, 1.0e-3);
+    assert!(adaptive.points.last().unwrap().voltage("out").unwrap() > 0.0);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `transientAdaptive`, an LTE-controlled transient surface with bounded
+  step growth/shrinkage and `euler` / `trap` / `gear2` method routing.
 - Add trapezoidal transient integration parity for capacitors and inductors,
   enabling LC damping comparisons against Gear-2.
 - Add Gear-2 transient integration with BDF2 capacitor/inductor companion

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -6,7 +6,7 @@ primitives for TypeScript.
 The current slices implement DC operating-point analysis, DC source sweeps, DC
 sensitivity analysis, seeded DC Monte Carlo analysis, DC small-signal
 transfer-function analysis, AC small-signal frequency sweeps, and fixed-step
-AC noise analysis, and RC/RL transient analysis for linear circuits using
+AC noise analysis, and fixed/adaptive RC/RL transient analysis for linear circuits using
 modified nodal analysis (MNA). The package supports
 resistors, capacitors, inductors, diodes, BJTs, Level-1 MOSFETs, independent current sources,
 independent voltage sources, voltage-controlled current sources (VCCS),
@@ -21,6 +21,7 @@ import {
   PwlWaveform,
   resistor,
   transient,
+  transientAdaptive,
   voltageSourceWithWaveform,
 } from "@coding-adventures/spice-engine";
 
@@ -40,4 +41,5 @@ circuit.add(
 circuit.add(resistor("Rload", "in", "0", 1_000.0));
 
 const points = transient(circuit, 0.5e-9, 1.0e-9);
+const adaptive = transientAdaptive(circuit, 0.5e-9, 1.0e-9, { method: "gear2" });
 ```

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -630,6 +630,20 @@ export interface TransientPoint {
   branchCurrent(sourceName: string): number | undefined;
 }
 
+export interface AdaptiveTransientOptions {
+  readonly method?: TransientMethod;
+  readonly tolerance?: number;
+  readonly minStep?: number;
+  readonly maxStep?: number;
+}
+
+export interface AdaptiveTransientResult {
+  readonly points: readonly TransientPoint[];
+  readonly method: TransientMethod;
+  readonly stepsRejected: number;
+  readonly converged: boolean;
+}
+
 export interface PssResidualEntry {
   readonly kind: "node" | "branch_current";
   readonly name: string;
@@ -1897,6 +1911,114 @@ export function transient(
   return points;
 }
 
+export function transientAdaptive(
+  circuit: Circuit,
+  timeStep: number,
+  stopTime: number,
+  options: AdaptiveTransientOptions = {},
+): AdaptiveTransientResult {
+  if (!Number.isFinite(timeStep) || timeStep <= 0.0) {
+    throw invalidElement("transient", "time step must be finite and positive");
+  }
+  if (!Number.isFinite(stopTime) || stopTime < 0.0) {
+    throw invalidElement("transient", "stop time must be finite and non-negative");
+  }
+  const method = options.method ?? "trap";
+  if (method !== "euler" && method !== "trap" && method !== "gear2") {
+    throw invalidElement("transient", "method must be euler, trap, or gear2");
+  }
+  const tolerance = options.tolerance ?? 1.0e-4;
+  const minStep = options.minStep ?? timeStep / 1_000.0;
+  const maxStep = options.maxStep ?? timeStep * 10.0;
+  if (!Number.isFinite(tolerance) || tolerance < 0.0) {
+    throw invalidElement("transient", "adaptive tolerance must be finite and non-negative");
+  }
+  if (!Number.isFinite(minStep) || minStep <= 0.0) {
+    throw invalidElement("transient", "minimum step must be finite and positive");
+  }
+  if (!Number.isFinite(maxStep) || maxStep < minStep) {
+    throw invalidElement("transient", "maximum step must be finite and at least the minimum step");
+  }
+
+  validateReactiveElements(circuit);
+
+  const capacitorStates = initialCapacitorStates(circuit, timeStep, method);
+  const inductorStates = initialInductorStates(circuit, timeStep, method);
+  const lineStates = initialTransmissionLineStates(circuit);
+  const initialCircuit = circuitWithTransmissionLineCompanions(circuit, lineStates, 0.0);
+  const initialSolution = solveLinearCircuit(
+    initialCircuit,
+    capacitorStates,
+    inductorStates,
+    0.0,
+  );
+  updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
+
+  const points: TransientPoint[] = [];
+  let stepsRejected = 0;
+  let currentTime = 0.0;
+  let step = Math.min(timeStep, maxStep);
+  let previousCapVoltages = capacitorVoltages(circuit, initialSolution.nodeVoltages);
+  let previousPreviousCapVoltages = new Map(previousCapVoltages);
+
+  while (currentTime < stopTime - timeStep * 1.0e-12) {
+    const remaining = stopTime - currentTime;
+    const proposedStep = remaining <= minStep ? remaining : Math.max(minStep, Math.min(step, remaining));
+    const proposedTime = currentTime + proposedStep;
+    const stepMethod = method === "gear2" && points.length === 0 ? "euler" : method;
+    setReactiveStateMethod(capacitorStates, inductorStates, stepMethod);
+    setReactiveStateStep(capacitorStates, inductorStates, proposedStep);
+    const companionCircuit = circuitWithTransmissionLineCompanions(
+      circuit,
+      lineStates,
+      proposedTime,
+    );
+    const solution = solveLinearCircuit(
+      companionCircuit,
+      capacitorStates,
+      inductorStates,
+      proposedTime,
+    );
+    const proposedCapVoltages = capacitorVoltages(circuit, solution.nodeVoltages);
+    const canEstimateLte = method !== "euler" && points.length >= 1;
+    const lte = canEstimateLte
+      ? transientLteEstimate(
+        circuit,
+        proposedCapVoltages,
+        previousCapVoltages,
+        previousPreviousCapVoltages,
+      )
+      : 0.0;
+    if (canEstimateLte && lte > tolerance && proposedStep > minStep + 1.0e-20) {
+      step = Math.max(proposedStep / 2.0, minStep);
+      stepsRejected += 1;
+      continue;
+    }
+
+    updateCapacitorStates(circuit, solution.nodeVoltages, capacitorStates);
+    updateInductorStates(circuit, solution.nodeVoltages, inductorStates);
+    const lineCurrents = updateTransmissionLineStates(
+      circuit,
+      solution.nodeVoltages,
+      lineStates,
+      proposedTime,
+    );
+    const branchCurrents = new Map(solution.branchCurrents);
+    for (const [name, current] of lineCurrents) {
+      branchCurrents.set(name, current);
+    }
+    points.push(makeTransientPoint(proposedTime, solution.nodeVoltages, branchCurrents));
+    currentTime = proposedTime;
+    previousPreviousCapVoltages = previousCapVoltages;
+    previousCapVoltages = proposedCapVoltages;
+    step = canEstimateLte && lte < tolerance / 8.0
+      ? Math.min(proposedStep * 2.0, maxStep)
+      : proposedStep;
+  }
+
+  return { points, method, stepsRejected, converged: true };
+}
+
 export function pssResidual(
   circuit: Circuit,
   stepsPerPeriod = 64,
@@ -2758,7 +2880,7 @@ interface CapacitorState {
   previousVoltage: number;
   previousPreviousVoltage: number;
   previousCurrent: number;
-  readonly timeStep: number;
+  timeStep: number;
   method: TransientMethod;
 }
 
@@ -2767,7 +2889,7 @@ interface InductorState {
   previousCurrent: number;
   previousPreviousCurrent: number;
   previousVoltage: number;
-  readonly timeStep: number;
+  timeStep: number;
   method: TransientMethod;
 }
 
@@ -4667,6 +4789,55 @@ function setReactiveStateMethod(
   for (const state of inductorStates) {
     state.method = method;
   }
+}
+
+function setReactiveStateStep(
+  capacitorStates: CapacitorState[],
+  inductorStates: InductorState[],
+  timeStep: number,
+): void {
+  for (const state of capacitorStates) {
+    state.timeStep = timeStep;
+  }
+  for (const state of inductorStates) {
+    state.timeStep = timeStep;
+  }
+}
+
+function capacitorVoltages(
+  circuit: Circuit,
+  nodeVoltages: ReadonlyMap<string, number>,
+): Map<string, number> {
+  const voltages = new Map<string, number>();
+  for (const element of circuit.elements()) {
+    if (element.kind === "capacitor") {
+      voltages.set(
+        element.name,
+        voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2),
+      );
+    }
+  }
+  return voltages;
+}
+
+function transientLteEstimate(
+  circuit: Circuit,
+  currentVoltages: ReadonlyMap<string, number>,
+  previousVoltages: ReadonlyMap<string, number>,
+  previousPreviousVoltages: ReadonlyMap<string, number>,
+): number {
+  let maxLte = 0.0;
+  for (const element of circuit.elements()) {
+    if (element.kind !== "capacitor") {
+      continue;
+    }
+    const current = currentVoltages.get(element.name) ?? element.initialVoltage;
+    const previous = previousVoltages.get(element.name) ?? element.initialVoltage;
+    const previousPrevious =
+      previousPreviousVoltages.get(element.name) ?? element.initialVoltage;
+    maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
+  }
+  return maxLte;
 }
 
 function initialTransmissionLineStates(circuit: Circuit): TransmissionLineState[] {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -25,6 +25,7 @@ import {
   pssResidual,
   resistor,
   transient,
+  transientAdaptive,
   transmissionLine,
   voltageSource,
   voltageSourceWithWaveform,
@@ -529,6 +530,48 @@ describe("transient", () => {
     const gearTail = Math.max(...gearPoints.slice(-4).map((point) => Math.abs(point.voltage("tank") ?? 0.0)));
 
     expect(gearTail).toBeLessThan(trapTail * 0.75);
+  });
+
+  it("matches fixed-step trap when adaptive bounds pin the step", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "vc", 1_000.0));
+    circuit.add(capacitor("C1", "vc", "0", 1.0e-6));
+
+    const fixed = transient(circuit, 1.0e-3, 3.0e-3, "trap");
+    const adaptive = transientAdaptive(circuit, 1.0e-3, 3.0e-3, {
+      method: "trap",
+      tolerance: 1.0,
+      minStep: 1.0e-3,
+      maxStep: 1.0e-3,
+    });
+
+    expect(adaptive.converged).toBe(true);
+    expect(adaptive.stepsRejected).toBe(0);
+    expect(adaptive.points.map((point) => point.time)).toEqual(
+      fixed.map((point) => point.time),
+    );
+    expectClose(adaptive.points.at(-1)?.voltage("vc"), fixed.at(-1)?.voltage("vc") ?? 0.0);
+  });
+
+  it("uses variable adaptive steps with Gear-2 after the bootstrap step", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("V1", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "vc", 1_000.0));
+    circuit.add(capacitor("C1", "vc", "0", 1.0e-6));
+
+    const adaptive = transientAdaptive(circuit, 1.0e-4, 1.0e-3, {
+      method: "gear2",
+      tolerance: 1.0,
+      maxStep: 5.0e-4,
+    });
+
+    expect(adaptive.method).toBe("gear2");
+    expect(adaptive.converged).toBe(true);
+    expect(adaptive.stepsRejected).toBe(0);
+    expect(adaptive.points.length).toBeLessThan(transient(circuit, 1.0e-4, 1.0e-3, "gear2").length);
+    expectClose(adaptive.points.at(-1)?.time, 1.0e-3);
+    expect((adaptive.points.at(-1)?.voltage("vc") ?? 0.0)).toBeGreaterThan(0.0);
   });
 
   it("couples secondary voltage through a mutual inductor", () => {

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -145,7 +145,9 @@ Status:
   trapezoidal integration. The parser packages now validate
   `.tran ... method=<euler|trap|gear2>`, preserve the method on transient
   analysis cards, and expose `.options method=<...>` as the fallback route.
-  Adaptive-step interaction remains follow-up work.
+  TypeScript and Rust now expose adaptive transient entry points with bounded
+  LTE-based step growth/shrinkage and method routing for Euler, trapezoidal,
+  and Gear-2. Phase 4 is complete for the current compatibility target.
 
 ### Phase 5 - Pseudo-Transient DC Continuation
 


### PR DESCRIPTION
## Summary

- add TypeScript `transientAdaptive` and Rust `transient_adaptive` entry points with LTE-based step control
- route adaptive transient through Euler, trapezoidal, and Gear-2 companions while updating reactive companion step sizes
- add TS/Rust tests for pinned fixed-step parity and variable-step Gear-2 bootstrap behavior
- update engine docs/changelogs and mark Phase 4 complete for the current SPICE compatibility target

## Validation

- `sh BUILD` in `code/packages/typescript/spice-engine`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`