### PR TITLE
fix(sql): INSERT RETURNING reflects auto-assigned IPK + defaults

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.1.0] - 2026-05-23
+
+### Fixed
+
+- ``INSERT(v) VALUES (...) RETURNING *`` on a table with an
+  auto-assigned INTEGER PRIMARY KEY column now returns the
+  assigned id instead of ``NULL``.  Was the documented "known
+  limitation" of 2.0.  Backend ``insert()`` reflects auto-
+  assigned values back to the caller's dict, so the VM's
+  ``LoadLastInsertedColumn`` path sees the post-assign state.
+- DEFAULT column values are similarly reflected — ``INSERT INTO
+  t(id) VALUES (1) RETURNING *`` on ``v TEXT DEFAULT 'hi'``
+  surfaces ``'hi'`` rather than ``NULL``.
+
 ## [2.0.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.0.0"
+version = "2.1.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_insert_returning_ipk.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_insert_returning_ipk.py
@@ -1,0 +1,94 @@
+"""Tests for ``INSERT ... RETURNING`` reflecting auto-assigned IPK.
+
+Mini-sqlite 2.0 added ``RETURNING *`` shorthand but inherited a
+pre-existing limitation: ``INSERT(v) VALUES (...) RETURNING *`` on a
+table with an auto-assigned INTEGER PRIMARY KEY column reported the
+``id`` as NULL.  The VM's ``LoadLastInsertedColumn`` path read from
+``st.last_inserted_row``, which was the dict the user passed in —
+missing the IPK because the auto-assign happened inside the backend.
+
+Mini-sqlite 2.1 (this PR) fixes the contract: the backend's
+``insert()`` mutates the caller's input dict to reflect auto-
+assigned and default values, so ``last_inserted_row`` carries the
+post-auto-assign state.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(*stmts: str, query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestAutoAssignedIPK:
+    """RETURNING * surfaces the auto-assigned id."""
+
+    def test_returning_star_after_partial_insert(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            query="INSERT INTO t(v) VALUES ('a') RETURNING *",
+        )
+
+    def test_returning_id_alone(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            query="INSERT INTO t(v) VALUES ('a') RETURNING id",
+        )
+
+    def test_returning_explicit_id_v(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            query="INSERT INTO t(v) VALUES ('a') RETURNING id, v",
+        )
+
+    def test_returning_sequential_inserts(self) -> None:
+        # The auto-assigned id increments for each successive INSERT.
+        mini = mini_sqlite.connect(":memory:")
+        ref = sqlite3.connect(":memory:")
+        for c in (mini, ref):
+            c.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        for v in ("a", "b", "c"):
+            q = f"INSERT INTO t(v) VALUES ('{v}') RETURNING id"
+            assert mini.execute(q).fetchall() == ref.execute(q).fetchall()
+
+
+class TestExplicitIPKStillWorks:
+    """When the user supplies the id explicitly, RETURNING returns that value."""
+
+    def test_explicit_id_returned_verbatim(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            query="INSERT INTO t VALUES (42, 'a') RETURNING *",
+        )
+
+
+class TestNonIPKDefault:
+    """Default values on non-IPK columns also propagate into RETURNING *."""
+
+    def test_text_default_reflected(self) -> None:
+        # When the user omits a column with a DEFAULT, RETURNING *
+        # surfaces the default value (matches SQLite).
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT DEFAULT 'hi')",
+            query="INSERT INTO t(id) VALUES (1) RETURNING *",
+        )
+
+
+class TestLastInsertRowidStillCorrect:
+    """The fix doesn't regress ``last_insert_rowid()``."""
+
+    def test_last_insert_rowid_after_partial_insert(self) -> None:
+        _both_match(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)",
+            "INSERT INTO t(v) VALUES ('a')",
+            query="SELECT last_insert_rowid()",
+        )

--- a/code/packages/python/sql-backend/CHANGELOG.md
+++ b/code/packages/python/sql-backend/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the `sql-backend` Python package are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-05-23
+
+### Changed
+
+- ``InMemoryBackend.insert`` now mutates the caller's input row
+  dict in place to reflect auto-assigned (INTEGER PRIMARY KEY) and
+  default-applied column values.  The hidden ``_ROWID_KEY`` stamp
+  is excluded — the caller's dict represents user-visible columns
+  only.  Required so the VM's ``LoadLastInsertedColumn`` path for
+  ``INSERT … RETURNING`` observes the auto-assigned id instead of
+  the NULL the caller originally passed in.
+
 ## [0.19.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/sql-backend/pyproject.toml
+++ b/code/packages/python/sql-backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-backend"
-version = "0.19.0"
+version = "0.20.0"
 description = "Pluggable data-source interface for the SQL pipeline — ships the Backend ABC, supporting types, an InMemoryBackend reference, and conformance test helpers."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-backend/src/sql_backend/in_memory.py
+++ b/code/packages/python/sql-backend/src/sql_backend/in_memory.py
@@ -791,6 +791,17 @@ class InMemoryBackend(Backend):
             full_row[_ROWID_KEY] = t._next_rowid
             t._next_rowid += 1
         t.rows.append(full_row)
+        # Reflect any auto-assigned / default values back into the caller's
+        # input dict so downstream consumers (e.g. the VM's
+        # ``LoadLastInsertedColumn`` path for ``INSERT … RETURNING``)
+        # observe the IPK auto-assign rather than the original NULL.
+        # The hidden ``_ROWID_KEY`` stamp is excluded — the caller's
+        # dict represents user-visible columns only.
+        for k, v in full_row.items():
+            if k == _ROWID_KEY:
+                continue
+            if k not in row or row.get(k) is None:
+                row[k] = v
 
     def _autoassign_ipk(self, t: _Table, row: Row) -> None:
         """Fill in the INTEGER PRIMARY KEY column with the next rowid.


### PR DESCRIPTION
## Summary

Fixes the documented known limitation from mini-sqlite 2.0: ``INSERT(v) VALUES (...) RETURNING *`` on a table with an auto-assigned INTEGER PRIMARY KEY reported the id as ``NULL``.

Root cause: the VM's ``LoadLastInsertedColumn`` reads from ``st.last_inserted_row``, which was the dict the caller built before any backend mutation. Auto-assign happened on a different dict inside the backend, so the caller's view never saw the new id.

Fix: ``InMemoryBackend.insert`` now copies auto-assigned and default-applied values back into the caller's input dict (excluding the hidden rowid stamp).

This also surfaces non-IPK column defaults in RETURNING.

## Test plan

- [x] sql-backend: 200 tests, 83.59% coverage
- [x] sql-vm: 921 tests, 80.31% coverage
- [x] mini-sqlite: 2228 tests, 90.96% coverage (7 new oracle tests)
- [x] ruff clean
- [x] /security-review passed

Versions: sql-backend 0.19 → 0.20, mini-sqlite 2.0 → 2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)