### PR TITLE
[codex] Add Board VM input callback transport checkpoints

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -193,6 +193,10 @@ transport retention policy.
 transport snapshot records with Rust-owned snapshot names, labels, queue-depth
 metadata, and messages, so frontends can display point-in-time transport state
 without rebuilding archive retention policy.
+`input_callback_transport_checkpoint_summary` preserves those snapshots as
+stable transport checkpoint records with Rust-owned checkpoint names, labels,
+queue-depth metadata, and messages, so adapters can resume or compare callback
+transport state without rebuilding snapshot policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -1440,6 +1440,64 @@ pub struct LanguageInputCallbackTransportSnapshotSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportCheckpointKind {
+    CallbackRunnerHandoffCheckpoint,
+    AdapterEventPublicationCheckpoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportCheckpointSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub checkpoint_label: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_checkpoint: u8,
+    pub message: String,
+    pub snapshot_summary: LanguageInputCallbackTransportSnapshotSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -2057,6 +2115,19 @@ pub const fn input_callback_transport_snapshot_kind_name(
         }
         LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot => {
             "adapter_event_publication_snapshot"
+        }
+    }
+}
+
+pub const fn input_callback_transport_checkpoint_kind_name(
+    kind: LanguageInputCallbackTransportCheckpointKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportCheckpointKind::CallbackRunnerHandoffCheckpoint => {
+            "callback_runner_handoff_checkpoint"
+        }
+        LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint => {
+            "adapter_event_publication_checkpoint"
         }
     }
 }
@@ -3740,6 +3811,66 @@ pub fn input_callback_transport_snapshot_summary(
     }
 }
 
+pub fn input_callback_transport_checkpoint_summary(
+    snapshot_summary: &LanguageInputCallbackTransportSnapshotSummary,
+) -> LanguageInputCallbackTransportCheckpointSummary {
+    let checkpoint_kind = input_callback_transport_checkpoint_kind(snapshot_summary.snapshot_kind);
+
+    LanguageInputCallbackTransportCheckpointSummary {
+        endpoint: snapshot_summary.endpoint.clone(),
+        connection_label: snapshot_summary.connection_label.clone(),
+        checkpoint_label: input_callback_transport_checkpoint_label(
+            snapshot_summary,
+            checkpoint_kind,
+        ),
+        checkpoint_kind,
+        checkpoint_name: input_callback_transport_checkpoint_kind_name(checkpoint_kind).to_owned(),
+        snapshot_kind: snapshot_summary.snapshot_kind,
+        snapshot_name: snapshot_summary.snapshot_name.clone(),
+        archive_kind: snapshot_summary.archive_kind,
+        archive_name: snapshot_summary.archive_name.clone(),
+        journal_kind: snapshot_summary.journal_kind,
+        journal_name: snapshot_summary.journal_name.clone(),
+        log_kind: snapshot_summary.log_kind,
+        log_name: snapshot_summary.log_name.clone(),
+        audit_kind: snapshot_summary.audit_kind,
+        audit_name: snapshot_summary.audit_name.clone(),
+        trace_kind: snapshot_summary.trace_kind,
+        trace_name: snapshot_summary.trace_name.clone(),
+        outcome_kind: snapshot_summary.outcome_kind,
+        outcome_name: snapshot_summary.outcome_name.clone(),
+        receipt_kind: snapshot_summary.receipt_kind,
+        receipt_name: snapshot_summary.receipt_name.clone(),
+        acknowledgement_kind: snapshot_summary.acknowledgement_kind,
+        acknowledgement_name: snapshot_summary.acknowledgement_name.clone(),
+        delivery_route: snapshot_summary.delivery_route,
+        delivery_route_name: snapshot_summary.delivery_route_name.clone(),
+        event_kind: snapshot_summary.event_kind,
+        event_name: snapshot_summary.event_name.clone(),
+        report_kind: snapshot_summary.report_kind,
+        report_name: snapshot_summary.report_name.clone(),
+        action: snapshot_summary.action,
+        action_name: snapshot_summary.action_name.clone(),
+        callback_runner_handoff: snapshot_summary.callback_runner_handoff,
+        adapter_event_published: snapshot_summary.adapter_event_published,
+        delivery_acknowledged: snapshot_summary.delivery_acknowledged,
+        receipt_recorded: snapshot_summary.receipt_recorded,
+        outcome_recorded: snapshot_summary.outcome_recorded,
+        trace_recorded: snapshot_summary.trace_recorded,
+        audit_recorded: snapshot_summary.audit_recorded,
+        log_recorded: snapshot_summary.log_recorded,
+        journal_recorded: snapshot_summary.journal_recorded,
+        archive_recorded: snapshot_summary.archive_recorded,
+        snapshot_recorded: snapshot_summary.snapshot_recorded,
+        checkpoint_recorded: true,
+        terminal: snapshot_summary.terminal,
+        retryable: snapshot_summary.retryable,
+        queue_depth_after_checkpoint: snapshot_summary.queue_depth_after_snapshot,
+        message: input_callback_transport_checkpoint_message(checkpoint_kind).to_owned(),
+        snapshot_summary: snapshot_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -5404,6 +5535,44 @@ fn input_callback_transport_snapshot_message(
         }
         LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot => {
             "Transport snapshot should capture the adapter event publication archive."
+        }
+    }
+}
+
+fn input_callback_transport_checkpoint_kind(
+    snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+) -> LanguageInputCallbackTransportCheckpointKind {
+    match snapshot_kind {
+        LanguageInputCallbackTransportSnapshotKind::CallbackRunnerHandoffSnapshot => {
+            LanguageInputCallbackTransportCheckpointKind::CallbackRunnerHandoffCheckpoint
+        }
+        LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot => {
+            LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint
+        }
+    }
+}
+
+fn input_callback_transport_checkpoint_label(
+    snapshot_summary: &LanguageInputCallbackTransportSnapshotSummary,
+    checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+) -> String {
+    format!(
+        "{} transport_checkpoint={} checkpoint_recorded=true queue_depth_after_checkpoint={}",
+        snapshot_summary.snapshot_label,
+        input_callback_transport_checkpoint_kind_name(checkpoint_kind),
+        snapshot_summary.queue_depth_after_snapshot
+    )
+}
+
+fn input_callback_transport_checkpoint_message(
+    checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+) -> &'static str {
+    match checkpoint_kind {
+        LanguageInputCallbackTransportCheckpointKind::CallbackRunnerHandoffCheckpoint => {
+            "Transport checkpoint should preserve the callback-runner handoff snapshot."
+        }
+        LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint => {
+            "Transport checkpoint should preserve the adapter event publication snapshot."
         }
     }
 }
