### PR TITLE
feat(sql): fix PRAGMA table_info notnull + dflt_value shape

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.97.0] - 2026-05-23
+
+### Changed
+
+- ``PRAGMA table_info`` now matches real ``sqlite3`` exactly:
+
+  * ``notnull`` distinguishes explicit ``NOT NULL`` from the implicit
+    ``NOT NULL`` that ``PRIMARY KEY`` introduces — ``CREATE TABLE t
+    (id INTEGER PRIMARY KEY)`` reports ``notnull=0``, while
+    ``... PRIMARY KEY NOT NULL`` reports ``notnull=1``.  Runtime
+    NOT NULL enforcement is unchanged — the backend still treats PK
+    as implicit NOT NULL (TEXT PK still rejects ``INSERT VALUES
+    (NULL, ...)``, INTEGER PK still auto-assigns the next rowid).
+  * ``dflt_value`` returns the literal source text instead of the
+    parsed Python value: ``DEFAULT 42`` → ``'42'``, ``DEFAULT 'x'``
+    → ``"'x'"`` (single quotes preserved), ``DEFAULT NULL`` →
+    ``'NULL'``, ``DEFAULT 3.14`` → ``'3.14'``.  ``X'hex'`` BLOB
+    literals also round-trip.
+
+- The adapter no longer sets ``not_null=True`` for PRIMARY KEY columns
+  (the codegen now reads the raw flag through to the backend).
+  Internal ``effective_not_null()`` continues to OR the PK bit in for
+  constraint validation.
+
 ## [1.96.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.96.0"
+version = "1.97.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1459,17 +1459,23 @@ def _col_def(node: ASTNode, state: _PlaceholderCounter | None = None) -> Backend
         if kw_seq == ("NOT", "NULL"):
             not_null = True
         elif kw_seq == ("PRIMARY", "KEY"):
+            # Don't set ``not_null = True`` here: ``primary_key=True``
+            # is already enough — ``ColumnDef.effective_not_null()``
+            # treats PK as implicit NOT NULL for constraint-validation
+            # purposes.  Leaving the raw ``not_null`` field False lets
+            # ``PRAGMA table_info`` distinguish PK-implied NULL-ness
+            # from explicit NOT NULL declarations (matching SQLite,
+            # which reports ``notnull = 0`` for ``id INTEGER PRIMARY
+            # KEY`` and ``notnull = 1`` only when the user wrote both
+            # ``PRIMARY KEY NOT NULL``).
             primary_key = True
-            not_null = True  # PRIMARY KEY implies NOT NULL.
         elif kw_seq == ("PRIMARY", "KEY", "AUTOINCREMENT"):
             # SQLite: AUTOINCREMENT is only valid after PRIMARY KEY on
-            # an INTEGER column.  We accept the keyword and mark the
-            # column; behaviour ("rowids never reuse after DELETE") is
-            # already true for the in-memory backend since
-            # ``_next_rowid`` is never decremented.
+            # an INTEGER column.  Same NOT NULL story as the
+            # PRIMARY-KEY-only branch: leave ``not_null`` False so the
+            # pragma surfaces the explicit-vs-implicit distinction.
             primary_key = True
             autoincrement = True
-            not_null = True  # PRIMARY KEY implies NOT NULL.
         elif kw_seq == ("UNIQUE",):
             unique = True
         elif kw_seq[0:1] == ("CHECK",):

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -683,6 +683,34 @@ def _run_explain_query_plan(
 # ---------------------------------------------------------------------------
 
 
+def _format_pragma_default(value: object) -> str:
+    """Render a column's stored default value as the SQL-literal text that
+    ``PRAGMA table_info.dflt_value`` reports.
+
+    SQLite's ``dflt_value`` column returns the literal source text that
+    appeared after ``DEFAULT`` — so ``DEFAULT 'x'`` reads back as
+    ``"'x'"`` (with the single quotes!), ``DEFAULT 42`` reads back as
+    ``"42"``, ``DEFAULT NULL`` reads back as ``"NULL"``, and so on.
+    Mini-sqlite's adapter parses the literal into a Python value at
+    CREATE TABLE time; this helper re-encodes it back to source-text
+    form so the pragma surfaces the same string sqlite3 does.
+
+    Bytes get the ``X'hex...'`` blob-literal form; bools collapse to
+    ``'0'`` / ``'1'`` (SQLite stores booleans as integers internally).
+    """
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, (bytes, bytearray)):
+        return "X'" + bytes(value).hex().upper() + "'"
+    # Default: treat as text — escape embedded single quotes by doubling.
+    text = str(value).replace("'", "''")
+    return f"'{text}'"
+
+
 # Boolean PRAGMA value parser.  SQLite accepts a wide range of representations
 # for "true / false" — integers (1/0, also any non-zero), and the keywords
 # ON, OFF, TRUE, FALSE, YES, NO (case-insensitive).  Returns:
