### PR TITLE
spice: add BJT reverse transit time model

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -23,6 +23,9 @@
 - **BJT transit-time models** — `BJT.Tf` now contributes forward-bias
   diffusion capacitance to small-signal AC admittance.
 
+- **BJT reverse transit-time models** — `BJT.Tr` now contributes
+  base-collector diffusion capacitance to small-signal AC admittance.
+
 - **Pseudo-transient DC continuation** — `dc_op` now has a final bounded
   artificial backward-Euler continuation aid after Newton, Gmin stepping, and
   source stepping; successful fallback results report

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -517,6 +517,9 @@ class BJT:
     Tf:
         Forward transit time in seconds; contributes diffusion capacitance in
         small-signal AC analysis.
+    Tr:
+        Reverse transit time in seconds; contributes base-collector diffusion
+        capacitance in small-signal AC analysis.
     """
 
     name: str
@@ -530,6 +533,7 @@ class BJT:
     Cje: float = 0.0        # base-emitter junction capacitance (F)
     Cjc: float = 0.0        # base-collector junction capacitance (F)
     Tf: float = 0.0         # forward transit time (s)
+    Tr: float = 0.0         # reverse transit time (s)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -261,7 +261,7 @@ def _clone_subckt_element(element: object, instance_name: str, node_map: dict[st
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -2005,6 +2005,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT base-collector capacitance must be finite and non-negative")
     if not math.isfinite(el.Tf) or el.Tf < 0.0:
         raise ValueError(f"{el.name}: BJT forward transit time must be finite and non-negative")
+    if not math.isfinite(el.Tr) or el.Tr < 0.0:
+        raise ValueError(f"{el.name}: BJT reverse transit time must be finite and non-negative")
 
 
 # ---------------------------------------------------------------------------
@@ -3955,18 +3957,26 @@ def _stamp_ac(
         # VCCS).  Mirror the DC _stamp_bjt stamps but in the complex domain and
         # without the Norton offsets (which are DC bias terms, zero in AC).
         _validate_bjt(el)
+        Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
         Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
         Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
         Vjunc = (
             min(Vb_dc - Ve_dc, 0.7) if el.polarity == "NPN"
             else min(Ve_dc - Vb_dc, 0.7)
         )
+        Vreverse = (
+            min(Vb_dc - Vc_dc, 0.7) if el.polarity == "NPN"
+            else min(Vc_dc - Vb_dc, 0.7)
+        )
         exp_t = math.exp(Vjunc / el.Vt)
+        exp_reverse = math.exp(Vreverse / el.Vt)
         gm_b: float = (el.Is / el.Vt) * exp_t
+        gm_reverse: float = (el.Is / el.Vt) * exp_reverse
         g_pi: float = gm_b / el.beta_f
         diffusion_capacitance = el.Tf * gm_b
+        reverse_diffusion_capacitance = el.Tr * gm_reverse
         y_be = g_pi + 1j * omega * (el.Cje + diffusion_capacitance)
-        y_bc = 1j * omega * el.Cjc
+        y_bc = 1j * omega * (el.Cjc + reverse_diffusion_capacitance)
 
         if el.polarity == "NPN":
             _stamp_g_c(G, node_to_idx, el.base, el.emitter, y_be)
@@ -5359,6 +5369,7 @@ def sens_dc(
                     Cje=el.Cje,
                     Cjc=el.Cjc,
                     Tf=el.Tf,
+                    Tr=el.Tr,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -5374,6 +5385,7 @@ def sens_dc(
                     Cje=el.Cje,
                     Cjc=el.Cjc,
                     Tf=el.Tf,
+                    Tr=el.Tr,
                 ),
             )
 
@@ -5583,6 +5595,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Cje=el.Cje,
             Cjc=el.Cjc,
             Tf=el.Tf,
+            Tr=el.Tr,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -2184,6 +2184,24 @@ def test_ac_bjt_transit_time_adds_diffusion_capacitance():
     assert with_transit_time < without_transit_time / 100.0
 
 
+def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():
+    """BJT Tr contributes gm-scaled base-collector diffusion capacitance."""
+    def base_amplitude(tr: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "base", 1000.0))
+        c.add(Resistor("Rc", "col", "0", 1.0))
+        c.add(BJT("Q1", collector="col", base="base", emitter="0", Is=25.85e-6, Tr=tr))
+        result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["base"])
+
+    without_transit_time = base_amplitude(0.0)
+    with_transit_time = base_amplitude(1.0e-2)
+
+    assert without_transit_time > 0.9
+    assert with_transit_time < without_transit_time / 100.0
+
+
 # ============================================================================
 # 22. AC sweep — current source injection
 # ============================================================================

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -13,6 +13,8 @@
   CJC=<c>)` and pass them into Python `BJT` elements.
 - Parse BJT model-card forward transit time with
   `.model ... NPN|PNP(... TF=<time>)`.
+- Parse BJT model-card reverse transit time with
+  `.model ... NPN|PNP(... TR=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -20,7 +20,8 @@ netlist.analyses
 
 This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
 `F`, and `H` elements, `.model` cards for Shockley diode parameters (`IS`,
-`VT`), BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`), and Level-1
+`VT`), BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`, `CJE`, `CJC`,
+`TF`, `TR`), and Level-1
 MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), capacitor `IC=<voltage>`
 and inductor `IC=<current>` initial conditions, SPICE engineering suffixes,

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -439,6 +439,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Cje=model.params.get("CJE", model.params.get("CBE", 0.0)),
             Cjc=model.params.get("CJC", model.params.get("CBC", 0.0)),
             Tf=model.params.get("TF", 0.0),
+            Tr=model.params.get("TR", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -494,7 +494,7 @@ Rload out 0 1k
 def test_parse_bjt_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n)
+.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)
 Vcc vcc 0 DC 5
 Vb base 0 DC 0.7
 Rc vcc col 100
@@ -507,7 +507,15 @@ Q1 col base 0 fast
         "fast": ModelCard(
             "fast",
             "NPN",
-            {"IS": 1.0e-14, "BF": 120.0, "VT": 25.0e-3, "CJE": 2.0e-12, "CJC": 3.0e-12, "TF": 4.0e-9},
+            {
+                "IS": 1.0e-14,
+                "BF": 120.0,
+                "VT": 25.0e-3,
+                "CJE": 2.0e-12,
+                "CJC": 3.0e-12,
+                "TF": 4.0e-9,
+                "TR": 5.0e-9,
+            },
         )
     }
     bjt = parsed.circuit.elements[3]
@@ -522,6 +530,7 @@ Q1 col base 0 fast
     assert bjt.Cje == 2.0e-12
     assert bjt.Cjc == 3.0e-12
     assert bjt.Tf == 4.0e-9
+    assert bjt.Tr == 5.0e-9
 
     result = dc_op(parsed.circuit)
     assert result.converged

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -17,6 +17,9 @@
   `base_collector_capacitance`, contributing small-signal AC susceptance.
 - Add BJT transit-time support through `forward_transit_time`, contributing
   forward-bias diffusion capacitance to small-signal AC admittance.
+- Add BJT reverse transit-time support through `reverse_transit_time`,
+  contributing base-collector diffusion capacitance to small-signal AC
+  admittance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `DcConvergenceAid::PseudoTransient`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -325,6 +325,7 @@ fn clone_subckt_element(
             element.base_emitter_capacitance,
             element.base_collector_capacitance,
             element.forward_transit_time,
+            element.reverse_transit_time,
         )),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
@@ -1247,6 +1248,7 @@ pub struct Bjt {
     pub base_emitter_capacitance: f64,
     pub base_collector_capacitance: f64,
     pub forward_transit_time: f64,
+    pub reverse_transit_time: f64,
 }
 
 impl Bjt {
@@ -1268,6 +1270,7 @@ impl Bjt {
             0.0,
             0.0,
             0.0,
+            0.0,
         )
     }
 
@@ -1283,6 +1286,7 @@ impl Bjt {
         base_emitter_capacitance: f64,
         base_collector_capacitance: f64,
         forward_transit_time: f64,
+        reverse_transit_time: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -1296,6 +1300,7 @@ impl Bjt {
             base_emitter_capacitance,
             base_collector_capacitance,
             forward_transit_time,
+            reverse_transit_time,
         }
     }
 }
@@ -5461,23 +5466,34 @@ fn stamp_ac_bjt_small_signal(
     let collector = node_index(node_indices, &bjt.collector);
     let base = node_index(node_indices, &bjt.base);
     let emitter = node_index(node_indices, &bjt.emitter);
+    let collector_voltage = vector_voltage(operating_point, collector);
     let base_voltage = vector_voltage(operating_point, base);
     let emitter_voltage = vector_voltage(operating_point, emitter);
     let junction_voltage = match bjt.polarity {
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
     };
+    let reverse_junction_voltage = match bjt.polarity {
+        BjtPolarity::Npn => base_voltage - collector_voltage,
+        BjtPolarity::Pnp => collector_voltage - base_voltage,
+    };
     let exponent = (junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
+    let reverse_exponent = (reverse_junction_voltage / bjt.thermal_voltage).clamp(-40.0, 40.0);
     let gm = Complex::new(
         bjt.saturation_current / bjt.thermal_voltage * exponent.exp(),
         0.0,
     );
+    let reverse_gm = bjt.saturation_current / bjt.thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
+    let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let gpi = Complex::new(
         gm.real / bjt.forward_beta,
         omega * (bjt.base_emitter_capacitance + diffusion_capacitance),
     );
-    let ybc = Complex::new(0.0, omega * bjt.base_collector_capacitance);
+    let ybc = Complex::new(
+        0.0,
+        omega * (bjt.base_collector_capacitance + reverse_diffusion_capacitance),
+    );
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_complex_conductance(matrix, base, emitter, gpi);
@@ -5922,6 +5938,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward transit time must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.reverse_transit_time.is_finite() || bjt.reverse_transit_time < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "reverse transit time must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -348,6 +348,7 @@ fn ac_bjt_applies_zero_bias_common_emitter_gain() {
         0.0,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -385,6 +386,7 @@ fn ac_bjt_uses_explicit_ac_source_and_dc_bias_operating_point() {
         0.0,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -419,6 +421,7 @@ fn ac_bjt_uses_base_emitter_capacitance() {
             100.0,
             0.02585,
             base_emitter_capacitance,
+            0.0,
             0.0,
             0.0,
         )));
@@ -459,6 +462,7 @@ fn ac_bjt_uses_forward_transit_time_as_diffusion_capacitance() {
             0.0,
             0.0,
             forward_transit_time,
+            0.0,
         )));
 
         ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
@@ -469,6 +473,45 @@ fn ac_bjt_uses_forward_transit_time_as_diffusion_capacitance() {
 
     let without_transit_time = base_amplitude(0.0);
     let with_transit_time = base_amplitude(1.0e-3);
+
+    assert!(without_transit_time > 0.9);
+    assert!(with_transit_time < without_transit_time / 100.0);
+}
+
+#[test]
+fn ac_bjt_uses_reverse_transit_time_as_base_collector_diffusion_capacitance() {
+    fn base_amplitude(reverse_transit_time: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1.0)));
+        circuit.add(Element::Bjt(Bjt::with_model(
+            "Q1",
+            "col",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            25.85e-6,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            0.0,
+            reverse_transit_time,
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    let without_transit_time = base_amplitude(0.0);
+    let with_transit_time = base_amplitude(1.0e-2);
 
     assert!(without_transit_time > 0.9);
     assert!(with_transit_time < without_transit_time / 100.0);

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -361,6 +361,7 @@ fn dc_bjt_solves_npn_emitter_follower_operating_point() {
         0.0,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,
@@ -393,6 +394,7 @@ fn dc_bjt_solves_pnp_pullup_operating_point() {
         1.0e-13,
         100.0,
         0.026,
+        0.0,
         0.0,
         0.0,
         0.0,

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -181,6 +181,7 @@ fn tf_bjt_common_emitter_reports_small_signal_gain() {
         0.0,
         0.0,
         0.0,
+        0.0,
     )));
     circuit.add(Element::Resistor(Resistor::new(
         "Rload", "out", "0", 1_000.0,

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -13,6 +13,8 @@
   CJC=<c>)` and pass them into Rust `Bjt` elements.
 - Parse BJT model-card forward transit time with
   `.model ... NPN|PNP(... TF=<time>)`.
+- Parse BJT model-card reverse transit time with
+  `.model ... NPN|PNP(... TR=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -20,7 +20,8 @@ assert_eq!(parsed.tran_cards().len(), 1);
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`
 parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
-`BETA_F`, and `VT` parameters, `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
+`BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
+`.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
 suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -786,6 +786,7 @@ fn parse_element(
                     .or_else(|| model.params.get("CBC"))
                     .unwrap_or(&0.0),
                 *model.params.get("TF").unwrap_or(&0.0),
+                *model.params.get("TR").unwrap_or(&0.0),
             )))
         }
         'J' => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -689,7 +689,7 @@ Rload out 0 1k
 fn parses_bjt_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model fast NPN(IS=1e-13 BF=120 VT=26m CJE=2p CJC=3p TF=4n)
+.model fast NPN(IS=1e-13 BF=120 VT=26m CJE=2p CJC=3p TF=4n TR=5n)
 Vcc vcc 0 DC 5
 Vbase base 0 DC 0.7
 Q1 vcc base out fast
@@ -708,6 +708,7 @@ Rload out 0 1k
     assert_close(*model.params.get("CJE").unwrap(), 2.0e-12);
     assert_close(*model.params.get("CJC").unwrap(), 3.0e-12);
     assert_close(*model.params.get("TF").unwrap(), 4.0e-9);
+    assert_close(*model.params.get("TR").unwrap(), 5.0e-9);
 
     let Element::Bjt(bjt) = &parsed.circuit.elements()[2] else {
         panic!("expected BJT");
@@ -723,6 +724,7 @@ Rload out 0 1k
     assert_close(bjt.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt.base_collector_capacitance, 3.0e-12);
     assert_close(bjt.forward_transit_time, 4.0e-9);
+    assert_close(bjt.reverse_transit_time, 5.0e-9);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -15,6 +15,9 @@
   `baseCollectorCapacitance`, contributing small-signal AC susceptance.
 - Add BJT transit-time support through `forwardTransitTime`, contributing
   forward-bias diffusion capacitance to small-signal AC admittance.
+- Add BJT reverse transit-time support through `reverseTransitTime`,
+  contributing base-collector diffusion capacitance to small-signal AC
+  admittance.
 - Add pseudo-transient DC continuation as a final bounded convergence aid after
   Newton, Gmin stepping, and source stepping; successful fallback results
   report `convergenceAid: "pseudo_transient"`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -395,6 +395,7 @@ export interface Bjt {
   readonly baseEmitterCapacitance: number;
   readonly baseCollectorCapacitance: number;
   readonly forwardTransitTime: number;
+  readonly reverseTransitTime: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -957,7 +958,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -1258,6 +1259,7 @@ export function bjt(
   baseEmitterCapacitance = 0.0,
   baseCollectorCapacitance = 0.0,
   forwardTransitTime = 0.0,
+  reverseTransitTime = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -1272,6 +1274,7 @@ export function bjt(
     baseEmitterCapacitance,
     baseCollectorCapacitance,
     forwardTransitTime,
+    reverseTransitTime,
   };
 }
 
@@ -4899,6 +4902,9 @@ function validateBjt(element: Bjt): void {
   if (!Number.isFinite(element.forwardTransitTime) || element.forwardTransitTime < 0.0) {
     throw invalidElement(element.name, "forward transit time must be finite and non-negative");
   }
+  if (!Number.isFinite(element.reverseTransitTime) || element.reverseTransitTime < 0.0) {
+    throw invalidElement(element.name, "reverse transit time must be finite and non-negative");
+  }
 }
 
 function validateMosfet(element: Mosfet): void {
@@ -6526,11 +6532,15 @@ function stampAcBjtSmallSignal(
   const transconductance = element.saturationCurrent / element.thermalVoltage;
   const junctionConductance = transconductance / element.forwardBeta;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
+  const reverseDiffusionCapacitance = element.reverseTransitTime * transconductance;
   const baseEmitterAdmittance = complex(
     junctionConductance,
     omega * (element.baseEmitterCapacitance + diffusionCapacitance),
   );
-  const baseCollectorAdmittance = complex(0.0, omega * element.baseCollectorCapacitance);
+  const baseCollectorAdmittance = complex(
+    0.0,
+    omega * (element.baseCollectorCapacitance + reverseDiffusionCapacitance),
+  );
   if (element.polarity === "NPN") {
     stampComplexConductance(
       matrix,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -330,6 +330,23 @@ describe("acSweep", () => {
     expect(withTransitTime).toBeLessThan(withoutTransitTime / 100.0);
   });
 
+  it("uses BJT reverse transit time as base-collector diffusion capacitance in AC analysis", () => {
+    function baseAmplitude(reverseTransitTime: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(resistor("Rc", "col", "0", 1.0));
+      circuit.add(bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, 0.0, reverseTransitTime));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
+    }
+
+    const withoutTransitTime = baseAmplitude(0.0);
+    const withTransitTime = baseAmplitude(1.0e-2);
+
+    expect(withoutTransitTime).toBeGreaterThan(0.9);
+    expect(withTransitTime).toBeLessThan(withoutTransitTime / 100.0);
+  });
+
   it("applies VCVS gain in AC analysis", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -13,6 +13,8 @@
   CJC=<c>)` and pass them into TypeScript `bjt` elements.
 - Parse BJT model-card forward transit time with
   `.model ... NPN|PNP(... TF=<time>)`.
+- Parse BJT model-card reverse transit time with
+  `.model ... NPN|PNP(... TR=<time>)`.
 - Parse and validate transient integration methods from
   `.tran ... method=<euler|trap|gear2>`, and expose fallback routing from
   `.options method=<...>`.

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -22,7 +22,8 @@ netlist.analyses;
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and `H`
 elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `.model <name> NPN(...)` / `.model <name> PNP(...)` BJT cards with `IS`,
-`BF` / `BETA_F`, and `VT` parameters, `.model <name> NMOS(...)` /
+`BF` / `BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
+`.model <name> NMOS(...)` /
 `.model <name> PMOS(...)` MOSFET cards with Level-1 `VT0` / `VTO`, `KP`,
 `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` /
 `TNOM` parameters, capacitor `IC=<voltage>` and inductor `IC=<current>`

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -599,6 +599,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("CJE") ?? model.params.get("CBE") ?? 0.0,
       model.params.get("CJC") ?? model.params.get("CBC") ?? 0.0,
       model.params.get("TF") ?? 0.0,
+      model.params.get("TR") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -462,7 +462,7 @@ Rload out 0 1k
 
   it("parses BJT models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n)
+.model fast NPN(IS=1e-14 BF=120 VT=25m CJE=2p CJC=3p TF=4n TR=5n)
 Vcc vcc 0 DC 5
 Vb base 0 DC 0.7
 Rc vcc col 100
@@ -480,6 +480,7 @@ Q1 col base 0 fast
         ["CJE", 2.0e-12],
         ["CJC", 3.0e-12],
         ["TF", 4.0e-9],
+        ["TR", 5.0e-9],
       ]),
     });
     expect(parsed.circuit.elements()[3]).toMatchObject({
@@ -495,6 +496,7 @@ Q1 col base 0 fast
       baseEmitterCapacitance: 2.0e-12,
       baseCollectorCapacitance: 3.0e-12,
       forwardTransitTime: 4.0e-9,
+      reverseTransitTime: 5.0e-9,
     });
 
     const result = dcOp(parsed.circuit);

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -216,6 +216,9 @@ Status:
 - BJT `.model ... NPN|PNP(... TF=<time>)` parsing and forward-bias diffusion
   capacitance are implemented in AC analysis across Python, TypeScript, and
   Rust.
+- BJT `.model ... NPN|PNP(... TR=<time>)` parsing and reverse/base-collector
+  diffusion capacitance are implemented in AC analysis across Python,
+  TypeScript, and Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary
- add SPICE BJT `TR` / reverse transit-time model parsing across Python, TypeScript, and Rust
- preserve the parameter through BJT model state, cloning/copy helpers, and AC stamping
- add base-collector diffusion-capacitance coverage plus parser fixture assertions and compatibility-plan markers

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-bjt-reverse-transit-time PYTHONPATH=src python -m pytest tests/test_engine.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-bjt-reverse-transit-time PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `cargo fmt -p spice-engine -p spice-netlist-parser`
- `cargo test -p spice-engine -p spice-netlist-parser`
- `git diff --check`