### PR TITLE
feat(sql): implement RETURNING * shorthand

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -197,7 +197,11 @@ assignment        = NAME "=" expr ;
 
 delete_stmt       = "DELETE" "FROM" NAME [ where_clause ] [ returning_clause ] ;
 
-returning_clause  = "RETURNING" expr { "," expr } ;
+returning_clause  = "RETURNING" returning_item { "," returning_item } ;
+# RETURNING accepts ``*`` (shorthand for every column of the target
+# table, in declaration order) as well as ordinary expressions —
+# matches SQLite's RETURNING grammar.
+returning_item    = "*" | expr ;
 
 # ── CREATE TABLE / DROP TABLE ─────────────────────────────────────────────────
 

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.0.0] - 2026-05-23
+
+### Added
+
+- ``RETURNING *`` shorthand is now supported on INSERT, UPDATE, and
+  DELETE — expands to one column per table column in declaration
+  order (matches SQLite).  Mixed forms like ``RETURNING id, *`` are
+  also accepted.
+
+  Implementation: parser accepts ``returning_item = "*" | expr``;
+  adapter emits :class:`Wildcard` sentinel; planner's
+  ``_expand_returning_wildcards()`` expands to ``Column(table, col)``
+  references at resolution time.
+
+### Known limitation
+
+- ``INSERT INTO t(v) VALUES (...) RETURNING *`` reports the
+  auto-assigned INTEGER PRIMARY KEY column as NULL when the user
+  omitted the id.  Pre-existing bug in INSERT RETURNING that's
+  independent of the ``*`` shorthand — explicit-id INSERTs and
+  UPDATE/DELETE RETURNING work correctly.  Filed for follow-up.
+
 ## [1.99.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "1.99.0"
+version = "2.0.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1021,18 +1021,30 @@ def _returning_exprs(
 ) -> tuple[Expr, ...]:
     """Parse a returning_clause child of a DML statement node.
 
-    ``returning_clause = 'RETURNING' expr { ',' expr }``
+    Grammar (mini-sqlite 2.0+)::
 
-    Returns an empty tuple when no returning_clause child is present.
+        returning_clause = "RETURNING" returning_item { "," returning_item } ;
+        returning_item   = "*" | expr ;
+
+    The bare-``*`` form yields a :class:`Wildcard` sentinel; the
+    planner expands it to every column of the target table at
+    resolution time (same handling SELECT * uses).  Returns an empty
+    tuple when no returning_clause child is present.
     """
     ret_node = _maybe_child(node, "returning_clause")
     if ret_node is None:
         return ()
-    return tuple(
-        _expr(c, state)
-        for c in ret_node.children
-        if isinstance(c, ASTNode) and c.rule_name == "expr"
-    )
+    items: list[Expr] = []
+    for c in ret_node.children:
+        if isinstance(c, ASTNode) and c.rule_name == "returning_item":
+            # ``*`` → Wildcard; ``expr`` → parsed expression.
+            if any(_is_token(t, type_="STAR") for t in c.children):
+                items.append(Wildcard())
+            else:
+                expr_node = _maybe_child(c, "expr")
+                if expr_node is not None:
+                    items.append(_expr(expr_node, state))
+    return tuple(items)
 
 
 def _conflict_action(node: ASTNode) -> str | None:

--- a/code/packages/python/mini-sqlite/tests/test_tier3_returning_star.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_returning_star.py
@@ -1,0 +1,129 @@
+"""Tests for ``RETURNING *`` shorthand in INSERT / UPDATE / DELETE.
+
+SQLite's RETURNING grammar accepts ``*`` as a shorthand for every
+column of the target table, in declaration order.  Mini-sqlite
+previously parse-errored on the literal ``*`` token after RETURNING;
+this PR adds:
+
+* Grammar: ``returning_item = "*" | expr``.
+* Adapter: ``*`` → :class:`Wildcard` sentinel in the returning list.
+* Planner: expands the Wildcard into one ``Column(table, col_name)``
+  per table column at resolution time (same approach as ``SELECT *``).
+
+These tests pin oracle compatibility with sqlite3 for the most common
+RETURNING * patterns.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both(*stmts: str, query: str) -> tuple:
+    """Run *stmts* + *query* on both engines, return (mini, ref) row lists."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    return (
+        mini.execute(query).fetchall(),
+        ref.execute(query).fetchall(),
+    )
+
+
+class TestInsertReturningStar:
+    """``INSERT ... RETURNING *`` returns every column of the inserted row."""
+
+    def test_insert_explicit_id(self) -> None:
+        # Use explicit id to sidestep mini-sqlite's pre-existing
+        # IPK-auto-assign-RETURNING gap (independent of this PR).
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            query="INSERT INTO t VALUES (5, 'a') RETURNING *",
+        )
+        assert m == r == [(5, "a")]
+
+    def test_three_column_table(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT, c REAL)",
+            query="INSERT INTO t VALUES (1, 'x', 2.5) RETURNING *",
+        )
+        assert m == r == [(1, "x", 2.5)]
+
+
+class TestUpdateReturningStar:
+    """``UPDATE ... RETURNING *`` returns one row per updated row."""
+
+    def test_update_all_returning_star(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b')",
+            query="UPDATE t SET v = 'X' RETURNING *",
+        )
+        assert m == r == [(1, "X"), (2, "X")]
+
+    def test_update_with_where(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b')",
+            query="UPDATE t SET v = 'X' WHERE id = 2 RETURNING *",
+        )
+        assert m == r == [(2, "X")]
+
+
+class TestDeleteReturningStar:
+    """``DELETE ... RETURNING *`` returns the deleted rows."""
+
+    def test_delete_returning_star(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b')",
+            query="DELETE FROM t WHERE id = 1 RETURNING *",
+        )
+        assert m == r == [(1, "a")]
+
+    def test_delete_all_returning_star(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+            query="DELETE FROM t RETURNING *",
+        )
+        assert m == r
+        assert len(m) == 3
+
+
+class TestExplicitColumnsStillWork:
+    """Existing RETURNING with explicit column lists still works."""
+
+    def test_returning_id_v(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b')",
+            query="UPDATE t SET v = 'X' WHERE id = 1 RETURNING id, v",
+        )
+        assert m == r == [(1, "X")]
+
+    def test_returning_single_column(self) -> None:
+        m, r = _both(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t VALUES (1, 'a')",
+            query="DELETE FROM t WHERE id = 1 RETURNING v",
+        )
+        assert m == r == [("a",)]
+
+
+class TestColumnOrder:
+    """RETURNING * follows table declaration order, not row insertion."""
+
+    def test_column_order_matches_table_declaration(self) -> None:
+        # The columns come back in declaration order regardless of
+        # which order the user supplied values in.
+        m, r = _both(
+            "CREATE TABLE t (a INT, b INT, c INT)",
+            query="INSERT INTO t (c, a, b) VALUES (3, 1, 2) RETURNING *",
+        )
+        # (a, b, c) order matches table declaration.
+        assert m == r == [(1, 2, 3)]

--- a/code/packages/python/sql-parser/CHANGELOG.md
+++ b/code/packages/python/sql-parser/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the SQL parser package will be documented in this file.
 
+## [0.40.0] - 2026-05-23
+
+### Changed
+
+- ``returning_clause`` now accepts ``*`` via a new ``returning_item``
+  alternative::
+
+      returning_clause = "RETURNING" returning_item { "," returning_item } ;
+      returning_item   = "*" | expr ;
+
+  Required for SQLite's ``RETURNING *`` shorthand.  Regenerated
+  ``_grammar.py``.
+
 ## [0.39.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-parser/pyproject.toml
+++ b/code/packages/python/sql-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-parser"
-version = "0.39.0"
+version = "0.40.0"
 description = "Parses SQL text into ASTs using the grammar-driven parser — a thin wrapper that loads sql.grammar"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-parser/src/sql_parser/_grammar.py
+++ b/code/packages/python/sql-parser/src/sql_parser/_grammar.py
@@ -730,15 +730,24 @@ PARSER_GRAMMAR = ParserGrammar(
             body=
             Sequence(elements=[
                 Literal(value='RETURNING'),
-                RuleReference(name='expr', is_token=False),
+                RuleReference(name='returning_item', is_token=False),
                 Repetition(element=
                     Sequence(elements=[
                         Literal(value=','),
-                        RuleReference(name='expr', is_token=False),
+                        RuleReference(name='returning_item', is_token=False),
                     ]),
                 ),
             ]),
             line_number=200,
+        ),
+        GrammarRule(
+            name='returning_item',
+            body=
+            Alternation(choices=[
+                Literal(value='*'),
+                RuleReference(name='expr', is_token=False),
+            ]),
+            line_number=204,
         ),
         GrammarRule(
             name='create_table_stmt',
@@ -767,7 +776,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='table_options', is_token=False),
                 ),
             ]),
-            line_number=204,
+            line_number=208,
         ),
         GrammarRule(
             name='table_options',
@@ -781,7 +790,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=213,
+            line_number=217,
         ),
         GrammarRule(
             name='table_option',
@@ -793,7 +802,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='NAME', is_token=True),
                 ]),
             ]),
-            line_number=214,
+            line_number=218,
         ),
         GrammarRule(
             name='col_def',
@@ -805,7 +814,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='col_constraint', is_token=False),
                 ),
             ]),
-            line_number=219,
+            line_number=223,
         ),
         GrammarRule(
             name='col_type',
@@ -826,7 +835,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=223,
+            line_number=227,
         ),
         GrammarRule(
             name='col_constraint',
@@ -883,7 +892,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=224,
+            line_number=228,
         ),
         GrammarRule(
             name='drop_table_stmt',
@@ -899,7 +908,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=235,
+            line_number=239,
         ),
         GrammarRule(
             name='alter_table_stmt',
@@ -941,7 +950,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=244,
+            line_number=248,
         ),
         GrammarRule(
             name='create_index_stmt',
@@ -975,7 +984,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='where_clause', is_token=False),
                 ),
             ]),
-            line_number=258,
+            line_number=262,
         ),
         GrammarRule(
             name='index_col',
@@ -995,7 +1004,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=275,
+            line_number=279,
         ),
         GrammarRule(
             name='drop_index_stmt',
@@ -1011,7 +1020,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=277,
+            line_number=281,
         ),
         GrammarRule(
             name='create_view_stmt',
@@ -1030,7 +1039,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='AS'),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=285,
+            line_number=289,
         ),
         GrammarRule(
             name='drop_view_stmt',
@@ -1046,7 +1055,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=287,
+            line_number=291,
         ),
         GrammarRule(
             name='begin_stmt',
@@ -1057,7 +1066,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=293,
+            line_number=297,
         ),
         GrammarRule(
             name='commit_stmt',
@@ -1068,7 +1077,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=294,
+            line_number=298,
         ),
         GrammarRule(
             name='rollback_stmt',
@@ -1079,7 +1088,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=295,
+            line_number=299,
         ),
         GrammarRule(
             name='savepoint_stmt',
@@ -1088,7 +1097,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='SAVEPOINT'),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=311,
+            line_number=315,
         ),
         GrammarRule(
             name='release_stmt',
@@ -1100,7 +1109,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=312,
+            line_number=316,
         ),
         GrammarRule(
             name='rollback_to_stmt',
@@ -1113,13 +1122,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=313,
+            line_number=317,
         ),
         GrammarRule(
             name='expr',
             body=
             RuleReference(name='or_expr', is_token=False),
-            line_number=317,
+            line_number=321,
         ),
         GrammarRule(
             name='or_expr',
@@ -1133,7 +1142,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=318,
+            line_number=322,
         ),
         GrammarRule(
             name='and_expr',
@@ -1147,7 +1156,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=319,
+            line_number=323,
         ),
         GrammarRule(
             name='not_expr',
@@ -1159,7 +1168,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='comparison', is_token=False),
             ]),
-            line_number=320,
+            line_number=324,
         ),
         GrammarRule(
             name='collated',
@@ -1173,7 +1182,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=333,
+            line_number=337,
         ),
         GrammarRule(
             name='comparison',
@@ -1271,7 +1280,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=334,
+            line_number=338,
         ),
         GrammarRule(
             name='in_expr',
@@ -1280,7 +1289,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='query_stmt', is_token=False),
                 RuleReference(name='value_list', is_token=False),
             ]),
-            line_number=350,
+            line_number=354,
         ),
         GrammarRule(
             name='cmp_op',
@@ -1293,7 +1302,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='<='),
                 Literal(value='>='),
             ]),
-            line_number=352,
+            line_number=356,
         ),
         GrammarRule(
             name='bitwise',
@@ -1314,7 +1323,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=366,
+            line_number=370,
         ),
         GrammarRule(
             name='additive',
@@ -1336,7 +1345,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=367,
+            line_number=371,
         ),
         GrammarRule(
             name='multiplicative',
@@ -1356,7 +1365,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=368,
+            line_number=372,
         ),
         GrammarRule(
             name='unary',
@@ -1373,7 +1382,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='primary', is_token=False),
             ]),
-            line_number=369,
+            line_number=373,
         ),
         GrammarRule(
             name='primary',
@@ -1407,7 +1416,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value=')'),
                 ]),
             ]),
-            line_number=389,
+            line_number=393,
         ),
         GrammarRule(
             name='column_ref',
@@ -1421,7 +1430,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=399,
+            line_number=403,
         ),
         GrammarRule(
             name='function_call',
@@ -1451,7 +1460,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='filter_clause', is_token=False),
                 ),
             ]),
-            line_number=413,
+            line_number=417,
         ),
         GrammarRule(
             name='filter_clause',
@@ -1463,7 +1472,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='expr', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=417,
+            line_number=421,
         ),
         GrammarRule(
             name='cast_expr',
@@ -1476,7 +1485,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='NAME', is_token=True),
                 Literal(value=')'),
             ]),
-            line_number=423,
+            line_number=427,
         ),
         GrammarRule(
             name='window_func_call',
@@ -1498,7 +1507,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='window_spec', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=452,
+            line_number=456,
         ),
         GrammarRule(
             name='window_spec',
@@ -1514,7 +1523,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_clause', is_token=False),
                 ),
             ]),
-            line_number=453,
+            line_number=457,
         ),
         GrammarRule(
             name='partition_clause',
@@ -1530,7 +1539,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=454,
+            line_number=458,
         ),
         GrammarRule(
             name='value_list',
@@ -1544,7 +1553,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=455,
+            line_number=459,
         ),
         GrammarRule(
             name='frame_clause',
@@ -1562,7 +1571,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_bound', is_token=False),
                 ]),
             ]),
-            line_number=477,
+            line_number=481,
         ),
         GrammarRule(
             name='frame_unit',
@@ -1572,7 +1581,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='RANGE'),
                 Literal(value='GROUPS'),
             ]),
-            line_number=479,
+            line_number=483,
         ),
         GrammarRule(
             name='frame_bound',
@@ -1599,7 +1608,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='FOLLOWING'),
                 ]),
             ]),
-            line_number=480,
+            line_number=484,
         ),
         GrammarRule(
             name='create_trigger_stmt',
@@ -1637,7 +1646,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=506,
+            line_number=510,
         ),
         GrammarRule(
             name='trigger_body_stmt',
@@ -1649,7 +1658,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='delete_stmt', is_token=False),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=511,
+            line_number=515,
         ),
         GrammarRule(
             name='drop_trigger_stmt',
@@ -1665,7 +1674,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=513,
+            line_number=517,
         ),
         GrammarRule(
             name='case_expr',
@@ -1687,13 +1696,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=528,
+            line_number=532,
         ),
         GrammarRule(
             name='case_operand',
             body=
             RuleReference(name='expr', is_token=False),
-            line_number=529,
+            line_number=533,
         ),
         GrammarRule(
             name='case_when',
@@ -1704,7 +1713,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='THEN'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=530,
+            line_number=534,
         ),
     ],
 )

--- a/code/packages/python/sql-planner/CHANGELOG.md
+++ b/code/packages/python/sql-planner/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.43.0] - 2026-05-23
+
+### Added
+
+- ``_expand_returning_wildcards()`` helper used by the INSERT,
+  UPDATE, and DELETE planners.  Walks the RETURNING list and
+  replaces every :class:`Wildcard` entry with one
+  ``Column(table, col)`` per table column in declaration order.
+  Required because the codegen rejects Wildcards in expression
+  position; expansion must happen before resolution.
+
 ## [0.42.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-planner/pyproject.toml
+++ b/code/packages/python/sql-planner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-planner"
-version = "0.42.0"
+version = "0.43.0"
 description = "Translates a structured SQL AST into a Logical Plan Tree of relational-algebra nodes."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-planner/src/sql_planner/planner.py
+++ b/code/packages/python/sql-planner/src/sql_planner/planner.py
@@ -1590,6 +1590,34 @@ def _resolve_upsert_expr(expr: Expr, table_cols: list[str], schema: SchemaProvid
             return expr
 
 
+def _expand_returning_wildcards(
+    returning: tuple[Expr, ...],
+    table: str,
+    cols: list[str],
+) -> tuple[Expr, ...]:
+    """Expand any ``RETURNING *`` Wildcards into one column ref per table column.
+
+    SQLite's ``RETURNING *`` short-hand emits every column of the
+    target table in declaration order.  The adapter encodes ``*`` as
+    a :class:`Wildcard` sentinel; the codegen can't handle Wildcards
+    in expression position, so we expand them here at planning time
+    — same approach SELECT * uses.  Non-Wildcard items pass through
+    unchanged so a mixed list like ``RETURNING id, *`` is also
+    supported (matches SQLite, though uncommon in practice).
+    """
+    out: list[Expr] = []
+    for item in returning:
+        if isinstance(item, Wildcard):
+            # ``Column`` is the unresolved (qualified-but-not-yet-typed)
+            # column reference; ``_resolve`` will turn it into the
+            # backend-bound form moments after this expansion runs.
+            for col_name in cols:
+                out.append(Column(table=table, col=col_name))
+        else:
+            out.append(item)
+    return tuple(out)
+
+
 def _plan_insert(stmt: InsertValuesStmt, schema: SchemaProvider) -> P.LogicalPlan:
     # Validate the target table and, if a column list is given, each column.
     table_cols = schema.columns(stmt.table)
@@ -1600,8 +1628,11 @@ def _plan_insert(stmt: InsertValuesStmt, schema: SchemaProvider) -> P.LogicalPla
     # Resolve RETURNING exprs against the table's column scope so that bare
     # column references like ``id`` become ``Column(table=stmt.table, col='id')``.
     returning_scope: Scope = {stmt.table: table_cols}
+    expanded_returning = _expand_returning_wildcards(
+        stmt.returning, stmt.table, table_cols
+    )
     resolved_returning = tuple(
-        _resolve(r, returning_scope, schema) for r in stmt.returning
+        _resolve(r, returning_scope, schema) for r in expanded_returning
     )
     upsert = _resolve_upsert(stmt.upsert_clause, table_cols, schema)
     return P.Insert(
@@ -1629,7 +1660,8 @@ def _plan_update(stmt: UpdateStmt, schema: SchemaProvider) -> P.LogicalPlan:
         predicate = _propagate_column_collation(predicate, schema)
     if predicate is not None and contains_aggregate(predicate):
         raise InvalidAggregate(message="aggregate function not allowed in UPDATE WHERE clause")
-    resolved_returning = tuple(_resolve(r, scope, schema) for r in stmt.returning)
+    expanded_returning = _expand_returning_wildcards(stmt.returning, stmt.table, cols)
+    resolved_returning = tuple(_resolve(r, scope, schema) for r in expanded_returning)
     return P.Update(
         table=stmt.table,
         assignments=resolved_assignments,
@@ -1646,7 +1678,8 @@ def _plan_delete(stmt: DeleteStmt, schema: SchemaProvider) -> P.LogicalPlan:
         predicate = _propagate_column_collation(predicate, schema)
     if predicate is not None and contains_aggregate(predicate):
         raise InvalidAggregate(message="aggregate function not allowed in DELETE WHERE clause")
-    resolved_returning = tuple(_resolve(r, scope, schema) for r in stmt.returning)
+    expanded_returning = _expand_returning_wildcards(stmt.returning, stmt.table, cols)
+    resolved_returning = tuple(_resolve(r, scope, schema) for r in expanded_returning)
     return P.Delete(table=stmt.table, predicate=predicate, returning=resolved_returning)
 
 


### PR DESCRIPTION
## Summary

SQLite's RETURNING grammar accepts ``*`` as shorthand for every column of the target table. Mini-sqlite previously parse-errored — ORM code emitting ``INSERT ... RETURNING *`` failed.

Three-layer wiring:
- **Grammar**: ``returning_item = "*" | expr``
- **Adapter**: ``*`` → ``Wildcard()`` sentinel
- **Planner**: ``_expand_returning_wildcards()`` replaces each Wildcard with one ``Column(table, col)`` per table column

## Test plan

- [x] sql-parser: regenerated grammar cache, 91 tests pass
- [x] sql-planner: 219 tests pass (new expand helper)
- [x] mini-sqlite: 2221 tests pass (9 new oracle tests), 90.92% coverage
- [x] Other packages: regression-only
- [x] ruff clean
- [x] /security-review passed

## Known limitation

``INSERT INTO t(v) VALUES (...) RETURNING *`` reports the auto-assigned INTEGER PRIMARY KEY as NULL when the user omitted the id. Pre-existing bug in INSERT RETURNING that's independent of the ``*`` shorthand — explicit-id INSERTs and UPDATE/DELETE RETURNING work correctly.

Versions: sql-parser 0.39 → 0.40, sql-planner 0.42 → 0.43, mini-sqlite 1.99 → 2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)