### PR TITLE
spice: add diode junction capacitance model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -10,6 +10,10 @@
 - **Diode breakdown models** — `Diode.BV` / `Diode.IBV` now add a bounded
   reverse-breakdown current and conductance foothold.
 
+- **Diode junction capacitance models** — `Diode.Cjo` now contributes a
+  small-signal AC susceptance in parallel with the linearized diode
+  conductance.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -424,6 +424,7 @@ class Diode:
     N: float = 1.0  # emission coefficient
     BV: float | None = None  # reverse breakdown voltage
     IBV: float = 1e-3  # reverse current at breakdown voltage
+    Cjo: float = 0.0  # zero-bias junction capacitance
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -253,6 +253,7 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
             element.N,
             element.BV,
             element.IBV,
+            element.Cjo,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_)
@@ -1715,6 +1716,8 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(f"{el.name}: diode breakdown voltage must be finite and positive")
     if not math.isfinite(el.IBV) or el.IBV <= 0.0:
         raise ValueError(f"{el.name}: diode breakdown current must be finite and positive")
+    if not math.isfinite(el.Cjo) or el.Cjo < 0.0:
+        raise ValueError(f"{el.name}: diode junction capacitance must be finite and non-negative")
     return el.Vt * el.N
 
 
@@ -3880,7 +3883,7 @@ def _stamp_ac(
         Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
         Vd = Va - Vk
         _, gd = _diode_current_conductance(el, Vd)
-        _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 0j)
+        _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 1j * omega * el.Cjo)
 
     elif isinstance(el, JFET):
         Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
@@ -5308,7 +5311,7 @@ def sens_dc(
             _make_entry(
                 "Is",
                 el.Is,
-                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N, el.BV, el.IBV),
+                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N, el.BV, el.IBV, el.Cjo),
             )
 
         elif isinstance(el, BJT):
@@ -5534,7 +5537,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
         )
 
     if isinstance(el, Diode):
-        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N, el.BV, el.IBV)
+        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N, el.BV, el.IBV, el.Cjo)
 
     if isinstance(el, BJT):
         return BJT(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -2081,6 +2081,22 @@ def test_ac_diode_reverse_biased_acts_like_open():
         )
 
 
+def test_ac_diode_junction_capacitance_shunts_high_frequency():
+    """Reverse-biased diode junction capacitance is stamped in AC."""
+    c = Circuit()
+    c.add(VoltageSource("Vac", "in", "0", 1.0))
+    c.add(Resistor("R1", "in", "node", 1000.0))
+    # Reverse-biased at the DC operating point, so the AC drop is dominated by Cjo.
+    c.add(Diode("D1", anode="0", cathode="node", Cjo=1.0e-6))
+
+    result = ac_sweep(c, f_start=10.0, f_stop=100000.0, n_points=2)
+    low = abs(result.points[0].node_voltages["node"])
+    high = abs(result.points[-1].node_voltages["node"])
+
+    assert low > 0.9
+    assert high < low / 100.0
+
+
 def test_ac_bjt_npn_small_signal():
     """NPN BJT in forward-active: small-signal current gain > 1.
 

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -6,6 +6,8 @@
   and pass them into Python `Diode` elements.
 - Parse diode model-card reverse-breakdown parameters with
   `.model ... D(... BV=<v> IBV=<i>)`.
+- Parse diode model-card junction capacitance with
+  `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -415,6 +415,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             N=model.params.get("N", 1.0),
             BV=model.params.get("BV"),
             IBV=model.params.get("IBV", 1e-3),
+            Cjo=model.params.get("CJO", model.params.get("CJ0", 0.0)),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -451,7 +451,7 @@ Rload out 0 500
 def test_parse_diode_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -460,7 +460,11 @@ Rload out 0 1k
     )
 
     assert parsed.models == {
-        "fast": ModelCard("fast", "D", {"IS": 1.0e-12, "VT": 25.0e-3, "N": 2.0, "BV": 5.0, "IBV": 1.0e-6})
+        "fast": ModelCard(
+            "fast",
+            "D",
+            {"IS": 1.0e-12, "VT": 25.0e-3, "N": 2.0, "BV": 5.0, "IBV": 1.0e-6, "CJO": 2.0e-12},
+        )
     }
     diode = parsed.circuit.elements[1]
     assert isinstance(diode, Diode)
@@ -471,6 +475,7 @@ Rload out 0 1k
     assert diode.N == 2.0
     assert diode.BV == 5.0
     assert diode.IBV == 1.0e-6
+    assert diode.Cjo == 2.0e-12
 
     result = dc_op(parsed.circuit)
     assert result.converged
@@ -792,7 +797,7 @@ Rload out 0 500
 def test_expands_subcircuit_diode_nodes_into_engine_elements() -> None:
     parsed = parse_netlist(
         """
