### PR TITLE
feat(visicalc): VC2-webcomp — Web Component cross-backend demo

### DIFF
--- a/demo/visicalc-webcomp/README.md
+++ b/demo/visicalc-webcomp/README.md
@@ -1,0 +1,62 @@
+# VisiCalc — WebComponent demo
+
+Second cross-backend visual demo (Phase 2 / VC2-webcomp), driven by a
+real Web Component. Companion to `demo/visicalc-html/`'s static
+snapshot.
+
+## What it shows
+
+- `<mos-formula-bar cell-address="A1" formula="=SUM(B1:B5)">` rendered
+  as a live custom element with its own shadow DOM. Styles compiled
+  in from `FormulaBar.dark.msl`.
+- Typing into the input dispatches `mosaic:formulaChange` /
+  `mosaic:commit` / `mosaic:cancel` CustomEvents that escape the
+  shadow root (because the emitter sets `bubbles: true, composed:
+  true`).
+- A small event log at the bottom shows the events as they fire —
+  proof the wiring works end-to-end.
+- A 5×5 sample grid below (hand-written for now — see the gap note).
+
+## How it's built
+
+```bash
+bash scripts/build.sh
+```
+
+Runs `mosaic-compile --backend webcomponent` against
+`demo/visicalc/mosaic/FormulaBar.{mil,desktop.mll,dark.msl}` and
+writes `build/FormulaBar.js`. The bundle is a self-registering
+script: it calls `customElements.define("mos-formula-bar", ...)` at
+parse time.
+
+## The Grid gap
+
+The `Grid` built-in primitive isn't yet supported by the
+`mosaic-emit-webcomponent` pipeline (only the React emitter knows how
+to lower it — see
+`code/packages/rust/mosaic-emit-react/src/pipeline.rs`). Until the
+WebComponent Grid emitter lands, the grid below the formula bar in
+`index.html` is hand-written to mirror what the eventual `<mos-grid>`
+custom element should render.
+
+## How to view
+
+```
+open demo/visicalc-webcomp/index.html
+```
+
+(Or just double-click the file in a file browser. Type into the
+formula bar and watch the events stream into the log below.)
+
+## Where this fits in the cross-backend demo plan
+
+| Phase | Demo | Status |
+|---|---|---|
+| 2 | VC2-html | ✅ |
+| 2 | VC2-webcomp (this one) | ✅ |
+| 2 | VC2-flutter | TODO |
+| 2 | VC2-qt | TODO |
+| 2 | VC2-swiftui | TODO |
+| 2 | VC2-xaml | TODO |
+| 3 | multi-component artifact-builder shells | TODO |
+| 4 | demo/visicalc-all/ (all 7 backends) | TODO |

