### PR TITLE
feat(visicalc): light .msl companions for FormulaBar + Grid (VC1.5)

### DIFF
--- a/demo/visicalc/mosaic/FormulaBar.light.msl
+++ b/demo/visicalc/mosaic/FormulaBar.light.msl
@@ -1,0 +1,55 @@
+// FormulaBar.light.msl — light theme for the formula bar (VC1.5).
+//
+// Companion to FormulaBar.dark.msl. Identical structure (same parts,
+// same property keys), only the colour palette inverts to match a
+// light system theme — the default on iOS, macOS (when system theme
+// is light), Windows in light mode, and most desktop browsers
+// before `prefers-color-scheme: dark` flipped the bias.
+//
+// Palette mapping rationale (dark → light):
+//
+//   #252526 toolbar background    → #f3f3f3 (system chrome grey)
+//   #2d2d30 address-label bg      → #e7e7e7 (slight contrast vs bar)
+//   #9d9d9d address-label fg      → #555555 (darker for legibility on light bg)
+//   #3f3f46 borders               → #c8c8c8 (subtle dividers on light)
+//   #cccccc input fg              → #1f1f1f (near-black for primary text)
+//
+// Border-bottom thickness + paddings + font-sizes stay the same —
+// the only axis that changes is colour. This keeps the layout shape
+// (the .mll) coupled-to-zero theme-axis decisions.
+
+style FormulaBar {
+  part bar {
+    background:          #f3f3f3 ;
+    padding:             4px ;
+    border-bottom-width: 1px ;
+    border-bottom-style: solid ;
+    border-bottom-color: #c8c8c8 ;
+  }
+
+  part address-label {
+    font-family:  monospace ;
+    font-size:    12px ;
+    color:        #555555 ;
+    background:   #e7e7e7 ;
+    min-width:    48px ;
+    padding:      4px ;
+    text-align:   right ;
+    margin-right: 8px ;
+  }
+
+  part formula-field {
+    font-family:         monospace ;
+    font-size:           13px ;
+    flex:                1 ;
+    border-style:        none ;
+    border-bottom-width: 1px ;
+    border-bottom-style: solid ;
+    border-bottom-color: #c8c8c8 ;
+    background:          transparent ;
+    color:               #1f1f1f ;
+    padding:             4px ;
+    outline:             none ;
+    width:               100% ;
+  }
+}

--- a/demo/visicalc/mosaic/Grid.light.msl
+++ b/demo/visicalc/mosaic/Grid.light.msl
@@ -1,0 +1,85 @@
+// Grid.light.msl — light theme for the spreadsheet grid (VC1.5).
+//
+// Companion to Grid.dark.msl. Identical structure — same sub-parts
+// (sheet, sheet/cell, sheet/header-cell, sheet/header-row,
+// sheet/data-row), same state blocks (selected, editing, even,
+// odd) — only the palette flips for a light system theme.
+//
+// Palette mapping rationale (dark → light):
+//
+//   #1e1e1e sheet bg              → #ffffff (paper white)
+//   #cccccc text                  → #1f1f1f (near-black)
+//   #3f3f46 gridlines             → #c8c8c8 (low-contrast on light bg)
+//   #2d2d30 header bg             → #f3f3f3 (light grey for chrome)
+//   #9d9d9d header fg             → #555555 (mid-grey for column labels)
+//   #264f78 selected bg           → #cce5ff (excel-blue, light variant)
+//   #ffffff selected fg           → #000000 (high contrast on light bg)
+//   #007acc selected outline      → #007acc (kept — accent colour reads on both themes)
+//   #1f4f3f editing bg            → #ccf4d9 (light mint, editing affordance)
+//   #252526 odd-row banding       → #f7f7f7 (subtle zebra-stripe)
+//
+// As with FormulaBar.light.msl, only colours change — the dark and
+// light variants share an identical part vocabulary and identical
+// state-block layout so the host can swap themes without re-running
+// the layout pipeline.
+
+style Grid {
+  part sheet {
+    font-family:     monospace ;
+    font-size:       12px ;
+    color:           #1f1f1f ;
+    background:      #ffffff ;
+    border-collapse: collapse ;
+    width:           100% ;
+  }
+
+  // Body cells. The `border-*` triplet draws the gridlines.
+  part sheet/cell {
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #c8c8c8 ;
+    padding:      2px ;
+    height:       22px ;
+
+    // Active-cell highlight. Excel-blue tuned for a light theme.
+    state selected {
+      background: #cce5ff ;
+      color:      #000000 ;
+      outline:    1px solid #007acc ;
+    }
+
+    // In-progress edit highlight. Light mint band so the editing
+    // affordance reads against #cce5ff (selected) without colliding.
+    state editing {
+      background: #ccf4d9 ;
+      outline:    1px solid #007acc ;
+    }
+  }
+
+  // Column-header cells.
+  part sheet/header-cell {
+    background:  #f3f3f3 ;
+    color:       #555555 ;
+    font-weight: normal ;
+    text-align:  center ;
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #c8c8c8 ;
+  }
+
+  part sheet/header-row {
+    height: 24px ;
+  }
+
+  // Body data rows: alternating zebra-stripe on light tones.
+  part sheet/data-row {
+    height: 22px ;
+
+    state even {
+      background: #ffffff ;
+    }
+    state odd {
+      background: #f7f7f7 ;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes plan item [E] in the UI30/VisiCalc cycle. Adds light-theme \`.msl\` variants for FormulaBar + Grid so hosts on light-default platforms (iOS, macOS in light, WinUI in light, browsers without \`prefers-color-scheme: dark\`) render with sensible chrome.

Each light file is a 1:1 structural mirror of its \`.dark.msl\` sibling — same parts, same state blocks, same property keys. Only the palette inverts:

| dark | light | use |
|---|---|---|
| \`#1e1e1e\` | \`#ffffff\` | sheet background |
| \`#cccccc\` | \`#1f1f1f\` | primary text |
| \`#3f3f46\` | \`#c8c8c8\` | gridlines / borders |
| \`#264f78\` | \`#cce5ff\` | selected cell bg (excel-blue) |
| \`#1f4f3f\` | \`#ccf4d9\` | editing cell bg (light mint) |
| \`#007acc\` | \`#007acc\` | accent outline (kept) |

The layout (\`.mll\`) is unchanged — themes are orthogonal to layouts. A backend with light-default chrome can now pair light \`.msl\` with desktop \`.mll\`, and a touch host (via UI30 ML2) can combine light + touch in the same way.

## Test plan

- [x] \`mosaic-compile --style FormulaBar.light.msl\` produces valid .tsx
- [x] \`mosaic-compile --style Grid.light.msl\` produces valid .tsx
- [x] Generated .tsx confirms light palette ends up in inline \`style\` props
- [x] Both files are pure colour swaps — structure (parts + state blocks) matches dark exactly
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)