### PR TITLE
spice: add diode transit time model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -14,6 +14,9 @@
   small-signal AC susceptance in parallel with the linearized diode
   conductance.
 
+- **Diode transit-time models** — `Diode.Tt` now contributes forward-bias
+  diffusion capacitance to small-signal AC admittance.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -425,6 +425,7 @@ class Diode:
     BV: float | None = None  # reverse breakdown voltage
     IBV: float = 1e-3  # reverse current at breakdown voltage
     Cjo: float = 0.0  # zero-bias junction capacitance
+    Tt: float = 0.0  # transit time / diffusion capacitance coefficient
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -254,6 +254,7 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
             element.BV,
             element.IBV,
             element.Cjo,
+            element.Tt,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_)
@@ -1718,6 +1719,8 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(f"{el.name}: diode breakdown current must be finite and positive")
     if not math.isfinite(el.Cjo) or el.Cjo < 0.0:
         raise ValueError(f"{el.name}: diode junction capacitance must be finite and non-negative")
+    if not math.isfinite(el.Tt) or el.Tt < 0.0:
+        raise ValueError(f"{el.name}: diode transit time must be finite and non-negative")
     return el.Vt * el.N
 
 
@@ -3883,7 +3886,8 @@ def _stamp_ac(
         Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
         Vd = Va - Vk
         _, gd = _diode_current_conductance(el, Vd)
-        _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 1j * omega * el.Cjo)
+        diffusion_capacitance = el.Tt * gd
+        _stamp_g_c(G, node_to_idx, el.anode, el.cathode, gd + 1j * omega * (el.Cjo + diffusion_capacitance))
 
     elif isinstance(el, JFET):
         Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
@@ -5311,7 +5315,7 @@ def sens_dc(
             _make_entry(
                 "Is",
                 el.Is,
-                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N, el.BV, el.IBV, el.Cjo),
+                Diode(el.name, el.anode, el.cathode, el.Is + delta_is, el.Vt, el.N, el.BV, el.IBV, el.Cjo, el.Tt),
             )
 
         elif isinstance(el, BJT):
@@ -5537,7 +5541,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
         )
 
     if isinstance(el, Diode):
-        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N, el.BV, el.IBV, el.Cjo)
+        return Diode(el.name, el.anode, el.cathode, _draw(el.Is), el.Vt, el.N, el.BV, el.IBV, el.Cjo, el.Tt)
 
     if isinstance(el, BJT):
         return BJT(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -2066,7 +2066,7 @@ def test_ac_diode_reverse_biased_acts_like_open():
     is determined only by the resistor divider.
     """
     c = Circuit()
-    c.add(VoltageSource("Vac", "in", "0", 1.0))
+    c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
     c.add(Resistor("R1", "in", "anode", 1000.0))
     c.add(Resistor("R2", "anode", "0", 1000.0))   # load
     # Diode reverse-biased: cathode at Vin, anode at V_mid ≈ 0.5 V
@@ -2095,6 +2095,23 @@ def test_ac_diode_junction_capacitance_shunts_high_frequency():
 
     assert low > 0.9
     assert high < low / 100.0
+
+
+def test_ac_diode_transit_time_shunts_forward_bias_at_high_frequency():
+    """Forward-biased diode transit time contributes diffusion capacitance."""
+    def high_frequency_anode(tt: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 1.0, ac=AcSource(1.0)))
+        c.add(Resistor("R1", "in", "anode", 1.0e6))
+        c.add(Diode("D1", anode="anode", cathode="0", Tt=tt))
+        result = ac_sweep(c, f_start=100000000.0, f_stop=100000000.0, n_points=1)
+        return abs(result.points[0].node_voltages["anode"])
+
+    without_transit = high_frequency_anode(0.0)
+    with_transit = high_frequency_anode(1.0e-6)
+
+    assert without_transit > 0.01
+    assert with_transit < without_transit / 100.0
 
 
 def test_ac_bjt_npn_small_signal():

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -8,6 +8,7 @@
   `.model ... D(... BV=<v> IBV=<i>)`.
 - Parse diode model-card junction capacitance with
   `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
+- Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -416,6 +416,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             BV=model.params.get("BV"),
             IBV=model.params.get("IBV", 1e-3),
             Cjo=model.params.get("CJO", model.params.get("CJ0", 0.0)),
+            Tt=model.params.get("TT", 0.0),
         )
     if prefix == "Q":
         _require_fields(fields, 5, "BJT")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -451,7 +451,7 @@ Rload out 0 500
 def test_parse_diode_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -463,7 +463,15 @@ Rload out 0 1k
         "fast": ModelCard(
             "fast",
             "D",
-            {"IS": 1.0e-12, "VT": 25.0e-3, "N": 2.0, "BV": 5.0, "IBV": 1.0e-6, "CJO": 2.0e-12},
+            {
+                "IS": 1.0e-12,
+                "VT": 25.0e-3,
+                "N": 2.0,
+                "BV": 5.0,
+                "IBV": 1.0e-6,
+                "CJO": 2.0e-12,
+                "TT": 4.0e-9,
+            },
         )
     }
     diode = parsed.circuit.elements[1]
@@ -476,6 +484,7 @@ Rload out 0 1k
     assert diode.BV == 5.0
     assert diode.IBV == 1.0e-6
     assert diode.Cjo == 2.0e-12
+    assert diode.Tt == 4.0e-9
 
     result = dc_op(parsed.circuit)
     assert result.converged
@@ -797,7 +806,7 @@ Rload out 0 500
 def test_expands_subcircuit_diode_nodes_into_engine_elements() -> None:
     parsed = parse_netlist(
         """
-.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p TT=5n)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -815,6 +824,7 @@ Xlim in out limiter
     assert diode.BV == 5.0
     assert diode.IBV == 1.0e-6
     assert diode.Cjo == 3.0e-12