-.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -809,6 +814,7 @@ Xlim in out limiter
     assert diode.N == 2.0
     assert diode.BV == 5.0
     assert diode.IBV == 1.0e-6
+    assert diode.Cjo == 3.0e-12
 
 
 def test_expands_subcircuit_bjt_nodes_into_engine_elements() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add diode breakdown support through `breakdown_voltage` /
   `breakdown_current`, adding a bounded reverse-breakdown current and
   conductance foothold.
+- Add diode junction capacitance support through `junction_capacitance`,
+  contributing small-signal AC susceptance in parallel with the linearized
+  diode conductance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -300,6 +300,7 @@ fn clone_subckt_element(
             element.emission_coefficient,
             element.breakdown_voltage,
             element.breakdown_current,
+            element.junction_capacitance,
         )),
         Element::Jfet(element) => Element::Jfet(Jfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1084,6 +1085,7 @@ pub struct Diode {
     pub emission_coefficient: f64,
     pub breakdown_voltage: Option<f64>,
     pub breakdown_current: f64,
+    pub junction_capacitance: f64,
 }
 
 impl Diode {
@@ -1129,6 +1131,7 @@ impl Diode {
             emission_coefficient,
             None,
             1.0e-3,
+            0.0,
         )
     }
 
@@ -1141,6 +1144,7 @@ impl Diode {
         emission_coefficient: f64,
         breakdown_voltage: Option<f64>,
         breakdown_current: f64,
+        junction_capacitance: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -1151,6 +1155,7 @@ impl Diode {
             emission_coefficient,
             breakdown_voltage,
             breakdown_current,
+            junction_capacitance,
         }
     }
 }
@@ -4683,7 +4688,7 @@ fn build_ac_matrix(
                     &mut matrix,
                     anode,
                     cathode,
-                    Complex::new(conductance, 0.0),
+                    Complex::new(conductance, omega * diode.junction_capacitance),
                 );
             }
             Element::Jfet(jfet) => {
@@ -5833,6 +5838,12 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "breakdown current must be finite and positive".to_string(),
+        });
+    }
+    if !diode.junction_capacitance.is_finite() || diode.junction_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "junction capacitance must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1,8 +1,8 @@
 use spice_engine::{
     ac_sweep, ac_sweep_corners, s_parameters, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit,
-    CornerOverride, CornerSpec, CurrentSource, Element, Inductor, Jfet, JfetPolarity, Mosfet,
-    MosfetLevel1Params, MosfetType, MutualInductor, Resistor, SpiceError, TransmissionLine, Vcvs,
-    VoltageSource,
+    CornerOverride, CornerSpec, CurrentSource, Diode, Element, Inductor, Jfet, JfetPolarity,
+    Mosfet, MosfetLevel1Params, MosfetType, MutualInductor, Resistor, SpiceError, TransmissionLine,
+    Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -60,6 +60,30 @@ fn ac_rc_low_pass_has_minus_three_db_corner() {
     let out = points[0].voltage("out").unwrap();
     assert_close(out.abs(), 1.0 / 2.0_f64.sqrt());
     assert_close(out.phase(), -std::f64::consts::FRAC_PI_4);
+}
+
+#[test]
+fn ac_diode_junction_capacitance_shunts_high_frequency() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vac", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "R1", "in", "node", 1_000.0,
+    )));
+    circuit.add(Element::Diode(Diode::with_model_and_breakdown(
+        "D1", "0", "node", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 1.0e-6,
+    )));
+
+    let points = ac_sweep(&circuit, 10.0, 100_000.0, 2).unwrap();
+    let low = points[0].voltage("node").unwrap().abs();
+    let high = points[points.len() - 1].voltage("node").unwrap().abs();
+
+    assert!(low > 0.9, "expected low-frequency pass, got {low}");
+    assert!(
+        high < low / 100.0,
+        "expected high-frequency shunt, got low={low} high={high}"
+    );
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -327,6 +327,7 @@ fn dc_diode_breakdown_voltage_increases_reverse_bias_current() {
         1.0,
         Some(5.0),
         1.0e-6,
+        0.0,
     )));
 
     let leakage_result = dc_op(&leakage).unwrap();

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -6,6 +6,8 @@
   and pass them into Rust `Diode` elements.
 - Parse diode model-card reverse-breakdown parameters with
   `.model ... D(... BV=<v> IBV=<i>)`.
