### PR TITLE
[codex] Add Board VM input callback transport journals

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -181,6 +181,10 @@ paths without rebuilding the trace chain.
 transport log records with Rust-owned log names, labels, queue-depth metadata,
 and messages, so adapters can persist or display callback transport logs
 without rebuilding audit policy.
+`input_callback_transport_journal_summary` indexes those logs into stable
+transport journal records with Rust-owned journal names, labels, queue-depth
+metadata, and messages, so adapters can maintain transport journal views
+without rebuilding log routing policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -1284,6 +1284,55 @@ pub struct LanguageInputCallbackTransportLogSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportJournalKind {
+    CallbackRunnerHandoffJournal,
+    AdapterEventPublicationJournal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportJournalSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub journal_label: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_journal: u8,
+    pub message: String,
+    pub log_summary: LanguageInputCallbackTransportLogSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -1862,6 +1911,19 @@ pub const fn input_callback_transport_log_kind_name(
         }
         LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog => {
             "adapter_event_publication_log"
+        }
+    }
+}
+
+pub const fn input_callback_transport_journal_kind_name(
+    kind: LanguageInputCallbackTransportJournalKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportJournalKind::CallbackRunnerHandoffJournal => {
+            "callback_runner_handoff_journal"
+        }
+        LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal => {
+            "adapter_event_publication_journal"
         }
     }
 }
@@ -3389,6 +3451,54 @@ pub fn input_callback_transport_log_summary(
         queue_depth_after_log: audit_summary.queue_depth_after_audit,
         message: input_callback_transport_log_message(log_kind).to_owned(),
         audit_summary: audit_summary.clone(),
+    }
+}
+
+pub fn input_callback_transport_journal_summary(
+    log_summary: &LanguageInputCallbackTransportLogSummary,
+) -> LanguageInputCallbackTransportJournalSummary {
+    let journal_kind = input_callback_transport_journal_kind(log_summary.log_kind);
+
+    LanguageInputCallbackTransportJournalSummary {
+        endpoint: log_summary.endpoint.clone(),
+        connection_label: log_summary.connection_label.clone(),
+        journal_label: input_callback_transport_journal_label(log_summary, journal_kind),
+        journal_kind,
+        journal_name: input_callback_transport_journal_kind_name(journal_kind).to_owned(),
+        log_kind: log_summary.log_kind,
+        log_name: log_summary.log_name.clone(),
+        audit_kind: log_summary.audit_kind,
+        audit_name: log_summary.audit_name.clone(),
+        trace_kind: log_summary.trace_kind,
+        trace_name: log_summary.trace_name.clone(),
+        outcome_kind: log_summary.outcome_kind,
+        outcome_name: log_summary.outcome_name.clone(),
+        receipt_kind: log_summary.receipt_kind,
+        receipt_name: log_summary.receipt_name.clone(),
+        acknowledgement_kind: log_summary.acknowledgement_kind,
+        acknowledgement_name: log_summary.acknowledgement_name.clone(),
+        delivery_route: log_summary.delivery_route,
+        delivery_route_name: log_summary.delivery_route_name.clone(),
+        event_kind: log_summary.event_kind,
+        event_name: log_summary.event_name.clone(),
+        report_kind: log_summary.report_kind,
+        report_name: log_summary.report_name.clone(),
+        action: log_summary.action,
+        action_name: log_summary.action_name.clone(),
+        callback_runner_handoff: log_summary.callback_runner_handoff,
+        adapter_event_published: log_summary.adapter_event_published,
+        delivery_acknowledged: log_summary.delivery_acknowledged,
+        receipt_recorded: log_summary.receipt_recorded,
+        outcome_recorded: log_summary.outcome_recorded,
+        trace_recorded: log_summary.trace_recorded,
+        audit_recorded: log_summary.audit_recorded,
+        log_recorded: log_summary.log_recorded,
+        journal_recorded: true,
+        terminal: log_summary.terminal,
+        retryable: log_summary.retryable,
+        queue_depth_after_journal: log_summary.queue_depth_after_log,
+        message: input_callback_transport_journal_message(journal_kind).to_owned(),
+        log_summary: log_summary.clone(),
     }
 }
 
@@ -4942,6 +5052,44 @@ fn input_callback_transport_log_message(
         }
         LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog => {
             "Transport log should include the adapter event publication audit."
+        }
+    }
+}
+
+fn input_callback_transport_journal_kind(
+    log_kind: LanguageInputCallbackTransportLogKind,
+) -> LanguageInputCallbackTransportJournalKind {
+    match log_kind {
+        LanguageInputCallbackTransportLogKind::CallbackRunnerHandoffLog => {
+            LanguageInputCallbackTransportJournalKind::CallbackRunnerHandoffJournal
+        }
+        LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog => {
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        }
+    }
+}
+
+fn input_callback_transport_journal_label(
+    log_summary: &LanguageInputCallbackTransportLogSummary,
+    journal_kind: LanguageInputCallbackTransportJournalKind,
+) -> String {
+    format!(
+        "{} transport_journal={} journal_recorded=true queue_depth_after_journal={}",
+        log_summary.log_label,
+        input_callback_transport_journal_kind_name(journal_kind),
+        log_summary.queue_depth_after_log
+    )
+}
+
+fn input_callback_transport_journal_message(
+    journal_kind: LanguageInputCallbackTransportJournalKind,
+) -> &'static str {
+    match journal_kind {
+        LanguageInputCallbackTransportJournalKind::CallbackRunnerHandoffJournal => {
+            "Transport journal should index the callback-runner handoff log."
+        }
+        LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal => {
+            "Transport journal should index the adapter event publication log."
         }
     }
 }
