### PR TITLE
spice: add pseudo-transient dc continuation

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
+  artificial backward-Euler continuation aid after Newton, Gmin stepping, and
+  source stepping; successful fallback results report
+  `convergence_aid="pseudo_transient"`.
+
 - **DC convergence-aid metadata** — `DcResult` now reports whether the
   operating point came from plain Newton, Gmin stepping, source stepping, or no
   successful convergence aid.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -1047,12 +1047,88 @@ def _dc_source_step(
     return result
 
 
+def _dc_pseudo_transient(
+    circuit: Circuit,
+    *,
+    max_iterations: int = 50,
+    tol: float = 1e-6,
+    n_steps: int = 20,
+    shunt_conductance: float = 1e-3,
+) -> DcResult | None:
+    """DC continuation through artificial backward-Euler node capacitors."""
+    if n_steps <= 0 or not math.isfinite(shunt_conductance) or shunt_conductance <= 0.0:
+        return None
+
+    _, nodes = _node_index(circuit)
+    if not nodes:
+        return None
+
+    branch_srcs = _branch_sources(circuit)
+    previous_node_voltages = {node: 0.0 for node in nodes}
+    x_init: list[float] | None = None
+    last_result: DcResult | None = None
+
+    for step in range(n_steps):
+        pseudo_elements = list(circuit.elements)
+        for node in nodes:
+            pseudo_elements.append(Resistor(
+                f"_ptran_g_{step}_{node}",
+                node,
+                "0",
+                1.0 / shunt_conductance,
+            ))
+            history_current = shunt_conductance * previous_node_voltages[node]
+            if history_current != 0.0:
+                pseudo_elements.append(CurrentSource(
+                    f"_ptran_i_{step}_{node}",
+                    "0",
+                    node,
+                    history_current,
+                ))
+
+        result = _dc_newton(
+            Circuit(elements=pseudo_elements),
+            max_iterations=max_iterations,
+            tol=tol,
+            x_init=x_init,
+        )
+        if not result.converged:
+            return None
+
+        delta = max(
+            abs(result.node_voltages.get(node, 0.0) - previous_node_voltages[node])
+            for node in nodes
+        )
+        previous_node_voltages = {
+            node: result.node_voltages.get(node, 0.0)
+            for node in nodes
+        }
+        x_init = _x_from_result(result, nodes, branch_srcs)
+        last_result = result
+        if delta < tol:
+            break
+
+    if last_result is None:
+        return None
+
+    final = _dc_newton(
+        circuit,
+        max_iterations=max_iterations,
+        tol=tol,
+        x_init=x_init,
+    )
+    return final if final.converged else None
+
+
 def dc_op(
     circuit: Circuit,
     *,
     max_iterations: int = 50,
     tol: float = 1e-6,
     convergence_aids: bool = True,
+    pseudo_transient_steps: int = 20,
+    pseudo_transient_shunt_conductance: float = 1e-3,
+    pseudo_transient_max_iterations: int | None = None,
 ) -> DcResult:
     """Solve DC operating point via Newton-Raphson on a linearized MNA.
 
@@ -1085,6 +1161,16 @@ def dc_op(
         When ``True`` (default), automatically fall back to Gmin stepping
         then source stepping when plain Newton diverges.  Set to ``False``
         to force plain Newton only (faster for simple linear circuits).
+    pseudo_transient_steps:
+        Maximum artificial backward-Euler continuation steps after Newton,
+        Gmin stepping, and source stepping fail.  Set to 0 to disable this
+        final convergence aid.
+    pseudo_transient_shunt_conductance:
+        Artificial node-to-ground conductance (S) used by the continuation
+        companion.  Larger values damp Newton more aggressively.
+    pseudo_transient_max_iterations:
+        Optional Newton iteration cap for each pseudo-transient step and final
+        polish solve.  Defaults to ``max_iterations``.
     """
     # Attempt 1: plain Newton-Raphson.
     result = _dc_newton(circuit, max_iterations=max_iterations, tol=tol)
@@ -1102,6 +1188,21 @@ def dc_op(
     src_result = _dc_source_step(circuit, max_iterations=max_iterations, tol=tol)
     if src_result is not None and src_result.converged:
         return replace(src_result, convergence_aid="source")
+
+    # Attempt 4: artificial pseudo-transient continuation.
+    pseudo_result = _dc_pseudo_transient(
+        circuit,
+        max_iterations=(
+            pseudo_transient_max_iterations
+            if pseudo_transient_max_iterations is not None
+            else max_iterations
+        ),
+        tol=tol,
+        n_steps=pseudo_transient_steps,
+        shunt_conductance=pseudo_transient_shunt_conductance,
+    )
+    if pseudo_result is not None and pseudo_result.converged:
+        return replace(pseudo_result, convergence_aid="pseudo_transient")
 
     # All methods exhausted — return the plain-Newton result (converged=False).
     return replace(result, convergence_aid="none")

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -5625,6 +5625,24 @@ def test_dc_op_reports_no_convergence_aid_when_disabled_solve_fails() -> None:
     assert result.convergence_aid == "none"
 
 
+def test_dc_op_pseudo_transient_recovers_after_earlier_aids_fail() -> None:
+    """Pseudo-transient continuation is the final DC fallback aid."""
+    c = Circuit([
+        VoltageSource("Vs", "in", "0", 10.0),
+        Diode("D1", anode="in", cathode="out", Is=1e-15, Vt=0.02585),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+    result = dc_op(
+        c,
+        max_iterations=1,
+        pseudo_transient_max_iterations=500,
+        pseudo_transient_steps=40,
+    )
+    assert result.converged
+    assert result.convergence_aid == "pseudo_transient"
+    assert 0.0 < result.node_voltages["out"] < 10.0
+
+
 # ---- _dc_gmin_step ---------------------------------------------------------
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add pseudo-transient DC continuation as a final bounded convergence aid after
+  Newton, Gmin stepping, and source stepping; successful fallback results
+  report `DcConvergenceAid::PseudoTransient`.
 - Add `DcResult::convergence_aid`, reporting whether the DC operating point
   came from plain Newton, Gmin stepping, source stepping, or no successful
   convergence aid.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1433,6 +1433,7 @@ pub enum DcConvergenceAid {
     Newton,
     Gmin,
     Source,
+    PseudoTransient,
     None,
 }
 
@@ -1493,6 +1494,9 @@ pub struct DcOpOptions {
     pub max_iterations: usize,
     pub tolerance: f64,
     pub convergence_aids: bool,
+    pub pseudo_transient_steps: usize,
+    pub pseudo_transient_conductance: f64,
+    pub pseudo_transient_max_iterations: usize,
 }
 
 impl Default for DcOpOptions {
@@ -1501,6 +1505,9 @@ impl Default for DcOpOptions {
             max_iterations: 80,
             tolerance: 1.0e-9,
             convergence_aids: true,
+            pseudo_transient_steps: 20,
+            pseudo_transient_conductance: 1.0e-3,
+            pseudo_transient_max_iterations: 80,
         }
     }
 }
@@ -2006,6 +2013,8 @@ pub fn dc_op_with_options(circuit: &Circuit, options: DcOpOptions) -> Result<DcR
             (aided, DcConvergenceAid::Gmin)
         } else if let Some(aided) = solve_dc_with_source_stepping(circuit, options)? {
             (aided, DcConvergenceAid::Source)
+        } else if let Some(aided) = solve_dc_with_pseudo_transient(circuit, options)? {
+            (aided, DcConvergenceAid::PseudoTransient)
         } else {
             (solution, DcConvergenceAid::None)
         };
@@ -2163,6 +2172,20 @@ fn validate_dc_op_options(options: DcOpOptions) -> Result<(), SpiceError> {
             reason: "tolerance must be finite and positive".to_string(),
         });
     }
