### PR TITLE
Add HTML parser browser render tree input

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
@@ -136,6 +136,11 @@ FORMAT_REGISTRY: tuple[FixtureFormat, ...] = (
         "parser-browser-content-tree",
     ),
     FixtureFormat(
+        "html-parser/tests/fixtures/html-browser-render-tree.json",
+        "venture-html-browser-render-tree/v1",
+        "parser-browser-render-tree",
+    ),
+    FixtureFormat(
         "html-parser/tests/fixtures/whatwg-block-boundary-audit.json",
         "whatwg-html-block-boundary-audit/v1",
         "parser-audit",
@@ -379,6 +384,10 @@ def check_category_contract(
         require_top_level(relative_path, data, "suite", str, errors)
         require_case_field(relative_path, data, "expected", dict, errors)
     elif category == "parser-browser-content-tree":
+        require_cases(relative_path, data, errors)
+        require_top_level(relative_path, data, "suite", str, errors)
+        require_case_field(relative_path, data, "expected", dict, errors)
+    elif category == "parser-browser-render-tree":
         require_cases(relative_path, data, errors)
         require_top_level(relative_path, data, "suite", str, errors)
         require_case_field(relative_path, data, "expected", dict, errors)

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -17,6 +17,7 @@ PARSER_FIXTURE_DIR = RUST_DIR / "html-parser" / "tests" / "fixtures"
 PARSER_SOURCE_FIXTURE = "html5lib-tree-construction-smoke.dat"
 BROWSER_READINESS_FORMAT = "venture-html-browser-readiness/v1"
 BROWSER_CONTENT_TREE_FORMAT = "venture-html-browser-content-tree/v1"
+BROWSER_RENDER_TREE_FORMAT = "venture-html-browser-render-tree/v1"
 NUMERIC_REFERENCE_FIXTURE = "whatwg-numeric-references.json"
 INPUT_STREAM_FIXTURE = "whatwg-input-stream.json"
 CHUNK_BOUNDARY_FIXTURE = "whatwg-chunk-boundaries.json"
@@ -84,6 +85,8 @@ def check_fixture_schemas() -> tuple[list[str], FixtureStats]:
                 errors.extend(check_browser_readiness_case(relative_path, index, case))
             elif data.get("format") == BROWSER_CONTENT_TREE_FORMAT:
                 errors.extend(check_browser_content_tree_case(relative_path, index, case))
+            elif data.get("format") == BROWSER_RENDER_TREE_FORMAT:
+                errors.extend(check_browser_render_tree_case(relative_path, index, case))
             elif fixture_path.parent == PARSER_FIXTURE_DIR:
                 errors.extend(check_parser_audit_case(relative_path, index, case))
             else:
@@ -121,7 +124,11 @@ def check_top_level_schema(relative_path: str, data: dict[str, Any]) -> list[str
     require_non_empty_string(relative_path, data, "format", errors)
     require_non_empty_string(relative_path, data, "description", errors)
 
-    if data.get("format") in (BROWSER_READINESS_FORMAT, BROWSER_CONTENT_TREE_FORMAT):
+    if data.get("format") in (
+        BROWSER_READINESS_FORMAT,
+        BROWSER_CONTENT_TREE_FORMAT,
+        BROWSER_RENDER_TREE_FORMAT,
+    ):
         require_non_empty_string(relative_path, data, "suite", errors)
     elif relative_path.startswith("html-parser/"):
         if data.get("source_fixture") != PARSER_SOURCE_FIXTURE:
@@ -339,6 +346,51 @@ def check_browser_content_node(
     require_object_list(node_path, node, "children", errors)
     for child_index, child in enumerate(object_list_items(node, "children")):
         check_browser_content_node(
+            f"{node_path}.children[{child_index}]",
+            child,
+            errors,
+        )
+
+
+def check_browser_render_tree_case(
+    relative_path: str,
+    index: int,
+    case: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    case_path = f"{relative_path}: cases[{index}]"
+
+    require_non_empty_string(case_path, case, "id", errors)
+    require_optional_non_empty_string(case_path, case, "description", errors)
+    require_string(case_path, case, "input", errors)
+
+    expected = case.get("expected")
+    if not isinstance(expected, dict):
+        errors.append(f"{case_path}.expected must be an object")
+        return errors
+    require_object_list(f"{case_path}.expected", expected, "children", errors)
+    for node_index, node in enumerate(object_list_items(expected, "children")):
+        check_browser_render_node(
+            f"{case_path}.expected.children[{node_index}]",
+            node,
+            errors,
+        )
+
+    return errors
+
+
+def check_browser_render_node(
+    node_path: str,
+    node: dict[str, Any],
+    errors: list[str],
+) -> None:
+    require_string(node_path, node, "display", errors)
+    require_string(node_path, node, "role", errors)
+    for field in ("name", "text", "href", "src", "alt", "control_type"):
+        require_optional_nullable_string(node_path, node, field, errors)
+    require_object_list(node_path, node, "children", errors)
+    for child_index, child in enumerate(object_list_items(node, "children")):
+        check_browser_render_node(
             f"{node_path}.children[{child_index}]",
             child,
             errors,

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
@@ -36,6 +36,7 @@ class HtmlFixtureFormatRegistryTest(unittest.TestCase):
                 "parser-audit",
                 "parser-browser-content-tree",
                 "parser-browser-readiness",
+                "parser-browser-render-tree",
             },
         )
 

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
@@ -94,6 +94,45 @@ class HtmlFixtureSchemasTest(unittest.TestCase):
 
         self.assertEqual(errors, [])
 
+    def test_browser_render_tree_cases_require_recursive_node_shape(self) -> None:
+        errors = schema_check.check_browser_render_tree_case(
+            "html-parser/tests/fixtures/html-browser-render-tree.json",
+            0,
+            {
+                "id": "example",
+                "input": "<p>body",
+                "expected": {
+                    "children": [
+                        {
+                            "display": "block",
+                            "role": "block",
+                            "name": "p",
+                            "text": None,
+                            "href": None,
+                            "src": None,
+                            "alt": None,
+                            "control_type": None,
+                            "children": [
+                                {
+                                    "display": "inline-text",
+                                    "role": "text",
+                                    "name": None,
+                                    "text": "body",
+                                    "href": None,
+                                    "src": None,
+                                    "alt": None,
+                                    "control_type": None,
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
+
+        self.assertEqual(errors, [])
+
     def test_chunk_split_points_must_stay_inside_input(self) -> None:
         errors = schema_check.check_lexer_case(
             "html-lexer/tests/fixtures/whatwg-chunk-boundaries.json",

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -184,6 +184,8 @@ documented in this file.
   consumers.
 - Browser-facing content tree extraction now projects parsed body content into
   CSS-independent structural nodes for early browser rendering pipelines.
+- Browser-facing render tree input extraction now maps parsed body structure
+  into stable default display categories for early layout pipelines.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -63,6 +63,8 @@ The current parser surface includes:
   attributes, form controls, and table summaries
 - browser-facing content tree extraction that filters parser-only shell and
   invisible nodes into a CSS-independent body structure for early rendering
+- browser-facing render tree input extraction that maps renderable content
+  nodes into stable default display categories for early layout
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources
@@ -324,8 +326,8 @@ audit report and pinned-count checks into the same local guard.
 ```rust
 use coding_adventures_html_lexer::HtmlScriptingMode;
 use coding_adventures_html_parser::{
-    parse_browser_content_tree, parse_browser_document, parse_html, parse_html_fragment,
-    parse_html_with_options, HtmlInitialTokenizerContext, HtmlParseOptions,
+    parse_browser_content_tree, parse_browser_document, parse_browser_render_tree, parse_html,
+    parse_html_fragment, parse_html_with_options, HtmlInitialTokenizerContext, HtmlParseOptions,
 };
 use dom_core::Node;
 
@@ -341,6 +343,10 @@ assert!(browser_document.resources.is_empty());
 let content_tree = parse_browser_content_tree("<h1>Example</h1><p>Hello <b>there</b>").unwrap();
 assert_eq!(content_tree.children[0].role, "heading");
 assert_eq!(content_tree.children[1].role, "block");
+
+let render_tree = parse_browser_render_tree("<p>Hello <img src=logo.gif alt=Logo>").unwrap();
+assert_eq!(render_tree.children[0].display, "block");
+assert_eq!(render_tree.children[0].children[1].display, "inline-replaced");
 
 match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -641,6 +641,16 @@ pub fn extract_browser_content_tree(document: &Document) -> BrowserContentTree {
     BrowserContentTree::from_document(document)
 }
 
+/// Parse a complete HTML string and extract a browser-facing render-tree input.
+pub fn parse_browser_render_tree(source: &str) -> Result<BrowserRenderTree, ParseError> {
+    parse_html(source).map(|document| extract_browser_render_tree(&document))
+}
+
+/// Extract a browser-facing render-tree input from a parsed DOM document.
+pub fn extract_browser_render_tree(document: &Document) -> BrowserRenderTree {
+    BrowserRenderTree::from_document(document)
+}
+
 /// Parse a complete HTML string into a DOM document plus lexer/parser diagnostics.
 pub fn parse_html_with_diagnostics(source: &str) -> Result<ParseOutput, ParseError> {
     parse_html_with_diagnostics_and_options(source, HtmlParseOptions::default())
@@ -864,6 +874,24 @@ pub struct BrowserContentNode {
     pub children: Vec<BrowserContentNode>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BrowserRenderTree {
+    pub children: Vec<BrowserRenderNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserRenderNode {
+    pub display: String,
+    pub role: String,
+    pub name: Option<String>,
+    pub text: Option<String>,
+    pub href: Option<String>,
+    pub src: Option<String>,
+    pub alt: Option<String>,
+    pub control_type: Option<String>,
+    pub children: Vec<BrowserRenderNode>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserHeading {
     pub level: u8,
@@ -961,6 +989,42 @@ impl BrowserContentTree {
         let mut children = Vec::new();
         collect_browser_content_nodes(nodes, &mut children);
         Self { children }
+    }
+}
+
+impl BrowserRenderTree {
+    pub fn from_document(document: &Document) -> Self {
+        Self::from_content_tree(&BrowserContentTree::from_document(document))
+    }
+
+    pub fn from_content_tree(content_tree: &BrowserContentTree) -> Self {
+        Self {
+            children: content_tree
+                .children
+                .iter()
+                .map(BrowserRenderNode::from_content_node)
+                .collect(),
+        }
+    }
+}
+
+impl BrowserRenderNode {
+    pub fn from_content_node(content_node: &BrowserContentNode) -> Self {
+        Self {
+            display: browser_render_display(&content_node.role).to_string(),
+            role: content_node.role.clone(),
+            name: content_node.name.clone(),
+            text: content_node.text.clone(),
+            href: content_node.href.clone(),
+            src: content_node.src.clone(),
+            alt: content_node.alt.clone(),
+            control_type: content_node.control_type.clone(),
+            children: content_node
+                .children
+                .iter()
+                .map(Self::from_content_node)
+                .collect(),
+        }
     }
 }
 
@@ -8218,6 +8282,23 @@ fn is_browser_block_element(name: &str) -> bool {
             | "summary"
             | "xmp"
     )
+}
+
+fn browser_render_display(role: &str) -> &'static str {
+    match role {
+        "text" => "inline-text",
+        "inline" | "link" => "inline",
+        "image" | "control" => "inline-replaced",
+        "line_break" => "line-break",
+        "heading" | "block" | "form" | "list" => "block",
+        "list_item" => "list-item",
+        "table" => "table",
+        "table_caption" => "table-caption",
+        "table_section" => "table-row-group",
+        "table_row" => "table-row",
+        "table_cell" => "table-cell",
+        _ => "inline",
+    }
 }
 
 fn collect_form_controls(nodes: &[Node]) -> Vec<BrowserFormControl> {

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -1,0 +1,92 @@
+use coding_adventures_html_parser::{
+    parse_browser_render_tree, BrowserRenderNode, BrowserRenderTree,
+};
+use serde::Deserialize;
+
+const BROWSER_RENDER_TREE_FIXTURE: &str = include_str!("fixtures/html-browser-render-tree.json");
+
+#[derive(Debug, Deserialize)]
+struct BrowserRenderTreeSuite {
+    format: String,
+    suite: String,
+    cases: Vec<BrowserRenderTreeCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BrowserRenderTreeCase {
+    id: String,
+    input: String,
+    expected: ExpectedRenderTree,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedRenderTree {
+    children: Vec<ExpectedRenderNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedRenderNode {
+    display: String,
+    role: String,
+    name: Option<String>,
+    text: Option<String>,
+    href: Option<String>,
+    src: Option<String>,
+    alt: Option<String>,
+    control_type: Option<String>,
+    children: Vec<ExpectedRenderNode>,
+}
+
+#[test]
+fn browser_render_tree_cases_extract_default_display_structure() {
+    let suite: BrowserRenderTreeSuite = serde_json::from_str(BROWSER_RENDER_TREE_FIXTURE)
+        .expect("browser render tree fixture should parse");
+
+    assert_eq!(suite.format, "venture-html-browser-render-tree/v1");
+    assert_eq!(suite.suite, "browser-render-tree");
+    assert!(!suite.cases.is_empty(), "fixture should contain cases");
+
+    for case in suite.cases {
+        let actual = parse_browser_render_tree(&case.input)
+            .unwrap_or_else(|error| panic!("{} should parse: {error}", case.id));
+
+        assert_eq!(
+            actual,
+            case.expected.into_browser_render_tree(),
+            "{} extracted browser render tree should match",
+            case.id
+        );
+    }
+}
+
+impl ExpectedRenderTree {
+    fn into_browser_render_tree(self) -> BrowserRenderTree {
+        BrowserRenderTree {
+            children: self
+                .children
+                .into_iter()
+                .map(ExpectedRenderNode::into_browser_render_node)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedRenderNode {
+    fn into_browser_render_node(self) -> BrowserRenderNode {
+        BrowserRenderNode {
+            display: self.display,
+            role: self.role,
+            name: self.name,
+            text: self.text,
+            href: self.href,
+            src: self.src,
+            alt: self.alt,
+            control_type: self.control_type,
+            children: self
+                .children
+                .into_iter()
+                .map(ExpectedRenderNode::into_browser_render_node)
+                .collect(),
+        }
+    }
+}

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -21,6 +21,11 @@ content can be filtered into renderable structural nodes such as headings,
 blocks, inline runs, links, images, form controls, lists, and tables while
 skipping parser shell, head metadata, comments, scripts, styles, and templates.
 
+`html-browser-render-tree.json` is a checked parser acceptance corpus for the
+browser-facing render-tree input projection. It verifies that the content tree
+is converted into stable default display categories such as block, inline,
+inline-replaced, list-item, and table display nodes for early layout work.
+
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 
 ```bash

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -1,0 +1,119 @@
+{
+  "format": "venture-html-browser-render-tree/v1",
+  "suite": "browser-render-tree",
+  "description": "Browser-facing parser acceptance cases for default display categories over renderable body content.",
+  "cases": [
+    {
+      "id": "flow-inline-and-replaced",
+      "description": "Headings and paragraphs become block layout inputs while text, links, images, and line breaks keep inline display categories.",
+      "input": "<body><h1>Example</h1><p>Hello <a href=next.html>Next</a><img src=logo.gif alt=Logo><br>Tail</p>",
+      "expected": {
+        "children": [
+          {
+            "display": "block",
+            "role": "heading",
+            "name": "h1",
+            "text": "Example",
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "display": "inline-text", "role": "text", "name": null, "text": "Example", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          },
+          {
+            "display": "block",
+            "role": "block",
+            "name": "p",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "display": "inline-text", "role": "text", "name": null, "text": "Hello", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              {
+                "display": "inline",
+                "role": "link",
+                "name": "a",
+                "text": "Next",
+                "href": "next.html",
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "display": "inline-text", "role": "text", "name": null, "text": "Next", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              },
+              { "display": "inline-replaced", "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "alt": "Logo", "control_type": null, "children": [] },
+              { "display": "line-break", "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "display": "inline-text", "role": "text", "name": null, "text": "Tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "form-and-table-display",
+      "description": "Form controls become inline replaced boxes, and parser-implied table sections become table row group inputs.",
+      "input": "<body><form><input value=query><button>Go</button></form><table><tr><td>A<td>B</table>",
+      "expected": {
+        "children": [
+          {
+            "display": "block",
+            "role": "form",
+            "name": "form",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "display": "inline-replaced", "role": "control", "name": "input", "text": "query", "href": null, "src": null, "alt": null, "control_type": "text", "children": [] },
+              { "display": "inline-replaced", "role": "control", "name": "button", "text": "Go", "href": null, "src": null, "alt": null, "control_type": "submit", "children": [] }
+            ]
+          },
+          {
+            "display": "table",
+            "role": "table",
+            "name": "table",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              {
+                "display": "table-row-group",
+                "role": "table_section",
+                "name": "tbody",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  {
+                    "display": "table-row",
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "display": "table-cell", "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "A", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "display": "table-cell", "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "B", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a browser-facing render-tree input projection over the existing content tree
- add checked render-tree fixture coverage for block, inline, replaced, form, and table display categories
- register and schema-check the new fixture format, with parser docs updated for the public API

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser