### PR TITLE
spice: report dc convergence aid metadata

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- **DC convergence-aid metadata** — `DcResult` now reports whether the
+  operating point came from plain Newton, Gmin stepping, source stepping, or no
+  successful convergence aid.
+
 - **Gear-2 damping fixture** — transient tests now cover a coarse LC oscillator
   where Gear-2 damps numerical ringing more aggressively than trapezoidal
   integration.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -270,6 +270,7 @@ class DcResult:
     branch_currents: dict[str, float]
     iterations: int
     converged: bool
+    convergence_aid: str = "newton"
 
 
 @dataclass(frozen=True)
@@ -1087,21 +1088,23 @@ def dc_op(
     """
     # Attempt 1: plain Newton-Raphson.
     result = _dc_newton(circuit, max_iterations=max_iterations, tol=tol)
-    if result.converged or not convergence_aids:
-        return result
+    if result.converged:
+        return replace(result, convergence_aid="newton")
+    if not convergence_aids:
+        return replace(result, convergence_aid="none")
 
     # Attempt 2: Gmin stepping.
     gmin_result = _dc_gmin_step(circuit, max_iterations=max_iterations, tol=tol)
     if gmin_result is not None and gmin_result.converged:
-        return gmin_result
+        return replace(gmin_result, convergence_aid="gmin")
 
     # Attempt 3: source stepping.
     src_result = _dc_source_step(circuit, max_iterations=max_iterations, tol=tol)
     if src_result is not None and src_result.converged:
-        return src_result
+        return replace(src_result, convergence_aid="source")
 
     # All methods exhausted — return the plain-Newton result (converged=False).
-    return result
+    return replace(result, convergence_aid="none")
 
 
 def _apply_corner_override(element: Element, override: CornerOverride) -> Element:

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -5609,7 +5609,20 @@ def test_dc_op_convergence_aids_false_still_converges_linear() -> None:
     ])
     result = dc_op(c, convergence_aids=False)
     assert result.converged
+    assert result.convergence_aid == "newton"
     assert result.node_voltages["a"] == pytest.approx(10.0)
+
+
+def test_dc_op_reports_no_convergence_aid_when_disabled_solve_fails() -> None:
+    """dc_op(convergence_aids=False) reports that no fallback aid converged."""
+    c = Circuit([
+        VoltageSource("Vs", "in", "0", 10.0),
+        Diode("D1", anode="in", cathode="out", Is=1e-15, Vt=0.02585),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+    result = dc_op(c, max_iterations=1, convergence_aids=False)
+    assert not result.converged
+    assert result.convergence_aid == "none"
 
 
 # ---- _dc_gmin_step ---------------------------------------------------------
@@ -5793,6 +5806,7 @@ def test_dc_op_iterations_field_is_populated() -> None:
     ])
     result = dc_op(c)
     assert result.converged
+    assert result.convergence_aid == "newton"
     assert result.iterations >= 1
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `DcResult::convergence_aid`, reporting whether the DC operating point
+  came from plain Newton, Gmin stepping, source stepping, or no successful
+  convergence aid.
 - Add `transient_adaptive`, an LTE-controlled transient surface with bounded
   step growth/shrinkage and `Euler` / `Trap` / `Gear2` method routing.
 - Add trapezoidal transient integration parity for capacitors and inductors,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1428,12 +1428,21 @@ impl Ccvs {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DcConvergenceAid {
+    Newton,
+    Gmin,
+    Source,
+    None,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct DcResult {
     pub node_voltages: BTreeMap<String, f64>,
     pub branch_currents: BTreeMap<String, f64>,
     pub iterations: usize,
     pub converged: bool,
+    pub convergence_aid: DcConvergenceAid,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1979,19 +1988,31 @@ pub fn dc_op(circuit: &Circuit) -> Result<DcResult, SpiceError> {
 pub fn dc_op_with_options(circuit: &Circuit, options: DcOpOptions) -> Result<DcResult, SpiceError> {
     validate_dc_op_options(options)?;
     let solution = solve_dc_newton(circuit, options, None)?;
-    if solution.converged || !options.convergence_aids {
-        return Ok(dc_result_from_linear_solution(solution));
+    if solution.converged {
+        return Ok(dc_result_from_linear_solution(
+            solution,
+            DcConvergenceAid::Newton,
+        ));
+    }
+    if !options.convergence_aids {
+        return Ok(dc_result_from_linear_solution(
+            solution,
+            DcConvergenceAid::None,
+        ));
     }
 
-    let final_solution =
+    let (final_solution, convergence_aid) =
         if let Some(aided) = solve_dc_with_gmin_stepping(circuit, options, &solution.vector)? {
-            aided
+            (aided, DcConvergenceAid::Gmin)
         } else if let Some(aided) = solve_dc_with_source_stepping(circuit, options)? {
-            aided
+            (aided, DcConvergenceAid::Source)
         } else {
-            solution
+            (solution, DcConvergenceAid::None)
         };
-    Ok(dc_result_from_linear_solution(final_solution))
+    Ok(dc_result_from_linear_solution(
+        final_solution,
+        convergence_aid,
+    ))
 }
 
 pub fn dc_corners(
@@ -2116,12 +2137,16 @@ fn apply_corner_override(
     }
 }
 
-fn dc_result_from_linear_solution(solution: LinearSolution) -> DcResult {
+fn dc_result_from_linear_solution(
+    solution: LinearSolution,
+    convergence_aid: DcConvergenceAid,
+) -> DcResult {
     DcResult {
         node_voltages: solution.node_voltages,
         branch_currents: solution.branch_currents,
         iterations: solution.iterations,
         converged: solution.converged,
+        convergence_aid,
     }
 }
 

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1,9 +1,9 @@
 use spice_engine::{
     dc_corners, dc_op, dc_op_with_options, dc_sweep, dc_sweep_corners, BSource, Bjt, BjtPolarity,
-    Cccs, Ccvs, Circuit, CornerOverride, CornerSpec, CurrentSource, DcOpOptions, Diode, Element,
-    Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform,
-    SpiceError, SubcircuitDefinition, SubcircuitElement, Vccs, Vcvs, VoltageSource, Waveform,
-    XInstance,
+    Cccs, Ccvs, Circuit, CornerOverride, CornerSpec, CurrentSource, DcConvergenceAid, DcOpOptions,
+    Diode, Element, Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, Resistor,
+    SinWaveform, SpiceError, SubcircuitDefinition, SubcircuitElement, Vccs, Vcvs, VoltageSource,
+    Waveform, XInstance,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -30,6 +30,7 @@ fn dc_voltage_divider_solves_midpoint_voltage() {
     assert_close(result.voltage("mid").unwrap(), 5.0);
     assert_close(result.voltage("0").unwrap(), 0.0);
     assert!(result.converged);
+    assert_eq!(result.convergence_aid, DcConvergenceAid::Newton);
     assert_eq!(result.iterations, 1);
 }
 
@@ -443,6 +444,7 @@ fn dc_op_reports_unconverged_nonlinear_result_when_aids_are_disabled() {
     .unwrap();
 
     assert!(!result.converged);
+    assert_eq!(result.convergence_aid, DcConvergenceAid::None);
     assert_eq!(result.iterations, 1);
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `DcResult.convergenceAid`, reporting whether the DC operating point came
+  from plain Newton, Gmin stepping, source stepping, or no successful
+  convergence aid.
 - Add `transientAdaptive`, an LTE-controlled transient surface with bounded
   step growth/shrinkage and `euler` / `trap` / `gear2` method routing.
 - Add trapezoidal transient integration parity for capacitors and inductors,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -459,9 +459,12 @@ export interface DcResult {
   readonly branchCurrents: ReadonlyMap<string, number>;
   readonly iterations: number;
   readonly converged: boolean;
+  readonly convergenceAid: DcConvergenceAid;
   voltage(node: string): number | undefined;
   branchCurrent(sourceName: string): number | undefined;
 }
+
+export type DcConvergenceAid = "newton" | "gmin" | "source" | "none";
 
 export interface DcOpOptions {
   readonly maxIterations?: number;
@@ -1368,24 +1371,41 @@ export function dcOp(
 ): DcResult {
   const solveOptions = validatedDcOpOptions(options);
   const solution = solveDcNewton(circuit, solveOptions);
-  if (solution.converged || !solveOptions.convergenceAids) {
+  if (solution.converged) {
     return makeDcResult(
       solution.nodeVoltages,
       solution.branchCurrents,
       solution.iterations,
       solution.converged,
+      "newton",
+    );
+  }
+  if (!solveOptions.convergenceAids) {
+    return makeDcResult(
+      solution.nodeVoltages,
+      solution.branchCurrents,
+      solution.iterations,
+      false,
+      "none",
     );
   }
 
-  const aided =
-    solveDcWithGminStepping(circuit, solveOptions, solution.vector) ??
-    solveDcWithSourceStepping(circuit, solveOptions);
-  const finalSolution = aided ?? solution;
+  const gminSolution = solveDcWithGminStepping(circuit, solveOptions, solution.vector);
+  const sourceSolution =
+    gminSolution === undefined ? solveDcWithSourceStepping(circuit, solveOptions) : undefined;
+  const finalSolution = gminSolution ?? sourceSolution ?? solution;
+  const convergenceAid: DcConvergenceAid =
+    gminSolution !== undefined
+      ? "gmin"
+      : sourceSolution !== undefined
+        ? "source"
+        : "none";
   return makeDcResult(
     finalSolution.nodeVoltages,
     finalSolution.branchCurrents,
     finalSolution.iterations,
     finalSolution.converged,
+    convergenceAid,
   );
 }
 
@@ -3824,12 +3844,14 @@ function makeDcResult(
   branchCurrents: ReadonlyMap<string, number>,
   iterations = 1,
   converged = true,
+  convergenceAid: DcConvergenceAid = converged ? "newton" : "none",
 ): DcResult {
   return {
     nodeVoltages,
     branchCurrents,
     iterations,
     converged,
+    convergenceAid,
     voltage(node: string): number | undefined {
       return isGround(node) ? 0.0 : nodeVoltages.get(node);
     },

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -44,6 +44,7 @@ describe("dcOp", () => {
     expectClose(result.voltage("mid"), 5.0);
     expectClose(result.voltage("0"), 0.0);
     expect(result.converged).toBe(true);
+    expect(result.convergenceAid).toBe("newton");
     expect(result.iterations).toBe(1);
   });
 
@@ -297,6 +298,7 @@ describe("dcOp", () => {
     });
 
     expect(result.converged).toBe(false);
+    expect(result.convergenceAid).toBe("none");
     expect(result.iterations).toBe(1);
   });
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -166,6 +166,13 @@ Acceptance:
   converge through the full aid chain.
 - Tests proving pseudo-transient does not run when earlier aids succeed.
 
+Status:
+
+- DC operating-point results now report which convergence path produced the
+  result (`newton`, `gmin`, `source`, or `none`) across Python, TypeScript, and
+  Rust. Pseudo-transient continuation can extend the same result contract in
+  the next slice.
+
 ### Phase 6 - 1970s Model-Card Depth
 
 Deepen semiconductor models enough for SPICE2-style examples.


### PR DESCRIPTION
## Summary

- add explicit DC convergence-aid metadata across Python, TypeScript, and Rust result surfaces
- report `newton`, `gmin`, `source`, or `none` from the existing DC aid chain
- update Phase 5 plan notes and package changelogs for the pseudo-transient continuation groundwork

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-dc-aid-metadata PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `npm run build && npx vitest run`
- `cargo test -p spice-engine`
- `git diff --check`