### PR TITLE
feat(sql): honour PRAGMA foreign_keys at INSERT/UPDATE/DELETE

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.99.0] - 2026-05-23
+
+### Added
+
+- ``PRAGMA foreign_keys`` is now honoured at INSERT/UPDATE/DELETE.
+  The engine reads the per-connection PRAGMA value and forwards it
+  to the VM's new ``fk_enabled`` flag.  Setting ``PRAGMA foreign_keys
+  = OFF`` disables FK enforcement for subsequent statements on the
+  same connection; ``PRAGMA foreign_keys = ON`` re-enables it.
+
+### Changed
+
+- ``_PRAGMA_DEFAULTS["foreign_keys"]`` flipped from ``0`` (OFF) to
+  ``1`` (ON) so the read value matches mini-sqlite's enforce-by-
+  default behaviour.  This is a *documented* deviation from SQLite,
+  which defaults the pragma to OFF.  ORMs and migration tools that
+  explicitly toggle the pragma get correct behaviour either way.
+- Two pragma-additions tests updated for the new default:
+  ``test_foreign_keys_default_off`` renamed/rewritten as
+  ``test_foreign_keys_default_on_in_mini_sqlite``;
+  ``test_foreign_keys_isolated_between_connections`` now toggles
+  c1 to OFF (rather than ON) so the isolation test still verifies
+  per-connection state.
+
 ## [1.98.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.98.0"
+version = "1.99.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -270,12 +270,20 @@ def run(
                 view_defs=view_defs,
                 user_functions=user_functions,
             )
