### PR TITLE
fix(sql-codegen): ORDER BY arbitrary expression no longer crashes

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.3.0] - 2026-05-23
+
+### Fixed
+
+- ``ORDER BY <expr>`` with arbitrary expressions (``ORDER BY a+b``,
+  ``ORDER BY UPPER(name)``, ``ORDER BY CASE WHEN … END``, …) now
+  matches SQLite row-for-row instead of raising
+  ``InternalError: unexpected error: ValueError: tuple.index(x): x not
+  in tuple``.  Root cause was in sql-codegen's hidden-column
+  injection pass — see sql-codegen CHANGELOG 1.40.0 for the full fix.
+
+  Also covers multiple expression sort keys (``ORDER BY a+1, b-1``),
+  mixed expression + column keys, and the ``LIMIT`` / ``OFFSET`` /
+  ``DISTINCT`` interactions on top.
+
 ## [2.2.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.2.0"
+version = "2.3.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_order_by_expression.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_order_by_expression.py
@@ -1,0 +1,103 @@
+"""Tests for ``ORDER BY <expr>`` with arbitrary expressions.
+
+Previously, mini-sqlite raised
+``InternalError: unexpected error: ValueError: tuple.index(x): x not in tuple``
+when ``ORDER BY`` referenced an expression whose natural display name was
+``"?"`` (the fallback the codegen used for un-named expressions like
+``a+b``, ``UPPER(name)``, ``CASE WHEN … END``, …).
+
+The fix extends sql-codegen's hidden-column injection to recognise the
+``"?"`` case: each expression sort key is projected as a hidden trailing
+column under a synthetic per-position name (``__sortkey_0``, …), the
+SortKey IR is rewritten to look up that name, and StripTrailingColumns
+removes the extras after the sort runs.  The result still matches
+SQLite's ``ORDER BY`` semantics row-for-row.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(*stmts: str, query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+_NUMS = (
+    "CREATE TABLE t (a INT, b INT)",
+    "INSERT INTO t VALUES (1, 5), (2, 3), (3, 4), (2, 2), (NULL, 1)",
+)
+
+_NAMES = (
+    "CREATE TABLE u (name TEXT, age INT)",
+    "INSERT INTO u VALUES ('bob', 30), ('Alice', 25), ('Carol', 28), ('alice', 25)",
+)
+
+
+class TestArithmeticExpression:
+    def test_order_by_a_plus_b(self) -> None:
+        _both_match(*_NUMS, query="SELECT a, b FROM t ORDER BY a+b")
+
+    def test_order_by_a_times_2_desc(self) -> None:
+        _both_match(*_NUMS, query="SELECT a FROM t ORDER BY (a*2) DESC")
+
+    def test_order_by_a_minus_b(self) -> None:
+        _both_match(*_NUMS, query="SELECT a, b FROM t ORDER BY a-b")
+
+
+class TestFunctionCall:
+    def test_order_by_upper(self) -> None:
+        _both_match(*_NAMES, query="SELECT name FROM u ORDER BY UPPER(name)")
+
+    def test_order_by_lower_desc(self) -> None:
+        _both_match(*_NAMES, query="SELECT name FROM u ORDER BY LOWER(name) DESC")
+
+    def test_order_by_length(self) -> None:
+        _both_match(*_NAMES, query="SELECT name FROM u ORDER BY LENGTH(name), name")
+
+
+class TestCaseExpression:
+    def test_order_by_case_when(self) -> None:
+        _both_match(
+            *_NUMS,
+            query=(
+                "SELECT a FROM t ORDER BY "
+                "CASE WHEN a < 2 THEN 0 WHEN a < 3 THEN 1 ELSE 2 END"
+            ),
+        )
+
+
+class TestMultipleExpressionKeys:
+    def test_two_expression_keys(self) -> None:
+        _both_match(*_NUMS, query="SELECT a FROM t ORDER BY a+1, b-1")
+
+    def test_expression_then_column(self) -> None:
+        _both_match(*_NUMS, query="SELECT a FROM t ORDER BY a+b, a")
+
+    def test_column_then_expression(self) -> None:
+        _both_match(*_NUMS, query="SELECT a FROM t ORDER BY a, b*10")
+
+
+class TestExpressionWithLimit:
+    """ORDER BY <expr> LIMIT N must still strip hidden columns correctly."""
+
+    def test_order_by_expression_with_limit(self) -> None:
+        _both_match(*_NUMS, query="SELECT a, b FROM t ORDER BY a+b LIMIT 2")
+
+    def test_order_by_expression_with_limit_offset(self) -> None:
+        _both_match(
+            *_NUMS,
+            query="SELECT a, b FROM t ORDER BY a+b LIMIT 2 OFFSET 1",
+        )
+
+
+class TestExpressionWithDistinct:
+    def test_distinct_order_by_expression(self) -> None:
+        _both_match(*_NUMS, query="SELECT DISTINCT a FROM t ORDER BY a*10")

--- a/code/packages/python/sql-codegen/CHANGELOG.md
+++ b/code/packages/python/sql-codegen/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.40.0] - 2026-05-23
+
+### Fixed
+
+- ``ORDER BY <expr>`` with arbitrary expressions (``a+b``,
+  ``UPPER(name)``, ``CASE WHEN … END``, …) no longer raises
+  ``ValueError: tuple.index(x): x not in tuple`` at SortResult time.
+
+  The hidden-column injection pass in ``_compile_read`` previously
+  short-circuited when the planner sort key's display name was ``"?"``
+  (the fallback for un-named expressions), so the VM ended up looking
+  up a non-existent ``"?"`` column in the result schema.  The pass now
+  recognises the expression case: each ``"?"``-named sort key is
+  projected as a hidden trailing column under a synthetic per-position
+  name (``__sortkey_0``, ``__sortkey_1``, …), and the corresponding
+  SortKey IR is rewritten to look up that synthetic name.
+  ``StripTrailingColumns`` removes the extras after the sort, so the
+  output shape is unchanged for the caller.
+
+  Position-local synthetic names are required because two ``ORDER BY``
+  terms with the same ``"?"`` display name would otherwise collide on
+  one hidden slot and silently sort by only the first expression.
+
 ## [1.39.0] - 2026-05-23
 
 ### Changed

--- a/code/packages/python/sql-codegen/pyproject.toml
+++ b/code/packages/python/sql-codegen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-codegen"
-version = "1.39.0"
+version = "1.40.0"
 description = "Compiles LogicalPlan trees into flat IR bytecode for the sql-vm."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
+++ b/code/packages/python/sql-codegen/src/sql_codegen/compiler.py
@@ -542,8 +542,12 @@ def _compile_read(p: LogicalPlan, ctx: _Ctx) -> list[Instruction]:
     # This only applies when the inner plan is a Project.  For Aggregate and
     # set-operation plans the sort key is always an output column (the planner
     # enforces this), so no injection is needed.
-    hidden_col_names: list[str] = []
+    hidden_pairs: list[tuple[str, object]] = []  # (col_name, planner_expr)
     extended_schema: tuple[str, ...] | None = None
+    # Maps positions in ir_sort_keys that need rewriting to point at a
+    # synthetic hidden-column name (used for arbitrary-expression sort keys
+    # like ``ORDER BY a+b`` whose natural display name is "?").
+    expr_key_renames: dict[int, str] = {}
 
     if ir_sort_keys is not None and isinstance(cur, Project) and not any(
         isinstance(it.expr, Wildcard) for it in cur.items  # type: ignore[union-attr]
@@ -559,46 +563,80 @@ def _compile_read(p: LogicalPlan, ctx: _Ctx) -> list[Instruction]:
         output_names: set[str] = {_projection_name(it) for it in cur.items}
         seen: set[str] = set()
 
-        for ir_sk, plan_sk in zip(ir_sort_keys, planner_sort_keys or (), strict=False):
-            col = ir_sk.column
+        for i, (ir_sk, plan_sk) in enumerate(
+            zip(ir_sort_keys, planner_sort_keys or (), strict=False),
+        ):
             # Skip positional sort keys (ORDER BY N): they use column_idx for
             # direct index lookup and always refer to visible output columns —
             # no hidden-column injection needed or possible.
-            # Skip "?" (un-named expression sort keys) — can't inject by name.
-            # Skip columns already in the SELECT output — no injection needed.
-            # Skip duplicates (same hidden column in multiple ORDER BY terms).
-            if ir_sk.column_idx is not None or col == "?" or col in output_names or col in seen:
+            if ir_sk.column_idx is not None:
                 continue
-            if isinstance(plan_sk, PlanSortKey):
-                hidden_col_names.append(col)
+            if not isinstance(plan_sk, PlanSortKey):
+                continue
+            col = ir_sk.column
+            if col == "?":
+                # Expression sort key (``ORDER BY a+b``, ``UPPER(x)``,
+                # ``CASE …``, …): the planner expr has no natural display
+                # name, so we cannot look it up by name in the result
+                # schema.  Inject it as a hidden trailing column under a
+                # synthetic name unique to this sort position, then rewrite
+                # the corresponding SortKey IR to reference that name.
+                #
+                # A position-local synthetic name (``__sortkey_<N>``) is
+                # required because two ``ORDER BY`` terms with the same
+                # display name (``"?"``) would otherwise collide on the
+                # same hidden slot — sharing one column would silently
+                # change the sort to use only the first expression.
+                synth = f"__sortkey_{len(hidden_pairs)}"
+                expr_key_renames[i] = synth
+                hidden_pairs.append((synth, plan_sk.expr))
+            elif col not in output_names and col not in seen:
+                # Named column not in SELECT output: inject under its
+                # natural name.  De-dup by column name so multiple ORDER BY
+                # terms referencing the same hidden column share one slot.
+                hidden_pairs.append((col, plan_sk.expr))
                 seen.add(col)
 
-        if hidden_col_names:
+        if hidden_pairs:
             # Compute the original schema before extending the Project.
             orig_schema = tuple(_projection_name(it) for it in cur.items)
+            hidden_col_names = [n for n, _ in hidden_pairs]
             extended_schema = orig_schema + tuple(hidden_col_names)
 
             # Build new ProjectionItems using the original planner expressions
             # so _compile_expr generates the right LoadColumn instructions (with
             # the correct table alias / cursor id), not a generic cursor-0 load.
-            extra_items: list[object] = []
-            for col in hidden_col_names:
-                # Find the matching planner SortKey to get its expression.
-                for ir_sk, plan_sk in zip(ir_sort_keys, planner_sort_keys or (), strict=False):
-                    if ir_sk.column == col and isinstance(plan_sk, PlanSortKey):
-                        extra_items.append(ProjectionItem(expr=plan_sk.expr, alias=col))
-                        break
+            extra_items: list[object] = [
+                ProjectionItem(expr=expr, alias=name)  # type: ignore[arg-type]
+                for name, expr in hidden_pairs
+            ]
 
             cur = Project(
                 input=cur.input,
                 items=cur.items + tuple(extra_items),  # type: ignore[arg-type]
             )
 
+            # Rewrite expression-key SortKey IRs to point at their synthetic
+            # hidden-column names, and replace the SortResult instruction in
+            # ``post`` with the rebuilt keys tuple.
+            if expr_key_renames:
+                from dataclasses import replace as _replace
+                ir_sort_keys = tuple(
+                    _replace(sk, column=expr_key_renames[idx])
+                    if idx in expr_key_renames
+                    else sk
+                    for idx, sk in enumerate(ir_sort_keys)
+                )
+                for j, ins in enumerate(post):
+                    if isinstance(ins, SortResult):
+                        post[j] = SortResult(keys=ir_sort_keys)
+                        break
+
             # Insert StripTrailingColumns immediately after SortResult in post.
             sort_idx = next(
                 i for i, ins in enumerate(post) if isinstance(ins, SortResult)
             )
-            post.insert(sort_idx + 1, StripTrailingColumns(count=len(hidden_col_names)))
+            post.insert(sort_idx + 1, StripTrailingColumns(count=len(hidden_pairs)))
 
     core = _compile_core(cur, ctx)
 


### PR DESCRIPTION
## Summary

- Fixes `InternalError: unexpected error: ValueError: tuple.index(x): x not in tuple` raised when `ORDER BY` references an arbitrary expression (`a+b`, `UPPER(name)`, `CASE WHEN … END`, …).
- Extends sql-codegen's hidden-column injection pass to handle expression sort keys: each `"?"`-named key is projected as a hidden trailing column under a synthetic per-position name (`__sortkey_0`, …), and the SortKey IR is rewritten to look up that name.
- Position-local synthetic names prevent two `"?"` keys from colliding on one hidden slot.

## Version bumps

- `sql-codegen`: 1.39 → 1.40
- `mini-sqlite`: 2.2 → 2.3

## Test plan

- [x] 13 new oracle tests pass against sqlite3 (arithmetic, function calls, CASE, multiple expr keys, expr + column, LIMIT/OFFSET/DISTINCT interactions)
- [x] sql-codegen suite (82 tests) clean
- [x] mini-sqlite suite (2152 tests) clean
- [x] Ruff clean on touched files
- [x] Security review passed — pure compiler-internal fix; synthetic names are never user-influenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)