### PR TITLE
spice: add BJT transit time model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -20,6 +20,9 @@
 - **BJT capacitance models** — `BJT.Cje` / `BJT.Cjc` now contribute
   base-emitter and base-collector small-signal AC susceptance.
 
+- **BJT transit-time models** — `BJT.Tf` now contributes forward-bias
+  diffusion capacitance to small-signal AC admittance.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -514,6 +514,9 @@ class BJT:
         Base-emitter junction capacitance in Farads.
     Cjc:
         Base-collector junction capacitance in Farads.
+    Tf:
+        Forward transit time in seconds; contributes diffusion capacitance in
+        small-signal AC analysis.
     """
 
     name: str
@@ -526,6 +529,7 @@ class BJT:
     Vt: float = 0.02585     # thermal voltage (V) at ~300 K
     Cje: float = 0.0        # base-emitter junction capacitance (F)
     Cjc: float = 0.0        # base-collector junction capacitance (F)
+    Tf: float = 0.0         # forward transit time (s)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -261,7 +261,7 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -2003,6 +2003,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT base-emitter capacitance must be finite and non-negative")
     if not math.isfinite(el.Cjc) or el.Cjc < 0.0:
         raise ValueError(f"{el.name}: BJT base-collector capacitance must be finite and non-negative")
+    if not math.isfinite(el.Tf) or el.Tf < 0.0:
+        raise ValueError(f"{el.name}: BJT forward transit time must be finite and non-negative")
 
 
 # ---------------------------------------------------------------------------
@@ -3962,7 +3964,8 @@ def _stamp_ac(
         exp_t = math.exp(Vjunc / el.Vt)
         gm_b: float = (el.Is / el.Vt) * exp_t
         g_pi: float = gm_b / el.beta_f
-        y_be = g_pi + 1j * omega * el.Cje
+        diffusion_capacitance = el.Tf * gm_b
+        y_be = g_pi + 1j * omega * (el.Cje + diffusion_capacitance)
         y_bc = 1j * omega * el.Cjc
 
         if el.polarity == "NPN":
@@ -5355,6 +5358,7 @@ def sens_dc(
                     Vt=el.Vt,
                     Cje=el.Cje,
                     Cjc=el.Cjc,
+                    Tf=el.Tf,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -5369,6 +5373,7 @@ def sens_dc(
                     Vt=el.Vt,
                     Cje=el.Cje,
                     Cjc=el.Cjc,
+                    Tf=el.Tf,
                 ),
             )
 
@@ -5577,6 +5582,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Vt=el.Vt,
             Cje=el.Cje,
             Cjc=el.Cjc,
+            Tf=el.Tf,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -2166,6 +2166,24 @@ def test_ac_bjt_junction_capacitance_shunts_high_frequency_base_drive():
     assert with_capacitance < without_capacitance / 100.0
 
 
+def test_ac_bjt_transit_time_adds_diffusion_capacitance():
+    """BJT Tf contributes gm-scaled diffusion capacitance in AC analysis."""
+    def base_amplitude(tf: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "base", 1000.0))
+        c.add(Resistor("Rc", "col", "0", 1000.0))
+        c.add(BJT("Q1", collector="col", base="base", emitter="0", Is=25.85e-6, Tf=tf))
+        result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["base"])
+
+    without_transit_time = base_amplitude(0.0)
+    with_transit_time = base_amplitude(1.0e-3)
+
+    assert without_transit_time > 0.9
+    assert with_transit_time < without_transit_time / 100.0
+
+
 # ============================================================================
 # 22. AC sweep — current source injection
 # ============================================================================

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
 - Parse BJT model-card capacitances with `.model ... NPN|PNP(... CJE=<c>
   CJC=<c>)` and pass them into Python `BJT` elements.
+- Parse BJT model-card forward transit time with
+  `.model ... NPN|PNP(... TF=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -438,6 +438,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Vt=model.params.get("VT", 0.02585),
             Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
             Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
+            Tf=model.params.get("TF", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -494,7 +494,7 @@ Rload out 0 1k
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p)
+.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n)
 Vcc vcc 0 DC 5
 Vb base 0 DC 0.7
 Rc vcc col 100
@@ -507,7 +507,7 @@ Q1 col base 0 fast
         "fast": ModelCard(
             "fast",
             "NPN",
-            {"IS": 1.0e-14, "BF": 120.0, "VT": 25.0e-3, "CJE": 2.0e-12, "CJC": 3.0e-12},
+            {"IS": 1.0e-14, "BF": 120.0, "VT": 25.0e-3, "CJE": 2.0e-12, "CJC": 3.0e-12, "TF": 4.0e-9},
         )
     }
     bjt = parsed.circuit.elements[3]
@@ -521,6 +521,7 @@ Q1 col base 0 fast
     assert bjt.Vt == 25.0e-3
     assert bjt.Cje == 2.0e-12
     assert bjt.Cjc == 3.0e-12
+    assert bjt.Tf == 4.0e-9
 
     result = dc_op(parsed.circuit)
     assert result.converged

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -15,6 +15,8 @@
   forward-bias diffusion capacitance to small-signal AC admittance.
 - Add BJT capacitance support through `base_emitter_capacitance` /
   `base_collector_capacitance`, contributing small-signal AC susceptance.
+- Add BJT transit-time support through `forward_transit_time`, contributing
+  forward-bias diffusion capacitance to small-signal AC admittance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -324,6 +324,7 @@ fn clone_subckt_element(
             element.thermal_voltage,
             element.base_emitter_capacitance,
             element.base_collector_capacitance,
+            element.forward_transit_time,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1245,6 +1246,7 @@ pub struct Bjt {
     pub thermal_voltage: f64,
     pub base_emitter_capacitance: f64,
     pub base_collector_capacitance: f64,
+    pub forward_transit_time: f64,
 }
 
 impl Bjt {
@@ -1265,6 +1267,7 @@ impl Bjt {
             0.02585,
             0.0,
             0.0,
+            0.0,
         )
     }
 
@@ -1279,6 +1282,7 @@ impl Bjt {
         thermal_voltage: f64,
         base_emitter_capacitance: f64,
         base_collector_capacitance: f64,
+        forward_transit_time: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -1291,6 +1295,7 @@ impl Bjt {
             thermal_voltage,
             base_emitter_capacitance,
             base_collector_capacitance,
+            forward_transit_time,
         }
     }
 }
@@ -5467,9 +5472,10 @@ fn stamp_ac_bjt_small_signal(
         bjt.saturation_current / bjt.thermal_voltage * exponent.exp(),
         0.0,
     );
+    let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let gpi = Complex::new(
         gm.real / bjt.forward_beta,
-        omega * bjt.base_emitter_capacitance,
+        omega * (bjt.base_emitter_capacitance + diffusion_capacitance),
     );
     let ybc = Complex::new(0.0, omega * bjt.base_collector_capacitance);
     match bjt.polarity {
@@ -5910,6 +5916,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "base-collector capacitance must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.forward_transit_time.is_finite() || bjt.forward_transit_time < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward transit time must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -347,6 +347,7 @@ fn ac_bjt_applies_zero_bias_common_emitter_gain() {
         0.02585,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -381,6 +382,7 @@ fn ac_bjt_uses_explicit_ac_source_and_dc_bias_operating_point() {
         25.85e-6,
         100.0,
         thermal_voltage,
+        0.0,
         0.0,
         0.0,
     )));
@@ -418,6 +420,7 @@ fn ac_bjt_uses_base_emitter_capacitance() {
             0.02585,
             base_emitter_capacitance,
             0.0,
+            0.0,
         )));
 
         ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
@@ -431,6 +434,44 @@ fn ac_bjt_uses_base_emitter_capacitance() {
 
     assert!(without_capacitance > 0.9);
     assert!(with_capacitance < without_capacitance / 100.0);
+}
+
+#[test]
+fn ac_bjt_uses_forward_transit_time_as_diffusion_capacitance() {
+    fn base_amplitude(forward_transit_time: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1_000.0)));
+        circuit.add(Element::Bjt(Bjt::with_model(
+            "Q1",
+            "col",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            25.85e-6,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            forward_transit_time,
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    let without_transit_time = base_amplitude(0.0);
+    let with_transit_time = base_amplitude(1.0e-3);
+
+    assert!(without_transit_time > 0.9);
+    assert!(with_transit_time < without_transit_time / 100.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -360,6 +360,7 @@ fn dc_bjt_solves_npn_emitter_follower_operating_point() {
         0.026,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -392,6 +393,7 @@ fn dc_bjt_solves_pnp_pullup_operating_point() {
         1.0e-13,
         100.0,
         0.026,
+        0.0,
         0.0,
         0.0,
     )));

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -180,6 +180,7 @@ fn tf_bjt_common_emitter_reports_small_signal_gain() {
         thermal_voltage,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
 - Parse BJT model-card capacitances with `.model ... NPN|PNP(... CJE=<c>
   CJC=<c>)` and pass them into Rust `Bjt` elements.
+- Parse BJT model-card forward transit time with
+  `.model ... NPN|PNP(... TF=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -785,6 +785,7 @@ fn parse_element(
                     .get("CJC")
                     .or_else(|| model.params.get("CBC"))
                     .unwrap_or(&0.0),
+                *model.params.get("TF").unwrap_or(&0.0),
             )))
         }
         'J' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -689,7 +689,7 @@ Rload out 0 1k
 fn parses_bjt_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast NPN(IS=1e-13 BF=120 VT=26m CJE=2p CJC=3p)
+.model fast NPN(IS=1e-13 BF=120 VT=26m CJE=2p CJC=3p TF=4n)
 Vcc vcc 0 DC 5
 Vbase base 0 DC 0.7
 Q1 vcc base out fast
@@ -707,6 +707,7 @@ Rload out 0 1k
     assert_close(*model.params.get("VT").unwrap(), 26.0e-3);
     assert_close(*model.params.get("CJE").unwrap(), 2.0e-12);
     assert_close(*model.params.get("CJC").unwrap(), 3.0e-12);
+    assert_close(*model.params.get("TF").unwrap(), 4.0e-9);
 
     let Element::Bjt(bjt) = &parsed.circuit.elements()[2] else {
         panic!("expected BJT");
@@ -721,6 +722,7 @@ Rload out 0 1k
     assert_close(bjt.thermal_voltage, 26.0e-3);
     assert_close(bjt.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt.base_collector_capacitance, 3.0e-12);
+    assert_close(bjt.forward_transit_time, 4.0e-9);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -13,6 +13,8 @@
   forward-bias diffusion capacitance to small-signal AC admittance.
 - Add BJT capacitance support through `baseEmitterCapacitance` /
   `baseCollectorCapacitance`, contributing small-signal AC susceptance.
+- Add BJT transit-time support through `forwardTransitTime`, contributing
+  forward-bias diffusion capacitance to small-signal AC admittance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -394,6 +394,7 @@ export interface Bjt {
   readonly thermalVoltage: number;
   readonly baseEmitterCapacitance: number;
   readonly baseCollectorCapacitance: number;
+  readonly forwardTransitTime: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -956,7 +957,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -1256,6 +1257,7 @@ export function bjt(
   thermalVoltage = 0.02585,
   baseEmitterCapacitance = 0.0,
   baseCollectorCapacitance = 0.0,
+  forwardTransitTime = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -1269,6 +1271,7 @@ export function bjt(
     thermalVoltage,
     baseEmitterCapacitance,
     baseCollectorCapacitance,
+    forwardTransitTime,
   };
 }
 
@@ -4893,6 +4896,9 @@ function validateBjt(element: Bjt): void {
   if (!Number.isFinite(element.baseCollectorCapacitance) || element.baseCollectorCapacitance < 0.0) {
     throw invalidElement(element.name, "base-collector capacitance must be finite and non-negative");
   }
+  if (!Number.isFinite(element.forwardTransitTime) || element.forwardTransitTime < 0.0) {
+    throw invalidElement(element.name, "forward transit time must be finite and non-negative");
+  }
 }
 
 function validateMosfet(element: Mosfet): void {
@@ -6519,9 +6525,10 @@ function stampAcBjtSmallSignal(
   const emitter = nodeIndex(nodeIndices, element.emitter);
   const transconductance = element.saturationCurrent / element.thermalVoltage;
   const junctionConductance = transconductance / element.forwardBeta;
+  const diffusionCapacitance = element.forwardTransitTime * transconductance;
   const baseEmitterAdmittance = complex(
     junctionConductance,
-    omega * element.baseEmitterCapacitance,
+    omega * (element.baseEmitterCapacitance + diffusionCapacitance),
   );
   const baseCollectorAdmittance = complex(0.0, omega * element.baseCollectorCapacitance);
   if (element.polarity === "NPN") {

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -313,6 +313,23 @@ describe("acSweep", () => {
     expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
   });
 
+  it("uses BJT forward transit time as diffusion capacitance in AC analysis", () => {
+    function baseAmplitude(forwardTransitTime: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(resistor("Rc", "col", "0", 1_000.0));
+      circuit.add(bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, forwardTransitTime));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
+    }
+
+    const withoutTransitTime = baseAmplitude(0.0);
+    const withTransitTime = baseAmplitude(1.0e-3);
+
+    expect(withoutTransitTime).toBeGreaterThan(0.9);
+    expect(withTransitTime).toBeLessThan(withoutTransitTime / 100.0);
+  });
+
   it("applies VCVS gain in AC analysis", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Parse diode model-card transit time with `.model ... D(... TT=<time>)`.
 - Parse BJT model-card capacitances with `.model ... NPN|PNP(... CJE=<c>
   CJC=<c>)` and pass them into TypeScript `bjt` elements.
+- Parse BJT model-card forward transit time with
+  `.model ... NPN|PNP(... TF=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -598,6 +598,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VT") ?? 0.02585,
       model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,
       model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,
+      model.params.get("TF") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -462,7 +462,7 @@ Rload out 0 1k
 
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p)
+.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n)
 Vcc vcc 0 DC 5
 Vb base 0 DC 0.7
 Rc vcc col 100
@@ -479,6 +479,7 @@ Q1 col base 0 fast
         ["VT", 25.0e-3],
         ["CJE", 2.0e-12],
         ["CJC", 3.0e-12],
+        ["TF", 4.0e-9],
       ]),
     });
     expect(parsed.circuit.elements()[3]).toMatchObject({
@@ -493,6 +494,7 @@ Q1 col base 0 fast
       thermalVoltage: 25.0e-3,
       baseEmitterCapacitance: 2.0e-12,
       baseCollectorCapacitance: 3.0e-12,
+      forwardTransitTime: 4.0e-9,
     });
 
     const result = dcOp(parsed.circuit);

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -213,6 +213,9 @@ Status:
 - BJT `.model ... NPN|PNP(... CJE=<capacitance> CJC=<capacitance>)` parsing
   and base-emitter/base-collector AC capacitance stamping are implemented
   across Python, TypeScript, and Rust.
+- BJT `.model ... NPN|PNP(... TF=<time>)` parsing and forward-bias diffusion
+  capacitance are implemented in AC analysis across Python, TypeScript, and
+  Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary

- add BJT forward transit-time fields across Python, TypeScript, and Rust engines
- stamp `TF * gm` diffusion capacitance into BJT AC small-signal admittance
- parse `.model ... NPN|PNP(... TF=<time>)` and update the 1970s compatibility plan

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-bjt-transit-time PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-bjt-transit-time PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `npm install --quiet && npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm install --quiet && npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `cargo fmt -p spice-engine -p spice-netlist-parser && cargo test -p spice-engine -p spice-netlist-parser`
- `git diff --check`