### PR TITLE
spice: add diode breakdown model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **Diode emission coefficient models** — `Diode.N` now scales the effective
   thermal voltage in DC and small-signal diode conductance calculations.
 
+- **Diode breakdown models** — `Diode.BV` / `Diode.IBV` now add a bounded
+  reverse-breakdown current and conductance foothold.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -422,6 +422,8 @@ class Diode:
     Is: float = 1e-15  # saturation current
     Vt: float = 0.02585  # thermal voltage
     N: float = 1.0  # emission coefficient
+    BV: float | None = None  # reverse breakdown voltage
+    IBV: float = 1e-3  # reverse current at breakdown voltage
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -251,6 +251,8 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
             element.Is,
             element.Vt,
             element.N,
+            element.BV,
+            element.IBV,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_)
@@ -1689,15 +1691,12 @@ def _stamp_diode(
 
     Newton: I0 = Is*(exp(Vd0/(N*Vt)) - 1), gd = (Is/(N*Vt))*exp(Vd0/(N*Vt)).
     Stamp gd as conductance + (gd*Vd0 - I0) as current source from cathode."""
-    vt_eff = _diode_effective_vt(el)
     Va = 0.0 if _is_ground(el.anode) else x[node_to_idx[el.anode]]
     Vk = 0.0 if _is_ground(el.cathode) else x[node_to_idx[el.cathode]]
     Vd = Va - Vk
     # Clamp to avoid exp overflow
     Vd = min(Vd, 0.7 * el.N)
-    exp_term = math.exp(Vd / vt_eff)
-    I0 = el.Is * (exp_term - 1.0)
-    gd = (el.Is / vt_eff) * exp_term
+    I0, gd = _diode_current_conductance(el, Vd)
 
     _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
     Ieq = I0 - gd * Vd
@@ -1712,7 +1711,24 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(f"{el.name}: diode emission coefficient must be finite and positive")
     if not math.isfinite(el.Vt) or el.Vt <= 0.0:
         raise ValueError(f"{el.name}: diode thermal voltage must be finite and positive")
+    if el.BV is not None and (not math.isfinite(el.BV) or el.BV <= 0.0):
+        raise ValueError(f"{el.name}: diode breakdown voltage must be finite and positive")
+    if not math.isfinite(el.IBV) or el.IBV <= 0.0:
+        raise ValueError(f"{el.name}: diode breakdown current must be finite and positive")
     return el.Vt * el.N
+
+
+def _diode_current_conductance(el: Diode, vd: float, *, clamp_forward: bool = True) -> tuple[float, float]:
+    vt_eff = _diode_effective_vt(el)
+    forward_vd = min(vd, 0.7 * el.N) if clamp_forward else vd
+    exp_term = math.exp(max(-40.0, min(40.0, forward_vd / vt_eff)))
+    current = el.Is * (exp_term - 1.0)
+    conductance = (el.Is / vt_eff) * exp_term
+    if el.BV is not None and vd <= -el.BV:
+        breakdown_exp = math.exp(max(-40.0, min(40.0, ((-vd) - el.BV) / vt_eff)))
+        current -= el.IBV * breakdown_exp
+        conductance += (el.IBV / vt_eff) * breakdown_exp
+    return current, conductance
 
 
 def _stamp_mosfet(
@@ -3860,11 +3876,10 @@ def _stamp_ac(
         # Small-signal model: linearised conductance gd = (Is/(N*Vt))·exp(Vd/(N*Vt)).
         # The dynamic (differential) conductance is the derivative of
         # I = Is*(exp(Vd/(N*Vt)) − 1) with respect to Vd, evaluated at the OP.
-        vt_eff = _diode_effective_vt(el)
         Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
         Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
-        Vd = min(Va - Vk, 0.7 * el.N)
-        gd = (el.Is / vt_eff) * math.exp(Vd / vt_eff)
+        Vd = Va - Vk
+        _, gd = _diode_current_conductance(el, Vd)
         _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 0j)
 
     elif isinstance(el, JFET):
@@ -4425,11 +4440,10 @@ def _build_ss_matrix(
 
         elif isinstance(el, Diode):
             # Small-signal conductance: gd = dI/dVd = (Is/(N*Vt))·exp(Vd/(N*Vt)).
-            vt_eff = _diode_effective_vt(el)
             Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
             Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
-            Vd = min(Va - Vk, 0.7 * el.N)
-            gd = (el.Is / vt_eff) * math.exp(Vd / vt_eff)
+            Vd = Va - Vk
+            _, gd = _diode_current_conductance(el, Vd)
             _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
 
         elif isinstance(el, JFET):
@@ -5294,7 +5308,7 @@ def sens_dc(
             _make_entry(
                 "Is",
                 el.Is,
-                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N),
+                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N, el.BV, el.IBV),
             )
 
         elif isinstance(el, BJT):
@@ -5520,7 +5534,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
         )
 
     if isinstance(el, Diode):
-        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N)
+        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N, el.BV, el.IBV)
 
     if isinstance(el, BJT):
         return BJT(
@@ -5914,7 +5928,7 @@ def _collect_noise_sources(
             Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
             Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
             Vd = Va - Vk  # actual operating-point junction voltage
-            I_D = el.Is * (math.exp(Vd / _diode_effective_vt(el)) - 1.0)
+            I_D, _ = _diode_current_conductance(el, Vd, clamp_forward=False)
             psd = q2 * abs(I_D)
             n_a = None if _is_ground(el.anode) else node_to_idx[el.anode]
             n_k = None if _is_ground(el.cathode) else node_to_idx[el.cathode]

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -716,6 +716,24 @@ def test_diode_emission_coefficient_reduces_forward_current():
     assert abs(high_n_result.branch_currents["I(V1)"]) < abs(base_result.branch_currents["I(V1)"]) * 1e-3
 
 
+def test_diode_breakdown_voltage_increases_reverse_current():
+    """BV/IBV adds a bounded reverse-breakdown current branch."""
+    leakage = Circuit()
+    leakage.add(VoltageSource("V1", "0", "a", voltage=5.0))
+    leakage.add(Diode("D1", anode="a", cathode="0", Is=1e-15, Vt=0.02585))
+    leakage_result = dc_op(leakage)
+
+    breakdown = Circuit()
+    breakdown.add(VoltageSource("V1", "0", "a", voltage=5.0))
+    breakdown.add(Diode("D1", anode="a", cathode="0", Is=1e-15, Vt=0.02585, BV=5.0, IBV=1e-6))
+    breakdown_result = dc_op(breakdown)
+
+    assert leakage_result.converged
+    assert breakdown_result.converged
+    assert abs(breakdown_result.branch_currents["I(V1)"]) > 1e6 * abs(leakage_result.branch_currents["I(V1)"])
+    assert abs(breakdown_result.branch_currents["I(V1)"]) == pytest.approx(1e-6, rel=1e-3)
+
+
 # ---- DC: Capacitor (open in DC) ----
 
 

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
   and pass them into Python `Diode` elements.
+- Parse diode model-card reverse-breakdown parameters with
+  `.model ... D(... BV=<v> IBV=<i>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -413,6 +413,8 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Is=model.params.get("IS", 1e-15),
             Vt=model.params.get("VT", 0.02585),
             N=model.params.get("N", 1.0),
+            BV=model.params.get("BV"),
+            IBV=model.params.get("IBV", 1e-3),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -451,7 +451,7 @@ Rload out 0 500
 def test_parse_diode_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast D(IS=1e-12 VT=25m N=2)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -460,7 +460,7 @@ Rload out 0 1k
     )
 
     assert parsed.models == {
-        "fast": ModelCard("fast", "D", {"IS": 1.0e-12, "VT": 25.0e-3, "N": 2.0})
+        "fast": ModelCard("fast", "D", {"IS": 1.0e-12, "VT": 25.0e-3, "N": 2.0, "BV": 5.0, "IBV": 1.0e-6})
     }
     diode = parsed.circuit.elements[1]
     assert isinstance(diode, Diode)
@@ -469,6 +469,8 @@ Rload out 0 1k
     assert diode.Is == 1.0e-12
     assert diode.Vt == 25.0e-3
     assert diode.N == 2.0
+    assert diode.BV == 5.0
+    assert diode.IBV == 1.0e-6
 
     result = dc_op(parsed.circuit)
     assert result.converged
@@ -790,7 +792,7 @@ Rload out 0 500
 def test_expands_subcircuit_diode_nodes_into_engine_elements() -> None:
     parsed = parse_netlist(
         """
-.model clamp D(IS=1e-12 VT=25m N=2)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -805,6 +807,8 @@ Xlim in out limiter
     assert diode.cathode == "out"
     assert diode.Is == 1.0e-12
     assert diode.N == 2.0
+    assert diode.BV == 5.0
+    assert diode.IBV == 1.0e-6
 
 
 def test_expands_subcircuit_bjt_nodes_into_engine_elements() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add diode emission coefficient support through `emission_coefficient`,
   scaling the effective thermal voltage in DC and small-signal diode
   conductance.
+- Add diode breakdown support through `breakdown_voltage` /
+  `breakdown_current`, adding a bounded reverse-breakdown current and
+  conductance foothold.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -291,13 +291,15 @@ fn clone_subckt_element(
             voltage_expr: map_bsource_expr_nodes(&element.voltage_expr, instance_name, node_map),
             current_expr: map_bsource_expr_nodes(&element.current_expr, instance_name, node_map),
         }),
