### PR TITLE
spice: add diode emission coefficient model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **Diode emission coefficient models** — `Diode.N` now scales the effective
+  thermal voltage in DC and small-signal diode conductance calculations.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -421,6 +421,7 @@ class Diode:
     cathode: str
     Is: float = 1e-15  # saturation current
     Vt: float = 0.02585  # thermal voltage
+    N: float = 1.0  # emission coefficient
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -244,7 +244,14 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
     if isinstance(element, BSource):
         return BSource(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_bsource_expr_nodes(element.voltage_expr, instance_name, node_map), _map_bsource_expr_nodes(element.current_expr, instance_name, node_map))
     if isinstance(element, Diode):
-        return Diode(name, _map_subckt_node(element.anode, instance_name, node_map), _map_subckt_node(element.cathode, instance_name, node_map), element.Is, element.Vt)
+        return Diode(
+            name,
+            _map_subckt_node(element.anode, instance_name, node_map),
+            _map_subckt_node(element.cathode, instance_name, node_map),
+            element.Is,
+            element.Vt,
+            element.N,
+        )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_)
     if isinstance(element, Mosfet):
@@ -1678,18 +1685,19 @@ def _stamp_diode(
     node_to_idx: dict[str, int],
     el: Diode,
 ) -> None:
-    """Linearized diode: I = Is*(exp(Vd/Vt) - 1).
+    """Linearized diode: I = Is*(exp(Vd/(N*Vt)) - 1).
 
