### PR TITLE
spice: add BJT capacitance model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -17,6 +17,9 @@
 - **Diode transit-time models** — `Diode.Tt` now contributes forward-bias
   diffusion capacitance to small-signal AC admittance.
 
+- **BJT capacitance models** — `BJT.Cje` / `BJT.Cjc` now contribute
+  base-emitter and base-collector small-signal AC susceptance.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -510,6 +510,10 @@ class BJT:
         Forward current gain hFE (default 100).
     Vt:
         Thermal voltage in Volts.  At 300 K, Vt = kT/q ≈ 25.85 mV.
+    Cje:
+        Base-emitter junction capacitance in Farads.
+    Cjc:
+        Base-collector junction capacitance in Farads.
     """
 
     name: str
@@ -520,6 +524,8 @@ class BJT:
     Is: float = 1e-14       # saturation current (A)
     beta_f: float = 100.0   # forward current gain hFE
     Vt: float = 0.02585     # thermal voltage (V) at ~300 K
+    Cje: float = 0.0        # base-emitter junction capacitance (F)
+    Cjc: float = 0.0        # base-collector junction capacitance (F)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -261,7 +261,7 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -1917,6 +1917,7 @@ def _stamp_bjt(
     to collector in the conventional direction.  Swapping C↔E and negating
     the control voltage (Ve - Vb vs Vb - Ve) yields the correct KCL stamps.
     """
+    _validate_bjt(el)
     # --- Resolve node voltages at the current Newton iterate -----------------
     Vb = 0.0 if _is_ground(el.base) else x[node_to_idx[el.base]]
     Ve = 0.0 if _is_ground(el.emitter) else x[node_to_idx[el.emitter]]