@@ -13297,6 +13466,251 @@ mod tests {
         assert_eq!(
             dropped.snapshot_label,
             "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=77 transport_action=drop_before_dispatch terminal=true retryable=false dispatch_callback=false emit_drop=true emit_result=false remove_from_queue=false keep_dispatch_scheduled=false queue_depth_after_effect=1 transport_report=drop emit_report=true queue_depth_after_report=1 transport_event=callback_dropped queue_depth_after_event=1 transport_delivery=adapter_event publish_event=true queue_depth_after_delivery=1 transport_acknowledgement=adapter_event_published delivery_acknowledged=true callback_runner_handoff=false adapter_event_published=true queue_depth_after_acknowledgement=1 transport_receipt=adapter_event_publication receipt_recorded=true queue_depth_after_receipt=1 transport_outcome=adapter_event_publication_recorded outcome_recorded=true queue_depth_after_outcome=1 transport_trace=adapter_event_publication_trace trace_recorded=true queue_depth_after_trace=1 transport_audit=adapter_event_publication_audit audit_recorded=true queue_depth_after_audit=1 transport_log=adapter_event_publication_log log_recorded=true queue_depth_after_log=1 transport_journal=adapter_event_publication_journal journal_recorded=true queue_depth_after_journal=1 transport_archive=adapter_event_publication_archive archive_recorded=true queue_depth_after_archive=1 transport_snapshot=adapter_event_publication_snapshot snapshot_recorded=true queue_depth_after_snapshot=1"
+        );
+    }
+
+    #[test]
+    fn input_callback_transport_checkpoints_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_action = input_callback_transport_action_summary(&completed_lifecycle);
+        let completed_effect = input_callback_transport_effect_summary(&completed_action);
+        let completed_report = input_callback_transport_report_summary(&completed_effect);
+        let completed_event = input_callback_transport_event_summary(&completed_report);
+        let completed_delivery = input_callback_transport_delivery_summary(&completed_event);
+        let completed_ack = input_callback_transport_acknowledgement_summary(&completed_delivery);
+        let completed_receipt = input_callback_transport_receipt_summary(&completed_ack);
+        let completed_outcome = input_callback_transport_outcome_summary(&completed_receipt);
+        let completed_trace = input_callback_transport_trace_summary(&completed_outcome);
+        let completed_audit = input_callback_transport_audit_summary(&completed_trace);
+        let completed_log = input_callback_transport_log_summary(&completed_audit);
+        let completed_journal = input_callback_transport_journal_summary(&completed_log);
+        let completed_archive = input_callback_transport_archive_summary(&completed_journal);
+        let completed_snapshot = input_callback_transport_snapshot_summary(&completed_archive);
+        let completed = input_callback_transport_checkpoint_summary(&completed_snapshot);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.checkpoint_kind,
+            LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint
+        );
+        assert_eq!(
+            completed.checkpoint_name,
+            "adapter_event_publication_checkpoint"
+        );
+        assert_eq!(
+            completed.snapshot_kind,
+            LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot
+        );
+        assert_eq!(
+            completed.archive_kind,
+            LanguageInputCallbackTransportArchiveKind::AdapterEventPublicationArchive
+        );
+        assert_eq!(
+            completed.journal_kind,
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        );
+        assert_eq!(
+            completed.log_kind,
+            LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog
+        );
+        assert_eq!(
+            completed.audit_kind,
+            LanguageInputCallbackTransportAuditKind::AdapterEventPublicationAudit
+        );
+        assert_eq!(
+            completed.trace_kind,
+            LanguageInputCallbackTransportTraceKind::AdapterEventPublicationTrace
+        );
+        assert_eq!(
+            completed.outcome_kind,
+            LanguageInputCallbackTransportOutcomeKind::AdapterEventPublicationRecorded
+        );
+        assert_eq!(
+            completed.receipt_kind,
+            LanguageInputCallbackTransportReceiptKind::AdapterEventPublication
+        );
+        assert_eq!(
+            completed.acknowledgement_kind,
+            LanguageInputCallbackTransportAcknowledgementKind::AdapterEventPublished
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_checkpoint, 2);
+        assert_eq!(
+            completed.message,
+            "Transport checkpoint should preserve the adapter event publication snapshot."
+        );
+        assert_eq!(completed.snapshot_summary, completed_snapshot);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_action = input_callback_transport_action_summary(&pending_lifecycle);
+        let pending_effect = input_callback_transport_effect_summary(&pending_action);
+        let pending_report = input_callback_transport_report_summary(&pending_effect);
+        let pending_event = input_callback_transport_event_summary(&pending_report);
+        let pending_delivery = input_callback_transport_delivery_summary(&pending_event);
+        let pending_ack = input_callback_transport_acknowledgement_summary(&pending_delivery);
+        let pending_receipt = input_callback_transport_receipt_summary(&pending_ack);
+        let pending_outcome = input_callback_transport_outcome_summary(&pending_receipt);
+        let pending_trace = input_callback_transport_trace_summary(&pending_outcome);
+        let pending_audit = input_callback_transport_audit_summary(&pending_trace);
+        let pending_log = input_callback_transport_log_summary(&pending_audit);
+        let pending_journal = input_callback_transport_journal_summary(&pending_log);
+        let pending_archive = input_callback_transport_archive_summary(&pending_journal);
+        let pending_snapshot = input_callback_transport_snapshot_summary(&pending_archive);
+        let pending = input_callback_transport_checkpoint_summary(&pending_snapshot);
+
+        assert_eq!(
+            pending.checkpoint_kind,
+            LanguageInputCallbackTransportCheckpointKind::CallbackRunnerHandoffCheckpoint
+        );
+        assert_eq!(
+            pending.checkpoint_name,
+            "callback_runner_handoff_checkpoint"
+        );
+        assert_eq!(
+            pending.snapshot_kind,
+            LanguageInputCallbackTransportSnapshotKind::CallbackRunnerHandoffSnapshot
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(pending.archive_recorded);
+        assert!(pending.snapshot_recorded);
+        assert!(pending.checkpoint_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_checkpoint, 3);
+        assert_eq!(
+            pending.checkpoint_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=42 transport_action=dispatch_callback terminal=false retryable=false dispatch_callback=true emit_drop=false emit_result=false remove_from_queue=false keep_dispatch_scheduled=true queue_depth_after_effect=3 transport_report=dispatch emit_report=false queue_depth_after_report=3 transport_event=dispatch_scheduled queue_depth_after_event=3 transport_delivery=callback_runner publish_event=false queue_depth_after_delivery=3 transport_acknowledgement=callback_runner_accepted delivery_acknowledged=true callback_runner_handoff=true adapter_event_published=false queue_depth_after_acknowledgement=3 transport_receipt=callback_runner_handoff receipt_recorded=true queue_depth_after_receipt=3 transport_outcome=callback_runner_handoff_recorded outcome_recorded=true queue_depth_after_outcome=3 transport_trace=callback_runner_handoff_trace trace_recorded=true queue_depth_after_trace=3 transport_audit=callback_runner_handoff_audit audit_recorded=true queue_depth_after_audit=3 transport_log=callback_runner_handoff_log log_recorded=true queue_depth_after_log=3 transport_journal=callback_runner_handoff_journal journal_recorded=true queue_depth_after_journal=3 transport_archive=callback_runner_handoff_archive archive_recorded=true queue_depth_after_archive=3 transport_snapshot=callback_runner_handoff_snapshot snapshot_recorded=true queue_depth_after_snapshot=3 transport_checkpoint=callback_runner_handoff_checkpoint checkpoint_recorded=true queue_depth_after_checkpoint=3"
+        );
+        assert_eq!(
+            pending.message,
+            "Transport checkpoint should preserve the callback-runner handoff snapshot."
+        );
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_action = input_callback_transport_action_summary(&dropped_lifecycle);
+        let dropped_effect = input_callback_transport_effect_summary(&dropped_action);
+        let dropped_report = input_callback_transport_report_summary(&dropped_effect);
+        let dropped_event = input_callback_transport_event_summary(&dropped_report);
+        let dropped_delivery = input_callback_transport_delivery_summary(&dropped_event);
+        let dropped_ack = input_callback_transport_acknowledgement_summary(&dropped_delivery);
+        let dropped_receipt = input_callback_transport_receipt_summary(&dropped_ack);
+        let dropped_outcome = input_callback_transport_outcome_summary(&dropped_receipt);
+        let dropped_trace = input_callback_transport_trace_summary(&dropped_outcome);
+        let dropped_audit = input_callback_transport_audit_summary(&dropped_trace);
+        let dropped_log = input_callback_transport_log_summary(&dropped_audit);
+        let dropped_journal = input_callback_transport_journal_summary(&dropped_log);
+        let dropped_archive = input_callback_transport_archive_summary(&dropped_journal);
+        let dropped_snapshot = input_callback_transport_snapshot_summary(&dropped_archive);
+        let dropped = input_callback_transport_checkpoint_summary(&dropped_snapshot);
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.checkpoint_kind,
+            LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_checkpoint, 1);
+        assert_eq!(
+            dropped.checkpoint_label,
+            "endpoint=tcp://board-vm.local:4170 callback=arduino-uno-r4-wifi:D3 sequence=77 transport_action=drop_before_dispatch terminal=true retryable=false dispatch_callback=false emit_drop=true emit_result=false remove_from_queue=false keep_dispatch_scheduled=false queue_depth_after_effect=1 transport_report=drop emit_report=true queue_depth_after_report=1 transport_event=callback_dropped queue_depth_after_event=1 transport_delivery=adapter_event publish_event=true queue_depth_after_delivery=1 transport_acknowledgement=adapter_event_published delivery_acknowledged=true callback_runner_handoff=false adapter_event_published=true queue_depth_after_acknowledgement=1 transport_receipt=adapter_event_publication receipt_recorded=true queue_depth_after_receipt=1 transport_outcome=adapter_event_publication_recorded outcome_recorded=true queue_depth_after_outcome=1 transport_trace=adapter_event_publication_trace trace_recorded=true queue_depth_after_trace=1 transport_audit=adapter_event_publication_audit audit_recorded=true queue_depth_after_audit=1 transport_log=adapter_event_publication_log log_recorded=true queue_depth_after_log=1 transport_journal=adapter_event_publication_journal journal_recorded=true queue_depth_after_journal=1 transport_archive=adapter_event_publication_archive archive_recorded=true queue_depth_after_archive=1 transport_snapshot=adapter_event_publication_snapshot snapshot_recorded=true queue_depth_after_snapshot=1 transport_checkpoint=adapter_event_publication_checkpoint checkpoint_recorded=true queue_depth_after_checkpoint=1"
         );
     }
 


### PR DESCRIPTION
Summary
- Add Rust-owned input callback transport checkpoint kinds, names, labels, queue-depth metadata, and summary records layered over transport snapshots.
- Carry the transport action/report/event/delivery/acknowledgement/receipt/outcome/trace/audit/log/journal/archive/snapshot chain into checkpoint summaries so language frontends can stay thin.
- Document the new checkpoint summary API in board-vm-language-core and cover callback-runner handoff plus adapter-event publication paths.

Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-checkpoint cargo test -p board-vm-language-core
- bash BUILD (in code/packages/rust/board-vm-language-core)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-checkpoint cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes
- Refreshed onto origin/main 3e94f3725573fcd1ca2f11e6dcad19f4b1009a39 before committing.
- Removed generated code/packages/rust/Cargo.lock before committing.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.