-        Element::Diode(element) => Element::Diode(Diode::with_model_and_emission_coefficient(
+        Element::Diode(element) => Element::Diode(Diode::with_model_and_breakdown(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.anode, instance_name, node_map),
             map_subckt_node(&element.cathode, instance_name, node_map),
             element.saturation_current,
             element.thermal_voltage,
             element.emission_coefficient,
+            element.breakdown_voltage,
+            element.breakdown_current,
         )),
         Element::Jfet(element) => Element::Jfet(Jfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1080,6 +1082,8 @@ pub struct Diode {
     pub saturation_current: f64,
     pub thermal_voltage: f64,
     pub emission_coefficient: f64,
+    pub breakdown_voltage: Option<f64>,
+    pub breakdown_current: f64,
 }
 
 impl Diode {
@@ -1116,6 +1120,28 @@ impl Diode {
         thermal_voltage: f64,
         emission_coefficient: f64,
     ) -> Self {
+        Self::with_model_and_breakdown(
+            name,
+            anode,
+            cathode,
+            saturation_current,
+            thermal_voltage,
+            emission_coefficient,
+            None,
+            1.0e-3,
+        )
+    }
+
+    pub fn with_model_and_breakdown(
+        name: impl Into<String>,
+        anode: impl Into<String>,
+        cathode: impl Into<String>,
+        saturation_current: f64,
+        thermal_voltage: f64,
+        emission_coefficient: f64,
+        breakdown_voltage: Option<f64>,
+        breakdown_current: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             anode: anode.into(),
@@ -1123,6 +1149,8 @@ impl Diode {
             saturation_current,
             thermal_voltage,
             emission_coefficient,
+            breakdown_voltage,
+            breakdown_current,
         }
     }
 }
@@ -4646,17 +4674,16 @@ fn build_ac_matrix(
             )?,
             Element::Diode(diode) => {
                 validate_diode(diode)?;
-                let vt_eff = diode_effective_thermal_voltage(diode);
                 let anode = node_index(node_indices, &diode.anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
-                let exponent = (voltage / vt_eff).clamp(-40.0, 40.0);
+                let (_, conductance) = diode_current_conductance(diode, voltage);
                 stamp_complex_conductance(
                     &mut matrix,
                     anode,
                     cathode,
-                    Complex::new(diode.saturation_current / vt_eff * exponent.exp(), 0.0),
+                    Complex::new(conductance, 0.0),
                 );
             }
             Element::Jfet(jfet) => {
@@ -4748,18 +4775,12 @@ fn build_small_signal_matrix(
             )?,
             Element::Diode(diode) => {
                 validate_diode(diode)?;
-                let vt_eff = diode_effective_thermal_voltage(diode);
                 let anode = node_index(node_indices, &diode.anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
-                let exponent = (voltage / vt_eff).clamp(-40.0, 40.0);
-                stamp_conductance(
-                    &mut matrix,
-                    anode,
-                    cathode,
-                    diode.saturation_current / vt_eff * exponent.exp(),
-                );
+                let (_, conductance) = diode_current_conductance(diode, voltage);
+                stamp_conductance(&mut matrix, anode, cathode, conductance);
             }
             Element::Jfet(jfet) => {
                 stamp_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point)?
@@ -5298,11 +5319,7 @@ fn stamp_diode(
     let cathode = node_index(node_indices, &diode.cathode);
     let voltage = anode.map_or(0.0, |index| operating_point[index])
         - cathode.map_or(0.0, |index| operating_point[index]);
-    let vt_eff = diode_effective_thermal_voltage(diode);
-    let exponent = (voltage / vt_eff).clamp(-40.0, 40.0);
-    let exp_value = exponent.exp();
-    let current = diode.saturation_current * (exp_value - 1.0);
-    let conductance = diode.saturation_current / vt_eff * exp_value;
+    let (current, conductance) = diode_current_conductance(diode, voltage);
     let equivalent_current = current - conductance * voltage;
 
     stamp_conductance(matrix, anode, cathode, conductance);
@@ -5767,6 +5784,24 @@ fn diode_effective_thermal_voltage(diode: &Diode) -> f64 {
     diode.thermal_voltage * diode.emission_coefficient
 }
 
+fn diode_current_conductance(diode: &Diode, voltage: f64) -> (f64, f64) {
+    let vt_eff = diode_effective_thermal_voltage(diode);
+    let forward_voltage = voltage.min(0.7 * diode.emission_coefficient);
+    let exp_value = (forward_voltage / vt_eff).clamp(-40.0, 40.0).exp();
+    let mut current = diode.saturation_current * (exp_value - 1.0);
+    let mut conductance = diode.saturation_current / vt_eff * exp_value;
+    if let Some(breakdown_voltage) = diode.breakdown_voltage {
+        if voltage <= -breakdown_voltage {
+            let breakdown_exp_value = (((-voltage) - breakdown_voltage) / vt_eff)
+                .clamp(-40.0, 40.0)
+                .exp();
+            current -= diode.breakdown_current * breakdown_exp_value;
+            conductance += diode.breakdown_current / vt_eff * breakdown_exp_value;
+        }
+    }
+    (current, conductance)
+}
+
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -5784,6 +5819,20 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "emission coefficient must be finite and positive".to_string(),
+        });
+    }
+    if let Some(breakdown_voltage) = diode.breakdown_voltage {
+        if !breakdown_voltage.is_finite() || breakdown_voltage <= 0.0 {
+            return Err(SpiceError::InvalidElement {
+                name: diode.name.clone(),
+                reason: "breakdown voltage must be finite and positive".to_string(),
+            });
+        }
+    }
+    if !diode.breakdown_current.is_finite() || diode.breakdown_current <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "breakdown current must be finite and positive".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -305,6 +305,40 @@ fn dc_diode_emission_coefficient_reduces_fixed_bias_current() {
 }
 
 #[test]
+fn dc_diode_breakdown_voltage_increases_reverse_bias_current() {
+    let mut leakage = Circuit::new();
+    leakage.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "0", "a", 5.0,
+    )));
+    leakage.add(Element::Diode(Diode::with_model(
+        "D1", "a", "0", 1.0e-15, 0.02585,
+    )));
+
+    let mut breakdown = Circuit::new();
+    breakdown.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "0", "a", 5.0,
+    )));
+    breakdown.add(Element::Diode(Diode::with_model_and_breakdown(
+        "D1",
+        "a",
+        "0",
+        1.0e-15,
+        0.02585,
+        1.0,
+        Some(5.0),
+        1.0e-6,
+    )));
+
+    let leakage_result = dc_op(&leakage).unwrap();
+    let breakdown_result = dc_op(&breakdown).unwrap();
+    assert!(
+        breakdown_result.branch_current("V1").unwrap().abs()
+            > leakage_result.branch_current("V1").unwrap().abs() * 1.0e6
+    );
+    assert!((breakdown_result.branch_current("V1").unwrap().abs() - 1.0e-6).abs() < 1.0e-9);
+}
+
+#[test]
 fn dc_bjt_solves_npn_emitter_follower_operating_point() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
   and pass them into Rust `Diode` elements.
