### PR TITLE
spec(CLOC09): javascript-ast taxonomy — ESTree-compat, V8-frontend-ready

### DIFF
--- a/code/specs/CLOC09-ast-taxonomy.md
+++ b/code/specs/CLOC09-ast-taxonomy.md
@@ -1,0 +1,470 @@
+# CLOC09 — JavaScript AST Taxonomy
+
+## What this spec locks down
+
+CLOC09 defines the full node taxonomy of `javascript-ast`. After
+the Stage 1–4 scaffold loop (CLOC01–CLOC08), `javascript-ast`
+shipped just `Program` and `SourceType`. Every optimization
+pass, the type-checker, and the emitter were therefore identity.
+This spec catalogues the variants the AST grows to so those
+bodies can fill in.
+
+The spec is binding for the implementation PRs that follow it,
+in order:
+
+- Phase 1 (this round): ~25 variants — enough to express
+  `function f(x){ return x + 1; } const a = f(7);` and to give
+  `constant-fold` and `dce` real work.
+- Phase 2: leaf coverage gaps (`BigIntLiteral`, `RegExpLiteral`,
+  `TemplateLiteral`), update/unary/spread, `SwitchStatement`,
+  `TryStatement`.
+- Phase 3: patterns (destructuring), arrow functions, classes.
+- Phase 4: modules (`import` / `export` declarations).
+- Phase 5: async / generators, optional chaining, nullish
+  coalescing, `??=` `||=` `&&=` assignment operators.
+
+This document focuses on Phase 1; subsequent phases extend the
+same enums additively.
+
+## Three load-bearing design decisions
+
+### 1. Full ESTree compatibility
+
+The AST mirrors the [ESTree
+spec](https://github.com/estree/estree) — the de facto
+interchange format used by every major JS tool (Babel, ESLint,
+Acorn, Espree, Prettier, Rollup, esbuild, swc, TypeScript). Node
+type names, field names, and per-variant shapes match ESTree
+exactly.
+
+**Why**: ESTree is the result of 10+ years of work by the JS
+tooling community to converge on a lossless representation of
+ECMAScript programs. Reusing it gets us:
+
+- a known-rich representation that handles every ES2025
+  construct (the underlying motivation is that *any* JS engine
+  has to handle them all),
+- interop with the broader ecosystem — a debugger, viz, or
+  linter that already understands ESTree can read our AST,
+- no design churn from arguments we'd otherwise have to
+  resolve internally (where should `optional` go on
+  `CallExpression`? what's the shape of a spread element? ESTree
+  has answers).
+
+We deviate from ESTree only in **two** ways:
+
+1. **No source ranges or location objects.** ESTree nodes carry
+   `loc: SourceLocation | null` and `range: [number, number] |
+   null`. Per [CLOC02](./CLOC02-javascript-ast-design.md) our
+   nodes carry only a `CvId` and look up source positions
+   through the correlation-vector graph. This is the structural
+   invariant that lets every optimization pass rewrite the AST
+   without invalidating source maps.
+2. **Rust idioms** for naming and field types. `Box<Expression>`
+   instead of `Expression | null` for nullable children; Rust
+   `enum` with `#[serde(tag = "type")]` to match ESTree's
+   `{ "type": "IfStatement", ... }` JSON wire format on
+   serialize. ESTree's `null`-able pieces (e.g. the `alternate`
+   of `IfStatement`) become `Option<Box<...>>`.
+
+### 2. AST is V8-frontend-ready
+
+The user's project plan includes a future V8-on-LANG-VM
+implementation that consumes this same AST. The V8 frontend
+will lower the AST into LANG VM bytecode rather than into JS
+source text, but it consumes the same node taxonomy the
+Closure-style passes do.
+
+This places one hard constraint on the AST: **it must be
+lossless enough that an interpreter / JIT can implement exact
+ECMAScript semantics from it.** A few examples of what
+"lossless" demands:
+
+- `VariableDeclaration` must distinguish `var` / `let` /
+  `const` (scope semantics differ across all three).
+- `FunctionDeclaration` / `FunctionExpression` /
+  `ArrowFunctionExpression` are three different variants
+  (`this` binding semantics differ).
+- `BlockStatement` must be a distinct variant from a bare
+  sequence of statements (block scoping for `let`/`const`).
+- `ObjectExpression` preserves property order (insertion order
+  is observable via `Object.keys` per ES2015+).
+- `MemberExpression` distinguishes `computed: true` (`a[b]`)
+  from `computed: false` (`a.b`) — meaning differs when the key
+  is a `Symbol`.
+- `BinaryExpression` and `LogicalExpression` are distinct
+  variants — short-circuit semantics of `&&` / `||` / `??` matter.
+- `AssignmentExpression` is distinct from `BinaryExpression`
+  (assignment evaluates RHS then LHS, with side effects).
+- `Literal` is split into typed variants (`NumericLiteral`,
+  `StringLiteral`, `BooleanLiteral`, `NullLiteral`, …) so the
+  type carries through statically without re-parsing the raw
+  text. (ESTree uses a single `Literal` with `value: any`; this
+  is one of the few places our Rust idioms make the typed split
+  natural — and it's lossless: the underlying value's type is
+  what matters.)
+
+ESTree was designed to be lossless across the full ECMAScript
+spec; it satisfies the V8-readiness constraint by construction.
+This spec calls out the constraint explicitly so future PRs
+don't accidentally optimize toward "what Closure-style passes
+need" at the cost of "what an interpreter needs."
+
+### 3. Per-node `CvId` is the only identity
+
+Every node carries exactly one `CvId` field, named `cv`. No
+spans, no parent pointers, no node IDs. The correlation-vector
+graph stores the actual `(file, byte_start, byte_end)` triple
+keyed by `CvId`.
+
+```rust
+pub struct IfStatement {
+    pub cv: CvId,
+    pub test: Expression,
+    pub consequent: Box<Statement>,
+    pub alternate: Option<Box<Statement>>,
+}
+```
+
+Why one identity, not many:
+
+- **Source-map preservation across passes**. Every pass that
+  rewrites a node creates a new `CvId` via `cv.fork(parent_cv)`
+  or `cv.create()`. The old CvId stays in the log marked
+  `deleted`. So the chain `original_source_byte → original_ast
+  → folded_ast → renamed_ast → emitted_token` is queryable
+  through the CV graph long after the AST itself has moved on.
+- **No parent pointers**. ESTree allows them (some tools attach
+  them) but they make every mutation a graph-fixup. Our passes
+  produce *new* trees rather than mutating in place; if a pass
+  needs the parent it threads it through the recursion.
+- **No span on the node**. The span is in the CV graph. This is
+  what makes the V8 frontend's job feasible — V8 needs to map
+  bytecode back to source positions for the debugger / profiler,
+  but it does so through whatever IR it produces, not by
+  carrying spans on every AST node through every pass.
+
+## Wire format
+
+Every variant serializes to JSON with a `"type": "..."` tag
+matching ESTree exactly. Internal field names are camelCase to
+match ESTree, applied via `#[serde(rename_all = "camelCase")]`.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Statement {
+    ExpressionStatement(ExpressionStatement),
+    BlockStatement(BlockStatement),
+    IfStatement(IfStatement),
+    // ...
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IfStatement {
+    pub cv: CvId,
+    pub test: Expression,
+    pub consequent: Box<Statement>,
+    pub alternate: Option<Box<Statement>>,
+}
+```
+
+A node serialized to JSON is exactly the ESTree shape modulo
+the `cv` field replacing `loc` / `range`. JSON-emitting tools
+(debug dumps, `--print_tree_json`) match what Babel / Acorn
+output for the same source.
+
+## Top-level structure
+
+```rust
+pub struct Program {
+    pub cv: CvId,
+    pub version: EsVersion,         // already present
+    pub source_type: SourceType,    // already present
+    pub body: Vec<ProgramItem>,     // NEW in Phase 1
+}
+
+pub enum ProgramItem {
+    Statement(Statement),
+    Declaration(Declaration),
+    // Phase 4: ModuleDeclaration(ModuleDeclaration),
+}
+```
+
+`Program.body` is a `Vec` of either statements or declarations.
+ESTree models top-level as `Statement | ModuleDeclaration` and
+lifts declarations into the statement enum; we keep them as a
+separate enum because most passes care about declarations
+specifically (renaming, treeshaking, remove-unused-vars).
+
+## Phase 1 — Statement variants
+
+| Variant               | Fields                                                                                                                                              |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ExpressionStatement` | `cv: CvId`, `expression: Expression`                                                                                                                |
+| `BlockStatement`      | `cv: CvId`, `body: Vec<Statement>` (Declarations land via Phase 1's `Statement::Declaration` lift — see below)                                      |
+| `IfStatement`         | `cv: CvId`, `test: Expression`, `consequent: Box<Statement>`, `alternate: Option<Box<Statement>>`                                                   |
+| `WhileStatement`      | `cv: CvId`, `test: Expression`, `body: Box<Statement>`                                                                                              |
+| `ForStatement`        | `cv: CvId`, `init: Option<ForInit>`, `test: Option<Expression>`, `update: Option<Expression>`, `body: Box<Statement>`                               |
+| `ReturnStatement`     | `cv: CvId`, `argument: Option<Expression>`                                                                                                          |
+| `BreakStatement`      | `cv: CvId`, `label: Option<Identifier>`                                                                                                             |
+| `ContinueStatement`   | `cv: CvId`, `label: Option<Identifier>`                                                                                                             |
+| `EmptyStatement`      | `cv: CvId`                                                                                                                                          |
+| `Declaration`         | wraps `Declaration` so a top-level or block-scoped declaration is also a `Statement` (matches ESTree's lift of `VariableDeclaration` etc. into `Statement`) |
+
+```rust
+pub enum ForInit {
+    VariableDeclaration(VariableDeclaration),
+    Expression(Expression),
+}
+```
+
+(Phase 2 adds `SwitchStatement`, `TryStatement`,
+`ThrowStatement`, `LabeledStatement`, `DoWhileStatement`,
+`ForInStatement`, `ForOfStatement`, `DebuggerStatement`,
+`WithStatement`.)
+
+## Phase 1 — Expression variants
+
+| Variant                 | Fields                                                                                                                                              |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Identifier`            | `cv: CvId`, `name: String`                                                                                                                          |
+| `NumericLiteral`        | `cv: CvId`, `value: f64`, `raw: String`                                                                                                             |
+| `StringLiteral`         | `cv: CvId`, `value: String`, `raw: String`                                                                                                          |
+| `BooleanLiteral`        | `cv: CvId`, `value: bool`                                                                                                                           |
+| `NullLiteral`           | `cv: CvId`                                                                                                                                          |
+| `BinaryExpression`      | `cv: CvId`, `operator: BinaryOperator`, `left: Box<Expression>`, `right: Box<Expression>`                                                           |
+| `LogicalExpression`     | `cv: CvId`, `operator: LogicalOperator`, `left: Box<Expression>`, `right: Box<Expression>`                                                          |
+| `UnaryExpression`       | `cv: CvId`, `operator: UnaryOperator`, `prefix: bool`, `argument: Box<Expression>`                                                                  |
+| `AssignmentExpression`  | `cv: CvId`, `operator: AssignmentOperator`, `left: AssignmentTarget`, `right: Box<Expression>`                                                      |
+| `ConditionalExpression` | `cv: CvId`, `test: Box<Expression>`, `consequent: Box<Expression>`, `alternate: Box<Expression>`                                                    |
+| `CallExpression`        | `cv: CvId`, `callee: Box<Expression>`, `arguments: Vec<Expression>`                                                                                 |
+| `MemberExpression`      | `cv: CvId`, `object: Box<Expression>`, `property: MemberProperty`, `computed: bool`                                                                 |
+| `ArrayExpression`       | `cv: CvId`, `elements: Vec<Option<Expression>>` (`None` represents an elision: `[1, , 3]`)                                                          |
+| `ObjectExpression`      | `cv: CvId`, `properties: Vec<Property>` (insertion order preserved per ES2015+)                                                                     |
+
+```rust
+pub enum BinaryOperator {
+    Eq, NotEq, StrictEq, StrictNotEq,
+    Lt, LtEq, Gt, GtEq,
+    LeftShift, RightShift, UnsignedRightShift,
+    Add, Sub, Mul, Div, Mod, Exp,
+    BitOr, BitXor, BitAnd,
+    In, InstanceOf,
+}
+
+pub enum LogicalOperator { And, Or, NullishCoalescing }
+
+pub enum UnaryOperator { Negate, Plus, Not, BitNot, TypeOf, Void, Delete }
+
+pub enum AssignmentOperator {
+    Eq,                                       // =
+    AddEq, SubEq, MulEq, DivEq, ModEq, ExpEq,
+    LeftShiftEq, RightShiftEq, UnsignedRightShiftEq,
+    BitOrEq, BitXorEq, BitAndEq,
+    // Phase 5 adds: LogicalAndEq (&&=), LogicalOrEq (||=), NullishCoalescingEq (??=)
+}
+
+pub enum MemberProperty {
+    Identifier(Identifier),         // `obj.foo`            (computed = false)
+    Expression(Expression),         // `obj[expr]`          (computed = true)
+}
+
+pub enum AssignmentTarget {
+    Identifier(Identifier),
+    MemberExpression(Box<MemberExpression>),
+    // Phase 3: Pattern (destructuring)
+}
+
+pub struct Property {
+    pub cv: CvId,
+    pub kind: PropertyKind,        // init | get | set
+    pub key: PropertyKey,
+    pub value: Box<Expression>,
+    pub computed: bool,
+    pub shorthand: bool,
+    pub method: bool,
+}
+
+pub enum PropertyKind { Init, Get, Set }
+pub enum PropertyKey {
+    Identifier(Identifier),
+    StringLiteral(StringLiteral),
+    NumericLiteral(NumericLiteral),
+    Expression(Expression),         // when `computed: true`
+}
+```
+
+(Phase 2 adds `BigIntLiteral`, `RegExpLiteral`,
+`TemplateLiteral`, `TaggedTemplateExpression`,
+`SequenceExpression`, `UpdateExpression`, `NewExpression`,
+`SpreadElement`, `ThisExpression`, `SuperExpression`.)
+
+## Phase 1 — Declaration variants
+
+| Variant               | Fields                                                                                                                                              |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VariableDeclaration` | `cv: CvId`, `kind: VarKind`, `declarations: Vec<VariableDeclarator>`                                                                                |
+| `FunctionDeclaration` | `cv: CvId`, `id: Identifier`, `params: Vec<FunctionParam>`, `body: BlockStatement`, `generator: bool`, `is_async: bool`                             |
+
+```rust
+pub enum VarKind { Var, Let, Const }
+
+pub struct VariableDeclarator {
+    pub cv: CvId,
+    pub id: BindingTarget,
+    pub init: Option<Expression>,
+}
+
+pub enum BindingTarget {
+    Identifier(Identifier),
+    // Phase 3: ArrayPattern, ObjectPattern (destructuring)
+}
+
+pub enum FunctionParam {
+    Identifier(Identifier),
+    // Phase 3: AssignmentPattern (default value), RestElement, ArrayPattern, ObjectPattern
+}
+```
+
+(Phase 3 adds `ClassDeclaration`; Phase 4 adds `ImportDeclaration`,
+`ExportNamedDeclaration`, `ExportDefaultDeclaration`,
+`ExportAllDeclaration`.)
+
+### `is_async` vs ESTree's `async`
+
+ESTree names the boolean `async`. Rust's `async` is a reserved
+keyword (raw identifiers `r#async` work but are awkward at call
+sites). We name the field `is_async` and tag it
+`#[serde(rename = "async")]` so the JSON wire format still
+matches ESTree exactly.
+
+This is the only field-name divergence Phase 1 introduces. It
+applies anywhere a function-like node has the async flag
+(`FunctionDeclaration`, future Phase 1.x `FunctionExpression`,
+Phase 3 `ArrowFunctionExpression`, `Method`, `ClassMethod`,
+etc.).
+
+## Why split `Statement` and `Declaration` enums
+
+ESTree puts declarations inside the `Statement` enum (so
+`VariableDeclaration` IS a `Statement`). We keep them in a
+separate `Declaration` enum AND wrap them as
+`Statement::Declaration(Declaration)` to support both views.
+
+Reason: passes that care specifically about declarations
+(`closure-pass-rename`, `closure-pass-treeshake`,
+`closure-pass-remove-unused-vars`) traverse `Vec<Declaration>`
+directly. Passes that traverse statement bodies
+(`closure-pass-constant-fold`, `closure-pass-dce`) pattern-match
+on `Statement` and reach declarations via the
+`Statement::Declaration` wrapping.
+
+The JSON wire format collapses this: on serialize,
+`Statement::Declaration(Declaration::VariableDeclaration(d))`
+serializes to `{"type": "VariableDeclaration", ...}` directly
+(via `#[serde(untagged)]` on `Statement::Declaration`'s wrapping
+arm). The Rust enum hierarchy is for pass ergonomics; the
+output JSON matches ESTree's flatter shape.
+
+## Visitor pattern (deferred to Phase 1.5)
+
+ESTree-walking tools typically expose a visitor pattern.
+`closure-pass-pipeline`'s `Pass::run` already provides a
+context-shaped entry point, and Phase 1 passes will do their
+walks inline. A first-class `Visitor` / `VisitorMut` trait in
+`javascript-ast` is **deferred to Phase 1.5** once we have
+real pass bodies and can identify the right shape from concrete
+needs rather than guessing.
+
+## Crate layout (Phase 1)
+
+```
+code/packages/rust/javascript-ast/
+├── Cargo.toml          (unchanged: serde, correlation-vector, javascript-tokens)
+├── src/
+│   ├── lib.rs          (re-exports + Program / SourceType / EsVersion)
+│   ├── statement.rs    (Statement enum + per-variant structs)
+│   ├── expression.rs   (Expression enum + per-variant structs + operators)
+│   └── declaration.rs  (Declaration enum + per-variant structs)
+├── README.md, CHANGELOG.md, BUILD, BUILD_windows, required_capabilities.json
+```
+
+Per-variant structs land in module files (one file per kind:
+`statement.rs`, `expression.rs`, `declaration.rs`). `lib.rs`
+re-exports the enums and the leaves so downstream code does
+`use coding_adventures_javascript_ast::{Program, IfStatement,
+BinaryOperator};` without knowing the file layout.
+
+## Test surface (Phase 1)
+
+Per CLOC02 the AST has no behavior to unit-test directly. The
+test surface is **round-trip property tests on the JSON wire
+format**:
+
+- For each variant, construct a representative node, serialize
+  to JSON, deserialize back, assert structural equality.
+- Round-trip the example program from Phase 1's intro
+  (`function f(x){ return x + 1; } const a = f(7);`) end-to-end.
+- Validate that the JSON `"type"` tag matches the ESTree-spec
+  expected value for each variant (`{"type":"IfStatement"}`,
+  not `{"type":"if_statement"}` etc.).
+
+Coverage target: every Phase 1 variant has at least one
+round-trip test. Aim for 95%+ line coverage on the new modules.
+
+## Migration impact on existing crates
+
+Adding variants to the AST is **additive** for every existing
+crate:
+
+- `closure-typechecker`: still receives `&Program`. Real
+  checking implementation lands in a follow-up PR; the API
+  doesn't change.
+- `closure-pass-*`: every `Pass::run` is identity today and stays
+  identity through this PR. Pass *bodies* fill in over
+  subsequent PRs, one pass at a time, as each pass gains the
+  ability to do real work on the now-rich AST.
+- `closure-emitter`: same. Identity through this PR; real
+  emission lands as a follow-up.
+- `closurec`: no change. The CLI parses Closure-Compiler flags;
+  the binary's body is still v1 identity.
+
+No pass dependency edges shift. No public function signatures
+change. The point of the Phase 1 PR is to grow the AST and
+ship that as a self-contained, mergeable unit; pass
+implementations are independent follow-ups.
+
+## What this PR locks down
+
+1. The full Phase 1 node taxonomy listed above (25 variants).
+2. Full ESTree-compat wire format: JSON `"type"` tags, camelCase
+   field names, structural shape per ESTree-spec.
+3. The `cv: CvId` convention as the only identity field on every
+   node.
+4. The `is_async` rename to JSON `"async"` (only field-name
+   divergence Phase 1 introduces).
+5. The split `Statement` / `Declaration` enum design with the
+   `Statement::Declaration` wrapping arm (untagged on serialize).
+6. The deferred decisions (visitor pattern, BigInt/RegExp
+   literals, async/generators) explicitly called out as Phase
+   1.5+/Phase 2+/Phase 5 so a reviewer doesn't think they were
+   forgotten.
+
+## What's coming
+
+- Phase 1 implementation PR (immediately after this spec
+  merges): all 25 variants, round-trip tests, no pass changes.
+- Phase 1.5: `Visitor` / `VisitorMut` traits with a default
+  walk implementation; revise after seeing the first real pass
+  body.
+- Phase 2: leaf coverage gaps + control-flow variants
+  (`SwitchStatement`, `TryStatement`, etc.).
+- Phase 3: patterns, arrow functions, classes.
+- Phase 4: modules.
+- Phase 5: async / generators / nullish / optional chaining.
+- Per-pass implementation PRs: once the AST has the variants a
+  given pass needs, that pass's `run` body fills in. Order is
+  flexible — passes don't depend on each other for variant
+  coverage, only for ordering at pipeline runtime.


### PR DESCRIPTION
## Summary

CLOC09 defines the full node taxonomy that `javascript-ast` will grow to, after Stages 1–4 scaffolded everything else as v1 identity. The Phase 1 implementation PR follows once this spec merges.

## Three load-bearing design decisions

1. **Full ESTree compatibility** — node type names, field names, JSON wire format match ESTree exactly. Deviates in only 2 ways: `cv: CvId` instead of `loc`/`range` (per CLOC02), and Rust idioms for nullable children (`Option<Box<...>>`).
2. **AST is V8-frontend-ready** — a future V8-on-LANG-VM will consume this same AST and lower it to LANG VM bytecode (instead of JS text). The spec calls out the "lossless enough to implement exact ECMAScript semantics" constraint explicitly so future PRs don't accidentally optimize toward "what Closure-style passes need" at the cost of "what an interpreter needs." ESTree satisfies this by construction.
3. **Per-node `CvId` is the only identity** — no spans, no parent pointers, no node IDs. Passes produce new trees; the CV graph tracks every byte's lineage independently.

## Phase 1 scope (~25 variants)

Enumerated in §"Phase 1 — Statement / Expression / Declaration variants" with full field-by-field structs. Enough to express `function f(x){ return x + 1; } const a = f(7);` and to give `constant-fold` and `dce` real work.

## Subsequent phases enumerated

- Phase 1.5: Visitor / VisitorMut traits (deferred until first real pass body shapes the right API).
- Phase 2: BigInt / RegExp / Template literals, SwitchStatement / TryStatement / etc., Sequence / Update / New / Spread / This / Super.
- Phase 3: patterns (destructuring), arrow functions, classes.
- Phase 4: modules (import / export).
- Phase 5: async / generators / nullish coalescing / optional chaining / `&&=` `||=` `??=`.

## Migration impact

**Zero** — adding variants is additive. Existing pass `Pass::run` bodies stay identity; pass implementations fill in as independent follow-up PRs.

## What this PR locks down

Quoted from spec §"What this PR locks down":

1. The full Phase 1 node taxonomy (25 variants).
2. Full ESTree-compat wire format (JSON `"type"` tags, camelCase fields, structural shape per ESTree-spec).
3. The `cv: CvId` convention.
4. The `is_async` rename to JSON `"async"` (only field-name divergence Phase 1 introduces).
5. Split `Statement` / `Declaration` enum design with `Statement::Declaration` untagged-wrap.
6. Deferred decisions explicitly called out (visitor pattern, BigInt/RegExp, async/generators) so reviewers don't think they're forgotten.

## Test plan

- [x] Spec is a single document — no code to test.
- [ ] Spec review: do the 25 Phase 1 variants cover enough to give constant-fold + dce real work? Are the V8-readiness arguments compelling?

🤖 Generated with [Claude Code](https://claude.com/claude-code)