### PR TITLE
feat(mini-sqlite): support CURRENT_DATE / CURRENT_TIME / CURRENT_TIMESTAMP

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [2.5.0] - 2026-05-23
+
+### Added
+
+- ``CURRENT_DATE``, ``CURRENT_TIME``, and ``CURRENT_TIMESTAMP`` SQL
+  keyword expressions are now supported, matching SQLite::
+
+      CURRENT_DATE      ⟶  'YYYY-MM-DD'             (10 chars)
+      CURRENT_TIME      ⟶  'HH:MM:SS'               (8  chars)
+      CURRENT_TIMESTAMP ⟶  'YYYY-MM-DD HH:MM:SS'    (19 chars)
+
+  Previously these raised ``OperationalError: unknown column:
+  'CURRENT_TIMESTAMP'`` because the SQL token grammar doesn't list
+  them as keywords — the lexer emits them as bare NAME tokens, and
+  the planner couldn't resolve any matching column.
+
+  Implementation: the adapter's ``_column_ref_to_expr`` intercepts
+  single-name column refs whose value (case-insensitive) matches
+  ``CURRENT_DATE`` / ``CURRENT_TIME`` / ``CURRENT_TIMESTAMP`` and
+  rewrites them to the equivalent scalar-function call
+  (``date('now')`` / ``time('now')`` / ``datetime('now')``) — both
+  paths already implemented in the VM.
+
+### Known limitation
+
+- A column literally named ``CURRENT_DATE`` (or ``CURRENT_TIME`` /
+  ``CURRENT_TIMESTAMP``) is shadowed by the keyword even when
+  referenced via the double-quoted form (e.g.
+  ``SELECT "CURRENT_DATE" FROM t``).  SQLite distinguishes the two
+  cases because it preserves the "was quoted" flag through tokenization;
+  mini-sqlite's lexer post-processing strips quotes from quoted
+  identifiers and loses that distinction.  Workaround: don't name
+  columns after SQL keyword expressions.  Tracked for follow-up if
+  it ever bites a real user.
+
 ## [2.4.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.4.0"
+version = "2.5.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -2703,10 +2703,36 @@ def _case_expr(node: ASTNode, state: _PlaceholderCounter) -> CaseExpr:
     return CaseExpr(whens=tuple(whens), else_=else_expr)
 
 
-def _column_ref_to_expr(node: ASTNode) -> Column:
+_CURRENT_TIME_KEYWORDS: dict[str, str] = {
+    "CURRENT_DATE": "date",
+    "CURRENT_TIME": "time",
+    "CURRENT_TIMESTAMP": "datetime",
+}
+
+
+def _column_ref_to_expr(node: ASTNode) -> Expr:
     # column_ref = NAME [ "." NAME ]
     names = [c for c in node.children if isinstance(c, Token) and _token_type(c) == "NAME"]
     if len(names) == 1:
+        # ``CURRENT_DATE``, ``CURRENT_TIME``, ``CURRENT_TIMESTAMP`` are SQL
+        # *expressions* (no parentheses), not column references, yet the
+        # lexer tokenises them as plain NAME tokens because the SQL token
+        # grammar doesn't list them as keywords.  Intercept the bare-name
+        # case here and rewrite to the equivalent scalar-function call —
+        # ``date('now')`` / ``time('now')`` / ``datetime('now')`` — which
+        # the sql-vm backend already implements.
+        #
+        # Matching is case-insensitive (SQLite accepts ``current_date``,
+        # ``Current_Date``, …).  Once rewritten, the planner / codegen /
+        # VM see a perfectly normal ``FunctionCall`` and don't need to
+        # know anything special about these keywords.
+        upper = names[0].value.upper()
+        fn = _CURRENT_TIME_KEYWORDS.get(upper)
+        if fn is not None:
+            return FunctionCall(
+                name=fn,
+                args=(FuncArg(value=Literal(value="now")),),
+            )
         return Column(table=None, col=names[0].value)
     return Column(table=names[0].value, col=names[1].value)
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_current_date_time.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_current_date_time.py
@@ -1,0 +1,146 @@
+"""Tests for ``CURRENT_DATE`` / ``CURRENT_TIME`` / ``CURRENT_TIMESTAMP``.
+
+SQLite recognises these three identifiers (case-insensitive) as
+*expressions* — not column references and not function calls — that
+return the current UTC date/time::
+
+    CURRENT_DATE      ⟶  'YYYY-MM-DD'                (10 chars)
+    CURRENT_TIME      ⟶  'HH:MM:SS'                  (8  chars)
+    CURRENT_TIMESTAMP ⟶  'YYYY-MM-DD HH:MM:SS'       (19 chars)
+
+Mini-sqlite previously failed with ``unknown column: 'CURRENT_DATE'``
+because the lexer emits these as bare NAME tokens (the SQL token
+grammar doesn't list them as keywords).  The adapter now intercepts
+single-name ``column_ref`` nodes whose name matches one of the three
+and rewrites them to the equivalent scalar-function call
+(``date('now')`` / ``time('now')`` / ``datetime('now')``) — both
+already implemented in the VM.
+
+The exact wallclock value naturally differs each run, so these tests
+focus on **shape** (length, format) rather than equality with sqlite3.
+A few cross-checks against sqlite3 confirm format compatibility, and
+the keyword path is verified in expression position (SELECT list,
+WHERE clause, CASE branch).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+
+import mini_sqlite
+
+
+def _connect() -> mini_sqlite.Connection:
+    return mini_sqlite.connect(":memory:")
+
+
+class TestShape:
+    """Lengths and format strings match SQLite's documented spec."""
+
+    def test_current_date_length(self) -> None:
+        assert _connect().execute("SELECT length(CURRENT_DATE)").fetchall() == [(10,)]
+
+    def test_current_time_length(self) -> None:
+        assert _connect().execute("SELECT length(CURRENT_TIME)").fetchall() == [(8,)]
+
+    def test_current_timestamp_length(self) -> None:
+        assert _connect().execute(
+            "SELECT length(CURRENT_TIMESTAMP)"
+        ).fetchall() == [(19,)]
+
+    def test_current_date_format(self) -> None:
+        (val,) = _connect().execute("SELECT CURRENT_DATE").fetchall()[0]
+        assert isinstance(val, str)
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", val) is not None, val
+
+    def test_current_time_format(self) -> None:
+        (val,) = _connect().execute("SELECT CURRENT_TIME").fetchall()[0]
+        assert isinstance(val, str)
+        assert re.fullmatch(r"\d{2}:\d{2}:\d{2}", val) is not None, val
+
+    def test_current_timestamp_format(self) -> None:
+        (val,) = _connect().execute("SELECT CURRENT_TIMESTAMP").fetchall()[0]
+        assert isinstance(val, str)
+        assert (
+            re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", val) is not None
+        ), val
+
+
+class TestCaseInsensitive:
+    """SQL is case-insensitive for unquoted identifiers — all three spellings work."""
+
+    def test_lowercase(self) -> None:
+        assert _connect().execute(
+            "SELECT length(current_timestamp)"
+        ).fetchall() == [(19,)]
+
+    def test_mixed_case(self) -> None:
+        assert _connect().execute(
+            "SELECT length(Current_Date)"
+        ).fetchall() == [(10,)]
+
+
+class TestInExpressionContext:
+    def test_in_where_clause(self) -> None:
+        # Always-true predicate just confirms the keyword evaluates to a
+        # comparable string — not the actual date.
+        assert _connect().execute(
+            "SELECT 1 WHERE CURRENT_DATE >= '2000-01-01'"
+        ).fetchall() == [(1,)]
+
+    def test_in_case_branch(self) -> None:
+        assert _connect().execute(
+            "SELECT CASE WHEN CURRENT_DATE >= '2000-01-01' THEN 'ok' END"
+        ).fetchall() == [("ok",)]
+
+    def test_in_strftime(self) -> None:
+        (val,) = _connect().execute(
+            "SELECT strftime('%Y', CURRENT_DATE)"
+        ).fetchall()[0]
+        assert isinstance(val, str)
+        assert re.fullmatch(r"\d{4}", val) is not None, val
+
+
+class TestSqliteFormatCompat:
+    """Format strings line up with sqlite3's — verified via length and shape."""
+
+    def test_dates_match_sqlite_format(self) -> None:
+        # Compare format only (not value — clocks differ on the microsecond
+        # boundary).  Both should produce the same length and the same
+        # number of dashes / colons / spaces.
+        mini_val = _connect().execute("SELECT CURRENT_TIMESTAMP").fetchall()[0][0]
+        ref_val = sqlite3.connect(":memory:").execute(
+            "SELECT CURRENT_TIMESTAMP"
+        ).fetchall()[0][0]
+        assert len(mini_val) == len(ref_val)
+        assert mini_val.count("-") == ref_val.count("-")
+        assert mini_val.count(":") == ref_val.count(":")
+        assert mini_val.count(" ") == ref_val.count(" ")
+
+
+class TestKnownLimitation:
+    """A user-created column literally named CURRENT_DATE is shadowed.
+
+    SQLite resolves bareword ``CURRENT_DATE`` to the keyword even when
+    a column with that exact name exists (the column is accessible only
+    via the double-quoted form ``"CURRENT_DATE"``).  Mini-sqlite
+    currently treats the double-quoted form the same way because the
+    lexer's post-processing strips quotes from quoted identifiers and
+    the adapter loses the "was quoted" distinction.  So this case
+    diverges from SQLite — the quoted reference also resolves to the
+    keyword.  Documented here so the divergence is visible.
+    """
+
+    def test_double_quoted_currentdate_diverges_from_sqlite(self) -> None:
+        # SQLite returns the stored column value ('hello').
+        # Mini-sqlite returns the date keyword value (today's date).
+        # This test pins the *current* mini-sqlite behaviour so we notice
+        # if a future fix unifies them.
+        m = _connect()
+        m.execute('CREATE TABLE t ("CURRENT_DATE" TEXT)')
+        m.execute("INSERT INTO t VALUES ('hello')")
+        (val,) = m.execute('SELECT "CURRENT_DATE" FROM t').fetchall()[0]
+        # Mini-sqlite returns today's date string, not 'hello'.
+        assert isinstance(val, str)
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", val) is not None, val


### PR DESCRIPTION
## Summary

- Adds SQLite's `CURRENT_DATE` / `CURRENT_TIME` / `CURRENT_TIMESTAMP` keyword expressions (no parens). Previously raised `OperationalError: unknown column: 'CURRENT_TIMESTAMP'`.
- Adapter's `_column_ref_to_expr` intercepts matching single-name column refs (case-insensitive) and rewrites them to `date('now')` / `time('now')` / `datetime('now')` — all already implemented in the VM.

## Version bumps

- `mini-sqlite`: 2.4 → 2.5

## Known limitation

A column literally named `CURRENT_DATE` is shadowed by the keyword even via `SELECT "CURRENT_DATE" FROM t` — mini-sqlite's lexer post-processing strips quotes and loses the "was quoted" distinction. Pinned by a regression test; documented in CHANGELOG.

## Test plan

- [x] 13 new oracle tests pass (length / format / case-insensitive / WHERE / CASE / strftime / sqlite3 format compat / known limitation)
- [x] mini-sqlite suite (2195 tests) clean
- [x] Ruff clean
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)