-    Newton: I0 = Is*(exp(Vd0/Vt) - 1), gd = (Is/Vt)*exp(Vd0/Vt).
+    Newton: I0 = Is*(exp(Vd0/(N*Vt)) - 1), gd = (Is/(N*Vt))*exp(Vd0/(N*Vt)).
     Stamp gd as conductance + (gd*Vd0 - I0) as current source from cathode."""
+    vt_eff = _diode_effective_vt(el)
     Va = 0.0 if _is_ground(el.anode) else x[node_to_idx[el.anode]]
     Vk = 0.0 if _is_ground(el.cathode) else x[node_to_idx[el.cathode]]
     Vd = Va - Vk
     # Clamp to avoid exp overflow
-    Vd = min(Vd, 0.7)
-    exp_term = math.exp(Vd / el.Vt)
+    Vd = min(Vd, 0.7 * el.N)
+    exp_term = math.exp(Vd / vt_eff)
     I0 = el.Is * (exp_term - 1.0)
-    gd = (el.Is / el.Vt) * exp_term
+    gd = (el.Is / vt_eff) * exp_term
 
     _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
     Ieq = I0 - gd * Vd
@@ -1697,6 +1705,14 @@ def _stamp_diode(
         b[node_to_idx[el.anode]] -= Ieq
     if not _is_ground(el.cathode):
         b[node_to_idx[el.cathode]] += Ieq
+
+
+def _diode_effective_vt(el: Diode) -> float:
+    if not math.isfinite(el.N) or el.N <= 0.0:
+        raise ValueError(f"{el.name}: diode emission coefficient must be finite and positive")
+    if not math.isfinite(el.Vt) or el.Vt <= 0.0:
+        raise ValueError(f"{el.name}: diode thermal voltage must be finite and positive")
+    return el.Vt * el.N
 
 
 def _stamp_mosfet(
@@ -3841,13 +3857,14 @@ def _stamp_ac(
         b[branch] += 0j
 
     elif isinstance(el, Diode):
-        # Small-signal model: linearised conductance gd = (Is/Vt)·exp(Vd/Vt).
+        # Small-signal model: linearised conductance gd = (Is/(N*Vt))·exp(Vd/(N*Vt)).
         # The dynamic (differential) conductance is the derivative of
-        # I = Is*(exp(Vd/Vt) − 1) with respect to Vd, evaluated at the OP.
+        # I = Is*(exp(Vd/(N*Vt)) − 1) with respect to Vd, evaluated at the OP.
+        vt_eff = _diode_effective_vt(el)
         Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
         Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
-        Vd = min(Va - Vk, 0.7)
-        gd = (el.Is / el.Vt) * math.exp(Vd / el.Vt)
+        Vd = min(Va - Vk, 0.7 * el.N)
+        gd = (el.Is / vt_eff) * math.exp(Vd / vt_eff)
         _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 0j)
 
     elif isinstance(el, JFET):
@@ -4407,11 +4424,12 @@ def _build_ss_matrix(
                         n_nodes + branch_srcs.index(el), ctrl_idx)
 
         elif isinstance(el, Diode):
-            # Small-signal conductance: gd = dI/dVd = (Is/Vt)·exp(Vd/Vt).
+            # Small-signal conductance: gd = dI/dVd = (Is/(N*Vt))·exp(Vd/(N*Vt)).
+            vt_eff = _diode_effective_vt(el)
             Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
             Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
-            Vd = min(Va - Vk, 0.7)
-            gd = (el.Is / el.Vt) * math.exp(Vd / el.Vt)
+            Vd = min(Va - Vk, 0.7 * el.N)
+            gd = (el.Is / vt_eff) * math.exp(Vd / vt_eff)
             _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
 
         elif isinstance(el, JFET):
@@ -5276,7 +5294,7 @@ def sens_dc(
             _make_entry(
                 "Is",
                 el.Is,
-                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt),
+                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N),
             )
 
         elif isinstance(el, BJT):
@@ -5502,7 +5520,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
         )
 
     if isinstance(el, Diode):
-        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt)
+        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N)
 
     if isinstance(el, BJT):
         return BJT(
@@ -5896,7 +5914,7 @@ def _collect_noise_sources(
             Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
             Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
             Vd = Va - Vk  # actual operating-point junction voltage
-            I_D = el.Is * (math.exp(Vd / el.Vt) - 1.0)
+            I_D = el.Is * (math.exp(Vd / _diode_effective_vt(el)) - 1.0)
             psd = q2 * abs(I_D)
             n_a = None if _is_ground(el.anode) else node_to_idx[el.anode]
             n_k = None if _is_ground(el.cathode) else node_to_idx[el.cathode]

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -699,6 +699,23 @@ def test_diode_reverse_bias():
     assert r.converged
 
 
+def test_diode_emission_coefficient_reduces_forward_current():
+    """Larger N uses N*Vt in the exponential and lowers fixed-bias current."""
+    base = Circuit()
+    base.add(VoltageSource("V1", "a", "0", voltage=0.7))
+    base.add(Diode("D1", anode="a", cathode="0", Is=1e-15, Vt=0.02585))
+    base_result = dc_op(base)
+
+    high_n = Circuit()
+    high_n.add(VoltageSource("V1", "a", "0", voltage=0.7))
+    high_n.add(Diode("D1", anode="a", cathode="0", Is=1e-15, Vt=0.02585, N=2.0))
+    high_n_result = dc_op(high_n)
+
+    assert base_result.converged
+    assert high_n_result.converged
+    assert abs(high_n_result.branch_currents["I(V1)"]) < abs(base_result.branch_currents["I(V1)"]) * 1e-3
+
+
 # ---- DC: Capacitor (open in DC) ----
 
 

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
+  and pass them into Python `Diode` elements.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -412,6 +412,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             fields[2],
             Is=model.params.get("IS", 1e-15),
             Vt=model.params.get("VT", 0.02585),
+            N=model.params.get("N", 1.0),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -451,7 +451,7 @@ Rload out 0 500
 def test_parse_diode_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast D(IS=1e-12 VT=25m)
+.model fast D(IS=1e-12 VT=25m N=2)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -460,7 +460,7 @@ Rload out 0 1k
     )
 
     assert parsed.models == {
-        "fast": ModelCard("fast", "D", {"IS": 1.0e-12, "VT": 25.0e-3})
+        "fast": ModelCard("fast", "D", {"IS": 1.0e-12, "VT": 25.0e-3, "N": 2.0})
     }
     diode = parsed.circuit.elements[1]
     assert isinstance(diode, Diode)
@@ -468,10 +468,11 @@ Rload out 0 1k
     assert diode.cathode == "out"
     assert diode.Is == 1.0e-12
     assert diode.Vt == 25.0e-3
+    assert diode.N == 2.0
 
     result = dc_op(parsed.circuit)
     assert result.converged
-    assert 0.1 < result.node_voltages["out"] < 0.7
+    assert 0.0 < result.node_voltages["out"] < 0.7
 
 
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
@@ -789,7 +790,7 @@ Rload out 0 500
 def test_expands_subcircuit_diode_nodes_into_engine_elements() -> None:
     parsed = parse_netlist(
         """
