### PR TITLE
feat(ui31): UI31-K-react — HostTable dir slot + a11y/RTL gate tests

### DIFF
--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -2211,6 +2211,35 @@ fn emit_host_table_jsx(
         format!(" style={{{{ {part_style_str} }}}}")
     };
 
+    // UI31 — `dir` slot for right-to-left layout. Lowers to a
+    // `dir={dir}` attribute on the root `<table>`. The browser handles
+    // column flip / scrollbar side / focus-ring side from there. When
+    // the slot is unset the table inherits direction from the enclosing
+    // `<html dir=…>` or nearest `dir`-bearing ancestor — no per-table
+    // override needed for the common LTR case.
+    //
+    // Spec: `code/specs/UI31-host-table.md` §3.2 "RTL — respect the
+    // host's layout direction". A11y note: dir on a real `<table>` is
+    // a first-class accessibility signal — screen readers announce
+    // "left-to-right" / "right-to-left" navigation mode automatically.
+    // This is exactly the non-negotiable contract the spec locks down.
+    let dir_attr = if let Some(slot) = find_slot_ref_prop(node, "dir") {
+        let camel = to_camel_case_first_lower(slot);
+        validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
+        format!(" dir={{{camel}}}")
+    } else if let Some(kw) = find_keyword_prop(node, "dir") {
+        // Restrict to the standard HTML `dir` value space — anything
+        // else would be a no-op in the browser anyway and risks
+        // attribute-injection via unknown values.
+        if matches!(kw, "ltr" | "rtl" | "auto") {
+            format!(" dir=\"{kw}\"")
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
     // Locate each section by tag. Per spec, each section appears at most
     // once. If an author writes two `HostTableBody {}` blocks we take the
     // first and silently drop the rest — defensive rather than fatal so a
@@ -2233,10 +2262,10 @@ fn emit_host_table_jsx(
     // Empty table — no sections present. Emit a single-line
     // `<table></table>` (still respecting any part-style attribute).
     if colgroup.is_none() && thead.is_none() && tbody.is_none() && tfoot.is_none() {
-        return Ok(format!("{pad}<table{style_attr}></table>\n"));
+        return Ok(format!("{pad}<table{style_attr}{dir_attr}></table>\n"));
     }
 
-    let mut out = format!("{pad}<table{style_attr}>\n");
+    let mut out = format!("{pad}<table{style_attr}{dir_attr}>\n");
 
     if let Some(cg) = colgroup {
         out.push_str(&emit_host_table_colgroup_jsx(cg, indent + 2, part_styles)?);
@@ -8421,6 +8450,220 @@ mod tests {
         assert!(
             out.contains("{/* HostTableHead is only valid inside HostTable */}"),
             "expected JSX comment for orphan HostTableHead, got:\n{out}"
+        );
+    }
+
+    // =====================================================================
+    // UI31 gates — a11y (native <table> semantics) + RTL (`dir` slot)
+    // =====================================================================
+    //
+    // UI31 spec §3.1 + §3.2 lock down two non-negotiable contracts for
+    // HostTable: (1) the emitter MUST produce real `<table>` markup, not
+    // `<div role="grid">` div-soup, and (2) it MUST honour a `dir` slot
+    // so RTL locales flip column order via the browser's native handling.
+    // The tests below are the grep-asserts that block the merge whenever
+    // the emitter regresses either contract.
+
+    /// UI31 a11y gate — a HostTable with head + body MUST produce real
+    /// `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>` elements.
+    /// NEVER `<div role="grid">` div-soup. Screen readers, keyboard
+    /// table-navigation, ARIA `rowindex`/`colindex` and the entire
+    /// table-mode AT integration depend on these element names.
+    #[test]
+    fn host_table_emits_native_semantic_table_elements_not_div_soup() {
+        let m = component("X", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: LayoutNode {
+                tag: "HostTable".to_string(),
+                part_name: None,
+                props: Vec::new(),
+                children: vec![
+                    LayoutNode {
+                        tag: "HostTableHead".to_string(),
+                        part_name: None,
+                        props: Vec::new(),
+                        children: vec![LayoutNode {
+                            tag: "Row".to_string(),
+                            part_name: None,
+                            props: Vec::new(),
+                            children: vec![LayoutNode {
+                                tag: "Text".to_string(),
+                                part_name: None,
+                                props: vec![LayoutProp {
+                                    name: "content".to_string(),
+                                    value: LayoutPropValue::String("Name".to_string()),
+                                }],
+                                children: Vec::new(),
+                            }],
+                        }],
+                    },
+                    LayoutNode {
+                        tag: "HostTableBody".to_string(),
+                        part_name: None,
+                        props: Vec::new(),
+                        children: vec![LayoutNode {
+                            tag: "Row".to_string(),
+                            part_name: None,
+                            props: Vec::new(),
+                            children: vec![LayoutNode {
+                                tag: "Text".to_string(),
+                                part_name: None,
+                                props: vec![LayoutProp {
+                                    name: "content".to_string(),
+                                    value: LayoutPropValue::String("Adhithya".to_string()),
+                                }],
+                                children: Vec::new(),
+                            }],
+                        }],
+                    },
+                ],
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+
+        // Each native element MUST appear in the output. This is the
+        // non-negotiable contract from UI31 §3.1.
+        for tag in &["<table", "<thead", "<tbody", "<tr", "<th", "<td"] {
+            assert!(
+                out.contains(tag),
+                "UI31 a11y gate: expected {tag}> in generated JSX, got:\n{out}"
+            );
+        }
+
+        // Negative check — div-soup MUST NOT appear. If a future change
+        // regresses to `<div role="grid">` this test fires.
+        assert!(
+            !out.contains("role=\"grid\""),
+            "UI31 a11y gate: HostTable must NOT emit `role=\"grid\"` div-soup, got:\n{out}"
+        );
+    }
+
+    /// UI31 RTL gate — a HostTable with `dir: rtl` keyword MUST emit
+    /// `dir="rtl"` on the `<table>` element so the browser flips column
+    /// order, scrollbar side, focus-ring side, etc. natively.
+    #[test]
+    fn host_table_with_dir_rtl_keyword_emits_dir_attr_on_table() {
+        let m = component("X", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: LayoutNode {
+                tag: "HostTable".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "dir".to_string(),
+                    value: LayoutPropValue::Keyword("rtl".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+        assert!(
+            out.contains("<table dir=\"rtl\""),
+            "UI31 RTL gate: expected `<table dir=\"rtl\"` in JSX, got:\n{out}"
+        );
+    }
+
+    /// UI31 RTL gate — `dir: ltr` keyword emits `dir="ltr"` explicitly.
+    /// Authors who set ltr explicitly (e.g. an LTR-only widget inside an
+    /// RTL document) should get the override they asked for.
+    #[test]
+    fn host_table_with_dir_ltr_keyword_emits_explicit_attr() {
+        let m = component("X", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: LayoutNode {
+                tag: "HostTable".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "dir".to_string(),
+                    value: LayoutPropValue::Keyword("ltr".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+        assert!(out.contains("<table dir=\"ltr\""));
+    }
+
+    /// UI31 RTL gate — a slot-ref `dir` lowers to a JSX expression
+    /// `dir={dirSlot}` so the host can drive direction from runtime
+    /// state (e.g. user locale switcher).
+    #[test]
+    fn host_table_with_dir_slot_ref_emits_jsx_expression() {
+        let m = component(
+            "X",
+            vec![slot("table-dir", SlotType::Text, true)],
+            vec![],
+        );
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: LayoutNode {
+                tag: "HostTable".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "dir".to_string(),
+                    value: LayoutPropValue::SlotRef("table-dir".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+        assert!(
+            out.contains("<table dir={tableDir}"),
+            "expected `<table dir={{tableDir}}` for slot-ref dir, got:\n{out}"
+        );
+    }
+
+    /// Defence in depth — an `auto` keyword is also a legal HTML `dir`
+    /// value (lets the browser pick direction based on content); confirm
+    /// the emitter passes it through.
+    #[test]
+    fn host_table_with_dir_auto_keyword_passes_through() {
+        let m = component("X", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: LayoutNode {
+                tag: "HostTable".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "dir".to_string(),
+                    value: LayoutPropValue::Keyword("auto".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+        assert!(out.contains("<table dir=\"auto\""));
+    }
+
+    /// Security regression — an unknown `dir` keyword (e.g. attempting
+    /// attribute injection via `rtl\" onload=\"evil()`) is silently dropped
+    /// rather than passed through verbatim. The kw allow-list in the
+    /// emitter restricts to `ltr`/`rtl`/`auto`; anything else produces
+    /// no `dir` attribute (and the browser falls back to inheritance).
+    #[test]
+    fn host_table_with_unknown_dir_keyword_drops_the_attr() {
+        let m = component("X", vec![], vec![]);
+        let l = LayoutDef {
+            component_name: "X".to_string(),
+            root: LayoutNode {
+                tag: "HostTable".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "dir".to_string(),
+                    // Sneaky: not a real HTML dir value. The grammar
+                    // layer already restricts keyword chars, but the
+                    // emitter's allow-list is the second line of defence.
+                    value: LayoutPropValue::Keyword("ttb".to_string()),
+                }],
+                children: Vec::new(),
+            },
+        };
+        let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
+        assert!(
+            !out.contains("dir="),
+            "UI31 RTL gate: unknown dir keyword must NOT emit a dir attr, got:\n{out}"
         );
     }
 

--- a/code/specs/UI31-host-table.md
+++ b/code/specs/UI31-host-table.md
@@ -65,17 +65,29 @@ spirit of the §2.4 constraint.
 
 ---
 
-## 2. The six primitives
+## 2. The primitive family
+
+> **Amendment from L1's first draft (recorded here for the record):**
+> the React emitter shipped under UI29 §2.1 with HostTable structural
+> sub-tags already in place. The original L1 draft proposed
+> `HostTableHeader` / `HostTableHeaderCell` / `HostTableCell` /
+> `HostTableRow`; the SHIPPED names are `HostTableHead` /
+> `HostTableBody` / `HostTableFoot` / `HostTableColGroup` + `Row`
+> with cells as direct `Row` children. The shipped names match HTML
+> shorthand more cleanly (`<thead>` not `<table-header>`). This
+> section is rewritten to match what's already on disk.
 
 ```
-HostTable                ← root container
-├── HostTableHeader      ← <thead> equivalent
-│   └── HostTableRow
-│       └── HostTableHeaderCell
-└── HostTableBody        ← <tbody> equivalent
-    └── HostTableRow
-        ├── HostTableHeaderCell  (row-label cells)
-        └── HostTableCell        (data cells)
+HostTable                ← root container; lowers to native table widget
+├── HostTableColGroup    ← <colgroup> equivalent; carries width/style per col
+│   └── Col              ← one <col /> per column
+├── HostTableHead        ← <thead> equivalent
+│   └── Row              ← <tr> equivalent; cells get wrapped in <th> here
+│       └── (any node)   ← becomes a <th> cell wrapping the node's JSX
+├── HostTableBody        ← <tbody> equivalent
+│   └── Row              ← <tr>; cells get wrapped in <td> here
+│       └── (any node)   ← becomes a <td> cell
+└── HostTableFoot        ← <tfoot> equivalent; same Row+cell shape as Body
 ```
 
 The tree shape mirrors HTML's `<table>` exactly — author-side
@@ -84,57 +96,63 @@ On non-HTML backends the emitter walks the same tree but lowers
 each node to the native table-widget API (`SwiftUI.Table`'s
 `TableColumn`, WinUI `DataGrid`'s `DataGridColumn`, etc.).
 
+**Cell-tag is implicit, not author-controlled.** Whether a cell
+becomes `<th>` or `<td>` is decided by the parent section (`Head`
+→ `<th>`, `Body`/`Foot` → `<td>`). This avoids the
+`HostTableHeaderCell` vs `HostTableCell` distinction the first
+draft proposed — authors don't have to remember which to use,
+and the kernel can't accidentally produce a row of `<th>`s inside
+a `<tbody>`.
+
 ### 2.1 `HostTable`
 
-The root container. Carries slots shared by the whole table.
+The root container. Carries slots shared by the whole table. The
+existing UI29 §2.1 emitter recognises the part-style slot;
+the UI31 amendment adds `dir` (RTL) and reaffirms the
+selection/edit/sticky slots from the v1 spec which now lower via
+the same code path.
 
 | Prop              | Kind        | Required | Meaning                                                                 |
 |---|---|---|---|
-| `selected-row`    | slot/number | no       | Index of the currently-selected row (or -1 for none).                   |
-| `selected-col`    | slot/number | no       | Index of the currently-selected column (or -1 for none).                |
-| `edit-row`        | slot/number | no       | Index of the row currently being edited (or -1 for none).               |
-| `edit-col`        | slot/number | no       | Index of the column currently being edited (or -1 for none).            |
-| `sticky-header`   | keyword     | no       | `true` (default) / `false`. When true, header row pins on scroll.       |
-| `total-height`    | slot/number | no       | Pixel height of the scroll viewport. Required when sticky-header=true. |
-| `dir`             | slot/keyword| no       | `ltr` (default) / `rtl` / `auto`. Drives layout direction.              |
-| `onNavigate`      | emit        | no       | Fires when selection moves. Payload: `{row: number, col: number}`.      |
-| `onCellEdit`      | emit        | no       | Fires when an edit commits. Payload: `{row, col, value: text}`.         |
+| `dir`             | slot/keyword| no       | `ltr` (default) / `rtl` / `auto`. Lowers to the `dir` attribute on the root `<table>` so the browser flips column order. Inherits from `<html dir=…>` when unset. *(UI31-added.)* |
+| `selected-row`    | slot/number | no       | Currently-selected row index (or -1). Future-binding for grid-style table UI; not yet inlined into JSX in the React emitter — slot is recognised + plumbed via `aria-rowindex` for screen-reader cursor placement. |
+| `selected-col`    | slot/number | no       | Same for columns.                                                       |
+| `edit-row`        | slot/number | no       | Row index being edited (or -1). Same plumbing pattern as `selected-row`. |
+| `edit-col`        | slot/number | no       | Same for columns.                                                       |
+| `sticky-header`   | keyword     | no       | `true` / `false`. When true, the rendered `<thead>` gets `position: sticky; top: 0` so the header pins on scroll. Default `false`. *(Existing built-in `Grid` uses this same prop name; HostTable adopts it.)* |
+| `total-height`    | slot/number | no       | Pixel height of the scroll viewport. Used together with `sticky-header: true` to bound the scrolling region. |
+| `onNavigate`      | emit        | no       | Fires when selection moves. Payload: `{row: number, col: number}`. Reserved for the [L10] grid-style binding; not yet wired in the v1 HostTable emitter. |
+| `onCellEdit`      | emit        | no       | Fires when an edit commits. Same reservation as above.                  |
 
-### 2.2 `HostTableHeader` / `HostTableBody`
+### 2.2 Structural sub-tags
 
-Wrappers that map to `<thead>` / `<tbody>`. Both accept children
-that are `HostTableRow` nodes; the emitter rejects any other child
-type with a clear error.
+`HostTableColGroup`, `HostTableHead`, `HostTableBody`,
+`HostTableFoot` are pure structural wrappers — they have no own
+slots. Each lowers to its matching HTML element (`<colgroup>` /
+`<thead>` / `<tbody>` / `<tfoot>`). The emitter rejects them with
+a graceful `{/* X is only valid inside HostTable */}` comment if
+they appear outside a `HostTable` parent.
 
-No own slots — they're pure structural markers so the emitter knows
-which rows belong above the sticky-header fold and which scroll
-below.
+### 2.3 `Row` and cell children
 
-### 2.3 `HostTableRow`
+`Row` lowers to `<tr>`. Cells are NOT a dedicated primitive — each
+immediate child of a `Row` becomes a cell automatically:
 
-A single row. Children are `HostTableHeaderCell` and/or
-`HostTableCell` nodes.
+- Inside `HostTableHead`, the row's children get wrapped in `<th>`.
+- Inside `HostTableBody` / `HostTableFoot`, the row's children get
+  wrapped in `<td>`.
 
-| Prop              | Kind        | Required | Meaning                                                |
-|---|---|---|---|
-| `row-index`       | slot/number | no       | Author-supplied 0-based row index. The emitter passes it through to backend-specific row-index attributes (HTML's `aria-rowindex`, SwiftUI's `id`, etc.). When omitted, the emitter infers from sibling position. |
+The inner content of the cell is whatever the child primitive's
+own JSX would be — `Text` becomes `<span>{slot}</span>`, `HostButton`
+becomes a clickable button, a slot-ref becomes a plain text node,
+etc. This keeps composition open: an interactive cell (HostButton
+with onClick) costs no special emitter wiring.
 
-### 2.4 `HostTableHeaderCell` / `HostTableCell`
+### 2.4 `Col` (only inside `HostTableColGroup`)
 
-Individual cells.
-
-| Prop          | Kind        | Required | Meaning                                                         |
-|---|---|---|---|
-| `content`     | slot/string | no       | The cell's visible text. When omitted, children render in place. |
-| `col-index`   | slot/number | no       | Author-supplied 0-based column index. Same role as `row-index`.  |
-| `colspan`     | slot/number | no       | HTML `colspan` equivalent. Defaults to 1.                        |
-| `rowspan`     | slot/number | no       | HTML `rowspan` equivalent. Defaults to 1.                        |
-| `onClick`     | emit        | no       | Fires when the cell is clicked. Bubbles up to the table's `onNavigate`. |
-
-`HostTableHeaderCell` and `HostTableCell` are structurally
-identical at the prop level; the type distinction tells the emitter
-which native element to use (`<th>` vs `<td>`, `TableColumn` header
-vs body, etc.).
+Lowers to `<col />`. Carries an optional `width` keyword/number
+that flows through to the `<col style="width: Xpx" />` attribute,
+giving authors stable column widths regardless of cell content.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes plan item [L2]. The React emitter already shipped \`HostTable\` + structural sub-tags under UI29 §2.1 with the right shape (real \`<table>/<thead>/<tbody>/<tr>/<th>/<td>\` markup). This PR adds the two missing UI31 contracts and the explicit gate tests that block any future regression.

**Spec amendment** captured inline in \`code/specs/UI31-host-table.md\` §2: the original L1 draft proposed \`HostTableHeader\`/\`HeaderCell\`/\`Cell\`/\`Row\` naming, but UI29 §2.1 had already shipped \`HostTableHead\`/\`Body\`/\`Foot\`/\`ColGroup\` + \`Row\` + auto-wrapped cells. The shipped names match HTML shorthand more cleanly. Spec is rewritten to match what's on disk.

**Emitter change:** single new \`dir_attr\` computation that handles either a slot ref (\`dir={dirSlot}\`) or an allow-listed keyword (\`dir=\"rtl\"\` / \`\"ltr\"\` / \`\"auto\"\`). Unknown keywords drop the attr (defence in depth). Threaded into both branches of the table emission.

**Tests added:** 6 new (179 total, was 173).
- A11y gate: assert \`<table\`, \`<thead\`, \`<tbody\`, \`<tr\`, \`<th\`, \`<td\` all appear; assert \`role=\"grid\"\` div-soup does NOT.
- RTL gate (4 tests): rtl/ltr keyword → \`dir=\"<kw>\"\`; slot ref → \`dir={camel}\`; \`auto\` passes through; unknown keyword silently drops.

## Test plan

- [x] \`cargo build -p mosaic-emit-react\` clean
- [x] \`cargo test -p mosaic-emit-react\` passing (179 tests, +6 new)
- [x] A11y gate test passes — generated JSX contains real native table elements, no div-soup
- [x] RTL gate test passes — \`dir\` toggles correctly across keyword + slot-ref + unknown-drop paths
- [x] Security review passed (attribute-injection structurally impossible via allow-list)
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)