@@ -817,10 +845,17 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
         rows = []
         for i, col in enumerate(cols):
             if isinstance(col, BackendColumnDef):
-                not_null = int(col.effective_not_null())
+                # SQLite's ``notnull`` reports the *explicit* NOT NULL
+                # declaration, not the implicit one from PRIMARY KEY.
+                # ``id INTEGER PRIMARY KEY`` → notnull=0;
+                # ``id INTEGER PRIMARY KEY NOT NULL`` → notnull=1.
+                # The adapter (mini-sqlite 1.97+) only sets the raw
+                # ``not_null`` flag for explicit declarations, so the
+                # raw field is the correct source.
+                not_null = int(col.not_null)
                 pk = int(col.primary_key)
                 type_name = col.type_name
-                dflt = col.default if col.has_default() else None
+                dflt = _format_pragma_default(col.default) if col.has_default() else None
                 name_str = col.name
             else:
                 not_null = 0

--- a/code/packages/python/mini-sqlite/tests/test_adapter.py
+++ b/code/packages/python/mini-sqlite/tests/test_adapter.py
@@ -254,8 +254,24 @@ def test_create_table_if_not_exists():
     assert stmt.if_not_exists is True
 
 
-def test_create_table_primary_key_implies_not_null():
+def test_create_table_primary_key_not_null_uses_effective():
+    # mini-sqlite 1.97+: PRIMARY KEY no longer forces the raw
+    # ``not_null`` flag to True — the adapter leaves it False so
+    # PRAGMA table_info's notnull column can distinguish explicit
+    # NOT NULL from PK-implied NOT NULL (matches SQLite).  The
+    # ``effective_not_null()`` helper reapplies the PK check at
+    # constraint-validation time, so behaviour is unchanged.
     stmt = adapt("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+    col = stmt.columns[0]
+    assert col.primary_key is True
+    assert col.not_null is False  # raw flag — was True pre-1.97
+    assert col.effective_not_null() is True  # PK still implies NOT NULL
+
+
+def test_create_table_explicit_not_null_primary_key():
+    # When the user writes both PRIMARY KEY AND NOT NULL, the raw
+    # flag IS set — only the implicit case from PK alone was changed.
+    stmt = adapt("CREATE TABLE t (id INTEGER PRIMARY KEY NOT NULL)")
     col = stmt.columns[0]
     assert col.primary_key is True
     assert col.not_null is True

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_table_info_shape.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_table_info_shape.py
@@ -1,0 +1,114 @@
+"""Tests for the PRAGMA table_info shape fixes (mini-sqlite 1.97+).
+
+Two discrepancies vs real ``sqlite3`` are fixed:
+
+1. ``notnull`` column was previously ``1`` for ``id INTEGER PRIMARY KEY``
+   (PK-implied NOT NULL).  SQLite reports ``0`` and only sets ``1``
+   when the user wrote both ``PRIMARY KEY`` and ``NOT NULL``.
+2. ``dflt_value`` was the parsed Python value.  SQLite returns the
+   literal source text — ``DEFAULT 42`` → ``'42'``, ``DEFAULT 'x'``
+   → ``"'x'"``, ``DEFAULT NULL`` → ``'NULL'``, etc.
+
+Oracle-tested against ``sqlite3`` for byte compatibility.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both(ddl: str) -> tuple:
+    """Return (mini_rows, ref_rows) for PRAGMA table_info(t) after *ddl*."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        c.execute(ddl)
+    return (
+        mini.execute("PRAGMA table_info(t)").fetchall(),
+        ref.execute("PRAGMA table_info(t)").fetchall(),
+    )
+
+
+class TestNotnullShape:
+    """``notnull`` distinguishes explicit-NOT-NULL from PK-implied."""
+
+    def test_ipk_without_explicit_not_null(self) -> None:
+        m, r = _both("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        assert m == r
+        assert m[0][3] == 0  # notnull=0 — PK alone doesn't set it
+
+    def test_ipk_with_explicit_not_null(self) -> None:
+        m, r = _both("CREATE TABLE t (id INTEGER PRIMARY KEY NOT NULL, v TEXT)")
+        assert m == r
+        assert m[0][3] == 1  # notnull=1 — user wrote it explicitly
+
+    def test_text_pk(self) -> None:
+        # Same rule for non-INTEGER PRIMARY KEY.
+        m, r = _both("CREATE TABLE t (id TEXT PRIMARY KEY, v TEXT)")
+        assert m == r
+        assert m[0][3] == 0
+
+    def test_explicit_not_null_on_non_pk(self) -> None:
+        # Non-PK columns: NOT NULL is always explicit, so notnull
+        # tracks the raw declaration directly.
+        m, r = _both("CREATE TABLE t (id INTEGER, name TEXT NOT NULL)")
+        assert m == r
+        assert m[0][3] == 0  # id: nullable
+        assert m[1][3] == 1  # name: explicitly NOT NULL
+
+
+class TestDefaultValueShape:
+    """``dflt_value`` returns the SQL-literal source text, not Python value."""
+
+    def test_string_default_keeps_quotes(self) -> None:
+        m, r = _both("CREATE TABLE t (v TEXT DEFAULT 'hello')")
+        assert m == r
+        assert m[0][4] == "'hello'"
+
+    def test_int_default_as_text(self) -> None:
+        m, r = _both("CREATE TABLE t (n INT DEFAULT 42)")
+        assert m == r
+        assert m[0][4] == "42"
+
+    def test_real_default_as_text(self) -> None:
+        m, r = _both("CREATE TABLE t (r REAL DEFAULT 3.14)")
+        assert m == r
+        assert m[0][4] == "3.14"
+
+    def test_null_default_as_text(self) -> None:
+        m, r = _both("CREATE TABLE t (x INT DEFAULT NULL)")
+        assert m == r
+        assert m[0][4] == "NULL"
+
+    def test_no_default_is_none(self) -> None:
+        # When there's no DEFAULT clause, dflt_value is Python None
+        # (which the DB-API surfaces as NULL).
+        m, r = _both("CREATE TABLE t (x INT)")
+        assert m == r
+        assert m[0][4] is None
+
+
+class TestEnforcementUnchanged:
+    """The shape fixes don't change runtime NOT NULL enforcement."""
+
+    def test_pk_still_rejects_explicit_null_for_non_integer_pk(self) -> None:
+        # TEXT PRIMARY KEY: PK still implies NOT NULL at runtime,
+        # so INSERT VALUES (NULL) is rejected (the rowid auto-assign
+        # path only fires for INTEGER PRIMARY KEY).
+        import pytest
+
+        from mini_sqlite import errors as mini_errors
+
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t (id TEXT PRIMARY KEY, v TEXT)")
+        with pytest.raises(mini_errors.IntegrityError):
+            mini.execute("INSERT INTO t VALUES (NULL, 'x')")
+
+    def test_ipk_auto_assigns_unchanged(self) -> None:
+        # INTEGER PRIMARY KEY still auto-assigns on omit/NULL.
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        mini.execute("INSERT INTO t(v) VALUES ('a')")
+        assert mini.execute("SELECT * FROM t").fetchall() == [(1, "a")]

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.39.0] - 2026-05-23
+
+### Changed
+
+- ``_to_ir_col`` now uses the raw ``ColumnDef.not_null`` flag for the
+  IR's ``nullable`` field (was ``c.effective_not_null()`` which folded
+  in PRIMARY KEY's implicit NOT NULL).  Constraint enforcement at the
+  backend is unchanged — the backend's ``effective_not_null()``
+  reapplies the PK check at insert/update time.  Required for
+  ``PRAGMA table_info`` to distinguish explicit-vs-implicit NOT NULL
+  (matches sqlite3).
+
 ## [1.38.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.38.0"
+version = "1.39.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -1857,7 +1857,13 @@ def _to_ir_col(c: AstColumnDef) -> IrColumnDef:
     return IrColumnDef(
         name=c.name,
         type=c.type_name,
-        nullable=not c.effective_not_null(),
+        # Preserve the raw NOT NULL declaration (not the PK-implied one).
+        # The backend's ``effective_not_null()`` reapplies the PK check
+        # at constraint-validation time, so dropping the implicit bit
+        # here doesn't loosen enforcement.  Keeps PRAGMA table_info's
+        # ``notnull`` column matching real sqlite3, which distinguishes
+        # explicit-vs-implicit NOT NULL.
+        nullable=not c.not_null,
         primary_key=c.primary_key,
         autoincrement=c.autoincrement,
         unique=c.unique,


### PR DESCRIPTION
## Summary

ORMs compare ``PRAGMA table_info`` output against their own schema definitions; tiny differences from real sqlite3 surface as false-positive "schema drift" alerts. Two such differences fixed:

1. **notnull column** — was always 1 for PRIMARY KEY columns. Now distinguishes explicit ``NOT NULL`` from PK-implied (matches sqlite3). Runtime enforcement unchanged (backend still treats PK as implicit NOT NULL).
2. **dflt_value column** — was the parsed Python value. Now returns the literal SQL source text (``DEFAULT 42`` → ``'42'``, ``DEFAULT 'x'`` → ``"'x'"`` with quotes preserved, ``DEFAULT NULL`` → ``'NULL'``).

## Test plan

- [x] sql-backend / sql-planner / sql-codegen / sql-vm / storage-sqlite: regression-only, no failures
- [x] mini-sqlite: 2194 tests pass (11 new oracle tests vs sqlite3, 1 stale adapter test replaced with 2 covering new behaviour)
- [x] ruff clean
- [x] /security-review passed

Versions: sql-codegen 1.38→1.39, mini-sqlite 1.96→1.97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)