-.model clamp D(IS=1e-12 VT=25m)
+.model clamp D(IS=1e-12 VT=25m N=2)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -803,6 +804,7 @@ Xlim in out limiter
     assert diode.anode == "in"
     assert diode.cathode == "out"
     assert diode.Is == 1.0e-12
+    assert diode.N == 2.0
 
 
 def test_expands_subcircuit_bjt_nodes_into_engine_elements() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add diode emission coefficient support through `emission_coefficient`,
+  scaling the effective thermal voltage in DC and small-signal diode
+  conductance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -291,12 +291,13 @@ fn clone_subckt_element(
             voltage_expr: map_bsource_expr_nodes(&element.voltage_expr, instance_name, node_map),
             current_expr: map_bsource_expr_nodes(&element.current_expr, instance_name, node_map),
         }),
-        Element::Diode(element) => Element::Diode(Diode::with_model(
+        Element::Diode(element) => Element::Diode(Diode::with_model_and_emission_coefficient(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.anode, instance_name, node_map),
             map_subckt_node(&element.cathode, instance_name, node_map),
             element.saturation_current,
             element.thermal_voltage,
+            element.emission_coefficient,
         )),
         Element::Jfet(element) => Element::Jfet(Jfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1078,6 +1079,7 @@ pub struct Diode {
     pub cathode: String,
     pub saturation_current: f64,
     pub thermal_voltage: f64,
+    pub emission_coefficient: f64,
 }
 
 impl Diode {
@@ -1096,12 +1098,31 @@ impl Diode {
         saturation_current: f64,
         thermal_voltage: f64,
     ) -> Self {
+        Self::with_model_and_emission_coefficient(
+            name,
+            anode,
+            cathode,
+            saturation_current,
+            thermal_voltage,
+            1.0,
+        )
+    }
+
+    pub fn with_model_and_emission_coefficient(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+        emission_coefficient: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             anode: anode.into(),
             cathode: cathode.into(),
             saturation_current,
             thermal_voltage,
+            emission_coefficient,
         }
     }
 }
@@ -4625,19 +4646,17 @@ fn build_ac_matrix(
             )?,
             Element::Diode(diode) => {
                 validate_diode(diode)?;
+                let vt_eff = diode_effective_thermal_voltage(diode);
                 let anode = node_index(node_indices, &diode.anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
-                let exponent = (voltage / diode.thermal_voltage).clamp(-40.0, 40.0);
+                let exponent = (voltage / vt_eff).clamp(-40.0, 40.0);
                 stamp_complex_conductance(
                     &mut matrix,
                     anode,
                     cathode,
-                    Complex::new(
-                        diode.saturation_current / diode.thermal_voltage * exponent.exp(),
-                        0.0,
-                    ),
+                    Complex::new(diode.saturation_current / vt_eff * exponent.exp(), 0.0),
                 );
             }
             Element::Jfet(jfet) => {
@@ -4729,16 +4748,17 @@ fn build_small_signal_matrix(
             )?,
             Element::Diode(diode) => {
                 validate_diode(diode)?;
+                let vt_eff = diode_effective_thermal_voltage(diode);
                 let anode = node_index(node_indices, &diode.anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
-                let exponent = (voltage / diode.thermal_voltage).clamp(-40.0, 40.0);
+                let exponent = (voltage / vt_eff).clamp(-40.0, 40.0);
                 stamp_conductance(
                     &mut matrix,
                     anode,
                     cathode,
-                    diode.saturation_current / diode.thermal_voltage * exponent.exp(),
+                    diode.saturation_current / vt_eff * exponent.exp(),
                 );
             }
             Element::Jfet(jfet) => {
@@ -5278,10 +5298,11 @@ fn stamp_diode(
     let cathode = node_index(node_indices, &diode.cathode);
     let voltage = anode.map_or(0.0, |index| operating_point[index])
         - cathode.map_or(0.0, |index| operating_point[index]);
-    let exponent = (voltage / diode.thermal_voltage).clamp(-40.0, 40.0);
+    let vt_eff = diode_effective_thermal_voltage(diode);
+    let exponent = (voltage / vt_eff).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
     let current = diode.saturation_current * (exp_value - 1.0);
-    let conductance = diode.saturation_current / diode.thermal_voltage * exp_value;
+    let conductance = diode.saturation_current / vt_eff * exp_value;
     let equivalent_current = current - conductance * voltage;
 
     stamp_conductance(matrix, anode, cathode, conductance);
@@ -5742,6 +5763,10 @@ fn validate_reactive_elements(circuit: &Circuit) -> Result<(), SpiceError> {
     Ok(())
 }
 
+fn diode_effective_thermal_voltage(diode: &Diode) -> f64 {
+    diode.thermal_voltage * diode.emission_coefficient
+}
+
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -5753,6 +5778,12 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "thermal voltage must be finite and positive".to_string(),
+        });
+    }
+    if !diode.emission_coefficient.is_finite() || diode.emission_coefficient <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "emission coefficient must be finite and positive".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -279,6 +279,32 @@ fn dc_diode_solves_forward_biased_operating_point() {
 }
 
 #[test]
+fn dc_diode_emission_coefficient_reduces_fixed_bias_current() {
+    let mut base = Circuit::new();
+    base.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "a", "0", 0.7,
+    )));
+    base.add(Element::Diode(Diode::with_model(
+        "D1", "a", "0", 1.0e-15, 0.02585,
+    )));
+
+    let mut high_n = Circuit::new();
+    high_n.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "a", "0", 0.7,
+    )));
+    high_n.add(Element::Diode(Diode::with_model_and_emission_coefficient(
+        "D1", "a", "0", 1.0e-15, 0.02585, 2.0,
+    )));
+
+    let base_result = dc_op(&base).unwrap();
+    let high_n_result = dc_op(&high_n).unwrap();
+    assert!(
+        high_n_result.branch_current("V1").unwrap().abs()
+            < base_result.branch_current("V1").unwrap().abs() * 1.0e-3
+    );
+}
+
+#[test]
 fn dc_bjt_solves_npn_emitter_follower_operating_point() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