--- a/demo/visicalc-webcomp/index.html
+++ b/demo/visicalc-webcomp/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<!--
+  VisiCalc — WebComponent demo (Phase 2 / VC2-webcomp).
+
+  Second cross-backend visual demo, this one driven by an actual
+  custom element. `build/FormulaBar.js` registers `<mos-formula-bar>`
+  as a shadow-DOM custom element; this page imports the bundle, mounts
+  the element with HTML attributes carrying the slot values, and
+  listens for the `mosaic:formulaChange` / `mosaic:commit` /
+  `mosaic:cancel` custom events the element dispatches on user input.
+
+  Unlike VC2-html (static snapshot, no JS), this demo:
+    1. Loads the FormulaBar.js bundle.
+    2. Mounts <mos-formula-bar cell-address="A1" formula="=SUM(B1:B5)">.
+    3. The element renders into its own shadow DOM with the styles
+       compiled in from FormulaBar.dark.msl.
+    4. Typing into the input fires `mosaic:formulaChange` events the
+       page handler logs to the console (proof the wiring works).
+
+  The Grid below is still a hand-written <table> because the
+  WebComponent emitter doesn't yet support the `Grid` built-in
+  primitive (only the React emitter does). When `<mos-grid>` lands
+  via the same pipeline, this hand-written block gets replaced.
+
+  To regenerate: cd demo/visicalc-webcomp && bash scripts/build.sh
+  To view:       open demo/visicalc-webcomp/index.html in any browser.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VisiCalc — Mosaic WebComponent demo</title>
+  <style>
+    body {
+      margin: 0;
+      background: #1e1e1e;
+      color: #cccccc;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .app {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 16px;
+    }
+    h1 {
+      font-size: 14px;
+      font-weight: normal;
+      color: #9d9d9d;
+      margin: 0 0 8px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    .note {
+      color: #9d9d9d;
+      font-size: 11px;
+      margin-top: 16px;
+      padding: 8px;
+      background: #252526;
+      border-left: 2px solid #007acc;
+    }
+    .note code { color: #cccccc; }
+    #event-log {
+      margin-top: 12px;
+      padding: 8px;
+      background: #1a1a1a;
+      border: 1px solid #3f3f46;
+      font-family: monospace;
+      font-size: 11px;
+      max-height: 100px;
+      overflow-y: auto;
+    }
+    #event-log:empty::before {
+      content: "(Edit the formula bar above to see events here…)";
+      color: #555;
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <h1>VisiCalc · Mosaic WebComponent demo</h1>
+
+    <!--
+      ===== FormulaBar (custom element) =====
+      `<mos-formula-bar>` is defined by build/FormulaBar.js. The
+      `cell-address`, `formula`, and `read-only` attributes map
+      directly to the FormulaBar.mil slots; the element observes them
+      via `attributeChangedCallback` and re-renders on change.
+
+      User input dispatches `mosaic:formulaChange` / `mosaic:commit` /
+      `mosaic:cancel` custom events with `bubbles: true, composed:
+      true` so they escape the shadow root. The script below listens
+      on the host and appends a one-liner to #event-log.
+    -->
+    <mos-formula-bar
+      cell-address="A1"
+      formula="=SUM(B1:B5)">
+    </mos-formula-bar>
+
+    <!--
+      ===== Grid (hand-written placeholder) =====
+      Same gap as VC2-html — the WebComponent pipeline emitter
+      doesn't yet support the `Grid` built-in primitive. Visual
+      contract matches Grid.dark.msl (#1e1e1e bg, #3f3f46 gridlines,
+      #264f78 selected cell). Once `<mos-grid>` lands, this block
+      becomes `<mos-grid column-headers="A,B,C,D,E" ...>`.
+    -->
+    <div data-mosaic-component="Grid">
+      <div style="overflow: auto; max-height: 400px; margin-top: 4px;">
+        <table style="font-family: monospace; font-size: 12px; color: #cccccc; background: #1e1e1e; border-collapse: collapse; width: 100%">
+          <colgroup>
+            <col style="width: 48px"><col style="width: 96px"><col style="width: 96px">
+            <col style="width: 96px"><col style="width: 96px"><col style="width: 96px">
+          </colgroup>
+          <thead style="position: sticky; top: 0; z-index: 1;">
+            <tr style="height: 24px">
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46"></th>
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">A</th>
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">B</th>
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">C</th>
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">D</th>
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">E</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style="height: 22px; background: #1e1e1e">
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">1</th>
+              <td style="border: 1px solid #3f3f46; padding: 2px; background: #264f78; color: #ffffff; outline: 1px solid #007acc">15</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">3</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">12</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">8</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">5</td>
+            </tr>
+            <tr style="height: 22px; background: #252526">
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">2</th>
+              <td style="border: 1px solid #3f3f46; padding: 2px">8</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">14</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">7</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">22</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">11</td>
+            </tr>
+            <tr style="height: 22px; background: #1e1e1e">
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">3</th>
+              <td style="border: 1px solid #3f3f46; padding: 2px">12</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">9</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">18</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">6</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">25</td>
+            </tr>
+            <tr style="height: 22px; background: #252526">
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">4</th>
+              <td style="border: 1px solid #3f3f46; padding: 2px">4</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">11</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">3</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">17</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">9</td>
+            </tr>
+            <tr style="height: 22px; background: #1e1e1e">
+              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">5</th>
+              <td style="border: 1px solid #3f3f46; padding: 2px">7</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">5</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">13</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">10</td>
+              <td style="border: 1px solid #3f3f46; padding: 2px">19</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <h1 style="margin-top: 24px;">Events from &lt;mos-formula-bar&gt;</h1>
+    <div id="event-log"></div>
+
+    <div class="note">
+      <strong>Live custom element.</strong> The
+      <code>&lt;mos-formula-bar&gt;</code> above is a real Web Component
+      registered by <code>build/FormulaBar.js</code> (compiled from
+      <code>FormulaBar.mil/.mll/.msl</code> via
+      <code>mosaic-compile --backend webcomponent</code>). It uses
+      shadow DOM, observed attributes, and fires
+      <code>mosaic:formulaChange</code> / <code>mosaic:commit</code> /
+      <code>mosaic:cancel</code> CustomEvents on user input — visible
+      in the log above. The Grid is still hand-written until the
+      WebComponent emitter learns the <code>Grid</code> primitive.
+    </div>
+  </div>
+
+  <script type="module">
+    // Import the compiled bundle — defines the <mos-formula-bar>
+    // element. The bundle is a plain script (not an ES module) so it
+    // self-registers via `customElements.define` on load. Using
+    // type="module" here is just a convenience for the small event-
+    // logging glue below; the FormulaBar bundle works in plain
+    // <script src="..."> too.
+    import "./build/FormulaBar.js";
+
+    // Listen for the FormulaBar's custom events and log them. The
+    // events bubble + cross the shadow boundary because the emitter
+    // sets `bubbles: true, composed: true`. Listening on the host
+    // element rather than `document` keeps the log scoped to this
+    // FormulaBar instance.
+    const fb = document.querySelector("mos-formula-bar");
+    const log = document.getElementById("event-log");
+    for (const evt of ["formulaChange", "commit", "cancel"]) {
+      fb.addEventListener(`mosaic:${evt}`, (e) => {
+        const time = new Date().toLocaleTimeString();
+        const payload = JSON.stringify(e.detail);
+        const line = document.createElement("div");
+        line.textContent = `[${time}] mosaic:${evt} → ${payload}`;
+        log.prepend(line);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/demo/visicalc-webcomp/scripts/build.sh
+++ b/demo/visicalc-webcomp/scripts/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# build.sh — regenerate the FormulaBar WebComponent bundle from the
+# Mosaic pipeline (mosaic-compile --backend webcomponent).
+#
+# Per the VisiCalc cross-backend demo plan (Phase 2 — VC2-webcomp):
+# this is the second cross-backend demo. The output is a JS file that
+# defines `<mos-formula-bar>` as a custom element with shadow-DOM
+# styling; index.html imports the bundle and mounts the element with
+# HTML attributes.
+#
+# Today we only compile FormulaBar through the pipeline. The Grid
+# fragment in index.html is hand-written (same gap as VC2-html — the
+# `Grid` built-in primitive isn't supported by the
+# mosaic-emit-webcomponent pipeline yet, only the React emitter knows
+# how to lower it). When the WebComponent Grid emitter lands, this
+# script gains a second `mosaic-compile --backend webcomponent ...`
+# line for Grid and index.html switches to `<mos-grid>` instead of
+# the hand-written `<table>` placeholder.
+#
+# Usage:
+#   cd demo/visicalc-webcomp
+#   bash scripts/build.sh
+#
+# Output:
+#   demo/visicalc-webcomp/build/FormulaBar.js
+#
+# Open `demo/visicalc-webcomp/index.html` in any browser to view.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$DEMO_DIR/../.." && pwd)"
+
+MOSAIC_COMPILE="$REPO_ROOT/code/packages/rust/target/debug/mosaic-compile"
+
+if [ ! -x "$MOSAIC_COMPILE" ]; then
+  echo "Building mosaic-compile..."
+  (cd "$REPO_ROOT/code/packages/rust" && cargo build -p mosaic-compile)
+fi
+
+SRC="$REPO_ROOT/demo/visicalc/mosaic"
+OUT_DIR="$DEMO_DIR/build"
+mkdir -p "$OUT_DIR"
+
+echo "Compiling FormulaBar (WebComponent)..."
+"$MOSAIC_COMPILE" --backend webcomponent \
+  --interface "$SRC/FormulaBar.mil" \
+  --layout    "$SRC/FormulaBar.desktop.mll" \
+  --style     "$SRC/FormulaBar.dark.msl" \
+  -o "$OUT_DIR/FormulaBar.js"
+
+# TODO(VC2-webcomp-grid): wire Grid once the WebComponent pipeline
+# emitter supports the `Grid` built-in primitive. Until then,
+# index.html uses a hand-written static-HTML <table> placeholder.
+
+echo "Done. Generated:"
+ls -la "$OUT_DIR"
+echo
+echo "Open $DEMO_DIR/index.html in a browser to view."


### PR DESCRIPTION
## Summary

Closes plan item [G]. Ships \`demo/visicalc-webcomp/\` — the second cross-backend VisiCalc visual demo, driven by a real Web Component this time (vs. VC2-html's static snapshot).

- **\`index.html\`** loads \`build/FormulaBar.js\` (compiled bundle that registers \`<mos-formula-bar>\` as a shadow-DOM custom element), mounts it with HTML attributes, and listens for the \`mosaic:formulaChange\` / \`mosaic:commit\` / \`mosaic:cancel\` CustomEvents the element dispatches on user input. A small event log proves the wiring works end-to-end.
- **\`scripts/build.sh\`** regenerates \`build/FormulaBar.js\` via \`mosaic-compile --backend webcomponent\` against the canonical Mosaic sources.
- **Grid** is hand-written placeholder (same gap as VC2-html — only the React emitter knows how to lower the \`Grid\` built-in primitive). Once the WebComponent Grid emitter lands, this becomes \`<mos-grid ...>\`.

## Test plan

- [x] \`bash demo/visicalc-webcomp/scripts/build.sh\` produces \`build/FormulaBar.js\`
- [x] FormulaBar.js defines \`<mos-formula-bar>\` via \`customElements.define\`
- [x] Element renders shadow DOM with compiled FormulaBar.dark.msl styling
- [x] CustomEvents bubble + cross shadow boundary (\`composed: true\`)
- [x] Security review passed
- [ ] Open \`demo/visicalc-webcomp/index.html\` in a browser, type in formula bar, verify events stream into log
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)