+- Parse diode model-card junction capacitance with
+  `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -736,6 +736,12 @@ fn parse_element(
                 *model.params.get("N").unwrap_or(&1.0),
                 model.params.get("BV").copied(),
                 *model.params.get("IBV").unwrap_or(&1.0e-3),
+                model
+                    .params
+                    .get("CJO")
+                    .or_else(|| model.params.get("CJ0"))
+                    .copied()
+                    .unwrap_or(0.0),
             )))
         }
         'Q' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -645,7 +645,7 @@ Rload out 0 500
 fn parses_diode_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -662,6 +662,7 @@ Rload out 0 1k
     assert_close(*model.params.get("N").unwrap(), 2.0);
     assert_close(*model.params.get("BV").unwrap(), 5.0);
     assert_close(*model.params.get("IBV").unwrap(), 1.0e-6);
+    assert_close(*model.params.get("CJO").unwrap(), 2.0e-12);
 
     let Element::Diode(diode) = &parsed.circuit.elements()[1] else {
         panic!("expected diode");
@@ -674,6 +675,7 @@ Rload out 0 1k
     assert_close(diode.emission_coefficient, 2.0);
     assert_close(diode.breakdown_voltage.unwrap(), 5.0);
     assert_close(diode.breakdown_current, 1.0e-6);
+    assert_close(diode.junction_capacitance, 2.0e-12);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();
@@ -1039,7 +1041,7 @@ Rload out 0 500
 fn expands_subcircuit_diode_nodes_into_engine_elements() {
     let parsed = parse_netlist(
         r#"
-.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -1057,6 +1059,7 @@ Xlim in out limiter
     assert_close(diode.emission_coefficient, 2.0);
     assert_close(diode.breakdown_voltage.unwrap(), 5.0);
     assert_close(diode.breakdown_current, 1.0e-6);
+    assert_close(diode.junction_capacitance, 3.0e-12);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -6,6 +6,9 @@
   the effective thermal voltage in DC and small-signal diode conductance.
 - Add diode breakdown support through `breakdownVoltage` / `breakdownCurrent`,
   adding a bounded reverse-breakdown current and conductance foothold.
+- Add diode junction capacitance support through `junctionCapacitance`,
+  contributing small-signal AC susceptance in parallel with the linearized
+  diode conductance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -362,6 +362,7 @@ export interface Diode {
   readonly emissionCoefficient: number;
   readonly breakdownVoltage?: number;
   readonly breakdownCurrent: number;
+  readonly junctionCapacitance: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -948,7 +949,7 @@ function cloneSubcktElement(
     case "b-source":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap), voltageExpr: mapBSourceExprNodes(element.voltageExpr, instanceName, nodeMap), currentExpr: mapBSourceExprNodes(element.currentExpr, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
@@ -1200,6 +1201,7 @@ export function diode(
   emissionCoefficient = 1.0,
   breakdownVoltage?: number,
   breakdownCurrent = 1.0e-3,
+  junctionCapacitance = 0.0,
 ): Diode {
   return {
     kind: "diode",
@@ -1211,6 +1213,7 @@ export function diode(
     emissionCoefficient,
     breakdownVoltage,
     breakdownCurrent,
+    junctionCapacitance,
   };
 }
 
@@ -3919,7 +3922,7 @@ function buildAcMatrix(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          complex(diodeConductance, 0.0),
+          complex(diodeConductance, omega * element.junctionCapacitance),
         );
         break;
       case "jfet":
@@ -4829,6 +4832,9 @@ function validateDiode(element: Diode): void {
   }
   if (!Number.isFinite(element.breakdownCurrent) || element.breakdownCurrent <= 0.0) {
     throw invalidElement(element.name, "breakdown current must be finite and positive");
+  }
+  if (!Number.isFinite(element.junctionCapacitance) || element.junctionCapacitance < 0.0) {
+    throw invalidElement(element.name, "junction capacitance must be finite and non-negative");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -11,6 +11,7 @@ import {
   complexPhase,
   currentSource,
   currentSourceWithAc,
+  diode,
   inductor,
   jfet,
   mutualInductor,
@@ -65,6 +66,20 @@ describe("acSweep", () => {
     expect(out).not.toBeUndefined();
     expectClose(complexAbs(out!), 1.0 / Math.sqrt(2.0));
     expectClose(complexPhase(out!), -Math.PI / 4.0);
+  });
+
+  it("stamps reverse-biased diode junction capacitance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vac", "in", "0", 1.0));
+    circuit.add(resistor("R1", "in", "node", 1_000.0));
+    circuit.add(diode("D1", "0", "node", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 1.0e-6));
+
+    const points = acSweep(circuit, 10.0, 100_000.0, 2);
+    const low = complexAbs(points[0].voltage("node")!);
+    const high = complexAbs(points[points.length - 1].voltage("node")!);
+
+    expect(low).toBeGreaterThan(0.9);
+    expect(high).toBeLessThan(low / 100.0);
   });
 
   it("runs frequency sweeps at each named corner", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -6,6 +6,8 @@
   and pass them into TypeScript `diode` elements.
 - Parse diode model-card reverse-breakdown parameters with
   `.model ... D(... BV=<v> IBV=<i>)`.
+- Parse diode model-card junction capacitance with
+  `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -570,6 +570,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("N") ?? 1.0,
       model.params.get("BV"),
       model.params.get("IBV") ?? 1.0e-3,
