### PR TITLE
feat(closurec): scaffold CLI driver (CLOC08 Phase 1)

### DIFF
--- a/code/programs/rust/closurec/BUILD
+++ b/code/programs/rust/closurec/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closurec -- --nocapture

--- a/code/programs/rust/closurec/BUILD_windows
+++ b/code/programs/rust/closurec/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-closurec -- --nocapture

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
+
+## [0.1.0] - 2026-05-23
+
+### Added
+- New program per CLOC08 — the CLI driver that ties together every crate in Stages 1–4 (lexer, parser, type sidecar, JSDoc extractor, type-checker, pass pipeline + every canonical pass per CLOC06, emitter, source-map generator).
+- CLI surface frozen:
+  - `--input PATH` (required) — input JavaScript file.
+  - `--output PATH` (defaults to stdout) — compiled output target.
+  - `--source-map BOOL` (default `true`) — emit companion source-map blob.
+  - `--ascii-only BOOL` (default `false`) — escape non-ASCII characters in output.
+  - `--pretty BOOL` (default `false`) — emit human-readable whitespace.
+  - `--disable NAME` (repeatable) — disable a canonical pass by name.
+  - `--help` / `-h` — print usage and exit 0.
+  - `--version` / `-V` — print version and exit 0.
+- BOOL synonyms: `true|false|1|0|yes|no|on|off` (case-insensitive).
+- Exit codes: 0 success, 2 usage error (POSIX convention). 1 reserved for future compilation failure.
+- `parse_args(&[String]) -> ParseResult` is a pure function with no I/O — tests drive it directly without spawning the binary.
+- `run(result) -> (text, ExitCode)` is similarly pure: converts a parse result into print-text + exit code. `main` is a thin wrapper that just prints + exits.
+- 17 tests covering: short and long forms of `--help` and `--version`, `--help` short-circuits past other args, missing `--input` is a usage error, unknown flag is a usage error, `--input`-only sets the documented defaults, every option round-trips through `parse_args` correctly, all BOOL synonyms parse (forward and reverse cases), invalid BOOL value is a usage error mentioning both the flag and the bad value, flag-without-value is a usage error, empty argv is a usage error, help text mentions every known pass (catches additions to `KNOWN_PASSES` that miss the help text), `version_string()` includes `CARGO_PKG_VERSION`, `run()` produces the correct text for each variant including the v1 identity-pipeline banner for `Compile`.
+
+### Notes
+- v1 is scaffolding. The whole pipeline is identity today (`javascript-ast` ships only `Program` / `SourceType` per CLOC02 Phase 1), so a successful compile prints `closurec v0.1.0 - identity pipeline\n` and exits 0. The real lex → parse → typecheck → pipeline → emit wiring lands when the AST grows nodes. Pinning the CLI surface now means scripts and CI configs that invoke `closurec` won't need to change when the body fills in.
+- Dependencies: every crate scaffolded in Stages 1–4. Listed exhaustively in `Cargo.toml`. No third-party CLI parser — `std::env::args` plus a small in-file parser covers v1.
+- Required capabilities: `fs.read` + `fs.write` (CLOC08 binary reads input file, writes output + source-map). v1 doesn't actually touch the filesystem yet (identity body skips it) but the manifest declares the future surface.

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "coding-adventures-closurec"
+version = "0.1.0"
+edition = "2021"
+description = "closurec — CLI driver for the Closure Compiler clone. Reads input JavaScript, runs the configured optimization pass pipeline, emits output JavaScript plus an optional source-map. Per CLOC08."
+
+[[bin]]
+name = "closurec"
+path = "src/main.rs"
+
+[dependencies]
+# Front end
+coding-adventures-javascript-tokens = { path = "../../../packages/rust/javascript-tokens" }
+coding-adventures-javascript-ast = { path = "../../../packages/rust/javascript-ast" }
+
+# Type checker
+coding-adventures-closure-typechecker = { path = "../../../packages/rust/closure-typechecker" }
+
+# Pass pipeline + every canonical pass per CLOC06
+coding-adventures-closure-pass-pipeline = { path = "../../../packages/rust/closure-pass-pipeline" }
+coding-adventures-closure-pass-constant-fold = { path = "../../../packages/rust/closure-pass-constant-fold" }
+coding-adventures-closure-pass-fold-control-flow = { path = "../../../packages/rust/closure-pass-fold-control-flow" }
+coding-adventures-closure-pass-dce = { path = "../../../packages/rust/closure-pass-dce" }
+coding-adventures-closure-pass-inline = { path = "../../../packages/rust/closure-pass-inline" }
+coding-adventures-closure-pass-rename = { path = "../../../packages/rust/closure-pass-rename" }
+coding-adventures-closure-pass-treeshake = { path = "../../../packages/rust/closure-pass-treeshake" }
+coding-adventures-closure-pass-collapse-properties = { path = "../../../packages/rust/closure-pass-collapse-properties" }
+coding-adventures-closure-pass-remove-unused-vars = { path = "../../../packages/rust/closure-pass-remove-unused-vars" }
+
+# Back end
+coding-adventures-closure-emitter = { path = "../../../packages/rust/closure-emitter" }
+coding-adventures-closure-source-map = { path = "../../../packages/rust/closure-source-map" }
+
+# Shared
+coding_adventures_correlation_vector = { path = "../../../packages/rust/correlation-vector" }
+coding-adventures-type-sidecar = { path = "../../../packages/rust/type-sidecar" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/code/programs/rust/closurec/README.md
+++ b/code/programs/rust/closurec/README.md
@@ -1,0 +1,108 @@
+# closurec
+
+`closurec` is the CLI driver for the Closure Compiler clone.
+Per [CLOC08](../../../specs/CLOC08-closurec-cli.md).
+
+```text
+closurec [OPTIONS] --input PATH
+```
+
+The binary ties together every crate in Stages 1–4: lexer,
+parser, type sidecar, JSDoc extractor, type-checker, pass
+pipeline + every canonical pass per CLOC06, emitter, and
+source-map generator. This crate is just the glue.
+
+## CLI surface (frozen in v0.1.0)
+
+| Flag | Value | Default | Meaning |
+|---|---|---|---|
+| `--input PATH` | path | *(required)* | Input JavaScript file. |
+| `--output PATH` | path | stdout | Where to write compiled output. |
+| `--source-map BOOL` | bool | `true` | Emit companion source-map blob. |
+| `--ascii-only BOOL` | bool | `false` | Escape non-ASCII characters in output. |
+| `--pretty BOOL` | bool | `false` | Emit human-readable whitespace. |
+| `--disable NAME` | pass name | — | Disable a pass. Repeatable. |
+| `--help`, `-h` | — | — | Print usage and exit 0. |
+| `--version`, `-V` | — | — | Print version and exit 0. |
+
+BOOL values accept `true | false | 1 | 0 | yes | no | on | off`
+(case-insensitive).
+
+Known pass names (`--disable`):
+
+```
+constant-fold, fold-control-flow, dce, inline, rename, treeshake,
+collapse-properties, remove-unused-vars
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `2` | Usage error (POSIX convention). |
+
+(Future `1` will mean compilation failure, once compilation
+actually does anything.)
+
+## Scope (v1)
+
+The whole pipeline is **identity** today — `javascript-ast`
+ships only `Program` / `SourceType` (CLOC02 Phase 1), so every
+pass is a no-op and the emitter returns empty output. v1 of
+`closurec` therefore:
+
+- parses the full CLI surface (so users can already script
+  against it),
+- validates argument combinations and exits 2 on misuse,
+- prints `closurec v0.1.0 - identity pipeline\n` on the happy
+  path,
+- exits 0 on success.
+
+The point of locking the CLI surface this early is that build
+systems and CI configs can wire up `closurec invocations` now,
+and they won't need to change when the body fills in.
+
+## Architecture
+
+```text
+  args ─► parse_args ──► ParseResult
+                            │
+                            ├─ Run(Action::PrintHelp)    ──► help_text()
+                            ├─ Run(Action::PrintVersion) ──► version_string()
+                            ├─ Run(Action::Compile(args)) ──► (v2+) pipeline
+                            └─ UsageError(msg)            ──► "error: …" + exit 2
+```
+
+`parse_args` is a **pure function** of `&[String]` — no I/O, no
+global state. Tests drive it directly without spawning the
+binary, which keeps the test suite fast and deterministic.
+
+`run(result)` is similarly pure: it converts a `ParseResult`
+into `(text_to_print, ExitCode)`. `main` is a thin wrapper that
+just prints + exits.
+
+## What's coming
+
+- v2: real lex → parse → typecheck → pipeline → emit wiring
+  once the AST grows variants. `--input` actually reads a
+  file; `--output` actually writes one. Compilation failures
+  surface as exit code 1.
+- A `--debug-cv` flag that dumps the CV log for tracing how
+  each output byte came from which input byte.
+- `--config FILE` for project-level defaults.
+
+## Dependency whitelist
+
+Front end: `javascript-tokens`, `javascript-ast`.
+Type checker: `closure-typechecker`.
+Pass pipeline: `closure-pass-pipeline` + every pass crate
+(`constant-fold`, `fold-control-flow`, `dce`, `inline`, `rename`,
+`treeshake`, `collapse-properties`, `remove-unused-vars`).
+Back end: `closure-emitter`, `closure-source-map`.
+Shared: `correlation-vector`, `type-sidecar`, `serde`,
+`serde_json`.
+
+No third-party CLI parser — `std::env::args` plus the tiny
+parser in `parse_args` covers v1's surface and keeps cold-start
+cheap.

--- a/code/programs/rust/closurec/required_capabilities.json
+++ b/code/programs/rust/closurec/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/closurec",
+  "capabilities": ["fs.read", "fs.write"],
+  "justification": "Reads input JavaScript from a file path on disk and writes compiled JavaScript + source-map to output paths. No network or process spawning."
+}

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -1,0 +1,605 @@
+//! `closurec` — CLI driver for the Closure Compiler clone.
+//!
+//! Per [CLOC08](../../../../specs/CLOC08-closurec-cli.md). The
+//! binary that ties the whole pipeline together: reads input
+//! JavaScript, runs the configured optimization pass pipeline,
+//! emits output JavaScript plus an optional source-map blob.
+//!
+//! # Stage 4 wrap-up: the role this binary plays
+//!
+//! ```text
+//!   ┌──────────────────────────────────────────────────────────┐
+//!   │ closurec                                                 │
+//!   │                                                          │
+//!   │  args ─► parse ──► [lex] ──► [parse] ──► [typecheck] ──► │
+//!   │                                                          │
+//!   │   ──► [pass pipeline] ──► [emit] ──► (out.js, out.js.map)│
+//!   └──────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Each `[bracketed]` stage is one of the crates we've scaffolded
+//! in Stages 1–4. This binary is just the glue.
+//!
+//! # Scope (v1)
+//!
+//! `javascript-ast` ships only `Program` / `SourceType` today and
+//! every pass + the emitter are identity. So v1 of `closurec`:
+//!
+//! - parses the CLI surface so users can already script against
+//!   the binary,
+//! - validates argument combinations and errors out clearly on
+//!   bad input,
+//! - prints `closurec v0.1.0 - identity pipeline` to stdout on
+//!   the happy path,
+//! - exits with status 0 on success, 2 on usage error
+//!   (per POSIX's "command-line usage" convention).
+//!
+//! The actual lex/parse/typecheck/passes/emit wiring lands when
+//! the AST grows nodes. Pinning the CLI now lets shell scripts,
+//! build systems, and the test harness all link against a
+//! stable surface today.
+//!
+//! # The CLI surface (frozen here)
+//!
+//! ```text
+//! closurec [OPTIONS] --input PATH
+//!
+//! Required:
+//!   --input PATH            Path to the input JavaScript file.
+//!
+//! Optional:
+//!   --output PATH           Path to write compiled output.
+//!                           Defaults to stdout when omitted.
+//!   --source-map BOOL       Emit a companion source-map blob.
+//!                           Default: true.
+//!   --ascii-only BOOL       Escape non-ASCII characters in output.
+//!                           Default: false (UTF-8 output).
+//!   --pretty BOOL           Emit human-readable output with
+//!                           whitespace. Default: false (minified).
+//!   --disable NAME          Disable a pass by canonical name.
+//!                           Repeatable.
+//!   --help, -h              Print this help text and exit 0.
+//!   --version, -V           Print "closurec 0.1.0" and exit 0.
+//! ```
+//!
+//! BOOL values accept `true|false|1|0|yes|no` (case-insensitive).
+//!
+//! No third-party clap dependency in v1 — `std::env::args` plus
+//! the small parser in [`parse_args`] is enough to cover this
+//! surface and stays cheap on cold-start.
+
+use std::process::ExitCode;
+
+/// Canonical pass names for `--disable`. Mirrors the pass set
+/// from CLOC06. We don't strictly validate the list (the user
+/// can disable a pass that doesn't exist; that's a no-op rather
+/// than an error) but the list is the documented input.
+const KNOWN_PASSES: &[&str] = &[
+    "constant-fold",
+    "fold-control-flow",
+    "dce",
+    "inline",
+    "rename",
+    "treeshake",
+    "collapse-properties",
+    "remove-unused-vars",
+];
+
+/// Result of parsing `argv`. Either we have a coherent
+/// invocation ([`Action`]) or the user did something wrong
+/// ([`UsageError`] — exit code 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseResult {
+    Run(Action),
+    UsageError(String),
+}
+
+/// What `closurec` was asked to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    /// `--help` / `-h`: print usage and exit 0.
+    PrintHelp,
+    /// `--version` / `-V`: print version and exit 0.
+    PrintVersion,
+    /// Compile a file. v1 still just prints the identity-pipeline
+    /// banner; the fields here are what v2+ will consume.
+    Compile(CompileArgs),
+}
+
+/// Fully-resolved compile invocation. Validation has already
+/// happened (input path is set, BOOL flags parsed, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileArgs {
+    /// Path to the input file. Required.
+    pub input: String,
+    /// Path to the output file, or `None` for stdout.
+    pub output: Option<String>,
+    /// Emit a source-map blob alongside the output.
+    pub source_map: bool,
+    /// Escape non-ASCII characters in the emitted JavaScript.
+    pub ascii_only: bool,
+    /// Emit human-readable whitespace.
+    pub pretty: bool,
+    /// Passes the user explicitly disabled (subset of
+    /// [`KNOWN_PASSES`], but we don't validate; unknown names
+    /// no-op).
+    pub disabled_passes: Vec<String>,
+}
+
+impl Default for CompileArgs {
+    fn default() -> Self {
+        Self {
+            input: String::new(),
+            output: None,
+            source_map: true,
+            ascii_only: false,
+            pretty: false,
+            disabled_passes: Vec::new(),
+        }
+    }
+}
+
+/// Parse `argv[1..]` (i.e., the args *without* the program
+/// name) into a [`ParseResult`].
+///
+/// Pure function: no I/O, no global state. Tests drive it
+/// directly without touching `std::env::args`.
+pub fn parse_args(args: &[String]) -> ParseResult {
+    // Handle --help / --version up front. They short-circuit
+    // even if there are other args, matching `gcc --help`,
+    // `cargo --help`, etc.
+    for a in args.iter() {
+        if a == "--help" || a == "-h" {
+            return ParseResult::Run(Action::PrintHelp);
+        }
+        if a == "--version" || a == "-V" {
+            return ParseResult::Run(Action::PrintVersion);
+        }
+    }
+
+    let mut compile = CompileArgs::default();
+    let mut input_seen = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        match a.as_str() {
+            "--input" => {
+                let value = match args.get(i + 1) {
+                    Some(v) => v,
+                    None => {
+                        return ParseResult::UsageError(
+                            "--input requires a path argument".to_string(),
+                        );
+                    }
+                };
+                compile.input = value.clone();
+                input_seen = true;
+                i += 2;
+            }
+            "--output" => {
+                let value = match args.get(i + 1) {
+                    Some(v) => v,
+                    None => {
+                        return ParseResult::UsageError(
+                            "--output requires a path argument".to_string(),
+                        );
+                    }
+                };
+                compile.output = Some(value.clone());
+                i += 2;
+            }
+            "--source-map" => {
+                let value = match args.get(i + 1) {
+                    Some(v) => v,
+                    None => {
+                        return ParseResult::UsageError(
+                            "--source-map requires a bool argument".to_string(),
+                        );
+                    }
+                };
+                match parse_bool(value) {
+                    Some(b) => compile.source_map = b,
+                    None => {
+                        return ParseResult::UsageError(format!(
+                            "--source-map expects a bool (true|false|1|0|yes|no), got {:?}",
+                            value
+                        ));
+                    }
+                }
+                i += 2;
+            }
+            "--ascii-only" => {
+                let value = match args.get(i + 1) {
+                    Some(v) => v,
+                    None => {
+                        return ParseResult::UsageError(
+                            "--ascii-only requires a bool argument".to_string(),
+                        );
+                    }
+                };
+                match parse_bool(value) {
+                    Some(b) => compile.ascii_only = b,
+                    None => {
+                        return ParseResult::UsageError(format!(
+                            "--ascii-only expects a bool (true|false|1|0|yes|no), got {:?}",
+                            value
+                        ));
+                    }
+                }
+                i += 2;
+            }
+            "--pretty" => {
+                let value = match args.get(i + 1) {
+                    Some(v) => v,
+                    None => {
+                        return ParseResult::UsageError(
+                            "--pretty requires a bool argument".to_string(),
+                        );
+                    }
+                };
+                match parse_bool(value) {
+                    Some(b) => compile.pretty = b,
+                    None => {
+                        return ParseResult::UsageError(format!(
+                            "--pretty expects a bool (true|false|1|0|yes|no), got {:?}",
+                            value
+                        ));
+                    }
+                }
+                i += 2;
+            }
+            "--disable" => {
+                let value = match args.get(i + 1) {
+                    Some(v) => v,
+                    None => {
+                        return ParseResult::UsageError(
+                            "--disable requires a pass name".to_string(),
+                        );
+                    }
+                };
+                compile.disabled_passes.push(value.clone());
+                i += 2;
+            }
+            other => {
+                return ParseResult::UsageError(format!("unknown argument {:?}", other));
+            }
+        }
+    }
+
+    if !input_seen {
+        return ParseResult::UsageError(
+            "--input is required (use --help for usage)".to_string(),
+        );
+    }
+
+    ParseResult::Run(Action::Compile(compile))
+}
+
+/// Parse a flag value into a `bool`. Accepts the common
+/// shell-friendly synonyms. Returns `None` on anything else so
+/// the caller can produce a sensible error.
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// The help text printed for `--help`. Pulled out so tests can
+/// assert on it and so the format string is in exactly one
+/// place.
+pub fn help_text() -> &'static str {
+    "closurec — Closure Compiler clone (CLOC08)\n\
+     \n\
+     Usage:\n  closurec [OPTIONS] --input PATH\n\
+     \n\
+     Required:\n  --input PATH            Path to the input JavaScript file.\n\
+     \n\
+     Optional:\n  --output PATH           Path to write compiled output (default: stdout).\n  \
+     --source-map BOOL       Emit a companion source-map blob (default: true).\n  \
+     --ascii-only BOOL       Escape non-ASCII characters in output (default: false).\n  \
+     --pretty BOOL           Emit human-readable output with whitespace (default: false).\n  \
+     --disable NAME          Disable a pass by canonical name (repeatable).\n  \
+     --help, -h              Print this help text and exit 0.\n  \
+     --version, -V           Print version and exit 0.\n\
+     \n\
+     Known passes (per CLOC06 canonical order):\n  \
+     constant-fold, fold-control-flow, dce, inline, rename, treeshake,\n  \
+     collapse-properties, remove-unused-vars.\n\
+     \n\
+     v0.1.0 is scaffolding — the pipeline is identity until the AST grows nodes.\n"
+}
+
+/// Returns the bin's canonical version string. Single source of
+/// truth so the test, the `--version` handler, and any future
+/// telemetry agree.
+pub fn version_string() -> &'static str {
+    concat!("closurec ", env!("CARGO_PKG_VERSION"))
+}
+
+/// Render a [`ParseResult`] into stdout text + exit code.
+///
+/// Pure function: no real I/O. Tests can call it directly and
+/// inspect both outputs. `main` is a thin wrapper that just
+/// prints + exits.
+pub fn run(result: ParseResult) -> (String, ExitCode) {
+    match result {
+        ParseResult::Run(Action::PrintHelp) => (help_text().to_string(), ExitCode::SUCCESS),
+        ParseResult::Run(Action::PrintVersion) => {
+            (format!("{}\n", version_string()), ExitCode::SUCCESS)
+        }
+        ParseResult::Run(Action::Compile(_args)) => {
+            // v1: identity pipeline. Print the banner so users
+            // know the binary loaded and parsed its args; real
+            // compilation lands when the AST grows nodes.
+            //
+            // We deliberately don't read `_args.input` yet —
+            // there'd be no point opening a file we can't
+            // actually compile. Refusing now would also mean
+            // every test had to set up a real file path.
+            //
+            // Once compilation lands, `_args.input` becomes the
+            // first thing we touch and a missing-file error will
+            // surface here.
+            (
+                "closurec v0.1.0 - identity pipeline\n".to_string(),
+                ExitCode::SUCCESS,
+            )
+        }
+        ParseResult::UsageError(msg) => {
+            // Conventional POSIX exit for misuse is 2 (1 is
+            // reserved for compilation failure, etc.).
+            (
+                format!("error: {}\nuse --help for usage\n", msg),
+                ExitCode::from(2),
+            )
+        }
+    }
+}
+
+/// Binary entry point.
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let result = parse_args(&argv);
+    let (text, code) = run(result);
+    print!("{}", text);
+    code
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests cover the parser and the renderer. The
+    //! parser is a pure function over `&[String]`, so we can
+    //! drive it directly without spawning the binary. That
+    //! keeps tests fast and deterministic.
+    use super::*;
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn help_short_flag_returns_print_help() {
+        assert_eq!(
+            parse_args(&args(&["-h"])),
+            ParseResult::Run(Action::PrintHelp)
+        );
+    }
+
+    #[test]
+    fn help_long_flag_returns_print_help() {
+        assert_eq!(
+            parse_args(&args(&["--help"])),
+            ParseResult::Run(Action::PrintHelp)
+        );
+    }
+
+    #[test]
+    fn version_short_flag_returns_print_version() {
+        assert_eq!(
+            parse_args(&args(&["-V"])),
+            ParseResult::Run(Action::PrintVersion)
+        );
+    }
+
+    #[test]
+    fn version_long_flag_returns_print_version() {
+        assert_eq!(
+            parse_args(&args(&["--version"])),
+            ParseResult::Run(Action::PrintVersion)
+        );
+    }
+
+    #[test]
+    fn help_short_circuits_even_with_other_args() {
+        // `gcc --help` etc. all short-circuit; matching that.
+        assert_eq!(
+            parse_args(&args(&["--input", "a.js", "--help"])),
+            ParseResult::Run(Action::PrintHelp)
+        );
+    }
+
+    #[test]
+    fn missing_input_is_usage_error() {
+        match parse_args(&args(&["--pretty", "true"])) {
+            ParseResult::UsageError(msg) => {
+                assert!(
+                    msg.contains("--input"),
+                    "expected --input mention in error; got {:?}",
+                    msg
+                );
+            }
+            other => panic!("expected UsageError; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unknown_flag_is_usage_error() {
+        match parse_args(&args(&["--input", "a.js", "--bogus"])) {
+            ParseResult::UsageError(msg) => {
+                assert!(
+                    msg.contains("--bogus"),
+                    "expected --bogus mention in error; got {:?}",
+                    msg
+                );
+            }
+            other => panic!("expected UsageError; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn input_only_sets_defaults() {
+        // Minimum legal invocation: just --input.
+        let r = parse_args(&args(&["--input", "src.js"]));
+        match r {
+            ParseResult::Run(Action::Compile(a)) => {
+                assert_eq!(a.input, "src.js");
+                assert_eq!(a.output, None);
+                assert!(a.source_map); // default true
+                assert!(!a.ascii_only); // default false
+                assert!(!a.pretty); // default false
+                assert!(a.disabled_passes.is_empty());
+            }
+            other => panic!("expected Compile; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn all_options_round_trip() {
+        let r = parse_args(&args(&[
+            "--input",
+            "in.js",
+            "--output",
+            "out.js",
+            "--source-map",
+            "false",
+            "--ascii-only",
+            "true",
+            "--pretty",
+            "yes",
+            "--disable",
+            "dce",
+            "--disable",
+            "rename",
+        ]));
+        match r {
+            ParseResult::Run(Action::Compile(a)) => {
+                assert_eq!(a.input, "in.js");
+                assert_eq!(a.output.as_deref(), Some("out.js"));
+                assert!(!a.source_map);
+                assert!(a.ascii_only);
+                assert!(a.pretty); // "yes" parses true
+                assert_eq!(a.disabled_passes, vec!["dce", "rename"]);
+            }
+            other => panic!("expected Compile; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bool_synonyms_all_parse() {
+        // Lock the synonym set so a future refactor doesn't
+        // accidentally drop one.
+        for v in &["true", "True", "TRUE", "1", "yes", "on"] {
+            assert_eq!(parse_bool(v), Some(true), "true synonym {:?}", v);
+        }
+        for v in &["false", "False", "FALSE", "0", "no", "off"] {
+            assert_eq!(parse_bool(v), Some(false), "false synonym {:?}", v);
+        }
+        assert_eq!(parse_bool("nope"), None);
+        assert_eq!(parse_bool(""), None);
+    }
+
+    #[test]
+    fn invalid_bool_is_usage_error() {
+        match parse_args(&args(&["--input", "a.js", "--pretty", "maybe"])) {
+            ParseResult::UsageError(msg) => {
+                assert!(msg.contains("--pretty"));
+                assert!(msg.contains("\"maybe\""));
+            }
+            other => panic!("expected UsageError; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn flag_without_value_is_usage_error() {
+        // --input at end of argv.
+        match parse_args(&args(&["--input"])) {
+            ParseResult::UsageError(msg) => {
+                assert!(msg.contains("--input"));
+            }
+            other => panic!("expected UsageError; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_argv_is_usage_error_missing_input() {
+        match parse_args(&args(&[])) {
+            ParseResult::UsageError(msg) => {
+                assert!(msg.contains("--input"));
+            }
+            other => panic!("expected UsageError; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn help_text_mentions_all_known_passes() {
+        // The known-pass list is documented; if a pass is added
+        // to KNOWN_PASSES but missed in the help text, this
+        // catches it.
+        let h = help_text();
+        for p in KNOWN_PASSES {
+            assert!(
+                h.contains(p),
+                "help text should mention pass {:?}; got:\n{}",
+                p,
+                h
+            );
+        }
+    }
+
+    #[test]
+    fn version_string_includes_crate_version() {
+        // env!("CARGO_PKG_VERSION") matches Cargo.toml's
+        // version = "0.1.0" today; if Cargo.toml moves to 0.2.0
+        // this test re-evaluates against the new value.
+        let v = version_string();
+        assert!(v.starts_with("closurec "));
+        assert!(v.contains(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn run_print_help_returns_success_and_help() {
+        let (text, _code) = run(ParseResult::Run(Action::PrintHelp));
+        assert!(text.contains("Usage:"));
+        // Can't easily assert on ExitCode equality (it doesn't
+        // impl PartialEq), but ExitCode::SUCCESS is what we
+        // return.
+    }
+
+    #[test]
+    fn run_print_version_returns_success_and_version() {
+        let (text, _code) = run(ParseResult::Run(Action::PrintVersion));
+        assert!(text.contains("0.1.0"));
+        assert!(text.contains("closurec"));
+    }
+
+    #[test]
+    fn run_compile_v1_prints_identity_banner() {
+        let (text, _code) = run(ParseResult::Run(Action::Compile(CompileArgs {
+            input: "x.js".to_string(),
+            ..Default::default()
+        })));
+        assert!(text.contains("identity pipeline"));
+        assert!(text.contains("v0.1.0"));
+    }
+
+    #[test]
+    fn run_usage_error_returns_nonzero_and_message() {
+        let (text, _code) =
+            run(ParseResult::UsageError("--input is required".to_string()));
+        assert!(text.contains("--input"));
+        assert!(text.contains("use --help"));
+    }
+}


### PR DESCRIPTION
## Summary

The binary that ties together every crate in Stages 1–4 — lexer, parser, type sidecar, JSDoc extractor, type-checker, pass pipeline + every canonical pass per CLOC06, emitter, and source-map generator. Per CLOC08.

This **completes the end-to-end Closure Compiler clone scaffold**.

## CLI surface (frozen in v0.1.0)

| Flag | Default | Meaning |
|---|---|---|
| `--input PATH` | *(required)* | Input JavaScript file. |
| `--output PATH` | stdout | Compiled output target. |
| `--source-map BOOL` | `true` | Emit companion source-map blob. |
| `--ascii-only BOOL` | `false` | Escape non-ASCII characters. |
| `--pretty BOOL` | `false` | Human-readable whitespace. |
| `--disable NAME` | — | Disable a pass. Repeatable. |
| `--help` / `-h` | — | Print usage, exit 0. |
| `--version` / `-V` | — | Print version, exit 0. |

BOOL synonyms: `true|false|1|0|yes|no|on|off` (case-insensitive). Exit codes: 0 success, 2 usage error (POSIX). 1 reserved for future compilation failure.

## Architecture

- `parse_args(&[String]) -> ParseResult` is a **pure function** with no I/O — tests drive it directly without spawning the binary.
- `run(result) -> (text, ExitCode)` is also pure.
- `main` is a thin wrapper.
- No third-party CLI parser — `std::env::args` + a small in-file parser covers v1.

## v1 body

The whole pipeline is identity today (`javascript-ast` ships only `Program`/`SourceType` per CLOC02 Phase 1), so a successful compile prints `closurec v0.1.0 - identity pipeline\n` and exits 0. Real wiring lands when the AST grows nodes. **Pinning the CLI surface now means scripts and CI configs that invoke `closurec` won't need to change when the body fills in.**

## Test plan

- [x] `cargo test` in `code/programs/rust/closurec/` passes (19/19).
- [ ] CI green on ubuntu/macos/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)