+- Parse diode model-card reverse-breakdown parameters with
+  `.model ... D(... BV=<v> IBV=<i>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -727,13 +727,15 @@ fn parse_element(
                     model.name, model.kind
                 )));
             }
-            Ok(Element::Diode(Diode::with_model_and_emission_coefficient(
+            Ok(Element::Diode(Diode::with_model_and_breakdown(
                 name,
                 &fields[1],
                 &fields[2],
                 *model.params.get("IS").unwrap_or(&1.0e-15),
                 *model.params.get("VT").unwrap_or(&0.02585),
                 *model.params.get("N").unwrap_or(&1.0),
+                model.params.get("BV").copied(),
+                *model.params.get("IBV").unwrap_or(&1.0e-3),
             )))
         }
         'Q' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -645,7 +645,7 @@ Rload out 0 500
 fn parses_diode_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast D(IS=1e-12 VT=25m N=2)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -660,6 +660,8 @@ Rload out 0 1k
     assert_close(*model.params.get("IS").unwrap(), 1.0e-12);
     assert_close(*model.params.get("VT").unwrap(), 25.0e-3);
     assert_close(*model.params.get("N").unwrap(), 2.0);
+    assert_close(*model.params.get("BV").unwrap(), 5.0);
+    assert_close(*model.params.get("IBV").unwrap(), 1.0e-6);
 
     let Element::Diode(diode) = &parsed.circuit.elements()[1] else {
         panic!("expected diode");
@@ -670,6 +672,8 @@ Rload out 0 1k
     assert_close(diode.saturation_current, 1.0e-12);
     assert_close(diode.thermal_voltage, 25.0e-3);
     assert_close(diode.emission_coefficient, 2.0);
+    assert_close(diode.breakdown_voltage.unwrap(), 5.0);
+    assert_close(diode.breakdown_current, 1.0e-6);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();
@@ -1035,7 +1039,7 @@ Rload out 0 500
 fn expands_subcircuit_diode_nodes_into_engine_elements() {
     let parsed = parse_netlist(
         r#"
-.model clamp D(IS=1e-12 VT=25m N=2)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -1051,6 +1055,8 @@ Xlim in out limiter
     assert_eq!(diode.anode, "in");
     assert_eq!(diode.cathode, "out");
     assert_close(diode.emission_coefficient, 2.0);
+    assert_close(diode.breakdown_voltage.unwrap(), 5.0);
+    assert_close(diode.breakdown_current, 1.0e-6);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add diode emission coefficient support through `emissionCoefficient`, scaling
   the effective thermal voltage in DC and small-signal diode conductance.
+- Add diode breakdown support through `breakdownVoltage` / `breakdownCurrent`,
+  adding a bounded reverse-breakdown current and conductance foothold.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -360,6 +360,8 @@ export interface Diode {
   readonly saturationCurrent: number;
   readonly thermalVoltage: number;
   readonly emissionCoefficient: number;
+  readonly breakdownVoltage?: number;
+  readonly breakdownCurrent: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -946,7 +948,7 @@ function cloneSubcktElement(
     case "b-source":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap), voltageExpr: mapBSourceExprNodes(element.voltageExpr, instanceName, nodeMap), currentExpr: mapBSourceExprNodes(element.currentExpr, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
@@ -1196,6 +1198,8 @@ export function diode(
   saturationCurrent = 1.0e-15,
   thermalVoltage = 0.02585,
   emissionCoefficient = 1.0,
+  breakdownVoltage?: number,
+  breakdownCurrent = 1.0e-3,
 ): Diode {
   return {
     kind: "diode",
@@ -1205,6 +1209,8 @@ export function diode(
     saturationCurrent,
     thermalVoltage,
     emissionCoefficient,
+    breakdownVoltage,
+    breakdownCurrent,
   };
 }
 
@@ -3733,11 +3739,14 @@ function buildSmallSignalMatrix(
         break;
       case "diode":
         validateDiode(element);
+        const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.anode)) -
+          vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.cathode));
+        const [, diodeConductance] = diodeCurrentConductance(element, diodeVoltage);
         stampConductance(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          element.saturationCurrent / diodeEffectiveThermalVoltage(element),
+          diodeConductance,
         );
         break;
       case "jfet":
@@ -3903,11 +3912,14 @@ function buildAcMatrix(
         break;
       case "diode":
         validateDiode(element);
+        const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.anode)) -
+          vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.cathode));
+        const [, diodeConductance] = diodeCurrentConductance(element, diodeVoltage);
         stampComplexConductance(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          complex(element.saturationCurrent / diodeEffectiveThermalVoltage(element), 0.0),
+          complex(diodeConductance, 0.0),
         );
         break;
       case "jfet":
@@ -4524,11 +4536,7 @@ function stampDiode(
   const voltage =
     (anode === undefined ? 0.0 : operatingPoint[anode]) -
     (cathode === undefined ? 0.0 : operatingPoint[cathode]);
-  const vtEff = diodeEffectiveThermalVoltage(element);
-  const exponent = Math.max(-40.0, Math.min(40.0, voltage / vtEff));
-  const expValue = Math.exp(exponent);
-  const current = element.saturationCurrent * (expValue - 1.0);
-  const conductance = element.saturationCurrent / vtEff * expValue;
+  const [current, conductance] = diodeCurrentConductance(element, voltage);
   const equivalentCurrent = current - conductance * voltage;
 
   stampConductance(matrix, anode, cathode, conductance);
@@ -4813,10 +4821,38 @@ function validateDiode(element: Diode): void {
   if (!Number.isFinite(element.emissionCoefficient) || element.emissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "emission coefficient must be finite and positive");
   }
+  if (
+    element.breakdownVoltage !== undefined &&
+    (!Number.isFinite(element.breakdownVoltage) || element.breakdownVoltage <= 0.0)
+  ) {
+    throw invalidElement(element.name, "breakdown voltage must be finite and positive");
+  }
+  if (!Number.isFinite(element.breakdownCurrent) || element.breakdownCurrent <= 0.0) {
+    throw invalidElement(element.name, "breakdown current must be finite and positive");
+  }
 }
 
 function diodeEffectiveThermalVoltage(element: Diode): number {
   return element.thermalVoltage * element.emissionCoefficient;
+}
+
+function diodeCurrentConductance(element: Diode, voltage: number): [number, number] {
+  const vtEff = diodeEffectiveThermalVoltage(element);
+  const forwardVoltage = Math.min(voltage, 0.7 * element.emissionCoefficient);
+  const exponent = Math.max(-40.0, Math.min(40.0, forwardVoltage / vtEff));
+  const expValue = Math.exp(exponent);
+  let current = element.saturationCurrent * (expValue - 1.0);
+  let conductance = element.saturationCurrent / vtEff * expValue;
+  if (element.breakdownVoltage !== undefined && voltage <= -element.breakdownVoltage) {
+    const breakdownExponent = Math.max(
+      -40.0,
+      Math.min(40.0, (-voltage - element.breakdownVoltage) / vtEff),
+    );
+    const breakdownExpValue = Math.exp(breakdownExponent);
+    current -= element.breakdownCurrent * breakdownExpValue;
+    conductance += element.breakdownCurrent / vtEff * breakdownExpValue;
+  }
+  return [current, conductance];
 }
 
 function validateBjt(element: Bjt): void {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -249,6 +249,26 @@ describe("dcOp", () => {
     );
   });
 
+  it("uses diode breakdown voltage in reverse-bias current", () => {
+    const leakage = new Circuit();
+    leakage.add(voltageSource("V1", "0", "a", 5.0));
+    leakage.add(diode("D1", "a", "0", 1.0e-15, 0.02585));
+
+    const breakdown = new Circuit();
+    breakdown.add(voltageSource("V1", "0", "a", 5.0));
+    breakdown.add(diode("D1", "a", "0", 1.0e-15, 0.02585, 1.0, 5.0, 1.0e-6));
+
+    const leakageResult = dcOp(leakage);
+    const breakdownResult = dcOp(breakdown);
+
+    expect(leakageResult.branchCurrent("V1")).toBeDefined();
+    expect(breakdownResult.branchCurrent("V1")).toBeDefined();
+    expect(Math.abs(breakdownResult.branchCurrent("V1")!)).toBeGreaterThan(
+      Math.abs(leakageResult.branchCurrent("V1")!) * 1.0e6,
+    );
+    expect(Math.abs(breakdownResult.branchCurrent("V1")!)).toBeCloseTo(1.0e-6, 9);
+  });
+
   it("solves an NPN BJT operating point", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
   and pass them into TypeScript `diode` elements.
+- Parse diode model-card reverse-breakdown parameters with
+  `.model ... D(... BV=<v> IBV=<i>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -568,6 +568,8 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("IS") ?? 1.0e-15,
       model.params.get("VT") ?? 0.02585,
       model.params.get("N") ?? 1.0,
+      model.params.get("BV"),
+      model.params.get("IBV") ?? 1.0e-3,
     );
   }
   if (prefix === "Q") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -421,7 +421,7 @@ Rload out 0 500
 
   it("parses diode models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast D(IS=1e-12 VT=25m N=2)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -435,6 +435,8 @@ Rload out 0 1k
         ["IS", 1.0e-12],
         ["VT", 25.0e-3],
         ["N", 2.0],
+        ["BV", 5.0],
+        ["IBV", 1.0e-6],
       ]),
     });
     expect(parsed.circuit.elements()[1]).toMatchObject({
@@ -445,6 +447,8 @@ Rload out 0 1k
       saturationCurrent: 1.0e-12,
       thermalVoltage: 25.0e-3,
       emissionCoefficient: 2.0,
+      breakdownVoltage: 5.0,
+      breakdownCurrent: 1.0e-6,
     });
 
     const result = dcOp(parsed.circuit);
