### PR TITLE
spice: add MOS Level-1 capacitance model

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params` now includes MOS Level-1 capacitance footholds (`CGSO`,
+  `CGDO`, `CGBO`, `CBS`, `CBD`) and reports them through `MosResult`.
 - `Level1Params`: SPICE Level-1 parameter set (VT0, KP, LAMBDA, GAMMA, PHI, W, L, IS, N_SUB, T_NOM, subthreshold_enable).
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: classical square-law I-V with body effect, channel-length modulation, and optional subthreshold current.
 - `MosResult`: Id + small-signal Jacobian (gm, gds, gmb) + Meyer capacitances + region label.

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -22,7 +22,7 @@ print(r.Id, r.gm, r.gds, r.region)
 
 ## v0.1.0 scope
 
-- `Level1Params`: 11-field parameter set with sane defaults for 130 nm-style NMOS.
+- `Level1Params`: Level-1 DC plus capacitance parameter set with sane defaults for 130 nm-style NMOS.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -28,6 +28,11 @@ class Level1Params:
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
+    CGSO: float = 0.0  # gate-source overlap capacitance per width (F/m)
+    CGDO: float = 0.0  # gate-drain overlap capacitance per width (F/m)
+    CGBO: float = 0.0  # gate-bulk overlap capacitance per width (F/m)
+    CBS: float = 0.0  # source-bulk zero-bias junction capacitance (F)
+    CBD: float = 0.0  # drain-bulk zero-bias junction capacitance (F)
     subthreshold_enable: bool = True
 
 
@@ -73,11 +78,14 @@ def evaluate_level1(
     V_OV = V_GS - V_t
     V_T = thermal_voltage(T)
 
-    Cgs_off = (2.0 / 3.0) * p.W * p.L * p.KP / 1.0  # placeholder; Meyer model
-    Cgd_off = 0.0
-    Cgb_off = 0.0
-    Cbs_off = 0.0
-    Cbd_off = 0.0
+    Cgs_overlap = p.CGSO * p.W
+    Cgd_overlap = p.CGDO * p.W
+    Cgb_overlap = p.CGBO * p.L
+    Cgs_intrinsic = (2.0 / 3.0) * p.W * p.L * p.KP / 1.0  # placeholder; Meyer model
+    Cgd_intrinsic = 0.0
+    Cgb_intrinsic = 0.0
+    Cbs_bulk = p.CBS
+    Cbd_bulk = p.CBD
 
     if V_OV <= 0:
         # Cutoff — optionally subthreshold.
@@ -92,12 +100,20 @@ def evaluate_level1(
             gds_sub = (beta * n * V_T) * exp(V_OV / (n * V_T)) * exp(-V_DS / V_T)
             return MosResult(
                 Id=Id_sub, gm=gm_sub, gds=gds_sub, gmb=0.0,
-                Cgs=Cgs_off, Cgd=Cgd_off, Cgb=Cgb_off, Cbs=Cbs_off, Cbd=Cbd_off,
+                Cgs=Cgs_overlap + Cgs_intrinsic,
+                Cgd=Cgd_overlap + Cgd_intrinsic,
+                Cgb=Cgb_overlap + Cgb_intrinsic,
+                Cbs=Cbs_bulk,
+                Cbd=Cbd_bulk,
                 region="subthreshold",
             )
         return MosResult(
             Id=0.0, gm=0.0, gds=0.0, gmb=0.0,
-            Cgs=Cgs_off, Cgd=Cgd_off, Cgb=Cgb_off, Cbs=Cbs_off, Cbd=Cbd_off,
+            Cgs=Cgs_overlap + Cgs_intrinsic,
+            Cgd=Cgd_overlap + Cgd_intrinsic,
+            Cgb=Cgb_overlap + Cgb_intrinsic,
+            Cbs=Cbs_bulk,
+            Cbd=Cbd_bulk,
             region="cutoff",
         )
 
@@ -117,8 +133,11 @@ def evaluate_level1(
             gmb = 0.0
         return MosResult(
             Id=Id, gm=gm, gds=gds, gmb=gmb,
-            Cgs=Cgs_off / 2.0, Cgd=Cgd_off / 2.0, Cgb=Cgb_off,
-            Cbs=Cbs_off, Cbd=Cbd_off,
+            Cgs=Cgs_overlap + Cgs_intrinsic / 2.0,
+            Cgd=Cgd_overlap + Cgd_intrinsic / 2.0,
+            Cgb=Cgb_overlap + Cgb_intrinsic,
+            Cbs=Cbs_bulk,
+            Cbd=Cbd_bulk,
             region="triode",
         )
 
@@ -133,6 +152,10 @@ def evaluate_level1(
         gmb = 0.0
     return MosResult(
         Id=Id, gm=gm, gds=gds, gmb=gmb,
-        Cgs=(2.0 / 3.0) * Cgs_off, Cgd=0.0, Cgb=0.0, Cbs=0.0, Cbd=0.0,
+        Cgs=Cgs_overlap + (2.0 / 3.0) * Cgs_intrinsic,
+        Cgd=Cgd_overlap,
+        Cgb=Cgb_overlap,
+        Cbs=Cbs_bulk,
+        Cbd=Cbd_bulk,
         region="saturation",
     )

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -125,6 +125,26 @@ def test_gds_increases_with_lambda():
     assert r_yes.gds > r_no.gds
 
 
+def test_overlap_and_bulk_capacitances_are_reported():
+    p = Level1Params(
+        W=2e-6,
+        L=1e-6,
+        CGSO=3e-10,
+        CGDO=4e-10,
+        CGBO=5e-10,
+        CBS=6e-12,
+        CBD=7e-12,
+        subthreshold_enable=False,
+    )
+    r = evaluate_level1(p, V_GS=0.0, V_DS=0.0)
+
+    assert r.Cgs >= 3e-10 * 2e-6
+    assert r.Cgd == 4e-10 * 2e-6
+    assert r.Cgb == 5e-10 * 1e-6
+    assert r.Cbs == 6e-12
+    assert r.Cbd == 7e-12
+
+
 # ---- MOSFET wrapper ----
 
 

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- **MOS Level-1 capacitance models** — `CGSO`, `CGDO`, `CGBO`, `CBS`, and
+  `CBD` now contribute MOSFET small-signal AC susceptance.
+
 - **Diode emission coefficient models** — `Diode.N` now scales the effective
   thermal voltage in DC and small-signal diode conductance calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -3939,6 +3939,11 @@ def _stamp_ac(
         gm_m: float = r.gm
         gds_m: float = r.gds
         _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_m + 0j)
+        _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * r.Cgs)
+        _stamp_g_c(G, node_to_idx, el.gate, el.drain, 1j * omega * r.Cgd)
+        _stamp_g_c(G, node_to_idx, el.gate, el.body, 1j * omega * r.Cgb)
+        _stamp_g_c(G, node_to_idx, el.body, el.source, 1j * omega * r.Cbs)
+        _stamp_g_c(G, node_to_idx, el.body, el.drain, 1j * omega * r.Cbd)
         if not _is_ground(el.drain):
             d = node_to_idx[el.drain]
             if not _is_ground(el.gate):

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -77,6 +77,7 @@ from math import exp, isclose
 
 import pytest
 
+from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
 from spice_engine import (
     BSource,
     BJT,
@@ -102,6 +103,7 @@ from spice_engine import (
     ExpWaveform,
     Inductor,
     JFET,
+    Mosfet,
     MutualInductor,
     McPoint,
     McResult,
@@ -2200,6 +2202,34 @@ def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():
 
     assert without_transit_time > 0.9
     assert with_transit_time < without_transit_time / 100.0
+
+
+def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():
+    """MOS Level-1 CGSO contributes gate-source AC susceptance."""
+    def gate_amplitude(cgso: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "gate", 1000.0))
+        c.add(Resistor("Rdrain", "drain", "0", 1000.0))
+        c.add(Mosfet(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CGSO=cgso)),
+            ),
+        ))
+        result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["gate"])
+
+    without_capacitance = gate_amplitude(0.0)
+    with_capacitance = gate_amplitude(1.0e-6)
+
+    assert without_capacitance > 0.9
+    assert with_capacitance < without_capacitance / 100.0
 
 
 # ============================================================================

--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse MOS Level-1 capacitance parameters with `.model ... NMOS|PMOS(... CGSO=<c>
+  CGDO=<c> CGBO=<c> CBS=<c> CBD=<c>)`.
 - Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
   and pass them into Python `Diode` elements.
 - Parse diode model-card reverse-breakdown parameters with

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -23,7 +23,8 @@ This parser slice supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`,
 `VT`), BJT parameters (`NPN`/`PNP`, `IS`, `BF`/`BETA_F`, `VT`, `CJE`, `CJC`,
 `TF`, `TR`), and Level-1
 MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
