### PR TITLE
feat(mini-sqlite): accept VALUES anchor in WITH RECURSIVE CTEs

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2.4.0] - 2026-05-23
+
+### Added
+
+- ``WITH RECURSIVE`` CTEs now accept a ``VALUES`` anchor, matching
+  SQLite.  The canonical "count from N" idiom works::
+
+      WITH RECURSIVE c(n) AS (
+          VALUES(1)
+          UNION ALL
+          SELECT n + 1 FROM c WHERE n < 5
+      ) SELECT n FROM c
+
+  Previously this raised ``ProgrammingError: expected child rule
+  'select_stmt' under query_stmt`` because the recursive CTE branch
+  of ``mini_sqlite.adapter`` only looked for a ``select_stmt`` child
+  in the inner ``query_stmt``.  The non-recursive branch already
+  supported VALUES via ``_query_stmt`` recursion.
+
+  Implementation: the adapter first tries ``values_stmt`` and, if
+  present, runs ``_values_stmt`` to build the anchor; otherwise falls
+  back to the existing ``select_stmt`` path.  Single-row VALUES
+  (which is what every realistic recursive anchor needs) maps cleanly
+  onto ``RecursiveCTERef.anchor: SelectStmt``.  Multi-row VALUES
+  anchors are rejected with a clear pointer to the
+  ``SELECT … UNION ALL SELECT …`` rewrite — the planner's recursive
+  anchor path expects a single SELECT.
+
 ## [2.3.0] - 2026-05-23
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.3.0"
+version = "2.4.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -262,9 +262,31 @@ def _query_stmt(
 
             if is_recursive and _child_nodes(inner_q, "set_op_clause"):
                 # Recursive CTE: body is "anchor UNION [ALL] recursive_step".
-                # Parse anchor with the CTEs accumulated so far.
-                anchor_node = _child_node(inner_q, "select_stmt")
-                anchor_stmt = _select(anchor_node, ctes=active_ctes)
+                # The anchor can be either a SELECT or a VALUES expression
+                # (SQLite accepts both — e.g. ``WITH RECURSIVE c(n) AS
+                # (VALUES(1) UNION ALL SELECT n+1 FROM c WHERE n < 5)``
+                # is the canonical "count from 1 to 5" pattern).
+                #
+                # Single-row VALUES yields a ``SelectStmt`` (a single SELECT
+                # with literal columns), which fits ``RecursiveCTERef.anchor``
+                # directly.  Multi-row VALUES yields a ``UnionStmt`` tree;
+                # the planner's recursive-CTE anchor path expects a
+                # ``SelectStmt`` (single base relation), so we reject the
+                # multi-row case with a clear pointer to the workaround.
+                anchor_values_node = _maybe_child(inner_q, "values_stmt")
+                if anchor_values_node is not None:
+                    values_anchor = _values_stmt(anchor_values_node)
+                    if not isinstance(values_anchor, SelectStmt):
+                        raise ProgrammingError(
+                            f"RECURSIVE CTE {cte_name!r} anchor: multi-row "
+                            f"VALUES is not yet supported (use a single "
+                            f"VALUES row, or rewrite as ``SELECT … UNION "
+                            f"ALL SELECT …`` for the anchor)"
+                        )
+                    anchor_stmt = values_anchor
+                else:
+                    anchor_node = _child_node(inner_q, "select_stmt")
+                    anchor_stmt = _select(anchor_node, ctes=active_ctes)
 
                 # Apply column aliases to the anchor's SELECT items so the
                 # planner derives the right output-column names.  For example:

--- a/code/packages/python/mini-sqlite/tests/test_tier3_recursive_cte_values_anchor.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_recursive_cte_values_anchor.py
@@ -1,0 +1,142 @@
+"""Tests for ``WITH RECURSIVE … AS (VALUES(…) UNION ALL SELECT …)``.
+
+Previously mini-sqlite raised
+``ProgrammingError: expected child rule 'select_stmt' under query_stmt``
+when the anchor of a recursive CTE was a ``VALUES`` expression rather
+than a ``SELECT`` statement.  The canonical "count from N" pattern is::
+
+    WITH RECURSIVE c(n) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT n + 1 FROM c WHERE n < 5
+    )
+    SELECT n FROM c
+
+The adapter now accepts a ``values_stmt`` child as the anchor for the
+recursive branch.  Single-row VALUES translates directly to a
+``SelectStmt`` (which is what ``RecursiveCTERef.anchor`` expects).
+Multi-row VALUES anchors are rejected with a clear error pointing
+users to the ``SELECT … UNION ALL SELECT …`` rewrite — the planner's
+recursive-CTE anchor path requires a single SELECT.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(*stmts: str, query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestBasic:
+    def test_count_one_to_five(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE c(n) AS ("
+                "  VALUES(1)"
+                "  UNION ALL"
+                "  SELECT n + 1 FROM c WHERE n < 5"
+                ") SELECT n FROM c"
+            ),
+        )
+
+    def test_count_zero_to_three(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE c(n) AS ("
+                "  VALUES(0)"
+                "  UNION ALL"
+                "  SELECT n + 1 FROM c WHERE n < 3"
+                ") SELECT n FROM c ORDER BY n"
+            ),
+        )
+
+
+class TestMultiColumnAnchor:
+    def test_two_column_anchor(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE pair(a, b) AS ("
+                "  VALUES(1, 10)"
+                "  UNION ALL"
+                "  SELECT a + 1, b * 2 FROM pair WHERE a < 4"
+                ") SELECT a, b FROM pair"
+            ),
+        )
+
+    def test_three_column_anchor(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE t(a, b, c) AS ("
+                "  VALUES(1, 2, 3)"
+                "  UNION ALL"
+                "  SELECT a + 1, b + 1, c + 1 FROM t WHERE a < 3"
+                ") SELECT a, b, c FROM t"
+            ),
+        )
+
+
+class TestUnionVariants:
+    def test_union_all(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE c(n) AS ("
+                "  VALUES(1)"
+                "  UNION ALL"
+                "  SELECT n + 1 FROM c WHERE n < 4"
+                ") SELECT n FROM c"
+            ),
+        )
+
+    def test_union_distinct(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE c(n) AS ("
+                "  VALUES(1)"
+                "  UNION"
+                "  SELECT n + 1 FROM c WHERE n < 3"
+                ") SELECT n FROM c"
+            ),
+        )
+
+
+class TestSelectAnchorStillWorks:
+    """Regression: pre-existing SELECT-anchor recursion must keep working."""
+
+    def test_select_anchor(self) -> None:
+        _both_match(
+            query=(
+                "WITH RECURSIVE c(n) AS ("
+                "  SELECT 1"
+                "  UNION ALL"
+                "  SELECT n + 1 FROM c WHERE n < 4"
+                ") SELECT n FROM c"
+            ),
+        )
+
+
+class TestMultiRowAnchorRejection:
+    """Multi-row VALUES anchor should fail with a clear, actionable error."""
+
+    def test_multi_row_values_anchor_rejected(self) -> None:
+        import pytest
+
+        from mini_sqlite import errors as mini_errors
+
+        mini = mini_sqlite.connect(":memory:")
+        with pytest.raises(mini_errors.ProgrammingError, match="multi-row VALUES"):
+            mini.execute(
+                "WITH RECURSIVE c(n) AS ("
+                "  VALUES(1), (2)"
+                "  UNION ALL"
+                "  SELECT n + 1 FROM c WHERE n < 5"
+                ") SELECT n FROM c"
+            )


### PR DESCRIPTION
## Summary

- Fixes `ProgrammingError: expected child rule 'select_stmt' under query_stmt` on the canonical SQLite `WITH RECURSIVE c(n) AS (VALUES(1) UNION ALL SELECT n+1 FROM c WHERE n < 5) SELECT n FROM c` pattern.
- Extends the recursive-CTE branch of `_query_stmt` to recognize a `values_stmt` anchor and build it via `_values_stmt` (single-row VALUES → `SelectStmt`, the shape `RecursiveCTERef.anchor` expects).
- Multi-row VALUES anchors are rejected with a clear pointer to the `SELECT … UNION ALL SELECT …` rewrite — the planner expects a single SELECT.

## Version bumps

- `mini-sqlite`: 2.3 → 2.4

## Test plan

- [x] 8 new oracle tests pass against sqlite3 (single/multi-column anchors, UNION ALL + UNION distinct, SELECT-anchor regression, multi-row rejection)
- [x] mini-sqlite suite (2187 tests) clean
- [x] Ruff clean
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)