@@ -749,7 +753,7 @@ Rload out 0 500
 
   it("expands subcircuit diode nodes into engine elements", () => {
     const parsed = parseNetlist(`
-.model clamp D(IS=1e-12 VT=25m N=2)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -762,6 +766,8 @@ Xlim in out limiter
       anode: "in",
       cathode: "out",
       emissionCoefficient: 2.0,
+      breakdownVoltage: 5.0,
+      breakdownCurrent: 1.0e-6,
     });
   });
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -201,6 +201,9 @@ Status:
   plumbing are implemented across Python, TypeScript, and Rust. DC and
   small-signal AC diode conductance now use `N * Vt`, with subcircuit remapping
   preserving the parameter.
+- Diode `.model ... D(... BV=<voltage> IBV=<current>)` parsing and reverse
+  breakdown current/conductance footholds are implemented across Python,
+  TypeScript, and Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary

- add diode reverse-breakdown fields (`BV` / `IBV`) across Python, TypeScript, and Rust engines
- parse `.model ... D(... BV=<v> IBV=<i>)` into diode elements across all netlist parsers
- document the Phase 6 diode breakdown foothold and add cross-language DC/parser tests

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-breakdown-model PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-breakdown-model PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `cargo test -p spice-engine -p spice-netlist-parser`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `git diff --check`