+  and pass them into Rust `Diode` elements.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -727,12 +727,13 @@ fn parse_element(
                     model.name, model.kind
                 )));
             }
-            Ok(Element::Diode(Diode::with_model(
+            Ok(Element::Diode(Diode::with_model_and_emission_coefficient(
                 name,
                 &fields[1],
                 &fields[2],
                 *model.params.get("IS").unwrap_or(&1.0e-15),
                 *model.params.get("VT").unwrap_or(&0.02585),
+                *model.params.get("N").unwrap_or(&1.0),
             )))
         }
         'Q' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -645,7 +645,7 @@ Rload out 0 500
 fn parses_diode_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast D(IS=1e-12 VT=25m)
+.model fast D(IS=1e-12 VT=25m N=2)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -659,6 +659,7 @@ Rload out 0 1k
     assert_eq!(model.kind, "D");
     assert_close(*model.params.get("IS").unwrap(), 1.0e-12);
     assert_close(*model.params.get("VT").unwrap(), 25.0e-3);
+    assert_close(*model.params.get("N").unwrap(), 2.0);
 
     let Element::Diode(diode) = &parsed.circuit.elements()[1] else {
         panic!("expected diode");
@@ -668,10 +669,11 @@ Rload out 0 1k
     assert_eq!(diode.cathode, "out");
     assert_close(diode.saturation_current, 1.0e-12);
     assert_close(diode.thermal_voltage, 25.0e-3);
+    assert_close(diode.emission_coefficient, 2.0);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();
-    assert!(out > 0.1, "expected forward-biased output, got {out}");
+    assert!(out > 0.0, "expected forward-biased output, got {out}");
     assert!(out < 0.7, "expected diode drop below source, got {out}");
 }
 
@@ -1033,7 +1035,7 @@ Rload out 0 500
 fn expands_subcircuit_diode_nodes_into_engine_elements() {
     let parsed = parse_netlist(
         r#"
-.model clamp D(IS=1e-12 VT=25m)
+.model clamp D(IS=1e-12 VT=25m N=2)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -1048,6 +1050,7 @@ Xlim in out limiter
     assert_eq!(diode.name, "Xlim.Dlim");
     assert_eq!(diode.anode, "in");
     assert_eq!(diode.cathode, "out");
+    assert_close(diode.emission_coefficient, 2.0);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add diode emission coefficient support through `emissionCoefficient`, scaling
+  the effective thermal voltage in DC and small-signal diode conductance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -359,6 +359,7 @@ export interface Diode {
   readonly cathode: string;
   readonly saturationCurrent: number;
   readonly thermalVoltage: number;
+  readonly emissionCoefficient: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -945,7 +946,7 @@ function cloneSubcktElement(
     case "b-source":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap), voltageExpr: mapBSourceExprNodes(element.voltageExpr, instanceName, nodeMap), currentExpr: mapBSourceExprNodes(element.currentExpr, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
@@ -1194,6 +1195,7 @@ export function diode(
   cathode: string,
   saturationCurrent = 1.0e-15,
   thermalVoltage = 0.02585,
+  emissionCoefficient = 1.0,
 ): Diode {
   return {
     kind: "diode",
@@ -1202,6 +1204,7 @@ export function diode(
     cathode,
     saturationCurrent,
     thermalVoltage,
+    emissionCoefficient,
   };
 }
 
@@ -3734,7 +3737,7 @@ function buildSmallSignalMatrix(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          element.saturationCurrent / element.thermalVoltage,
+          element.saturationCurrent / diodeEffectiveThermalVoltage(element),
         );
         break;
       case "jfet":
@@ -3904,7 +3907,7 @@ function buildAcMatrix(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          complex(element.saturationCurrent / element.thermalVoltage, 0.0),
+          complex(element.saturationCurrent / diodeEffectiveThermalVoltage(element), 0.0),
         );
         break;
       case "jfet":
@@ -4521,10 +4524,11 @@ function stampDiode(
   const voltage =
     (anode === undefined ? 0.0 : operatingPoint[anode]) -
     (cathode === undefined ? 0.0 : operatingPoint[cathode]);
-  const exponent = Math.max(-40.0, Math.min(40.0, voltage / element.thermalVoltage));
+  const vtEff = diodeEffectiveThermalVoltage(element);
+  const exponent = Math.max(-40.0, Math.min(40.0, voltage / vtEff));
   const expValue = Math.exp(exponent);
   const current = element.saturationCurrent * (expValue - 1.0);
-  const conductance = element.saturationCurrent / element.thermalVoltage * expValue;
+  const conductance = element.saturationCurrent / vtEff * expValue;
   const equivalentCurrent = current - conductance * voltage;
 
   stampConductance(matrix, anode, cathode, conductance);
@@ -4806,6 +4810,13 @@ function validateDiode(element: Diode): void {
   if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
     throw invalidElement(element.name, "thermal voltage must be finite and positive");
   }
+  if (!Number.isFinite(element.emissionCoefficient) || element.emissionCoefficient <= 0.0) {
+    throw invalidElement(element.name, "emission coefficient must be finite and positive");
+  }
+}
+
+function diodeEffectiveThermalVoltage(element: Diode): number {
+  return element.thermalVoltage * element.emissionCoefficient;
 }
 
 function validateBjt(element: Bjt): void {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -230,6 +230,25 @@ describe("dcOp", () => {
     expect(result.voltage("out")).toBeLessThan(0.7);
   });
 
+  it("uses diode emission coefficient in fixed-bias current", () => {
+    const base = new Circuit();
+    base.add(voltageSource("V1", "a", "0", 0.7));
+    base.add(diode("D1", "a", "0", 1.0e-15, 0.02585));
+
+    const highN = new Circuit();
+    highN.add(voltageSource("V1", "a", "0", 0.7));
+    highN.add(diode("D1", "a", "0", 1.0e-15, 0.02585, 2.0));
+
+    const baseResult = dcOp(base);
+    const highNResult = dcOp(highN);
+
+    expect(highNResult.branchCurrent("V1")).toBeDefined();
+    expect(baseResult.branchCurrent("V1")).toBeDefined();
+    expect(Math.abs(highNResult.branchCurrent("V1")!)).toBeLessThan(
+      Math.abs(baseResult.branchCurrent("V1")!) * 1.0e-3,
+    );
+  });
+
   it("solves an NPN BJT operating point", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
+  and pass them into TypeScript `diode` elements.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -567,6 +567,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       fields[2],
       model.params.get("IS") ?? 1.0e-15,
       model.params.get("VT") ?? 0.02585,
+      model.params.get("N") ?? 1.0,
     );
   }
   if (prefix === "Q") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -421,7 +421,7 @@ Rload out 0 500
 
   it("parses diode models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast D(IS=1e-12 VT=25m)
+.model fast D(IS=1e-12 VT=25m N=2)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -434,6 +434,7 @@ Rload out 0 1k
       params: new Map([
         ["IS", 1.0e-12],
         ["VT", 25.0e-3],
+        ["N", 2.0],
       ]),
     });
     expect(parsed.circuit.elements()[1]).toMatchObject({
@@ -443,10 +444,11 @@ Rload out 0 1k
       cathode: "out",
       saturationCurrent: 1.0e-12,
       thermalVoltage: 25.0e-3,
+      emissionCoefficient: 2.0,
     });
 
     const result = dcOp(parsed.circuit);
-    expect(result.voltage("out")).toBeGreaterThan(0.1);
+    expect(result.voltage("out")).toBeGreaterThan(0.0);
     expect(result.voltage("out")).toBeLessThan(0.7);
   });
 
@@ -747,7 +749,7 @@ Rload out 0 500
 
   it("expands subcircuit diode nodes into engine elements", () => {
     const parsed = parseNetlist(`
-.model clamp D(IS=1e-12 VT=25m)
+.model clamp D(IS=1e-12 VT=25m N=2)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -759,6 +761,7 @@ Xlim in out limiter
       name: "Xlim.Dlim",
       anode: "in",
       cathode: "out",
+      emissionCoefficient: 2.0,
     });
   });
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -195,6 +195,13 @@ Acceptance:
 - DC/AC/transient fixtures that prove capacitance and temperature parameters
   change results in expected directions.
 
+Status:
+
+- Diode `.model ... D(... N=<emission coefficient>)` parsing and engine
+  plumbing are implemented across Python, TypeScript, and Rust. DC and
+  small-signal AC diode conductance now use `N * Vt`, with subcircuit remapping
+  preserving the parameter.
+
 ### Phase 7 - Classic Text Output and Control Cards
 
 Make deck-level output feel like SPICE rather than only package APIs.


### PR DESCRIPTION
## Summary

- add diode emission coefficient (`N`) fields across Python, TypeScript, and Rust engines
- parse `.model ... D(... N=<n>)` into diode elements across all netlist parsers
- document the Phase 6 model-card foothold and add cross-language DC/parser tests

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-emission-model PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-emission-model PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `cargo test -p spice-engine -p spice-netlist-parser`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `git diff --check`