+        # Honour PRAGMA foreign_keys on this connection.  Mini-sqlite
+        # defaults to ON (deviation from SQLite, which defaults to OFF);
+        # the per-connection PRAGMA state can override.  When OFF, the
+        # VM's FK validation short-circuits for every INSERT/UPDATE/
+        # DELETE.
+        fk_setting = _pragma_get(backend, "foreign_keys")
+        fk_enabled = bool(fk_setting) if fk_setting is not None else True
         result = execute(
             program,
             backend,
             check_registry=check_registry,
             fk_child=fk_child,
             fk_parent=fk_parent,
+            fk_enabled=fk_enabled,
             event_cb=event_cb,
             filtered_columns=_filtered,
             trigger_executor=_trigger_executor,
@@ -779,7 +787,12 @@ def _parse_bool_pragma(s: str) -> bool | None:
 # unmodified PRAGMA returns the same value SQLite would.
 _PRAGMA_DEFAULTS: dict[str, tuple[object, str]] = {
     # name              (default_value,    column_type)
-    "foreign_keys":     (0,                "integer"),  # off by default in SQLite
+    # SQLite defaults this to 0 (FK enforcement OFF).  Mini-sqlite has
+    # historically enforced FKs unconditionally; rather than break that
+    # behaviour, we default to 1 (ON) so the pragma's read value matches
+    # the enforcement default.  ``PRAGMA foreign_keys = OFF`` still
+    # works — the VM consults this setting on every INSERT/UPDATE/DELETE.
+    "foreign_keys":     (1,                "integer"),  # ON by default in mini-sqlite
     "recursive_triggers": (0,              "integer"),
     "case_sensitive_like": (0,             "integer"),
     "legacy_alter_table": (0,              "integer"),

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_additions.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_additions.py
@@ -46,8 +46,14 @@ def test_database_list_main():
 # ---------------------------------------------------------------------------
 
 
-def test_foreign_keys_default_off():
-    _check("PRAGMA foreign_keys")
+def test_foreign_keys_default_on_in_mini_sqlite():
+    # Documented deviation from SQLite: mini-sqlite defaults FK
+    # enforcement to ON (real SQLite: OFF).  The pragma read value
+    # mirrors the enforcement default so the two stay consistent.
+    # We don't oracle-compare this one because the engines disagree
+    # on purpose — see PR for honoring PRAGMA foreign_keys.
+    mini = mini_sqlite.connect(":memory:")
+    assert mini.execute("PRAGMA foreign_keys").fetchall() == [(1,)]
 
 
 def test_recursive_triggers_default_off():
@@ -226,14 +232,19 @@ def test_locking_mode_exclusive():
 
 
 def test_foreign_keys_isolated_between_connections():
-    """Setting a PRAGMA on one connection does not leak into another."""
+    """Setting a PRAGMA on one connection does not leak into another.
+
+    Mini-sqlite defaults ``foreign_keys`` to ON (documented deviation
+    from SQLite).  This test exercises isolation by toggling OFF on
+    one connection and verifying the other keeps the default ON.
+    """
     c1 = mini_sqlite.connect(":memory:")
     c2 = mini_sqlite.connect(":memory:")
-    c1.execute("PRAGMA foreign_keys = ON")
-    # c1 reads back ON
-    assert c1.execute("PRAGMA foreign_keys").fetchall() == [(1,)]
-    # c2 still default OFF
-    assert c2.execute("PRAGMA foreign_keys").fetchall() == [(0,)]
+    c1.execute("PRAGMA foreign_keys = OFF")
+    # c1 reads back OFF
+    assert c1.execute("PRAGMA foreign_keys").fetchall() == [(0,)]
+    # c2 still default ON — the PRAGMA on c1 didn't leak across.
+    assert c2.execute("PRAGMA foreign_keys").fetchall() == [(1,)]
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_foreign_keys_toggle.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_foreign_keys_toggle.py
@@ -1,0 +1,139 @@
+"""Tests for honouring ``PRAGMA foreign_keys`` at INSERT/UPDATE/DELETE.
+
+Mini-sqlite defaults FK enforcement to ON (documented deviation from
+SQLite's OFF default).  ``PRAGMA foreign_keys = OFF`` disables
+enforcement on a per-connection basis; ``PRAGMA foreign_keys = ON``
+re-enables it.  Toggling the setting in the middle of a session
+takes effect for subsequent statements.
+
+These tests pin the toggle behaviour and verify both the child-side
+(orphan INSERT) and parent-side (DELETE with referencing children)
+short-circuit paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import mini_sqlite
+from mini_sqlite import errors as mini_errors
+
+
+class TestDefaultOn:
+    """The default FK state is ON (mini-sqlite deviation from SQLite)."""
+
+    def test_default_rejects_orphan(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        with pytest.raises(mini_errors.IntegrityError):
+            c.execute("INSERT INTO c VALUES (1, 999)")
+
+    def test_default_pragma_reads_one(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        assert c.execute("PRAGMA foreign_keys").fetchone() == (1,)
+
+
+class TestPragmaOff:
+    """``PRAGMA foreign_keys = OFF`` disables enforcement."""
+
+    def test_orphan_accepted_with_fk_off(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA foreign_keys = OFF")
+        c.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        # No exception — FK enforcement is off.
+        c.execute("INSERT INTO c VALUES (1, 999)")
+        assert c.execute("SELECT * FROM c").fetchall() == [(1, 999)]
+
+    def test_parent_delete_succeeds_with_fk_off(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA foreign_keys = OFF")
+        c.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        c.execute("INSERT INTO p VALUES (1)")
+        c.execute("INSERT INTO c VALUES (1, 1)")
+        # With FK on, this DELETE would be rejected because c.p_id=1
+        # references p.id=1.  With FK off, it's permitted.
+        c.execute("DELETE FROM p WHERE id = 1")
+        assert c.execute("SELECT COUNT(*) FROM p").fetchone() == (0,)
+
+    def test_foreign_key_check_surfaces_violations_after_off_inserts(self) -> None:
+        # End-to-end story: turn FK off, insert orphans, turn FK back
+        # on, ask foreign_key_check what's wrong.
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA foreign_keys = OFF")
+        c.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        c.execute("INSERT INTO c VALUES (1, 100)")
+        c.execute("INSERT INTO c VALUES (2, 200)")
+        c.execute("PRAGMA foreign_keys = ON")
+        rows = c.execute("PRAGMA foreign_key_check").fetchall()
+        assert len(rows) == 2
+        assert {r[1] for r in rows} == {1, 2}  # both child rowids
+        assert all(r[0] == "c" and r[2] == "p" for r in rows)
+
+
+class TestPragmaToggleMidSession:
+    """Toggling FK mid-session takes effect immediately."""
+
+    def test_re_enable_blocks_subsequent_orphan(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("PRAGMA foreign_keys = OFF")
+        c.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        # First insert: OK (FK off)
+        c.execute("INSERT INTO c VALUES (1, 999)")
+        # Re-enable
+        c.execute("PRAGMA foreign_keys = ON")
+        # Second insert: rejected (FK on)
+        with pytest.raises(mini_errors.IntegrityError):
+            c.execute("INSERT INTO c VALUES (2, 888)")
+
+
+class TestPerConnectionIsolation:
+    """PRAGMA state doesn't leak across connections."""
+
+    def test_off_on_one_connection_does_not_affect_another(self) -> None:
+        c1 = mini_sqlite.connect(":memory:")
+        c2 = mini_sqlite.connect(":memory:")
+        c1.execute("PRAGMA foreign_keys = OFF")
+        # c2 still defaults to ON
+        c2.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c2.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        with pytest.raises(mini_errors.IntegrityError):
+            c2.execute("INSERT INTO c VALUES (1, 999)")
+
+
+class TestNullValueStillPasses:
+    """NULL FK values pass regardless of the foreign_keys setting."""
+
+    def test_null_accepted_with_fk_on(self) -> None:
+        c = mini_sqlite.connect(":memory:")
+        c.execute("CREATE TABLE p (id INTEGER PRIMARY KEY)")
+        c.execute(
+            "CREATE TABLE c (id INTEGER PRIMARY KEY, "
+            "p_id INTEGER REFERENCES p(id))"
+        )
+        # NULL FK is always permitted (SQL standard: unknown reference
+        # is not an error).
+        c.execute("INSERT INTO c VALUES (1, NULL)")
+        assert c.execute("SELECT * FROM c").fetchall() == [(1, None)]

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.55.0 — 2026-05-23
+
+### Added
+
+- ``execute()`` accepts a new ``fk_enabled: bool = True`` keyword
+  forwarded to ``_VmState.fk_enabled``.  ``_check_fk_child`` and
+  ``_check_fk_parent`` short-circuit to a no-op when False, mirroring
+  SQLite's ``PRAGMA foreign_keys = OFF`` behaviour.  The default
+  preserves existing call sites: omitting the kwarg keeps FK
+  enforcement on.
+
 ## 1.54.0 — 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.54.0"
+version = "1.55.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/vm.py
+++ b/code/packages/python/sql-vm/src/sql_vm/vm.py
@@ -292,6 +292,14 @@ class _VmState:
     # parent_col=None means "the parent's PRIMARY KEY column".
     fk_child: dict[str, list[tuple[str, str, str | None]]] = field(default_factory=dict)
     fk_parent: dict[str, list[tuple[str, str, str | None]]] = field(default_factory=dict)
+    # Master switch for FOREIGN KEY enforcement.  When False, all
+    # ``_check_fk_child`` / ``_check_fk_parent`` calls short-circuit
+    # to a no-op.  Mirrors SQLite's ``PRAGMA foreign_keys = OFF``.
+    # Defaults to True (mini-sqlite enforces FKs by default — a
+    # documented deviation from SQLite's OFF default).  The mini-sqlite
+    # engine consults its per-connection PRAGMA state and forwards the
+    # value here on each ``execute()`` call.
+    fk_enabled: bool = True
     # Working-set rows for recursive CTEs.  Populated by _execute_with_cursors
     # before running the recursive sub-program; read by OpenWorkingSetScan to
     # create a fresh _SubqueryCursor on each loop entry (handles JOIN context).
@@ -383,6 +391,7 @@ def execute(
     check_registry: dict[str, list[tuple[str, tuple[Instruction, ...]]]] | None = None,
     fk_child: dict[str, list[tuple[str, str, str | None]]] | None = None,
     fk_parent: dict[str, list[tuple[str, str, str | None]]] | None = None,
+    fk_enabled: bool = True,
     event_cb: Callable[[QueryEvent], None] | None = None,
     filtered_columns: list[str] | None = None,
     trigger_executor: Callable | None = None,
@@ -433,6 +442,7 @@ def execute(
         check_registry=registry,
         fk_child=fk_c,
         fk_parent=fk_p,
+        fk_enabled=fk_enabled,
         trigger_executor=trigger_executor,
         trigger_depth=trigger_depth,
         user_functions=user_functions,
@@ -2664,7 +2674,12 @@ def _check_fk_child(table: str, row: dict, st: _VmState) -> None:
 
     NULL FK values pass unconditionally (SQL standard: unknown reference is
     not an error).  Non-NULL values must have a matching row in the parent.
+
+    Honours :attr:`_VmState.fk_enabled` — when False (mirrors SQLite's
+    ``PRAGMA foreign_keys = OFF``), all FK checks are skipped.
     """
+    if not st.fk_enabled:
+        return
     fks = st.fk_child.get(table)
     if not fks:
         return
@@ -2690,7 +2705,13 @@ def _check_fk_parent(table: str, row: dict, st: _VmState) -> None:
     Only the columns registered in ``fk_parent`` are checked.  NULL values in
     the parent's referenced column cannot be referenced by any child (because
     child NULL passes unconditionally in :func:`_check_fk_child`), so we skip.
+
+    Honours :attr:`_VmState.fk_enabled` — when False (mirrors SQLite's
+    ``PRAGMA foreign_keys = OFF``), DELETE is permitted even when child
+    rows reference the deleted parent.
     """
+    if not st.fk_enabled:
+        return
     refs = st.fk_parent.get(table)
     if not refs:
         return


### PR DESCRIPTION
## Summary

ORMs and migration tools commonly disable FK enforcement during bulk operations (``PRAGMA foreign_keys = OFF``), reload data, then re-enable it. Mini-sqlite previously ignored the setting — FK validation was unconditional, so the OFF path couldn't be used to insert orphans or delete referenced parents.

This change plumbs the per-connection PRAGMA value through to the VM's FK validation. ``_VmState.fk_enabled`` short-circuits both ``_check_fk_child`` and ``_check_fk_parent`` when False.

**Default deviation from SQLite** (documented): mini-sqlite continues to enforce FK by default (sets ``PRAGMA foreign_keys = 1``), where real SQLite defaults to OFF. Both engines respect explicit toggles identically.

## Test plan

- [x] sql-vm: 921 tests, 80.31% coverage
- [x] mini-sqlite: 2212 tests, 90.93% coverage (8 new toggle tests + 2 pre-existing updated for new default)
- [x] Other packages: regression-only
- [x] ruff clean
- [x] /security-review passed

Versions: sql-vm 1.54 → 1.55, mini-sqlite 1.98 → 1.99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)