### PR TITLE
feat(sql): PRAGMA index_info + fix PRAGMA index_list shape

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.96.0] - 2026-05-23
+
+### Added
+
+- ``PRAGMA index_info(<index-name>)`` is now implemented.  Returns
+  one row per indexed column with the SQLite-standard triple
+  ``(seqno, cid, name)``: the position in the index key, the column
+  id in the parent table, and the column name.  Returns zero rows
+  (no error) for an unknown index — matches SQLite.
+
+### Changed
+
+- ``PRAGMA index_list(<table>)`` now returns the SQLite-standard
+  5-column shape ``(seq, name, unique, origin, partial)`` instead of
+  the previous 3-column ``(seq, name, unique)``.  ``origin`` is
+  ``'c'`` for user-created indexes and ``'u'`` for auto-created
+  ``sqlite_autoindex_*`` indexes.  ``partial`` is always 0 —
+  mini-sqlite doesn't support partial indexes.
+- ``index_info`` added to the ``PRAGMA pragma_list`` enumeration.
+
 ## [1.95.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.95.0"
+version = "1.96.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -841,9 +841,71 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
             indexes = backend.list_indexes(table=arg)
         except Exception:  # noqa: BLE001
             indexes = []
+        # SQLite's index_list emits five columns:
+        #
+        #   seq      INTEGER  — 0-based position in the list
+        #   name     TEXT     — index name
+        #   unique   INTEGER  — 1 if UNIQUE, 0 otherwise
+        #   origin   TEXT     — 'c' (CREATE INDEX) | 'u' (UNIQUE column
+        #                       constraint) | 'pk' (PRIMARY KEY constraint).
+        #                       Mini-sqlite distinguishes user CREATE INDEX
+        #                       from auto-indexes by the ``sqlite_autoindex_``
+        #                       name prefix; we map ``sqlite_autoindex_*`` →
+        #                       'u' (UNIQUE column constraint) since the
+        #                       backend's auto-indexes back UNIQUE/PK
+        #                       columns interchangeably.
+        #   partial  INTEGER  — 1 if a WHERE clause; mini-sqlite does not
+        #                       support partial indexes, so always 0.
+        rows = []
+        for seq, idx in enumerate(indexes):
+            origin = "u" if idx.name.startswith("sqlite_autoindex_") else "c"
+            rows.append((seq, idx.name, int(idx.unique), origin, 0))
         return QueryResult(
-            columns=("seq", "name", "unique"),
-            rows=tuple((seq, idx.name, int(idx.unique)) for seq, idx in enumerate(indexes)),
+            columns=("seq", "name", "unique", "origin", "partial"),
+            rows=tuple(rows),
+        )
+
+    if name == "index_info":
+        # PRAGMA index_info(<index-name>) — for each column the index
+        # covers, return a row (seqno, cid, name):
+        #
+        #   seqno  INTEGER  — 0-based position in the index key
+        #   cid    INTEGER  — column id in the parent table (0-based)
+        #   name   TEXT     — column name
+        #
+        # Returns an empty result if the index doesn't exist (matches
+        # SQLite's behaviour — no error, just zero rows).
+        if not arg:
+            raise ProgrammingError("PRAGMA index_info requires an index name")
+        idx = None
+        try:
+            # list_indexes() without a table arg returns all indexes;
+            # we filter by name here.
+            for candidate in backend.list_indexes():
+                if candidate.name == arg:
+                    idx = candidate
+                    break
+        except Exception:  # noqa: BLE001 — backend may not implement
+            pass
+        if idx is None:
+            return QueryResult(columns=("seqno", "cid", "name"), rows=())
+        # Resolve each indexed column name to its 0-based cid in the
+        # parent table.  ``backend.columns`` returns ColumnDef objects
+        # in declaration order, so the position is the cid.
+        try:
+            parent_cols = backend.columns(idx.table)
+        except Exception:  # noqa: BLE001
+            parent_cols = []
+        col_to_cid = {
+            (getattr(c, "name", c)): i for i, c in enumerate(parent_cols)
+        }
+        info_rows = tuple(
+            (seqno, col_to_cid.get(col_name, -1), col_name)
+            for seqno, col_name in enumerate(idx.columns)
+        )
+        return QueryResult(
+            columns=("seqno", "cid", "name"),
+            rows=info_rows,
         )
 
     if name == "foreign_key_list":
@@ -982,6 +1044,7 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
             "database_list",
             "foreign_key_list",
             "function_list",
