### PR TITLE
feat(ui30): VisiCalc touch-variant layouts (ML3 proof-of-concept)

### DIFF
--- a/demo/visicalc/mosaic/FormulaBar.touch.mll
+++ b/demo/visicalc/mosaic/FormulaBar.touch.mll
@@ -1,0 +1,42 @@
+// FormulaBar.touch.mll — touch / mobile layout for the formula bar (UI30).
+//
+// On a phone-sized viewport the desktop's "address-label sits to the LEFT
+// of the formula field" arrangement doesn't fit — there's not enough
+// horizontal room for both a recognisable cell address and a usable
+// formula input. The touch variant stacks them vertically instead:
+//
+//   Column [bar]
+//     Text [address-label] (content: slot: cell-address)
+//     HostInput [formula-field] (... full-width, larger tap target via .msl)
+//
+// The interface (FormulaBar.mil) is unchanged — same slots, same emits.
+// Only the spatial arrangement differs. This is the UI30 invariant in
+// action: one component, many layouts, identical host contract.
+//
+// What the touch variant changes vs. .desktop.mll:
+//
+//   1. Row [bar] → Column [bar]
+//      Vertical stack instead of horizontal row. The address label
+//      sits ABOVE the formula field, giving the input full width.
+//   2. (everything else identical)
+//      The slot bindings and emit wiring are byte-for-byte the same.
+//      Tap-target sizing (the Apple-HIG 44 px minimum, etc.) belongs
+//      to the .msl — the layout just establishes the spatial shape.
+//
+// Why HostInput (not Input): consistency with the desktop variant
+// post-Phase-1 — both variants use the kernel-canonical UI29 §2.1
+// primitive so the React/Flutter/etc. emitters lower them identically.
+
+layout FormulaBar {
+  Column [bar] {
+    Text [address-label] (content: slot: cell-address)
+    HostInput [formula-field] (
+      value:       slot: formula,
+      read-only:   slot: read-only,
+      placeholder: "Enter formula",
+      onChange:    emit: onFormulaChange,
+      onCommit:    emit: onCommit,
+      onCancel:    emit: onCancel
+    )
+  }
+}

--- a/demo/visicalc/mosaic/Grid.touch.mll
+++ b/demo/visicalc/mosaic/Grid.touch.mll
@@ -1,0 +1,44 @@
+// Grid.touch.mll — touch / mobile layout for the spreadsheet grid (UI30).
+//
+// The desktop layout pins the column-header row at the top of the
+// scroll viewport via `sticky-header: true` — when the user scrolls
+// the body, the headers stay visible. This works well on a desktop
+// because there's plenty of vertical real estate; the sticky band
+// only costs ~24 px out of a typically ~600 px viewport.
+//
+// On a phone the same band steals ~5-10% of the visible viewport
+// for every scroll position, and worse — the horizontal-scroll pattern
+// that lets desktop users see distant columns doesn't work as well
+// on touch, where users naturally swipe through cells. The touch
+// variant therefore drops sticky-header: false (= the default), so
+// the header row scrolls away normally and the user gets the full
+// viewport back as they scroll.
+//
+// What the touch variant changes vs. .desktop.mll:
+//
+//   1. sticky-header: true  →  sticky-header: false
+//      (See above. The kernel Grid primitive treats `false` as the
+//      default, so we could simply omit the prop — we make it
+//      explicit here for readability + diff legibility.)
+//   2. (everything else identical)
+//
+// The interface (Grid.mil) is unchanged — same 9 slots, same
+// onNavigate emit. Tap-target sizing for individual cells lives in
+// the .msl (a follow-up could add a Grid.touch.dark.msl that bumps
+// row height to ≥44 px per Apple HIG); for v1 of the touch
+// variant the .desktop.msl's styling is reused.
+
+layout Grid {
+  Grid [sheet] (
+    headers:       slot: column-headers,
+    rows:          slot: viewport-rows,
+    column-widths: slot: column-widths,
+    selected-row:  slot: selected-row,
+    selected-col:  slot: selected-col,
+    edit-row:      slot: edit-row,
+    edit-col:      slot: edit-col,
+    sticky-header: false,
+    total-height:  slot: total-height,
+    onNavigate:    emit: onNavigate
+  )
+}


### PR DESCRIPTION
## Summary

Closes plan item [C] in the UI30 cycle. Demonstrates the multi-layout pipeline end-to-end on real VisiCalc components.

Two new files:
- \`demo/visicalc/mosaic/FormulaBar.touch.mll\` — stacks vertically (\`Column [bar]\` instead of \`Row [bar]\`)
- \`demo/visicalc/mosaic/Grid.touch.mll\` — drops \`sticky-header: true\` → \`false\`

**Generated React diffs (verified):**

| Component | Desktop | Touch |
|---|---|---|
| FormulaBar | \`flexDirection: \"row\"\` | \`flexDirection: \"column\"\` |
| Grid | \`<div overflow:auto><table><thead position:sticky>\` | \`<table><thead>\` |

**Critical invariant verified:** the \`.mil\` interfaces (slots + emits) are UNCHANGED. Every host prop (\`columnHeaders\`, \`viewportRows\`, \`dispatch\`, \`formula\`, \`cellAddress\`, …) is byte-for-byte identical between the two variants. Host code doesn't change to swap variants — it just imports a different artifact file.

This validates UI30's core promise: ONE interface, MANY layouts, host contract unchanged.

## Test plan

- [x] \`mosaic-compile --variant desktop\` produces the original .tsx unchanged
- [x] \`mosaic-compile --variant touch\` for FormulaBar shows flexDirection: column
- [x] \`mosaic-compile --variant touch\` for Grid drops the sticky scroll wrapper
- [x] Both variants validate against the singular .mil interface (no slot/emit drift)
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)