+      model.params.get("CJO") ?? model.params.get("CJ0") ?? 0.0,
     );
   }
   if (prefix === "Q") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -421,7 +421,7 @@ Rload out 0 500
 
   it("parses diode models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -437,6 +437,7 @@ Rload out 0 1k
         ["N", 2.0],
         ["BV", 5.0],
         ["IBV", 1.0e-6],
+        ["CJO", 2.0e-12],
       ]),
     });
     expect(parsed.circuit.elements()[1]).toMatchObject({
@@ -449,6 +450,7 @@ Rload out 0 1k
       emissionCoefficient: 2.0,
       breakdownVoltage: 5.0,
       breakdownCurrent: 1.0e-6,
+      junctionCapacitance: 2.0e-12,
     });
 
     const result = dcOp(parsed.circuit);
@@ -753,7 +755,7 @@ Rload out 0 500
 
   it("expands subcircuit diode nodes into engine elements", () => {
     const parsed = parseNetlist(`
-.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -768,6 +770,7 @@ Xlim in out limiter
       emissionCoefficient: 2.0,
       breakdownVoltage: 5.0,
       breakdownCurrent: 1.0e-6,
+      junctionCapacitance: 3.0e-12,
     });
   });
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -204,6 +204,9 @@ Status:
 - Diode `.model ... D(... BV=<voltage> IBV=<current>)` parsing and reverse
   breakdown current/conductance footholds are implemented across Python,
   TypeScript, and Rust.
+- Diode `.model ... D(... CJO=<capacitance>)` / `CJ0` parsing and AC
+  junction-capacitance admittance are implemented across Python, TypeScript,
+  and Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary

- add diode junction-capacitance fields across Python, TypeScript, and Rust diode elements
- parse `.model ... D(... CJO=<c>)` / `CJ0` into diode elements across all netlist parsers
- stamp diode `jωCjo` small-signal AC admittance and document the Phase 6 compatibility foothold

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-capacitance-model PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-capacitance-model PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `cargo test -p spice-engine -p spice-netlist-parser`
- `git diff --check`