+    if !options.pseudo_transient_conductance.is_finite()
+        || options.pseudo_transient_conductance <= 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: "dc_op".to_string(),
+            reason: "pseudo_transient_conductance must be finite and positive".to_string(),
+        });
+    }
+    if options.pseudo_transient_max_iterations == 0 {
+        return Err(SpiceError::InvalidElement {
+            name: "dc_op".to_string(),
+            reason: "pseudo_transient_max_iterations must be positive".to_string(),
+        });
+    }
     Ok(())
 }
 
@@ -2214,6 +2237,103 @@ fn solve_dc_with_source_stepping(
     }
 
     Ok(final_solution)
+}
+
+fn solve_dc_with_pseudo_transient(
+    circuit: &Circuit,
+    options: DcOpOptions,
+) -> Result<Option<LinearSolution>, SpiceError> {
+    if options.pseudo_transient_steps == 0 {
+        return Ok(None);
+    }
+
+    let node_indices = collect_node_indices(circuit);
+    if node_indices.is_empty() {
+        return Ok(None);
+    }
+    let mut nodes_by_index: Vec<(&String, &usize)> = node_indices.iter().collect();
+    nodes_by_index.sort_by_key(|(_, index)| **index);
+    let nodes: Vec<String> = nodes_by_index
+        .into_iter()
+        .map(|(node, _)| node.clone())
+        .collect();
+
+    let mut previous_node_voltages: BTreeMap<String, f64> =
+        nodes.iter().map(|node| (node.clone(), 0.0)).collect();
+    let mut warm_start: Option<Vec<f64>> = None;
+    let mut last_solution = None;
+    let pseudo_options = DcOpOptions {
+        max_iterations: options.pseudo_transient_max_iterations,
+        ..options
+    };
+
+    for step in 0..options.pseudo_transient_steps {
+        let pseudo_circuit = circuit_with_pseudo_transient_companions(
+            circuit,
+            &nodes,
+            &previous_node_voltages,
+            options.pseudo_transient_conductance,
+            step,
+        );
+        let solution = solve_dc_newton(&pseudo_circuit, pseudo_options, warm_start.as_deref())?;
+        if !solution.converged {
+            return Ok(None);
+        }
+
+        let mut delta: f64 = 0.0;
+        let mut next_node_voltages = BTreeMap::new();
+        for node in &nodes {
+            let next = *solution.node_voltages.get(node).unwrap_or(&0.0);
+            let previous = *previous_node_voltages.get(node).unwrap_or(&0.0);
+            delta = delta.max((next - previous).abs());
+            next_node_voltages.insert(node.clone(), next);
+        }
+        previous_node_voltages = next_node_voltages;
+        warm_start = Some(solution.vector.clone());
+        last_solution = Some(solution);
+        if delta < options.tolerance {
+            break;
+        }
+    }
+
+    if last_solution.is_none() {
+        return Ok(None);
+    }
+
+    let final_solution = solve_dc_newton(circuit, pseudo_options, warm_start.as_deref())?;
+    if final_solution.converged {
+        Ok(Some(final_solution))
+    } else {
+        Ok(None)
+    }
+}
+
+fn circuit_with_pseudo_transient_companions(
+    circuit: &Circuit,
+    nodes: &[String],
+    previous_node_voltages: &BTreeMap<String, f64>,
+    conductance: f64,
+    step: usize,
+) -> Circuit {
+    let mut pseudo_circuit = circuit.clone();
+    for node in nodes {
+        pseudo_circuit.add(Element::Resistor(Resistor::new(
+            format!("__ptran_g_{step}_{node}"),
+            node.clone(),
+            "0",
+            1.0 / conductance,
+        )));
+        let history_current = conductance * previous_node_voltages.get(node).unwrap_or(&0.0);
+        if history_current != 0.0 {
+            pseudo_circuit.add(Element::CurrentSource(CurrentSource::new(
+                format!("__ptran_i_{step}_{node}"),
+                "0",
+                node.clone(),
+                history_current,
+            )));
+        }
+    }
+    pseudo_circuit
 }
 
 fn dc_gmin_sequence() -> Vec<f64> {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -449,6 +449,34 @@ fn dc_op_reports_unconverged_nonlinear_result_when_aids_are_disabled() {
 }
 
 #[test]
+fn dc_op_pseudo_transient_recovers_after_earlier_aids_fail() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vs", "in", "0", 10.0,
+    )));
+    circuit.add(Element::Diode(Diode::with_model(
+        "D1", "in", "out", 1.0e-15, 0.02585,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rload", "out", "0", 100.0)));
+
+    let result = dc_op_with_options(
+        &circuit,
+        DcOpOptions {
+            max_iterations: 1,
+            pseudo_transient_max_iterations: 500,
+            pseudo_transient_steps: 40,
+            ..DcOpOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.converged);
+    assert_eq!(result.convergence_aid, DcConvergenceAid::PseudoTransient);
+    assert!(result.voltage("out").unwrap() > 0.0);
+    assert!(result.voltage("out").unwrap() < 10.0);
+}
+
+#[test]
 fn dc_mosfet_rejects_invalid_level1_params() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add pseudo-transient DC continuation as a final bounded convergence aid after
+  Newton, Gmin stepping, and source stepping; successful fallback results
+  report `convergenceAid: "pseudo_transient"`.
 - Add `DcResult.convergenceAid`, reporting whether the DC operating point came
   from plain Newton, Gmin stepping, source stepping, or no successful
   convergence aid.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -464,12 +464,15 @@ export interface DcResult {
   branchCurrent(sourceName: string): number | undefined;
 }
 
-export type DcConvergenceAid = "newton" | "gmin" | "source" | "none";
+export type DcConvergenceAid = "newton" | "gmin" | "source" | "pseudo_transient" | "none";
 
 export interface DcOpOptions {
   readonly maxIterations?: number;
   readonly tolerance?: number;
   readonly convergenceAids?: boolean;
+  readonly pseudoTransientSteps?: number;
+  readonly pseudoTransientConductance?: number;
+  readonly pseudoTransientMaxIterations?: number;
 }
 
 export interface CornerOverride {
@@ -1393,13 +1396,19 @@ export function dcOp(
   const gminSolution = solveDcWithGminStepping(circuit, solveOptions, solution.vector);
   const sourceSolution =
     gminSolution === undefined ? solveDcWithSourceStepping(circuit, solveOptions) : undefined;
-  const finalSolution = gminSolution ?? sourceSolution ?? solution;
+  const pseudoSolution =
+    gminSolution === undefined && sourceSolution === undefined
+      ? solveDcWithPseudoTransient(circuit, solveOptions)
+      : undefined;
+  const finalSolution = gminSolution ?? sourceSolution ?? pseudoSolution ?? solution;
   const convergenceAid: DcConvergenceAid =
     gminSolution !== undefined
       ? "gmin"
       : sourceSolution !== undefined
         ? "source"
-        : "none";
+        : pseudoSolution !== undefined
+          ? "pseudo_transient"
+          : "none";
   return makeDcResult(
     finalSolution.nodeVoltages,
     finalSolution.branchCurrents,
@@ -2943,6 +2952,9 @@ interface ResolvedDcOpOptions {
   readonly maxIterations: number;
   readonly tolerance: number;
   readonly convergenceAids: boolean;
+  readonly pseudoTransientSteps: number;
+  readonly pseudoTransientConductance: number;
+  readonly pseudoTransientMaxIterations: number;
 }
 
 interface AcSolution {
@@ -3152,16 +3164,31 @@ function solveLinearCircuitAtOperatingPointOrFailure(
 function validatedDcOpOptions(options: DcOpOptions): ResolvedDcOpOptions {
   const maxIterations = options.maxIterations ?? 80;
   const tolerance = options.tolerance ?? 1.0e-9;
+  const pseudoTransientSteps = options.pseudoTransientSteps ?? 20;
+  const pseudoTransientConductance = options.pseudoTransientConductance ?? 1.0e-3;
+  const pseudoTransientMaxIterations = options.pseudoTransientMaxIterations ?? maxIterations;
   if (!Number.isInteger(maxIterations) || maxIterations < 1) {
     throw invalidElement("dcOp", "maxIterations must be a positive integer");
   }
   if (!Number.isFinite(tolerance) || tolerance <= 0.0) {
     throw invalidElement("dcOp", "tolerance must be finite and positive");
   }
+  if (!Number.isInteger(pseudoTransientSteps) || pseudoTransientSteps < 0) {
+    throw invalidElement("dcOp", "pseudoTransientSteps must be a non-negative integer");
+  }
+  if (!Number.isFinite(pseudoTransientConductance) || pseudoTransientConductance <= 0.0) {
+    throw invalidElement("dcOp", "pseudoTransientConductance must be finite and positive");
+  }
+  if (!Number.isInteger(pseudoTransientMaxIterations) || pseudoTransientMaxIterations < 1) {
+    throw invalidElement("dcOp", "pseudoTransientMaxIterations must be a positive integer");
+  }
   return {
     maxIterations,
     tolerance,
     convergenceAids: options.convergenceAids ?? true,
+    pseudoTransientSteps,
+    pseudoTransientConductance,
+    pseudoTransientMaxIterations,
   };
 }
 
@@ -3207,6 +3234,86 @@ function solveDcWithSourceStepping(
   }
 
   return finalSolution;
+}
+
+function solveDcWithPseudoTransient(
+  circuit: Circuit,
+  options: ResolvedDcOpOptions,
+): LinearSolution | undefined {
+  if (options.pseudoTransientSteps === 0) {
+    return undefined;
+  }
+
+  const nodeIndices = collectNodeIndices(circuit);
+  const nodesByIndex = Array.from(nodeIndices.entries()).sort(
+    ([, left], [, right]) => left - right,
+  );
+  if (nodesByIndex.length === 0) {
+    return undefined;
+  }
+
+  let previousNodeVoltages = new Map<string, number>(
+    nodesByIndex.map(([node]) => [node, 0.0]),
+  );
+  let warmStart: readonly number[] | undefined;
+  let lastSolution: LinearSolution | undefined;
+  const pseudoOptions: ResolvedDcOpOptions = {
+    ...options,
+    maxIterations: options.pseudoTransientMaxIterations,
+  };
+
+  for (let step = 0; step < options.pseudoTransientSteps; step++) {
+    const pseudoCircuit = circuitWithPseudoTransientCompanions(
+      circuit,
+      nodesByIndex.map(([node]) => node),
+      previousNodeVoltages,
+      options.pseudoTransientConductance,
+      step,
+    );
+    const solution = solveDcNewton(pseudoCircuit, pseudoOptions, warmStart);
+    if (!solution.converged) {
+      return undefined;
+    }
+
+    let delta = 0.0;
+    const nextNodeVoltages = new Map<string, number>();
+    for (const [node] of nodesByIndex) {
+      const next = solution.nodeVoltages.get(node) ?? 0.0;
+      delta = Math.max(delta, Math.abs(next - (previousNodeVoltages.get(node) ?? 0.0)));
+      nextNodeVoltages.set(node, next);
+    }
+    previousNodeVoltages = nextNodeVoltages;
+    warmStart = solution.vector;
+    lastSolution = solution;
+    if (delta < options.tolerance) {
+      break;
+    }
+  }
+
+  if (lastSolution === undefined) {
+    return undefined;
+  }
+
+  const finalSolution = solveDcNewton(circuit, pseudoOptions, warmStart);
+  return finalSolution.converged ? finalSolution : undefined;
+}
+
+function circuitWithPseudoTransientCompanions(
+  circuit: Circuit,
+  nodes: readonly string[],
+  previousNodeVoltages: ReadonlyMap<string, number>,
+  conductance: number,
+  step: number,
+): Circuit {
+  const pseudoCircuit = circuitFromElements(circuit.elements());
+  for (const node of nodes) {
+    pseudoCircuit.add(resistor(`__ptran_g_${step}_${node}`, node, "0", 1.0 / conductance));
+    const historyCurrent = conductance * (previousNodeVoltages.get(node) ?? 0.0);
+    if (historyCurrent !== 0.0) {
+      pseudoCircuit.add(currentSource(`__ptran_i_${step}_${node}`, "0", node, historyCurrent));
+    }
+  }
+  return pseudoCircuit;
 }
 
 function dcGminSequence(): number[] {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -302,6 +302,24 @@ describe("dcOp", () => {
     expect(result.iterations).toBe(1);
   });
 
+  it("recovers with pseudo-transient continuation after earlier aids fail", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vs", "in", "0", 10.0));
+    circuit.add(diode("D1", "in", "out", 1.0e-15, 0.02585));
+    circuit.add(resistor("Rload", "out", "0", 100.0));
+
+    const result = dcOp(circuit, {
+      maxIterations: 1,
+      pseudoTransientMaxIterations: 500,
+      pseudoTransientSteps: 40,
+    });
+
+    expect(result.converged).toBe(true);
+    expect(result.convergenceAid).toBe("pseudo_transient");
+    expect(result.voltage("out")).toBeGreaterThan(0.0);
+    expect(result.voltage("out")).toBeLessThan(10.0);
+  });
+
   it("rejects invalid MOSFET model parameters", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdd", "vdd", "0", 1.8));

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -169,9 +169,12 @@ Acceptance:
 Status:
 
 - DC operating-point results now report which convergence path produced the
-  result (`newton`, `gmin`, `source`, or `none`) across Python, TypeScript, and
-  Rust. Pseudo-transient continuation can extend the same result contract in
-  the next slice.
+  result (`newton`, `gmin`, `source`, `pseudo_transient`, or `none`) across
+  Python, TypeScript, and Rust.
+- Python, TypeScript, and Rust now include a bounded pseudo-transient DC
+  continuation fallback after Newton, Gmin stepping, and source stepping. The
+  aid uses artificial backward-Euler node companions, has step/conductance and
+  per-step Newton caps, and reports `pseudo_transient` when it converges.
 
 ### Phase 6 - 1970s Model-Card Depth
 


### PR DESCRIPTION
## Summary

- add bounded pseudo-transient DC continuation after Newton, Gmin stepping, and source stepping
- expose pseudo-transient step, conductance, and per-step Newton caps across Python, TypeScript, and Rust
- report `pseudo_transient` / `PseudoTransient` convergence metadata and add cross-language recovery fixtures

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-pseudo-transient-dc PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `npm run build && npx vitest run`
- `cargo test -p spice-engine`
- `git diff --check`