### PR TITLE
[codex] Add Board VM input callback transport cursors

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -201,6 +201,10 @@ transport state without rebuilding snapshot policy.
 transport marker records with Rust-owned marker names, labels, queue-depth
 metadata, and messages, so frontends can correlate handoff and adapter-event
 boundaries without rebuilding checkpoint policy.
+`input_callback_transport_cursor_summary` points at those markers as stable
+transport cursor records with Rust-owned cursor names, labels, queue-depth
+metadata, and messages, so frontends can resume marked transport views without
+rebuilding marker policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -1559,6 +1559,70 @@ pub struct LanguageInputCallbackTransportMarkerSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportCursorKind {
+    CallbackRunnerHandoffCursor,
+    AdapterEventPublicationCursor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportCursorSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub cursor_label: String,
+    pub cursor_kind: LanguageInputCallbackTransportCursorKind,
+    pub cursor_name: String,
+    pub marker_kind: LanguageInputCallbackTransportMarkerKind,
+    pub marker_name: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub marker_recorded: bool,
+    pub cursor_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_cursor: u8,
+    pub message: String,
+    pub marker_summary: LanguageInputCallbackTransportMarkerSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -2202,6 +2266,19 @@ pub const fn input_callback_transport_marker_kind_name(
         }
         LanguageInputCallbackTransportMarkerKind::AdapterEventPublicationMarker => {
             "adapter_event_publication_marker"
+        }
+    }
+}
+
+pub const fn input_callback_transport_cursor_kind_name(
+    kind: LanguageInputCallbackTransportCursorKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportCursorKind::CallbackRunnerHandoffCursor => {
+            "callback_runner_handoff_cursor"
+        }
+        LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor => {
+            "adapter_event_publication_cursor"
         }
     }
 }
@@ -4005,6 +4082,69 @@ pub fn input_callback_transport_marker_summary(
     }
 }
 
+pub fn input_callback_transport_cursor_summary(
+    marker_summary: &LanguageInputCallbackTransportMarkerSummary,
+) -> LanguageInputCallbackTransportCursorSummary {
+    let cursor_kind = input_callback_transport_cursor_kind(marker_summary.marker_kind);
+
+    LanguageInputCallbackTransportCursorSummary {
+        endpoint: marker_summary.endpoint.clone(),
+        connection_label: marker_summary.connection_label.clone(),
+        cursor_label: input_callback_transport_cursor_label(marker_summary, cursor_kind),
+        cursor_kind,
+        cursor_name: input_callback_transport_cursor_kind_name(cursor_kind).to_owned(),
+        marker_kind: marker_summary.marker_kind,
+        marker_name: marker_summary.marker_name.clone(),
+        checkpoint_kind: marker_summary.checkpoint_kind,
+        checkpoint_name: marker_summary.checkpoint_name.clone(),
+        snapshot_kind: marker_summary.snapshot_kind,
+        snapshot_name: marker_summary.snapshot_name.clone(),
+        archive_kind: marker_summary.archive_kind,
+        archive_name: marker_summary.archive_name.clone(),
+        journal_kind: marker_summary.journal_kind,
+        journal_name: marker_summary.journal_name.clone(),
+        log_kind: marker_summary.log_kind,
+        log_name: marker_summary.log_name.clone(),
+        audit_kind: marker_summary.audit_kind,
+        audit_name: marker_summary.audit_name.clone(),
+        trace_kind: marker_summary.trace_kind,
+        trace_name: marker_summary.trace_name.clone(),
+        outcome_kind: marker_summary.outcome_kind,
+        outcome_name: marker_summary.outcome_name.clone(),
+        receipt_kind: marker_summary.receipt_kind,
+        receipt_name: marker_summary.receipt_name.clone(),
+        acknowledgement_kind: marker_summary.acknowledgement_kind,
+        acknowledgement_name: marker_summary.acknowledgement_name.clone(),
+        delivery_route: marker_summary.delivery_route,
+        delivery_route_name: marker_summary.delivery_route_name.clone(),
+        event_kind: marker_summary.event_kind,
+        event_name: marker_summary.event_name.clone(),
+        report_kind: marker_summary.report_kind,
+        report_name: marker_summary.report_name.clone(),
+        action: marker_summary.action,
+        action_name: marker_summary.action_name.clone(),
+        callback_runner_handoff: marker_summary.callback_runner_handoff,
+        adapter_event_published: marker_summary.adapter_event_published,
+        delivery_acknowledged: marker_summary.delivery_acknowledged,
+        receipt_recorded: marker_summary.receipt_recorded,
+        outcome_recorded: marker_summary.outcome_recorded,
+        trace_recorded: marker_summary.trace_recorded,
+        audit_recorded: marker_summary.audit_recorded,
+        log_recorded: marker_summary.log_recorded,
+        journal_recorded: marker_summary.journal_recorded,
+        archive_recorded: marker_summary.archive_recorded,
+        snapshot_recorded: marker_summary.snapshot_recorded,
+        checkpoint_recorded: marker_summary.checkpoint_recorded,
+        marker_recorded: marker_summary.marker_recorded,
+        cursor_recorded: true,
+        terminal: marker_summary.terminal,
+        retryable: marker_summary.retryable,
+        queue_depth_after_cursor: marker_summary.queue_depth_after_marker,
+        message: input_callback_transport_cursor_message(cursor_kind).to_owned(),
+        marker_summary: marker_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -5745,6 +5885,44 @@ fn input_callback_transport_marker_message(
         }
         LanguageInputCallbackTransportMarkerKind::AdapterEventPublicationMarker => {
             "Transport marker should tag the adapter event publication checkpoint."
+        }
+    }
+}
+
+fn input_callback_transport_cursor_kind(
+    marker_kind: LanguageInputCallbackTransportMarkerKind,
+) -> LanguageInputCallbackTransportCursorKind {
+    match marker_kind {
+        LanguageInputCallbackTransportMarkerKind::CallbackRunnerHandoffMarker => {
+            LanguageInputCallbackTransportCursorKind::CallbackRunnerHandoffCursor
+        }
+        LanguageInputCallbackTransportMarkerKind::AdapterEventPublicationMarker => {
+            LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor
+        }
+    }
+}
+
+fn input_callback_transport_cursor_label(
+    marker_summary: &LanguageInputCallbackTransportMarkerSummary,
+    cursor_kind: LanguageInputCallbackTransportCursorKind,
+) -> String {
+    format!(
+        "{} transport_cursor={} cursor_recorded=true queue_depth_after_cursor={}",
+        marker_summary.marker_label,
+        input_callback_transport_cursor_kind_name(cursor_kind),
+        marker_summary.queue_depth_after_marker
+    )
+}
+
+fn input_callback_transport_cursor_message(
+    cursor_kind: LanguageInputCallbackTransportCursorKind,
+) -> &'static str {
+    match cursor_kind {
+        LanguageInputCallbackTransportCursorKind::CallbackRunnerHandoffCursor => {
+            "Transport cursor should point at the callback-runner handoff marker."
+        }
+        LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor => {
+            "Transport cursor should point at the adapter event publication marker."
         }
     }
 }
@@ -14149,6 +14327,281 @@ mod tests {
             )
         );
         assert_eq!(dropped.checkpoint_summary, dropped_checkpoint);
+    }
+
+    #[test]
+    fn input_callback_transport_cursors_are_owned_by_rust_language_core() {
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_action = input_callback_transport_action_summary(&completed_lifecycle);
+        let completed_effect = input_callback_transport_effect_summary(&completed_action);
+        let completed_report = input_callback_transport_report_summary(&completed_effect);
+        let completed_event = input_callback_transport_event_summary(&completed_report);
+        let completed_delivery = input_callback_transport_delivery_summary(&completed_event);
+        let completed_ack = input_callback_transport_acknowledgement_summary(&completed_delivery);
+        let completed_receipt = input_callback_transport_receipt_summary(&completed_ack);
+        let completed_outcome = input_callback_transport_outcome_summary(&completed_receipt);
+        let completed_trace = input_callback_transport_trace_summary(&completed_outcome);
+        let completed_audit = input_callback_transport_audit_summary(&completed_trace);
+        let completed_log = input_callback_transport_log_summary(&completed_audit);
+        let completed_journal = input_callback_transport_journal_summary(&completed_log);
+        let completed_archive = input_callback_transport_archive_summary(&completed_journal);
+        let completed_snapshot = input_callback_transport_snapshot_summary(&completed_archive);
+        let completed_checkpoint = input_callback_transport_checkpoint_summary(&completed_snapshot);
+        let completed_marker = input_callback_transport_marker_summary(&completed_checkpoint);
+        let completed = input_callback_transport_cursor_summary(&completed_marker);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.cursor_kind,
+            LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor
+        );
+        assert_eq!(completed.cursor_name, "adapter_event_publication_cursor");
+        assert_eq!(
+            completed.marker_kind,
+            LanguageInputCallbackTransportMarkerKind::AdapterEventPublicationMarker
+        );
+        assert_eq!(
+            completed.checkpoint_kind,
+            LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint
+        );
+        assert_eq!(
+            completed.snapshot_kind,
+            LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot
+        );
+        assert_eq!(
+            completed.archive_kind,
+            LanguageInputCallbackTransportArchiveKind::AdapterEventPublicationArchive
+        );
+        assert_eq!(
+            completed.journal_kind,
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        );
+        assert_eq!(
+            completed.log_kind,
+            LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog
+        );
+        assert_eq!(
+            completed.audit_kind,
+            LanguageInputCallbackTransportAuditKind::AdapterEventPublicationAudit
+        );
+        assert_eq!(
+            completed.trace_kind,
+            LanguageInputCallbackTransportTraceKind::AdapterEventPublicationTrace
+        );
+        assert_eq!(
+            completed.outcome_kind,
+            LanguageInputCallbackTransportOutcomeKind::AdapterEventPublicationRecorded
+        );
+        assert_eq!(
+            completed.receipt_kind,
+            LanguageInputCallbackTransportReceiptKind::AdapterEventPublication
+        );
+        assert_eq!(
+            completed.acknowledgement_kind,
+            LanguageInputCallbackTransportAcknowledgementKind::AdapterEventPublished
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.marker_recorded);
+        assert!(completed.cursor_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_cursor, 2);
+        assert_eq!(
+            completed.cursor_label,
+            format!(
+                "{} transport_cursor=adapter_event_publication_cursor cursor_recorded=true queue_depth_after_cursor=2",
+                completed_marker.marker_label
+            )
+        );
+        assert_eq!(
+            completed.message,
+            "Transport cursor should point at the adapter event publication marker."
+        );
+        assert_eq!(completed.marker_summary, completed_marker);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_action = input_callback_transport_action_summary(&pending_lifecycle);
+        let pending_effect = input_callback_transport_effect_summary(&pending_action);
+        let pending_report = input_callback_transport_report_summary(&pending_effect);
+        let pending_event = input_callback_transport_event_summary(&pending_report);
+        let pending_delivery = input_callback_transport_delivery_summary(&pending_event);
+        let pending_ack = input_callback_transport_acknowledgement_summary(&pending_delivery);
+        let pending_receipt = input_callback_transport_receipt_summary(&pending_ack);
+        let pending_outcome = input_callback_transport_outcome_summary(&pending_receipt);
+        let pending_trace = input_callback_transport_trace_summary(&pending_outcome);
+        let pending_audit = input_callback_transport_audit_summary(&pending_trace);
+        let pending_log = input_callback_transport_log_summary(&pending_audit);
+        let pending_journal = input_callback_transport_journal_summary(&pending_log);
+        let pending_archive = input_callback_transport_archive_summary(&pending_journal);
+        let pending_snapshot = input_callback_transport_snapshot_summary(&pending_archive);
+        let pending_checkpoint = input_callback_transport_checkpoint_summary(&pending_snapshot);
+        let pending_marker = input_callback_transport_marker_summary(&pending_checkpoint);
+        let pending = input_callback_transport_cursor_summary(&pending_marker);
+
+        assert_eq!(
+            pending.cursor_kind,
+            LanguageInputCallbackTransportCursorKind::CallbackRunnerHandoffCursor
+        );
+        assert_eq!(pending.cursor_name, "callback_runner_handoff_cursor");
+        assert_eq!(
+            pending.marker_kind,
+            LanguageInputCallbackTransportMarkerKind::CallbackRunnerHandoffMarker
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(pending.archive_recorded);
+        assert!(pending.snapshot_recorded);
+        assert!(pending.checkpoint_recorded);
+        assert!(pending.marker_recorded);
+        assert!(pending.cursor_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_cursor, 3);
+        assert_eq!(
+            pending.cursor_label,
+            format!(
+                "{} transport_cursor=callback_runner_handoff_cursor cursor_recorded=true queue_depth_after_cursor=3",
+                pending_marker.marker_label
+            )
+        );
+        assert_eq!(
+            pending.message,
+            "Transport cursor should point at the callback-runner handoff marker."
+        );
+        assert_eq!(pending.marker_summary, pending_marker);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_action = input_callback_transport_action_summary(&dropped_lifecycle);
+        let dropped_effect = input_callback_transport_effect_summary(&dropped_action);
+        let dropped_report = input_callback_transport_report_summary(&dropped_effect);
+        let dropped_event = input_callback_transport_event_summary(&dropped_report);
+        let dropped_delivery = input_callback_transport_delivery_summary(&dropped_event);
+        let dropped_ack = input_callback_transport_acknowledgement_summary(&dropped_delivery);
+        let dropped_receipt = input_callback_transport_receipt_summary(&dropped_ack);
+        let dropped_outcome = input_callback_transport_outcome_summary(&dropped_receipt);
+        let dropped_trace = input_callback_transport_trace_summary(&dropped_outcome);
+        let dropped_audit = input_callback_transport_audit_summary(&dropped_trace);
+        let dropped_log = input_callback_transport_log_summary(&dropped_audit);
+        let dropped_journal = input_callback_transport_journal_summary(&dropped_log);
+        let dropped_archive = input_callback_transport_archive_summary(&dropped_journal);
+        let dropped_snapshot = input_callback_transport_snapshot_summary(&dropped_archive);
+        let dropped_checkpoint = input_callback_transport_checkpoint_summary(&dropped_snapshot);
+        let dropped_marker = input_callback_transport_marker_summary(&dropped_checkpoint);
+        let dropped = input_callback_transport_cursor_summary(&dropped_marker);
+
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.cursor_kind,
+            LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.marker_recorded);
+        assert!(dropped.cursor_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_cursor, 1);
+        assert_eq!(
+            dropped.cursor_label,
+            format!(
+                "{} transport_cursor=adapter_event_publication_cursor cursor_recorded=true queue_depth_after_cursor=1",
+                dropped_marker.marker_label
+            )
+        );
+        assert_eq!(dropped.marker_summary, dropped_marker);
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Add Rust-owned input callback transport cursor kinds, names, labels, queue-depth metadata, and summary records layered over transport markers.
- Carry the transport action/report/event/delivery/acknowledgement/receipt/outcome/trace/audit/log/journal/archive/snapshot/checkpoint/marker chain into cursor summaries so language frontends can stay thin.
- Document the cursor summary API in board-vm-language-core and cover callback-runner handoff plus adapter-event publication paths.

Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-cursor cargo test -p board-vm-language-core
- bash BUILD (in code/packages/rust/board-vm-language-core)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-cursor cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes
- Refreshed onto origin/main 115a9732d5fb1b48808122ced18b196d3e688e4a before pushing.
- Removed generated code/packages/rust/Cargo.lock, code/packages/rust/build-plan.json, and build-plan.json before committing if present.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.