-`W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`), capacitor `IC=<voltage>`
+`W`, `L`, `IS`, `N_SUB`/`NSUB`, `T_NOM`/`TNOM`, `CGSO`, `CGDO`, `CGBO`,
+`CBS`, `CBD`), capacitor `IC=<voltage>`
 and inductor `IC=<current>` initial conditions, SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -597,7 +597,7 @@ Jp drain gate source pslow
 def test_parse_mosfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """
-.model nfast NMOS(VT0=0.45 KP=200u LAMBDA=0.02)
+.model nfast NMOS(VT0=0.45 KP=200u LAMBDA=0.02 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
 Vdd vdd 0 DC 1.8
 Vgate gate 0 DC 1.8
 Rload vdd out 1k
@@ -611,6 +611,7 @@ M1 out gate 0 0 nfast W=2u L=180n
     assert parsed.models["nfast"].params["VT0"] == 0.45
     assert isclose(parsed.models["nfast"].params["KP"], 200.0e-6)
     assert parsed.models["nfast"].params["LAMBDA"] == 0.02
+    assert isclose(parsed.models["nfast"].params["CGSO"], 3.0e-12)
     mosfet = parsed.circuit.elements[3]
     assert isinstance(mosfet, Mosfet)
     assert mosfet.drain == "out"
@@ -621,6 +622,11 @@ M1 out gate 0 0 nfast W=2u L=180n
     assert isinstance(mosfet.model.model, Level1Model)
     assert mosfet.model.model.params.VT0 == 0.45
     assert isclose(mosfet.model.model.params.KP, 200.0e-6)
+    assert isclose(mosfet.model.model.params.CGSO, 3.0e-12)
+    assert isclose(mosfet.model.model.params.CGDO, 4.0e-12)
+    assert isclose(mosfet.model.model.params.CGBO, 5.0e-12)
+    assert isclose(mosfet.model.model.params.CBS, 6.0e-12)
+    assert isclose(mosfet.model.model.params.CBD, 7.0e-12)
     assert isclose(mosfet.model.model.params.W, 2.0e-6)
     assert isclose(mosfet.model.model.params.L, 180.0e-9)
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add MOS Level-1 capacitance support through `CGSO`, `CGDO`, `CGBO`, `CBS`,
+  and `CBD`, contributing small-signal AC susceptance.
 - Add diode emission coefficient support through `emission_coefficient`,
   scaling the effective thermal voltage in DC and small-signal diode
   conductance.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -1323,6 +1323,11 @@ pub struct MosfetLevel1Params {
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
+    pub gate_source_overlap_capacitance: f64,
+    pub gate_drain_overlap_capacitance: f64,
+    pub gate_bulk_overlap_capacitance: f64,
+    pub source_bulk_capacitance: f64,
+    pub drain_bulk_capacitance: f64,
 }
 
 impl Default for MosfetLevel1Params {
@@ -1338,6 +1343,11 @@ impl Default for MosfetLevel1Params {
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
+            gate_source_overlap_capacitance: 0.0,
+            gate_drain_overlap_capacitance: 0.0,
+            gate_bulk_overlap_capacitance: 0.0,
+            source_bulk_capacitance: 0.0,
+            drain_bulk_capacitance: 0.0,
         }
     }
 }
@@ -4726,9 +4736,13 @@ fn build_ac_matrix(
             Element::Bjt(bjt) => {
                 stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point, omega)?
             }
-            Element::Mosfet(mosfet) => {
-                stamp_ac_mosfet_small_signal(mosfet, node_indices, &mut matrix, operating_point)?
-            }
+            Element::Mosfet(mosfet) => stamp_ac_mosfet_small_signal(
+                mosfet,
+                node_indices,
+                &mut matrix,
+                operating_point,
+                omega,
+            )?,
             Element::Vccs(source) => stamp_ac_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_ac_vcvs(
                 source,
@@ -5515,6 +5529,11 @@ struct MosfetDcResult {
     gm: f64,
     gds: f64,
     gmb: f64,
+    cgs: f64,
+    cgd: f64,
+    cgb: f64,
+    cbs: f64,
+    cbd: f64,
 }
 
 struct JfetDcResult {
@@ -5645,6 +5664,11 @@ fn evaluate_mosfet_level1(mosfet: &Mosfet, vgs: f64, vds: f64, vbs: f64) -> Mosf
                 gm: result.gm,
                 gds: result.gds,
                 gmb: result.gmb,
+                cgs: result.cgs,
+                cgd: result.cgd,
+                cgb: result.cgb,
+                cbs: result.cbs,
+                cbd: result.cbd,
             }
         }
         MosfetType::Nmos => evaluate_nmos_level1(&mosfet.params, vgs, vds, vbs),
@@ -5658,6 +5682,10 @@ fn evaluate_nmos_level1(
     vbs: f64,
 ) -> MosfetDcResult {
     let beta = params.kp * (params.w / params.l);
+    let cgs_overlap = params.gate_source_overlap_capacitance * params.w;
+    let cgd_overlap = params.gate_drain_overlap_capacitance * params.w;
+    let cgb_overlap = params.gate_bulk_overlap_capacitance * params.l;
+    let cgs_intrinsic = (2.0 / 3.0) * params.w * params.l * params.kp;
     let threshold = if params.phi - vbs >= 0.0 {
         params.vt0 + params.gamma * ((params.phi - vbs).sqrt() - params.phi.sqrt())
     } else {
@@ -5670,6 +5698,11 @@ fn evaluate_nmos_level1(
             gm: 0.0,
             gds: 0.0,
             gmb: 0.0,
+            cgs: cgs_overlap + cgs_intrinsic,
+            cgd: cgd_overlap,
+            cgb: cgb_overlap,
+            cbs: params.source_bulk_capacitance,
+            cbd: params.drain_bulk_capacitance,
         };
     }
 
@@ -5687,6 +5720,11 @@ fn evaluate_nmos_level1(
             gm,
             gds: beta * (overdrive - vds) * modulation + beta * channel * params.lambda,
             gmb: gm * body_factor,
+            cgs: cgs_overlap + cgs_intrinsic / 2.0,
+            cgd: cgd_overlap,
+            cgb: cgb_overlap,
+            cbs: params.source_bulk_capacitance,
+            cbd: params.drain_bulk_capacitance,
         };
     }
 
@@ -5697,6 +5735,11 @@ fn evaluate_nmos_level1(
         gm,
         gds: 0.5 * beta * overdrive * overdrive * params.lambda,
         gmb: gm * body_factor,
+        cgs: cgs_overlap + (2.0 / 3.0) * cgs_intrinsic,
+        cgd: cgd_overlap,
+        cgb: cgb_overlap,
+        cbs: params.source_bulk_capacitance,
+        cbd: params.drain_bulk_capacitance,
     }
 }
 
@@ -5757,6 +5800,7 @@ fn stamp_ac_mosfet_small_signal(
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<Complex>],
     operating_point: &[f64],
+    omega: f64,
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
     let drain = node_index(node_indices, &mosfet.drain);
@@ -5772,6 +5816,11 @@ fn stamp_ac_mosfet_small_signal(
     let vbs = body_voltage - source_voltage;
     let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
+    stamp_complex_conductance(matrix, gate, source, Complex::new(0.0, omega * result.cgs));
+    stamp_complex_conductance(matrix, gate, drain, Complex::new(0.0, omega * result.cgd));
+    stamp_complex_conductance(matrix, gate, body, Complex::new(0.0, omega * result.cgb));
+    stamp_complex_conductance(matrix, body, source, Complex::new(0.0, omega * result.cbs));
+    stamp_complex_conductance(matrix, body, drain, Complex::new(0.0, omega * result.cbd));
     stamp_complex_transconductance(
         matrix,
         drain,
@@ -5984,6 +6033,11 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
         ("T_NOM", params.t_nom),
+        ("CGSO", params.gate_source_overlap_capacitance),
+        ("CGDO", params.gate_drain_overlap_capacitance),
+        ("CGBO", params.gate_bulk_overlap_capacitance),
+        ("CBS", params.source_bulk_capacitance),
+        ("CBD", params.drain_bulk_capacitance),
     ] {
         if !value.is_finite() {
             return Err(SpiceError::InvalidElement {
@@ -6014,6 +6068,17 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET IS, N_SUB, and T_NOM must be positive".to_string(),
+        });
+    }
+    if params.gate_source_overlap_capacitance < 0.0
+        || params.gate_drain_overlap_capacitance < 0.0
+        || params.gate_bulk_overlap_capacitance < 0.0
+        || params.source_bulk_capacitance < 0.0
+        || params.drain_bulk_capacitance < 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET capacitances must be non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -547,6 +547,7 @@ fn ac_mosfet_common_source_suppresses_dc_supplies_without_ac_spec() {
             saturation_current: 1.0e-15,
             n_sub: 1.0,
             t_nom: 300.15,
+            ..MosfetLevel1Params::default()
         },
     )));
 
@@ -557,6 +558,48 @@ fn ac_mosfet_common_source_suppresses_dc_supplies_without_ac_spec() {
     assert_close(out.real, -1.0);
     assert_close(out.imag, 0.0);
     assert_close(points[0].voltage("vdd").unwrap().abs(), 0.0);
+}
+
+#[test]
+fn ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive() {
+    fn gate_amplitude(cgso: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                gate_source_overlap_capacitance: cgso,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("gate")
+            .unwrap()
+            .abs()
+    }
+
+    let without_capacitance = gate_amplitude(0.0);
+    let with_capacitance = gate_amplitude(1.0e-6);
+
+    assert!(without_capacitance > 0.9);
+    assert!(with_capacitance < without_capacitance / 100.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -224,6 +224,7 @@ fn tf_mosfet_common_source_uses_gate_bias_for_small_signal_gain() {
             saturation_current: 1.0e-15,
             n_sub: 1.0,
             t_nom: 300.15,
+            ..MosfetLevel1Params::default()
         },
     )));
 

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse MOS Level-1 capacitance parameters with `.model ... NMOS|PMOS(... CGSO=<c>
+  CGDO=<c> CGBO=<c> CBS=<c> CBD=<c>)`.
 - Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
   and pass them into Rust `Diode` elements.
 - Parse diode model-card reverse-breakdown parameters with

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -23,7 +23,8 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
-`W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` / `TNOM`), SPICE engineering
+`W`, `L`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`, `CGBO`,
+`CBS`, and `CBD`), SPICE engineering
 suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -600,6 +600,11 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "IS" => params.saturation_current = value,
         "N_SUB" | "NSUB" | "N" => params.n_sub = value,
         "T_NOM" | "TNOM" => params.t_nom = value,
+        "CGSO" => params.gate_source_overlap_capacitance = value,
+        "CGDO" => params.gate_drain_overlap_capacitance = value,
+        "CGBO" => params.gate_bulk_overlap_capacitance = value,
+        "CBS" => params.source_bulk_capacitance = value,
+        "CBD" => params.drain_bulk_capacitance = value,
         _ => {}
     }
 }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -803,7 +803,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n NSUB=1.5 TNOM=300)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n
@@ -818,6 +818,7 @@ Rload out 0 1k
     assert_eq!(model.kind, "NMOS");
     assert_close(*model.params.get("VTO").unwrap(), 0.45);
     assert_close(*model.params.get("KP").unwrap(), 250.0e-6);
+    assert_close(*model.params.get("CGSO").unwrap(), 3.0e-12);
 
     let Element::Mosfet(mosfet) = &parsed.circuit.elements()[2] else {
         panic!("expected MOSFET");
@@ -837,6 +838,11 @@ Rload out 0 1k
     assert_close(mosfet.params.l, 200.0e-9);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
+    assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);
+    assert_close(mosfet.params.gate_drain_overlap_capacitance, 4.0e-12);
+    assert_close(mosfet.params.gate_bulk_overlap_capacitance, 5.0e-12);
+    assert_close(mosfet.params.source_bulk_capacitance, 6.0e-12);
+    assert_close(mosfet.params.drain_bulk_capacitance, 7.0e-12);
 
     let result = dc_op(&parsed.circuit).unwrap();
     let out = result.voltage("out").unwrap();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add MOS Level-1 capacitance support through `CGSO`, `CGDO`, `CGBO`, `CBS`,
+  and `CBD`, contributing small-signal AC susceptance.
 - Add diode emission coefficient support through `emissionCoefficient`, scaling
   the effective thermal voltage in DC and small-signal diode conductance.
 - Add diode breakdown support through `breakdownVoltage` / `breakdownCurrent`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -411,6 +411,11 @@ export interface MosfetLevel1Params {
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
+  readonly CGSO: number;
+  readonly CGDO: number;
+  readonly CGBO: number;
+  readonly CBS: number;
+  readonly CBD: number;
 }
 
 export interface Mosfet {
@@ -1290,6 +1295,11 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
+    CGSO: 0.0,
+    CGDO: 0.0,
+    CGBO: 0.0,
+    CBS: 0.0,
+    CBD: 0.0,
   };
 }
 
@@ -3948,7 +3958,7 @@ function buildAcMatrix(
         stampAcBjtSmallSignal(element, nodeIndices, matrix, omega);
         break;
       case "mosfet":
-        stampAcMosfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
+        stampAcMosfetSmallSignal(element, nodeIndices, matrix, operatingPoint, omega);
         break;
       case "vccs":
         stampAcVccs(element, nodeIndices, matrix);
@@ -4614,6 +4624,11 @@ interface MosfetDcResult {
   readonly gm: number;
   readonly gds: number;
   readonly gmb: number;
+  readonly cgs: number;
+  readonly cgd: number;
+  readonly cgb: number;
+  readonly cbs: number;
+  readonly cbd: number;
 }
 
 interface JfetDcResult {
@@ -4755,6 +4770,11 @@ function evaluateMosfetLevel1(
       gm: result.gm,
       gds: result.gds,
       gmb: result.gmb,
+      cgs: result.cgs,
+      cgd: result.cgd,
+      cgb: result.cgb,
+      cbs: result.cbs,
+      cbd: result.cbd,
     };
   }
   return evaluateNmosLevel1(element.params, vgs, vds, vbs);
@@ -4767,13 +4787,24 @@ function evaluateNmosLevel1(
   vbs: number,
 ): MosfetDcResult {
   const beta = params.KP * (params.W / params.L);
+  const cgsOverlap = params.CGSO * params.W;
+  const cgdOverlap = params.CGDO * params.W;
+  const cgbOverlap = params.CGBO * params.L;
+  const cgsIntrinsic = (2.0 / 3.0) * params.W * params.L * params.KP;
+  const capacitances = {
+    cgs: cgsOverlap + cgsIntrinsic,
+    cgd: cgdOverlap,
+    cgb: cgbOverlap,
+    cbs: params.CBS,
+    cbd: params.CBD,
+  };
   const threshold =
     params.PHI - vbs >= 0.0
       ? params.VT0 + params.GAMMA * (Math.sqrt(params.PHI - vbs) - Math.sqrt(params.PHI))
       : params.VT0;
   const overdrive = vgs - threshold;
   if (overdrive <= 0.0) {
-    return { drainCurrent: 0.0, gm: 0.0, gds: 0.0, gmb: 0.0 };
+    return { drainCurrent: 0.0, gm: 0.0, gds: 0.0, gmb: 0.0, ...capacitances };
   }
   const bodyFactor =
     params.PHI - vbs > 0.0
@@ -4788,6 +4819,11 @@ function evaluateNmosLevel1(
       gm,
       gds: beta * (overdrive - vds) * modulation + beta * channel * params.LAMBDA,
       gmb: gm * bodyFactor,
+      cgs: cgsOverlap + cgsIntrinsic / 2.0,
+      cgd: cgdOverlap,
+      cgb: cgbOverlap,
+      cbs: params.CBS,
+      cbd: params.CBD,
     };
   }
   const current = 0.5 * beta * overdrive * overdrive * (1.0 + params.LAMBDA * vds);
@@ -4797,6 +4833,11 @@ function evaluateNmosLevel1(
     gm,
     gds: 0.5 * beta * overdrive * overdrive * params.LAMBDA,
     gmb: gm * bodyFactor,
+    cgs: cgsOverlap + (2.0 / 3.0) * cgsIntrinsic,
+    cgd: cgdOverlap,
+    cgb: cgbOverlap,
+    cbs: params.CBS,
+    cbd: params.CBD,
   };
 }
 
@@ -4928,6 +4969,15 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.IS <= 0.0 || params.N_SUB <= 0.0 || params.T_NOM <= 0.0) {
     throw invalidElement(element.name, "MOSFET IS, N_SUB, and T_NOM must be positive");
+  }
+  if (
+    params.CGSO < 0.0 ||
+    params.CGDO < 0.0 ||
+    params.CGBO < 0.0 ||
+    params.CBS < 0.0 ||
+    params.CBD < 0.0
+  ) {
+    throw invalidElement(element.name, "MOSFET capacitances must be non-negative");
   }
 }
 
@@ -6581,6 +6631,7 @@ function stampAcMosfetSmallSignal(
   nodeIndices: ReadonlyMap<string, number>,
   matrix: Complex[][],
   operatingPoint: readonly number[],
+  omega: number,
 ): void {
   validateMosfet(element);
   const drain = nodeIndex(nodeIndices, element.drain);
@@ -6606,6 +6657,11 @@ function stampAcMosfetSmallSignal(
     source,
     complex(result.gm, 0.0),
   );
+  stampComplexConductance(matrix, gate, source, complex(0.0, omega * result.cgs));
+  stampComplexConductance(matrix, gate, drain, complex(0.0, omega * result.cgd));
+  stampComplexConductance(matrix, gate, body, complex(0.0, omega * result.cgb));
+  stampComplexConductance(matrix, body, source, complex(0.0, omega * result.cbs));
+  stampComplexConductance(matrix, body, drain, complex(0.0, omega * result.cbd));
   stampComplexTransconductance(
     matrix,
     drain,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -15,6 +15,7 @@ import {
   diode,
   inductor,
   jfet,
+  mosfet,
   mutualInductor,
   resistor,
   sParameters,
@@ -294,6 +295,28 @@ describe("acSweep", () => {
     expectClose(out!.real, -4.0);
     expectClose(out!.imag, 0.0);
     expectClose(complexAbs(points[0].voltage("vdd")!), 0.0);
+  });
+
+  it("uses MOSFET overlap capacitance in AC analysis", () => {
+    function gateAmplitude(CGSO: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CGSO,
+      }));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("gate")!);
+    }
+
+    const withoutCapacitance = gateAmplitude(0.0);
+    const withCapacitance = gateAmplitude(1.0e-6);
+
+    expect(withoutCapacitance).toBeGreaterThan(0.9);
+    expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
   });
 
   it("uses BJT base-emitter capacitance in AC analysis", () => {

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse MOS Level-1 capacitance parameters with `.model ... NMOS|PMOS(... CGSO=<c>
+  CGDO=<c> CGBO=<c> CBS=<c> CBD=<c>)`.
 - Parse diode model-card emission coefficients with `.model ... D(... N=<n>)`
   and pass them into TypeScript `diode` elements.
 - Parse diode model-card reverse-breakdown parameters with

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -26,7 +26,8 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 `.model <name> NMOS(...)` /
 `.model <name> PMOS(...)` MOSFET cards with Level-1 `VT0` / `VTO`, `KP`,
 `LAMBDA`, `GAMMA`, `PHI`, `W`, `L`, `IS`, `N_SUB` / `NSUB`, and `T_NOM` /
-`TNOM` parameters, capacitor `IC=<voltage>` and inductor `IC=<current>`
+`TNOM`, `CGSO`, `CGDO`, `CGBO`, `CBS`, and `CBD` parameters, capacitor
+`IC=<voltage>` and inductor `IC=<current>`
 initial conditions,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`,

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -424,6 +424,11 @@ function isMosfetParam(name: keyof MosfetLevel1Params): boolean {
     "IS",
     "N_SUB",
     "T_NOM",
+    "CGSO",
+    "CGDO",
+    "CGBO",
+    "CBS",
+    "CBD",
   ].includes(name);
 }
 

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -571,7 +571,7 @@ Jp drain gate source pslow
 
   it("parses MOSFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
-.model nfast NMOS(VT0=0.45 KP=200u LAMBDA=0.02)
+.model nfast NMOS(VT0=0.45 KP=200u LAMBDA=0.02 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
 Vdd vdd 0 DC 1.8
 Vgate gate 0 DC 1.8
 Rload vdd out 1k
@@ -584,6 +584,7 @@ M1 out gate 0 0 nfast W=2u L=180n
     expect(model?.kind).toBe("NMOS");
     expect(model?.params.get("VT0")).toBe(0.45);
     expect(model?.params.get("KP")).toBeCloseTo(200.0e-6, 12);
+    expect(model?.params.get("CGSO")).toBeCloseTo(3.0e-12, 18);
     expect(parsed.circuit.elements()[3]).toMatchObject({
       kind: "mosfet",
       name: "M1",
@@ -603,6 +604,11 @@ M1 out gate 0 0 nfast W=2u L=180n
       throw new Error("unexpected element kind");
     }
     expect(element.params.KP).toBeCloseTo(200.0e-6, 12);
+    expect(element.params.CGSO).toBeCloseTo(3.0e-12, 18);
+    expect(element.params.CGDO).toBeCloseTo(4.0e-12, 18);
+    expect(element.params.CGBO).toBeCloseTo(5.0e-12, 18);
+    expect(element.params.CBS).toBeCloseTo(6.0e-12, 18);
+    expect(element.params.CBD).toBeCloseTo(7.0e-12, 18);
     expect(element.params.W).toBeCloseTo(2.0e-6, 12);
     expect(element.params.L).toBeCloseTo(180.0e-9, 12);
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -219,6 +219,10 @@ Status:
 - BJT `.model ... NPN|PNP(... TR=<time>)` parsing and reverse/base-collector
   diffusion capacitance are implemented in AC analysis across Python,
   TypeScript, and Rust.
+- MOS Level-1 `.model ... NMOS|PMOS(... CGSO=<capacitance> CGDO=<capacitance>
+  CGBO=<capacitance> CBS=<capacitance> CBD=<capacitance>)` parsing and
+  small-signal AC capacitance stamping are implemented across Python,
+  TypeScript, and Rust.
 
 ### Phase 7 - Classic Text Output and Control Cards
 


### PR DESCRIPTION
## Summary
- add MOS Level-1 capacitance parameters `CGSO`, `CGDO`, `CGBO`, `CBS`, and `CBD` across Python, TypeScript, and Rust
- stamp MOSFET small-signal AC capacitances between gate/source, gate/drain, gate/body, body/source, and body/drain
- add parser fixtures, engine AC fixtures, mosfet-models coverage, changelog/README notes, and the Phase 6 compatibility marker

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-mos-level1-capacitance PYTHONPATH=src:../device-physics/src python -m pytest tests/test_models.py -q` in `code/packages/python/mosfet-models`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-mos-level1-capacitance PYTHONPATH=src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_engine.py -q` in `code/packages/python/spice-engine`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-mos-level1-capacitance PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q` in `code/packages/python/spice-netlist-parser`
- `npm install --quiet && npm run build && npx vitest run` in `code/packages/typescript/spice-engine`
- `npm install --quiet && npm run build && npx vitest run` in `code/packages/typescript/spice-netlist-parser`
- `cargo fmt -p spice-engine -p spice-netlist-parser && cargo test -p spice-engine -p spice-netlist-parser` in `code/packages/rust`
- `git diff --check`