@@ -1987,6 +1988,21 @@ def _stamp_bjt(
             b[node_to_idx[el.emitter]] -= Ieq_coll
         if not _is_ground(el.collector):
             b[node_to_idx[el.collector]] += Ieq_coll
+
+
+def _validate_bjt(el: BJT) -> None:
+    if el.polarity not in {"NPN", "PNP"}:
+        raise ValueError(f"{el.name}: BJT polarity must be NPN or PNP")
+    if not math.isfinite(el.Is) or el.Is <= 0.0:
+        raise ValueError(f"{el.name}: BJT saturation current must be finite and positive")
+    if not math.isfinite(el.beta_f) or el.beta_f <= 0.0:
+        raise ValueError(f"{el.name}: BJT forward beta must be finite and positive")
+    if not math.isfinite(el.Vt) or el.Vt <= 0.0:
+        raise ValueError(f"{el.name}: BJT thermal voltage must be finite and positive")
+    if not math.isfinite(el.Cje) or el.Cje < 0.0:
+        raise ValueError(f"{el.name}: BJT base-emitter capacitance must be finite and non-negative")
+    if not math.isfinite(el.Cjc) or el.Cjc < 0.0:
+        raise ValueError(f"{el.name}: BJT base-collector capacitance must be finite and non-negative")
 
 
 # ---------------------------------------------------------------------------
@@ -3936,6 +3952,7 @@ def _stamp_ac(
         # Small-signal model: g_π (junction conductance) + gm (transconductance
         # VCCS).  Mirror the DC _stamp_bjt stamps but in the complex domain and
         # without the Norton offsets (which are DC bias terms, zero in AC).
+        _validate_bjt(el)
         Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
         Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
         Vjunc = (
@@ -3945,9 +3962,12 @@ def _stamp_ac(
         exp_t = math.exp(Vjunc / el.Vt)
         gm_b: float = (el.Is / el.Vt) * exp_t
         g_pi: float = gm_b / el.beta_f
+        y_be = g_pi + 1j * omega * el.Cje
+        y_bc = 1j * omega * el.Cjc
 
         if el.polarity == "NPN":
-            _stamp_g_c(G, node_to_idx, el.base, el.emitter, g_pi + 0j)
+            _stamp_g_c(G, node_to_idx, el.base, el.emitter, y_be)
+            _stamp_g_c(G, node_to_idx, el.base, el.collector, y_bc)
             if not _is_ground(el.collector):
                 c_i = node_to_idx[el.collector]
                 if not _is_ground(el.base):
@@ -3961,7 +3981,8 @@ def _stamp_ac(
                 if not _is_ground(el.emitter):
                     G[e_i][node_to_idx[el.emitter]] += gm_b + 0j
         else:  # PNP
-            _stamp_g_c(G, node_to_idx, el.emitter, el.base, g_pi + 0j)
+            _stamp_g_c(G, node_to_idx, el.emitter, el.base, y_be)
+            _stamp_g_c(G, node_to_idx, el.base, el.collector, y_bc)
             if not _is_ground(el.emitter):
                 e_i = node_to_idx[el.emitter]
                 if not _is_ground(el.emitter):
@@ -5332,6 +5353,8 @@ def sens_dc(
                     Is=el.Is + delta_is,
                     beta_f=el.beta_f,
                     Vt=el.Vt,
+                    Cje=el.Cje,
+                    Cjc=el.Cjc,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -5344,6 +5367,8 @@ def sens_dc(
                     Is=el.Is,
                     beta_f=el.beta_f + delta_beta,
                     Vt=el.Vt,
+                    Cje=el.Cje,
+                    Cjc=el.Cjc,
                 ),
             )
 
@@ -5550,6 +5575,8 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Is=_draw(el.Is),
             beta_f=_draw(el.beta_f),
             Vt=el.Vt,
+            Cje=el.Cje,
+            Cjc=el.Cjc,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -2148,6 +2148,24 @@ def test_ac_bjt_npn_small_signal():
         assert "base" in pt.node_voltages
 
 
+def test_ac_bjt_junction_capacitance_shunts_high_frequency_base_drive():
+    """BJT Cje contributes base-emitter capacitance in AC analysis."""
+    def base_amplitude(cje: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "base", 1000.0))
+        c.add(Resistor("Rc", "col", "0", 1000.0))
+        c.add(BJT("Q1", collector="col", base="base", emitter="0", Cje=cje))
+        result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["base"])
+
+    without_capacitance = base_amplitude(0.0)
+    with_capacitance = base_amplitude(1.0e-6)
+
+    assert without_capacitance > 0.9
+    assert with_capacitance < without_capacitance / 100.0
+
+
 # ============================================================================
 # 22. AC sweep — current source injection
 # ============================================================================

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Parse diode model-card junction capacitance with
   `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
 - Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
+- Parse BJT model-card capacitances with `.model ... NPN|PNP(... CJE=<c>
+  CJC=<c>)` and pass them into Python `BJT` elements.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -436,6 +436,8 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Is=model.params.get("IS", 1e-14),
             beta_f=model.params.get("BETA_F", model.params.get("BF", 100.0)),
             Vt=model.params.get("VT", 0.02585),
+            Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
+            Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -494,7 +494,7 @@ Rload out 0 1k
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast NPN(IS=1e-14 BF=120 VT=25m)
+.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p)
 Vcc vcc 0 DC 5
 Vb base 0 DC 0.7
 Rc vcc col 100
@@ -504,7 +504,11 @@ Q1 col base 0 fast
     )
 
     assert parsed.models == {
-        "fast": ModelCard("fast", "NPN", {"IS": 1.0e-14, "BF": 120.0, "VT": 25.0e-3})
+        "fast": ModelCard(
+            "fast",
+            "NPN",
+            {"IS": 1.0e-14, "BF": 120.0, "VT": 25.0e-3, "CJE": 2.0e-12, "CJC": 3.0e-12},
+        )
     }
     bjt = parsed.circuit.elements[3]
     assert isinstance(bjt, BJT)
@@ -515,6 +519,8 @@ Q1 col base 0 fast
     assert bjt.Is == 1.0e-14
     assert bjt.beta_f == 120.0
     assert bjt.Vt == 25.0e-3
+    assert bjt.Cje == 2.0e-12
+    assert bjt.Cjc == 3.0e-12
 
     result = dc_op(parsed.circuit)
     assert result.converged

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -13,6 +13,8 @@
   diode conductance.
 - Add diode transit-time support through `transit_time`, contributing
   forward-bias diffusion capacitance to small-signal AC admittance.
+- Add BJT capacitance support through `base_emitter_capacitance` /
+  `base_collector_capacitance`, contributing small-signal AC susceptance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -322,6 +322,8 @@ fn clone_subckt_element(
             element.saturation_current,
             element.forward_beta,
             element.thermal_voltage,
+            element.base_emitter_capacitance,
+            element.base_collector_capacitance,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1241,6 +1243,8 @@ pub struct Bjt {
     pub saturation_current: f64,
     pub forward_beta: f64,
     pub thermal_voltage: f64,
+    pub base_emitter_capacitance: f64,
+    pub base_collector_capacitance: f64,
 }
 
 impl Bjt {
@@ -1259,6 +1263,8 @@ impl Bjt {
             1.0e-14,
             100.0,
             0.02585,
+            0.0,
+            0.0,
         )
     }
 
@@ -1271,6 +1277,8 @@ impl Bjt {
         saturation_current: f64,
         forward_beta: f64,
         thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -1281,6 +1289,8 @@ impl Bjt {
             saturation_current,
             forward_beta,
             thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
         }
     }
 }
@@ -4704,7 +4714,7 @@ fn build_ac_matrix(
                 stamp_ac_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point)?
             }
             Element::Bjt(bjt) => {
-                stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point)?
+                stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point, omega)?
             }
             Element::Mosfet(mosfet) => {
                 stamp_ac_mosfet_small_signal(mosfet, node_indices, &mut matrix, operating_point)?
@@ -5440,6 +5450,7 @@ fn stamp_ac_bjt_small_signal(
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<Complex>],
     operating_point: &[f64],
+    omega: f64,
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
     let collector = node_index(node_indices, &bjt.collector);
@@ -5456,14 +5467,20 @@ fn stamp_ac_bjt_small_signal(
         bjt.saturation_current / bjt.thermal_voltage * exponent.exp(),
         0.0,
     );
-    let gpi = Complex::new(gm.real / bjt.forward_beta, 0.0);
+    let gpi = Complex::new(
+        gm.real / bjt.forward_beta,
+        omega * bjt.base_emitter_capacitance,
+    );
+    let ybc = Complex::new(0.0, omega * bjt.base_collector_capacitance);
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_complex_conductance(matrix, base, emitter, gpi);
+            stamp_complex_conductance(matrix, base, collector, ybc);
             stamp_complex_transconductance(matrix, collector, emitter, base, emitter, gm);
         }
         BjtPolarity::Pnp => {
             stamp_complex_conductance(matrix, emitter, base, gpi);
+            stamp_complex_conductance(matrix, base, collector, ybc);
             stamp_complex_transconductance(matrix, emitter, collector, emitter, base, gm);
         }
     }
@@ -5881,6 +5898,18 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "thermal voltage must be finite and positive".to_string(),
+        });
+    }
+    if !bjt.base_emitter_capacitance.is_finite() || bjt.base_emitter_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-emitter capacitance must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.base_collector_capacitance.is_finite() || bjt.base_collector_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-collector capacitance must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -345,6 +345,8 @@ fn ac_bjt_applies_zero_bias_common_emitter_gain() {
         25.85e-6,
         100.0,
         0.02585,
+        0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -379,6 +381,8 @@ fn ac_bjt_uses_explicit_ac_source_and_dc_bias_operating_point() {
         25.85e-6,
         100.0,
         thermal_voltage,
+        0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -390,6 +394,43 @@ fn ac_bjt_uses_explicit_ac_source_and_dc_bias_operating_point() {
     let out = points[0].voltage("out").unwrap();
     assert_close(out.real, -2.0);
     assert_close(out.imag, 0.0);
+}
+
+#[test]
+fn ac_bjt_uses_base_emitter_capacitance() {
+    fn base_amplitude(base_emitter_capacitance: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1_000.0)));
+        circuit.add(Element::Bjt(Bjt::with_model(
+            "Q1",
+            "col",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-14,
+            100.0,
+            0.02585,
+            base_emitter_capacitance,
+            0.0,
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    let without_capacitance = base_amplitude(0.0);
+    let with_capacitance = base_amplitude(1.0e-6);
+
+    assert!(without_capacitance > 0.9);
+    assert!(with_capacitance < without_capacitance / 100.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -358,6 +358,8 @@ fn dc_bjt_solves_npn_emitter_follower_operating_point() {
         1.0e-13,
         120.0,
         0.026,
+        0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -390,6 +392,8 @@ fn dc_bjt_solves_pnp_pullup_operating_point() {
         1.0e-13,
         100.0,
         0.026,
+        0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -178,6 +178,8 @@ fn tf_bjt_common_emitter_reports_small_signal_gain() {
         25.85e-6,
         100.0,
         thermal_voltage,
+        0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Parse diode model-card junction capacitance with
   `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
 - Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
+- Parse BJT model-card capacitances with `.model ... NPN|PNP(... CJE=<c>
+  CJC=<c>)` and pass them into Rust `Bjt` elements.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -775,6 +775,16 @@ fn parse_element(
                 *model.params.get("IS").unwrap_or(&1.0e-14),
                 forward_beta,
                 *model.params.get("VT").unwrap_or(&0.02585),
+                *model
+                    .params
+                    .get("CJE")
+                    .or_else(|| model.params.get("CBE"))
+                    .unwrap_or(&0.0),
+                *model
+                    .params
+                    .get("CJC")
+                    .or_else(|| model.params.get("CBC"))
+                    .unwrap_or(&0.0),
             )))
         }
         'J' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -689,7 +689,7 @@ Rload out 0 1k
 fn parses_bjt_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast NPN(IS=1e-13 BF=120 VT=26m)
+.model fast NPN(IS=1e-13 BF=120 VT=26m CJE=2p CJC=3p)
 Vcc vcc 0 DC 5
 Vbase base 0 DC 0.7
 Q1 vcc base out fast
@@ -705,6 +705,8 @@ Rload out 0 1k
     assert_close(*model.params.get("IS").unwrap(), 1.0e-13);
     assert_close(*model.params.get("BF").unwrap(), 120.0);
     assert_close(*model.params.get("VT").unwrap(), 26.0e-3);
+    assert_close(*model.params.get("CJE").unwrap(), 2.0e-12);
+    assert_close(*model.params.get("CJC").unwrap(), 3.0e-12);
 
     let Element::Bjt(bjt) = &parsed.circuit.elements()[2] else {
         panic!("expected BJT");
@@ -717,6 +719,8 @@ Rload out 0 1k
     assert_close(bjt.saturation_current, 1.0e-13);
     assert_close(bjt.forward_beta, 120.0);
     assert_close(bjt.thermal_voltage, 26.0e-3);
+    assert_close(bjt.base_emitter_capacitance, 2.0e-12);
+    assert_close(bjt.base_collector_capacitance, 3.0e-12);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -11,6 +11,8 @@
   diode conductance.
 - Add diode transit-time support through `transitTime`, contributing
   forward-bias diffusion capacitance to small-signal AC admittance.
+- Add BJT capacitance support through `baseEmitterCapacitance` /
+  `baseCollectorCapacitance`, contributing small-signal AC susceptance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -392,6 +392,8 @@ export interface Bjt {
   readonly saturationCurrent: number;
   readonly forwardBeta: number;
   readonly thermalVoltage: number;
+  readonly baseEmitterCapacitance: number;
+  readonly baseCollectorCapacitance: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -954,7 +956,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -1252,6 +1254,8 @@ export function bjt(
   saturationCurrent = 1.0e-14,
   forwardBeta = 100.0,
   thermalVoltage = 0.02585,
+  baseEmitterCapacitance = 0.0,
+  baseCollectorCapacitance = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -1263,6 +1267,8 @@ export function bjt(
     saturationCurrent,
     forwardBeta,
     thermalVoltage,
+    baseEmitterCapacitance,
+    baseCollectorCapacitance,
   };
 }
 
@@ -3933,7 +3939,7 @@ function buildAcMatrix(
         stampAcJfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
         break;
       case "bjt":
-        stampAcBjtSmallSignal(element, nodeIndices, matrix);
+        stampAcBjtSmallSignal(element, nodeIndices, matrix, omega);
         break;
       case "mosfet":
         stampAcMosfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
@@ -4880,6 +4886,12 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
     throw invalidElement(element.name, "thermal voltage must be finite and positive");
+  }
+  if (!Number.isFinite(element.baseEmitterCapacitance) || element.baseEmitterCapacitance < 0.0) {
+    throw invalidElement(element.name, "base-emitter capacitance must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.baseCollectorCapacitance) || element.baseCollectorCapacitance < 0.0) {
+    throw invalidElement(element.name, "base-collector capacitance must be finite and non-negative");
   }
 }
 
@@ -6499,6 +6511,7 @@ function stampAcBjtSmallSignal(
   element: Bjt,
   nodeIndices: ReadonlyMap<string, number>,
   matrix: Complex[][],
+  omega: number,
 ): void {
   validateBjt(element);
   const collector = nodeIndex(nodeIndices, element.collector);
@@ -6506,13 +6519,19 @@ function stampAcBjtSmallSignal(
   const emitter = nodeIndex(nodeIndices, element.emitter);
   const transconductance = element.saturationCurrent / element.thermalVoltage;
   const junctionConductance = transconductance / element.forwardBeta;
+  const baseEmitterAdmittance = complex(
+    junctionConductance,
+    omega * element.baseEmitterCapacitance,
+  );
+  const baseCollectorAdmittance = complex(0.0, omega * element.baseCollectorCapacitance);
   if (element.polarity === "NPN") {
     stampComplexConductance(
       matrix,
       base,
       emitter,
-      complex(junctionConductance, 0.0),
+      baseEmitterAdmittance,
     );
+    stampComplexConductance(matrix, base, collector, baseCollectorAdmittance);
     stampComplexTransconductance(
       matrix,
       collector,
@@ -6526,8 +6545,9 @@ function stampAcBjtSmallSignal(
       matrix,
       emitter,
       base,
-      complex(junctionConductance, 0.0),
+      baseEmitterAdmittance,
     );
+    stampComplexConductance(matrix, base, collector, baseCollectorAdmittance);
     stampComplexTransconductance(
       matrix,
       emitter,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -4,6 +4,7 @@ import {
   SpiceError,
   acSweep,
   acSweepCorners,
+  bjt,
   capacitor,
   cccs,
   ccvs,
@@ -293,6 +294,23 @@ describe("acSweep", () => {
     expectClose(out!.real, -4.0);
     expectClose(out!.imag, 0.0);
     expectClose(complexAbs(points[0].voltage("vdd")!), 0.0);
+  });
+
+  it("uses BJT base-emitter capacitance in AC analysis", () => {
+    function baseAmplitude(baseEmitterCapacitance: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(resistor("Rc", "col", "0", 1_000.0));
+      circuit.add(bjt("Q1", "col", "base", "0", "NPN", 1.0e-14, 100.0, 0.02585, baseEmitterCapacitance));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
+    }
+
+    const withoutCapacitance = baseAmplitude(0.0);
+    const withCapacitance = baseAmplitude(1.0e-6);
+
+    expect(withoutCapacitance).toBeGreaterThan(0.9);
+    expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
   });
 
   it("applies VCVS gain in AC analysis", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Parse diode model-card junction capacitance with
   `.model ... D(... CJO=<c>)` / `.model ... D(... CJ0=<c>)`.
 - Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
+- Parse BJT model-card capacitances with `.model ... NPN|PNP(... CJE=<c>
+  CJC=<c>)` and pass them into TypeScript `bjt` elements.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -596,6 +596,8 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("IS") ?? 1.0e-14,
       model.params.get("BF") ?? model.params.get("BETA_F") ?? 100.0,
       model.params.get("VT") ?? 0.02585,
+      model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,
+      model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -462,7 +462,7 @@ Rload out 0 1k
 
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast NPN(IS=1e-14 BF=120 VT=25m)
+.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p)
 Vcc vcc 0 DC 5
 Vb base 0 DC 0.7
 Rc vcc col 100
@@ -477,6 +477,8 @@ Q1 col base 0 fast
         ["IS", 1.0e-14],
         ["BF", 120.0],
         ["VT", 25.0e-3],
+        ["CJE", 2.0e-12],
+        ["CJC", 3.0e-12],
       ]),
     });
     expect(parsed.circuit.elements()[3]).toMatchObject({
@@ -489,6 +491,8 @@ Q1 col base 0 fast
       saturationCurrent: 1.0e-14,
       forwardBeta: 120.0,
       thermalVoltage: 25.0e-3,
+      baseEmitterCapacitance: 2.0e-12,
+      baseCollectorCapacitance: 3.0e-12,
     });
 
     const result = dcOp(parsed.circuit);

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -210,6 +210,9 @@ Status:
 - Diode `.model ... D(... TT=<time>)` parsing and forward-bias diffusion
   capacitance are implemented in AC analysis across Python, TypeScript, and
   Rust.
+- BJT `.model ... NPN|PNP(... CJE=<capacitance> CJC=<capacitance>)` parsing
+  and base-emitter/base-collector AC capacitance stamping are implemented
+  across Python, TypeScript, and Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary

- add BJT base-emitter/base-collector capacitance fields across Python, TypeScript, and Rust engines
- stamp BJT capacitances into AC small-signal matrices and preserve them through subcircuit cloning
- parse `.model ... NPN|PNP(... CJE=<c> CJC=<c>)` plus `CBE`/`CBC` aliases and update the 1970s compatibility plan

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-bjt-capacitance-model PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-bjt-capacitance-model PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `cargo fmt -p spice-engine -p spice-netlist-parser && cargo test -p spice-engine -p spice-netlist-parser`
- `git diff --check`