@@ -12155,6 +12303,223 @@ mod tests {
         assert_eq!(
             dropped.log_label,
             "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=77 transport_action=drop_before_dispatch terminal=true retryable=false dispatch_callback=false emit_drop=true emit_result=false remove_from_queue=false keep_dispatch_scheduled=false queue_depth_after_effect=1 transport_report=drop emit_report=true queue_depth_after_report=1 transport_event=callback_dropped queue_depth_after_event=1 transport_delivery=adapter_event publish_event=true queue_depth_after_delivery=1 transport_acknowledgement=adapter_event_published delivery_acknowledged=true callback_runner_handoff=false adapter_event_published=true queue_depth_after_acknowledgement=1 transport_receipt=adapter_event_publication receipt_recorded=true queue_depth_after_receipt=1 transport_outcome=adapter_event_publication_recorded outcome_recorded=true queue_depth_after_outcome=1 transport_trace=adapter_event_publication_trace trace_recorded=true queue_depth_after_trace=1 transport_audit=adapter_event_publication_audit audit_recorded=true queue_depth_after_audit=1 transport_log=adapter_event_publication_log log_recorded=true queue_depth_after_log=1"
+        );
+    }
+
+    #[test]
+    fn input_callback_transport_journals_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_action = input_callback_transport_action_summary(&completed_lifecycle);
+        let completed_effect = input_callback_transport_effect_summary(&completed_action);
+        let completed_report = input_callback_transport_report_summary(&completed_effect);
+        let completed_event = input_callback_transport_event_summary(&completed_report);
+        let completed_delivery = input_callback_transport_delivery_summary(&completed_event);
+        let completed_ack = input_callback_transport_acknowledgement_summary(&completed_delivery);
+        let completed_receipt = input_callback_transport_receipt_summary(&completed_ack);
+        let completed_outcome = input_callback_transport_outcome_summary(&completed_receipt);
+        let completed_trace = input_callback_transport_trace_summary(&completed_outcome);
+        let completed_audit = input_callback_transport_audit_summary(&completed_trace);
+        let completed_log = input_callback_transport_log_summary(&completed_audit);
+        let completed = input_callback_transport_journal_summary(&completed_log);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.journal_kind,
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        );
+        assert_eq!(completed.journal_name, "adapter_event_publication_journal");
+        assert_eq!(
+            completed.log_kind,
+            LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog
+        );
+        assert_eq!(
+            completed.audit_kind,
+            LanguageInputCallbackTransportAuditKind::AdapterEventPublicationAudit
+        );
+        assert_eq!(
+            completed.trace_kind,
+            LanguageInputCallbackTransportTraceKind::AdapterEventPublicationTrace
+        );
+        assert_eq!(
+            completed.outcome_kind,
+            LanguageInputCallbackTransportOutcomeKind::AdapterEventPublicationRecorded
+        );
+        assert_eq!(
+            completed.receipt_kind,
+            LanguageInputCallbackTransportReceiptKind::AdapterEventPublication
+        );
+        assert_eq!(
+            completed.acknowledgement_kind,
+            LanguageInputCallbackTransportAcknowledgementKind::AdapterEventPublished
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_journal, 2);
+        assert_eq!(
+            completed.message,
+            "Transport journal should index the adapter event publication log."
+        );
+        assert_eq!(completed.log_summary, completed_log);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_action = input_callback_transport_action_summary(&pending_lifecycle);
+        let pending_effect = input_callback_transport_effect_summary(&pending_action);
+        let pending_report = input_callback_transport_report_summary(&pending_effect);
+        let pending_event = input_callback_transport_event_summary(&pending_report);
+        let pending_delivery = input_callback_transport_delivery_summary(&pending_event);
+        let pending_ack = input_callback_transport_acknowledgement_summary(&pending_delivery);
+        let pending_receipt = input_callback_transport_receipt_summary(&pending_ack);
+        let pending_outcome = input_callback_transport_outcome_summary(&pending_receipt);
+        let pending_trace = input_callback_transport_trace_summary(&pending_outcome);
+        let pending_audit = input_callback_transport_audit_summary(&pending_trace);
+        let pending_log = input_callback_transport_log_summary(&pending_audit);
+        let pending = input_callback_transport_journal_summary(&pending_log);
+
+        assert_eq!(
+            pending.journal_kind,
+            LanguageInputCallbackTransportJournalKind::CallbackRunnerHandoffJournal
+        );
+        assert_eq!(pending.journal_name, "callback_runner_handoff_journal");
+        assert_eq!(
+            pending.log_kind,
+            LanguageInputCallbackTransportLogKind::CallbackRunnerHandoffLog
+        );
+        assert_eq!(
+            pending.audit_kind,
+            LanguageInputCallbackTransportAuditKind::CallbackRunnerHandoffAudit
+        );
+        assert_eq!(
+            pending.trace_kind,
+            LanguageInputCallbackTransportTraceKind::CallbackRunnerHandoffTrace
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_journal, 3);
+        assert_eq!(
+            pending.journal_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=42 transport_action=dispatch_callback terminal=false retryable=false dispatch_callback=true emit_drop=false emit_result=false remove_from_queue=false keep_dispatch_scheduled=true queue_depth_after_effect=3 transport_report=dispatch emit_report=false queue_depth_after_report=3 transport_event=dispatch_scheduled queue_depth_after_event=3 transport_delivery=callback_runner publish_event=false queue_depth_after_delivery=3 transport_acknowledgement=callback_runner_accepted delivery_acknowledged=true callback_runner_handoff=true adapter_event_published=false queue_depth_after_acknowledgement=3 transport_receipt=callback_runner_handoff receipt_recorded=true queue_depth_after_receipt=3 transport_outcome=callback_runner_handoff_recorded outcome_recorded=true queue_depth_after_outcome=3 transport_trace=callback_runner_handoff_trace trace_recorded=true queue_depth_after_trace=3 transport_audit=callback_runner_handoff_audit audit_recorded=true queue_depth_after_audit=3 transport_log=callback_runner_handoff_log log_recorded=true queue_depth_after_log=3 transport_journal=callback_runner_handoff_journal journal_recorded=true queue_depth_after_journal=3"
+        );
+        assert_eq!(
+            pending.message,
+            "Transport journal should index the callback-runner handoff log."
+        );
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_action = input_callback_transport_action_summary(&dropped_lifecycle);
+        let dropped_effect = input_callback_transport_effect_summary(&dropped_action);
+        let dropped_report = input_callback_transport_report_summary(&dropped_effect);
+        let dropped_event = input_callback_transport_event_summary(&dropped_report);
+        let dropped_delivery = input_callback_transport_delivery_summary(&dropped_event);
+        let dropped_ack = input_callback_transport_acknowledgement_summary(&dropped_delivery);
+        let dropped_receipt = input_callback_transport_receipt_summary(&dropped_ack);
+        let dropped_outcome = input_callback_transport_outcome_summary(&dropped_receipt);
+        let dropped_trace = input_callback_transport_trace_summary(&dropped_outcome);
+        let dropped_audit = input_callback_transport_audit_summary(&dropped_trace);
+        let dropped_log = input_callback_transport_log_summary(&dropped_audit);
+        let dropped = input_callback_transport_journal_summary(&dropped_log);
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.journal_kind,
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_journal, 1);
+        assert_eq!(
+            dropped.journal_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=77 transport_action=drop_before_dispatch terminal=true retryable=false dispatch_callback=false emit_drop=true emit_result=false remove_from_queue=false keep_dispatch_scheduled=false queue_depth_after_effect=1 transport_report=drop emit_report=true queue_depth_after_report=1 transport_event=callback_dropped queue_depth_after_event=1 transport_delivery=adapter_event publish_event=true queue_depth_after_delivery=1 transport_acknowledgement=adapter_event_published delivery_acknowledged=true callback_runner_handoff=false adapter_event_published=true queue_depth_after_acknowledgement=1 transport_receipt=adapter_event_publication receipt_recorded=true queue_depth_after_receipt=1 transport_outcome=adapter_event_publication_recorded outcome_recorded=true queue_depth_after_outcome=1 transport_trace=adapter_event_publication_trace trace_recorded=true queue_depth_after_trace=1 transport_audit=adapter_event_publication_audit audit_recorded=true queue_depth_after_audit=1 transport_log=adapter_event_publication_log log_recorded=true queue_depth_after_log=1 transport_journal=adapter_event_publication_journal journal_recorded=true queue_depth_after_journal=1"
         );
     }
 


### PR DESCRIPTION
Summary
- Add Rust-owned input callback transport journal kinds, names, labels, queue-depth metadata, and summary records layered over transport logs.
- Carry the transport action/report/event/delivery/acknowledgement/receipt/outcome/trace/audit/log chain into journal summaries so language frontends can stay thin.
- Document the new journal summary API in board-vm-language-core and cover callback-runner handoff plus adapter-event publication paths.

Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-journal cargo test -p board-vm-language-core
- bash BUILD (in code/packages/rust/board-vm-language-core)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-journal cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes
- Removed generated code/packages/rust/Cargo.lock before committing.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.