### PR TITLE
feat(sql): implement PRAGMA foreign_key_check

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.98.0] - 2026-05-23
+
+### Added
+
+- ``PRAGMA foreign_key_check`` is now implemented.  Walks every (or
+  one named) child table and reports one row per FK violation::
+
+      table   TEXT    — child table holding the bad row
+      rowid   INTEGER — the bad row's rowid
+      parent  TEXT    — referenced parent table
+      fkid    INTEGER — 0-based FK position (matches
+                        ``foreign_key_list.id``)
+
+  NULL child FK values pass unconditionally (SQL standard).  When the
+  ``REFERENCES`` clause omits a parent column, the parent's first
+  PRIMARY KEY column is used — matches the existing INSERT-time FK
+  validation.  ``foreign_key_check(<table>)`` restricts the scan to
+  one child table.
+- ``foreign_key_check`` added to ``PRAGMA pragma_list``.
+
 ## [1.97.0] - 2026-05-23
 
 ### Changed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.97.0"
+version = "1.98.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -683,6 +683,43 @@ def _run_explain_query_plan(
 # ---------------------------------------------------------------------------
 
 
+def _fk_find_pk(table: str, backend: Backend) -> str:
+    """Return the PRIMARY KEY column name for *table*, falling back to ``'id'``.
+
+    Used by ``PRAGMA foreign_key_check`` when a ``REFERENCES`` clause
+    omits the parent column (``REFERENCES p`` instead of
+    ``REFERENCES p(col)``).  Same algorithm sql-vm uses internally.
+    """
+    try:
+        cols = backend.columns(table)
+    except Exception:  # noqa: BLE001 — parent table missing → conventional fallback
+        return "id"
+    for c in cols:
+        if getattr(c, "primary_key", False):
+            return c.name
+    return "id"
+
+
+def _fk_row_exists(
+    table: str, col: str, value: object, backend: Backend
+) -> bool:
+    """Return True if any row in *table* has *col* == *value*.
+
+    Walks the table linearly via ``backend.scan`` — fine for diagnostic
+    PRAGMAs but ``O(N*M)`` for the full ``foreign_key_check`` sweep.
+    """
+    try:
+        cur = backend.scan(table)
+    except Exception:  # noqa: BLE001 — parent table missing → every row is a violation
+        return False
+    while True:
+        row = cur.next()
+        if row is None:
+            return False
+        if row.get(col) == value:
+            return True
+
+
 def _format_pragma_default(value: object) -> str:
     """Render a column's stored default value as the SQL-literal text that
     ``PRAGMA table_info.dflt_value`` reports.
@@ -958,6 +995,66 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
             rows=tuple(fk_rows),
         )
 
+    if name == "foreign_key_check":
+        # SQLite: scan every (or one named) child table; for each row,
+        # for each declared FOREIGN KEY, verify the referenced parent
+        # row exists.  Returns one row per violation::
+        #
+        #   table   TEXT    — the child table where the bad row lives
+        #   rowid   INTEGER — the bad row's rowid
+        #   parent  TEXT    — the referenced parent table
+        #   fkid    INTEGER — the FK's position in foreign_key_list (0-based)
+        #
+        # Rules:
+        #   * NULL child values pass unconditionally (SQL "unknown
+        #     reference is not an error" rule).
+        #   * If no ``parent_col`` was declared (i.e. ``REFERENCES p``),
+        #     resolve to the parent's first PRIMARY KEY column.
+        #   * If the parent table is missing, every non-NULL child row
+        #     is a violation.
+        viol_rows: list[tuple] = []
+        if fk_child:
+            # Optional table-name filter: ``PRAGMA foreign_key_check(t)``
+            # restricts scanning to one child table.
+            table_filter = arg or None
+            for child_table, fks in fk_child.items():
+                if table_filter and child_table != table_filter:
+                    continue
+                try:
+                    parent_pk_cache: dict[str, str] = {}
+                    cur = backend.scan(child_table)
+                except Exception:  # noqa: BLE001 — table missing → skip
+                    continue
+                while True:
+                    row = cur.next()
+                    if row is None:
+                        break
+                    rowid = getattr(cur, "rowid", lambda: None)()
+                    for fk_id, (child_col, parent_table, parent_col) in enumerate(fks):
+                        value = row.get(child_col)
+                        if value is None:
+                            continue
+                        # Resolve target column (cached per parent table
+                        # to avoid repeated PK lookups).
+                        if parent_col is None:
+                            if parent_table not in parent_pk_cache:
+                                parent_pk_cache[parent_table] = _fk_find_pk(
+                                    parent_table, backend
+                                )
+                            ref_col = parent_pk_cache[parent_table]
+                        else:
+                            ref_col = parent_col
+                        if not _fk_row_exists(
+                            parent_table, ref_col, value, backend
+                        ):
+                            viol_rows.append(
+                                (child_table, rowid, parent_table, fk_id)
+                            )
+        return QueryResult(
+            columns=("table", "rowid", "parent", "fkid"),
+            rows=tuple(viol_rows),
+        )
+
     if name == "table_list":
         tables = backend.tables()
         return QueryResult(
@@ -1077,6 +1174,7 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
             "compile_options",
             "data_version",
             "database_list",
+            "foreign_key_check",
             "foreign_key_list",
             "function_list",
             "index_info",

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_foreign_key_check.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_foreign_key_check.py
@@ -1,0 +1,167 @@
+"""Tests for ``PRAGMA foreign_key_check``.
+
+SQLite's ``PRAGMA foreign_key_check`` walks every (or one named) child
+table and reports one row per FK violation::
+
+    table   TEXT    — child table holding the bad row
+    rowid   INTEGER — the bad row's rowid
+    parent  TEXT    — referenced parent table
+    fkid    INTEGER — 0-based FK position (matches ``foreign_key_list.id``)
+
+The pragma is read-only and produces no error even when used on tables
+with no FK declarations.  ORMs and migration tools call it to validate
+schema integrity after disabling FK enforcement (``PRAGMA foreign_keys
+= OFF``) for bulk operations.
+
+Mini-sqlite enforces FKs unconditionally on INSERT (a known deviation
+from SQLite, which defaults to OFF), so producing violations through
+normal SQL is impossible.  These tests use the backend's row-list
+directly to inject violations, then verify the pragma surfaces them
+correctly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+_ROWID_KEY = "\x00rowid"
+
+
+def _inject_orphan(conn, table: str, row: dict) -> None:
+    """Bypass FK enforcement and append a row directly to the backend.
+
+    Used to construct violations the engine wouldn't otherwise let
+    happen — necessary because mini-sqlite enforces FKs at INSERT
+    time and won't accept an orphan child via normal SQL.
+    """
+    stamped = dict(row)
+    stamped.setdefault(_ROWID_KEY, row.get("id", 1))
+    conn._backend._tables[table].rows.append(stamped)  # noqa: SLF001
+
+
+class TestEmptyCases:
+    """Clean schemas return zero rows."""
+
+    def test_no_tables(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        assert mini.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    def test_no_fks(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE t (x INT)")
+        mini.execute("INSERT INTO t VALUES (1), (2)")
+        assert mini.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    def test_fks_satisfied(self) -> None:
+        # Oracle: real sqlite3 returns [] too when every child has a parent.
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+            c.execute(
+                "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+                "p_id INTEGER REFERENCES p(id))"
+            )
+            c.execute("INSERT INTO p VALUES (1), (2)")
+            c.execute("INSERT INTO c VALUES (1, 1), (2, 2)")
+        q = "PRAGMA foreign_key_check"
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall() == []
+
+
+class TestViolations:
+    """Injected orphans surface as violation rows."""
+
+    def test_single_violation(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+        mini.execute(
+            "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        mini.execute("INSERT INTO p VALUES (1)")
+        _inject_orphan(mini, "c", {"id": 99, "p_id": 999})
+        assert mini.execute("PRAGMA foreign_key_check").fetchall() \
+            == [("c", 99, "p", 0)]
+
+    def test_oracle_match(self) -> None:
+        # Same scenario in real sqlite3 (FK off by default → orphan
+        # accepted) — verify the violation row matches mini-sqlite's.
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+            c.execute(
+                "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+                "p_id INTEGER REFERENCES p(id))"
+            )
+            c.execute("INSERT INTO p VALUES (1)")
+        _inject_orphan(mini, "c", {"id": 99, "p_id": 999})
+        ref.execute("INSERT INTO c VALUES (99, 999)")
+        q = "PRAGMA foreign_key_check"
+        assert mini.execute(q).fetchall() == ref.execute(q).fetchall()
+
+    def test_multiple_violations(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+        mini.execute(
+            "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        _inject_orphan(mini, "c", {"id": 1, "p_id": 100})
+        _inject_orphan(mini, "c", {"id": 2, "p_id": 200})
+        _inject_orphan(mini, "c", {"id": 3, "p_id": 300})
+        rows = mini.execute("PRAGMA foreign_key_check").fetchall()
+        # Three violations, all in 'c' referencing 'p'.
+        assert len(rows) == 3
+        assert all(r[0] == "c" and r[2] == "p" and r[3] == 0 for r in rows)
+
+
+class TestNullValuePassesUnconditionally:
+    """NULL child FK values are not violations (SQL standard)."""
+
+    def test_null_value_skipped(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+        mini.execute(
+            "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        _inject_orphan(mini, "c", {"id": 7, "p_id": None})
+        assert mini.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+class TestTableFilter:
+    """``PRAGMA foreign_key_check(<table>)`` restricts the scan."""
+
+    def test_filter_to_violating_table(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+        mini.execute(
+            "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        _inject_orphan(mini, "c", {"id": 5, "p_id": 50})
+        assert mini.execute("PRAGMA foreign_key_check(c)").fetchall() \
+            == [("c", 5, "p", 0)]
+
+    def test_filter_to_unrelated_table_returns_empty(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        mini.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")
+        mini.execute(
+            "CREATE TABLE c(id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        _inject_orphan(mini, "c", {"id": 5, "p_id": 50})
+        # p has no FK declarations, so filtering to p sees no violations.
+        assert mini.execute("PRAGMA foreign_key_check(p)").fetchall() == []
+
+
+class TestListed:
+    """``foreign_key_check`` appears in PRAGMA pragma_list."""
+
+    def test_in_pragma_list(self) -> None:
+        mini = mini_sqlite.connect(":memory:")
+        names = {r[0] for r in mini.execute("PRAGMA pragma_list").fetchall()}
+        assert "foreign_key_check" in names


### PR DESCRIPTION
## Summary

ORMs and migration tools call ``PRAGMA foreign_key_check`` to validate schema integrity. Mini-sqlite previously returned empty. This adds the handler — walks the fk_child registry, scans each child table, reports one row per violation:

```
table   TEXT    — child table holding the bad row
rowid   INTEGER — the bad row's rowid
parent  TEXT    — referenced parent table
fkid    INTEGER — 0-based FK position (matches foreign_key_list.id)
```

NULL child FK values pass unconditionally (SQL standard). ``PRAGMA foreign_key_check(<table>)`` restricts to one child table. Added to ``PRAGMA pragma_list``.

## Test plan

- [x] mini-sqlite: 2204 tests, 90.93% coverage (10 new oracle tests covering empty cases, single/multiple violations, NULL pass-through, table filter, pragma_list discovery)
- [x] Other packages: regression-only, no failures
- [x] ruff clean
- [x] /security-review passed

Version: mini-sqlite 1.97 → 1.98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)