+    assert diode.Tt == 5.0e-9
 
 
 def test_expands_subcircuit_bjt_nodes_into_engine_elements() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Add diode junction capacitance support through `junction_capacitance`,
   contributing small-signal AC susceptance in parallel with the linearized
   diode conductance.
+- Add diode transit-time support through `transit_time`, contributing
+  forward-bias diffusion capacitance to small-signal AC admittance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -301,6 +301,7 @@ fn clone_subckt_element(
             element.breakdown_voltage,
             element.breakdown_current,
             element.junction_capacitance,
+            element.transit_time,
         )),
         Element::Jfet(element) => Element::Jfet(Jfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1086,6 +1087,7 @@ pub struct Diode {
     pub breakdown_voltage: Option<f64>,
     pub breakdown_current: f64,
     pub junction_capacitance: f64,
+    pub transit_time: f64,
 }
 
 impl Diode {
@@ -1132,6 +1134,7 @@ impl Diode {
             None,
             1.0e-3,
             0.0,
+            0.0,
         )
     }
 
@@ -1145,6 +1148,7 @@ impl Diode {
         breakdown_voltage: Option<f64>,
         breakdown_current: f64,
         junction_capacitance: f64,
+        transit_time: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -1156,6 +1160,7 @@ impl Diode {
             breakdown_voltage,
             breakdown_current,
             junction_capacitance,
+            transit_time,
         }
     }
 }
@@ -4684,11 +4689,15 @@ fn build_ac_matrix(
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
                 let (_, conductance) = diode_current_conductance(diode, voltage);
+                let diffusion_capacitance = diode.transit_time * conductance;
                 stamp_complex_conductance(
                     &mut matrix,
                     anode,
                     cathode,
-                    Complex::new(conductance, omega * diode.junction_capacitance),
+                    Complex::new(
+                        conductance,
+                        omega * (diode.junction_capacitance + diffusion_capacitance),
+                    ),
                 );
             }
             Element::Jfet(jfet) => {
@@ -5844,6 +5853,12 @@ fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),
             reason: "junction capacitance must be finite and non-negative".to_string(),
+        });
+    }
+    if !diode.transit_time.is_finite() || diode.transit_time < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "transit time must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -65,14 +65,14 @@ fn ac_rc_low_pass_has_minus_three_db_corner() {
 #[test]
 fn ac_diode_junction_capacitance_shunts_high_frequency() {
     let mut circuit = Circuit::new();
-    circuit.add(Element::VoltageSource(VoltageSource::new(
-        "Vac", "in", "0", 1.0,
+    circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+        "Vac", "in", "0", 0.0, 1.0, 0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "R1", "in", "node", 1_000.0,
     )));
     circuit.add(Element::Diode(Diode::with_model_and_breakdown(
-        "D1", "0", "node", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 1.0e-6,
+        "D1", "0", "node", 1.0e-15, 0.02585, 1.0, None, 1.0e-3, 1.0e-6, 0.0,
     )));
 
     let points = ac_sweep(&circuit, 10.0, 100_000.0, 2).unwrap();
@@ -83,6 +83,45 @@ fn ac_diode_junction_capacitance_shunts_high_frequency() {
     assert!(
         high < low / 100.0,
         "expected high-frequency shunt, got low={low} high={high}"
+    );
+}
+
+#[test]
+fn ac_diode_transit_time_shunts_forward_bias_at_high_frequency() {
+    fn high_frequency_anode(transit_time: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 1.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("R1", "in", "anode", 1.0e6)));
+        circuit.add(Element::Diode(Diode::with_model_and_breakdown(
+            "D1",
+            "anode",
+            "0",
+            1.0e-15,
+            0.02585,
+            1.0,
+            None,
+            1.0e-3,
+            0.0,
+            transit_time,
+        )));
+        ac_sweep(&circuit, 100_000_000.0, 100_000_000.0, 1).unwrap()[0]
+            .voltage("anode")
+            .unwrap()
+            .abs()
+    }
+
+    let without_transit = high_frequency_anode(0.0);
+    let with_transit = high_frequency_anode(1.0e-6);
+
+    assert!(
+        without_transit > 0.01,
+        "expected measurable high-frequency voltage without transit time, got {without_transit}"
+    );
+    assert!(
+        with_transit < without_transit / 100.0,
+        "expected transit-time high-frequency shunt, got no_tt={without_transit} tt={with_transit}"
     );
 }
 

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -328,6 +328,7 @@ fn dc_diode_breakdown_voltage_increases_reverse_bias_current() {
         Some(5.0),
         1.0e-6,
         0.0,
+        0.0,
     )));
 
     let leakage_result = dc_op(&leakage).unwrap();

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -8,6 +8,7 @@
   `.model ... D(... BV=<v> IBV=<i>)`.
 - Parse diode model-card junction capacitance with
   `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
+- Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -742,6 +742,7 @@ fn parse_element(
                     .or_else(|| model.params.get("CJ0"))
                     .copied()
                     .unwrap_or(0.0),
+                *model.params.get("TT").unwrap_or(&0.0),
             )))
         }
         'Q' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -645,7 +645,7 @@ Rload out 0 500
 fn parses_diode_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -663,6 +663,7 @@ Rload out 0 1k
     assert_close(*model.params.get("BV").unwrap(), 5.0);
     assert_close(*model.params.get("IBV").unwrap(), 1.0e-6);
     assert_close(*model.params.get("CJO").unwrap(), 2.0e-12);
+    assert_close(*model.params.get("TT").unwrap(), 4.0e-9);
 
     let Element::Diode(diode) = &parsed.circuit.elements()[1] else {
         panic!("expected diode");
@@ -676,6 +677,7 @@ Rload out 0 1k
     assert_close(diode.breakdown_voltage.unwrap(), 5.0);
     assert_close(diode.breakdown_current, 1.0e-6);
     assert_close(diode.junction_capacitance, 2.0e-12);
+    assert_close(diode.transit_time, 4.0e-9);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();
@@ -1041,7 +1043,7 @@ Rload out 0 500
 fn expands_subcircuit_diode_nodes_into_engine_elements() {
     let parsed = parse_netlist(
         r#"
-.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p TT=5n)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -1060,6 +1062,7 @@ Xlim in out limiter
     assert_close(diode.breakdown_voltage.unwrap(), 5.0);
     assert_close(diode.breakdown_current, 1.0e-6);
     assert_close(diode.junction_capacitance, 3.0e-12);
+    assert_close(diode.transit_time, 5.0e-9);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Add diode junction capacitance support through `junctionCapacitance`,
   contributing small-signal AC susceptance in parallel with the linearized
   diode conductance.
+- Add diode transit-time support through `transitTime`, contributing
+  forward-bias diffusion capacitance to small-signal AC admittance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -363,6 +363,7 @@ export interface Diode {
   readonly breakdownVoltage?: number;
   readonly breakdownCurrent: number;
   readonly junctionCapacitance: number;
+  readonly transitTime: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -949,7 +950,7 @@ function cloneSubcktElement(
     case "b-source":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap), voltageExpr: mapBSourceExprNodes(element.voltageExpr, instanceName, nodeMap), currentExpr: mapBSourceExprNodes(element.currentExpr, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
@@ -1202,6 +1203,7 @@ export function diode(
   breakdownVoltage?: number,
   breakdownCurrent = 1.0e-3,
   junctionCapacitance = 0.0,
+  transitTime = 0.0,
 ): Diode {
   return {
     kind: "diode",
@@ -1214,6 +1216,7 @@ export function diode(
     breakdownVoltage,
     breakdownCurrent,
     junctionCapacitance,
+    transitTime,
   };
 }
 
@@ -3918,11 +3921,12 @@ function buildAcMatrix(
         const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.anode)) -
           vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.cathode));
         const [, diodeConductance] = diodeCurrentConductance(element, diodeVoltage);
+        const diffusionCapacitance = element.transitTime * diodeConductance;
         stampComplexConductance(
           matrix,
           nodeIndex(nodeIndices, element.anode),
           nodeIndex(nodeIndices, element.cathode),
-          complex(diodeConductance, omega * element.junctionCapacitance),
+          complex(diodeConductance, omega * (element.junctionCapacitance + diffusionCapacitance)),
         );
         break;
       case "jfet":
@@ -4835,6 +4839,9 @@ function validateDiode(element: Diode): void {
   }
   if (!Number.isFinite(element.junctionCapacitance) || element.junctionCapacitance < 0.0) {
     throw invalidElement(element.name, "junction capacitance must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.transitTime) || element.transitTime < 0.0) {
+    throw invalidElement(element.name, "transit time must be finite and non-negative");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -70,7 +70,7 @@ describe("acSweep", () => {
 
   it("stamps reverse-biased diode junction capacitance", () => {
     const circuit = new Circuit();
-    circuit.add(voltageSource("Vac", "in", "0", 1.0));
+    circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
     circuit.add(resistor("R1", "in", "node", 1_000.0));
     circuit.add(diode("D1", "0", "node", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 1.0e-6));
 
@@ -80,6 +80,22 @@ describe("acSweep", () => {
 
     expect(low).toBeGreaterThan(0.9);
     expect(high).toBeLessThan(low / 100.0);
+  });
+
+  it("stamps forward-biased diode transit-time diffusion capacitance", () => {
+    const highFrequencyAnode = (transitTime: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 1.0, 1.0));
+      circuit.add(resistor("R1", "in", "anode", 1.0e6));
+      circuit.add(diode("D1", "anode", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 0.0, transitTime));
+      return complexAbs(acSweep(circuit, 100_000_000.0, 100_000_000.0, 1)[0].voltage("anode")!);
+    };
+
+    const withoutTransit = highFrequencyAnode(0.0);
+    const withTransit = highFrequencyAnode(1.0e-6);
+
+    expect(withoutTransit).toBeGreaterThan(0.01);
+    expect(withTransit).toBeLessThan(withoutTransit / 100.0);
   });
 
   it("runs frequency sweeps at each named corner", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -8,6 +8,7 @@
   `.model ... D(... BV=<v> IBV=<i>)`.
 - Parse diode model-card junction capacitance with
   `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
+- Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -571,6 +571,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("BV"),
       model.params.get("IBV") ?? 1.0e-3,
       model.params.get("CJO") ?? model.params.get("CJ0") ?? 0.0,
+      model.params.get("TT") ?? 0.0,
     );
   }
   if (prefix === "Q") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -421,7 +421,7 @@ Rload out 0 500
 
   it("parses diode models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p)
+.model fast D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJO=2p TT=4n)
 V1 in 0 DC 0.7
 D1 in out fast
 Rload out 0 1k
@@ -438,6 +438,7 @@ Rload out 0 1k
         ["BV", 5.0],
         ["IBV", 1.0e-6],
         ["CJO", 2.0e-12],
+        ["TT", 4.0e-9],
       ]),
     });
     expect(parsed.circuit.elements()[1]).toMatchObject({
@@ -451,6 +452,7 @@ Rload out 0 1k
       breakdownVoltage: 5.0,
       breakdownCurrent: 1.0e-6,
       junctionCapacitance: 2.0e-12,
+      transitTime: 4.0e-9,
     });
 
     const result = dcOp(parsed.circuit);
@@ -755,7 +757,7 @@ Rload out 0 500
 
   it("expands subcircuit diode nodes into engine elements", () => {
     const parsed = parseNetlist(`
-.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p)
+.model clamp D(IS=1e-12 VT=25m N=2 BV=5 IBV=1u CJ0=3p TT=5n)
 .subckt limiter inp outp
 Dlim inp outp clamp
 .ends limiter
@@ -771,6 +773,7 @@ Xlim in out limiter
       breakdownVoltage: 5.0,
       breakdownCurrent: 1.0e-6,
       junctionCapacitance: 3.0e-12,
+      transitTime: 5.0e-9,
     });
   });
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -207,6 +207,9 @@ Status:
 - Diode `.model ... D(... CJO=<capacitance>)` / `CJ0` parsing and AC
   junction-capacitance admittance are implemented across Python, TypeScript,
   and Rust.
+- Diode `.model ... D(... TT=<time>)` parsing and forward-bias diffusion
+  capacitance are implemented in AC analysis across Python, TypeScript, and
+  Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary

- add diode transit-time fields across Python, TypeScript, and Rust diode elements
- parse `.model ... D(... TT=<time>)` into diode elements across all netlist parsers
- stamp forward-bias diffusion capacitance as `TT * gd` in diode small-signal AC admittance and document the Phase 6 foothold

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-transit-time PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-diode-transit-time PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `cargo test -p spice-engine -p spice-netlist-parser`
- `git diff --check`