+            "index_info",
             "index_list",
             "integrity_check",
             "module_list",

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_index_info.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_index_info.py
@@ -1,0 +1,114 @@
+"""Tests for ``PRAGMA index_info`` and the corrected ``PRAGMA index_list`` shape.
+
+``PRAGMA index_info(<name>)`` returns one row per indexed column with
+the SQLite-standard ``(seqno, cid, name)`` triple, where:
+
+* ``seqno`` is the 0-based position in the index key
+* ``cid`` is the column's 0-based position in the parent table
+* ``name`` is the indexed column's name
+
+``PRAGMA index_list(<table>)`` previously returned three columns
+``(seq, name, unique)``.  SQLite returns five; the two additions are
+``origin`` (``'c'``/``'u'``/``'pk'``) and ``partial`` (always 0 here —
+mini-sqlite doesn't support partial indexes).
+
+Both pragmas are foundational for ORM index inspection.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+class TestIndexListShape:
+    """``index_list`` now returns the SQLite-standard 5-column shape."""
+
+    def test_columns_match_sqlite(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE t(x INT)")
+            c.execute("CREATE INDEX ix_x ON t(x)")
+        m_desc = [d[0] for d in mini.execute("PRAGMA index_list(t)").description]
+        r_desc = [d[0] for d in ref.execute("PRAGMA index_list(t)").description]
+        assert m_desc == r_desc == ["seq", "name", "unique", "origin", "partial"]
+
+    def test_user_index_origin_is_c(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t(x INT)")
+        mini.execute("CREATE INDEX ix_x ON t(x)")
+        rows = mini.execute("PRAGMA index_list(t)").fetchall()
+        assert rows == [(0, "ix_x", 0, "c", 0)]
+
+    def test_unique_user_index(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t(x INT)")
+        mini.execute("CREATE UNIQUE INDEX ix_x ON t(x)")
+        rows = mini.execute("PRAGMA index_list(t)").fetchall()
+        # unique=1, origin='c', partial=0
+        assert rows == [(0, "ix_x", 1, "c", 0)]
+
+
+class TestIndexInfoSingleColumn:
+    """Single-column index returns one row."""
+
+    def test_basic(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE t(x INT, y INT, z INT)")
+            c.execute("CREATE INDEX ix_y ON t(y)")
+        assert mini.execute("PRAGMA index_info(ix_y)").fetchall() \
+            == ref.execute("PRAGMA index_info(ix_y)").fetchall() \
+            == [(0, 1, "y")]
+
+
+class TestIndexInfoCompositeIndex:
+    """Multi-column indexes return one row per indexed column."""
+
+    def test_two_columns(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE t(x INT, y INT, z INT)")
+            c.execute("CREATE INDEX ix_multi ON t(z, x)")
+        # seqno=0 → cid=2 (z), seqno=1 → cid=0 (x)
+        expected = [(0, 2, "z"), (1, 0, "x")]
+        assert mini.execute("PRAGMA index_info(ix_multi)").fetchall() == expected
+        assert ref.execute("PRAGMA index_info(ix_multi)").fetchall() == expected
+
+
+class TestIndexInfoMissing:
+    """An unknown index name returns zero rows (no error) — matches SQLite."""
+
+    def test_missing_index_returns_empty(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE t(x INT)")
+        assert mini.execute("PRAGMA index_info(no_such)").fetchall() == []
+        assert ref.execute("PRAGMA index_info(no_such)").fetchall() == []
+
+
+class TestIndexInfoRequiresName:
+    """Calling without an argument raises a ProgrammingError."""
+
+    def test_no_arg(self) -> None:
+        import pytest
+
+        from mini_sqlite import errors as mini_errors
+
+        mini = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_errors.ProgrammingError):
+            mini.execute("PRAGMA index_info").fetchall()
+
+
+class TestIndexInfoListed:
+    """``index_info`` appears in PRAGMA pragma_list."""
+
+    def test_appears_in_pragma_list(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        names = {r[0] for r in mini.execute("PRAGMA pragma_list").fetchall()}
+        assert "index_info" in names


### PR DESCRIPTION
## Summary

ORMs and migration tools use ``PRAGMA index_info(<name>)`` to enumerate the columns covered by an index — needed to verify composite-index prefixes match query predicates. Mini-sqlite previously returned zero rows.

This change:
1. **Adds ``PRAGMA index_info``** — returns ``(seqno, cid, name)`` per indexed column (matches SQLite exactly).
2. **Fixes ``PRAGMA index_list``** — was 3 columns, now the SQLite-standard 5 ``(seq, name, unique, origin, partial)``.
3. **Adds ``index_info`` to ``PRAGMA pragma_list``** so clients can discover it.

## Test plan

- [x] mini-sqlite: 2182 tests pass, 91.41% coverage (8 new oracle tests vs sqlite3)
- [x] sql-backend / sql-planner / sql-codegen / sql-vm / storage-sqlite: regression-only, no failures
- [x] ruff clean
- [x] /security-review passed

Version: mini-sqlite 1.95 → 1.96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)