### PR TITLE
[codex] Add Board VM input callback transport bookmarks

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -205,6 +205,10 @@ boundaries without rebuilding checkpoint policy.
 transport cursor records with Rust-owned cursor names, labels, queue-depth
 metadata, and messages, so frontends can resume marked transport views without
 rebuilding marker policy.
+`input_callback_transport_bookmark_summary` saves those cursors as stable
+transport bookmark records with Rust-owned bookmark names, labels, queue-depth
+metadata, and messages, so frontends can restore callback transport positions
+without rebuilding cursor policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -1623,6 +1623,73 @@ pub struct LanguageInputCallbackTransportCursorSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportBookmarkKind {
+    CallbackRunnerHandoffBookmark,
+    AdapterEventPublicationBookmark,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportBookmarkSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub bookmark_label: String,
+    pub bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+    pub bookmark_name: String,
+    pub cursor_kind: LanguageInputCallbackTransportCursorKind,
+    pub cursor_name: String,
+    pub marker_kind: LanguageInputCallbackTransportMarkerKind,
+    pub marker_name: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub marker_recorded: bool,
+    pub cursor_recorded: bool,
+    pub bookmark_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_bookmark: u8,
+    pub message: String,
+    pub cursor_summary: LanguageInputCallbackTransportCursorSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -2279,6 +2346,19 @@ pub const fn input_callback_transport_cursor_kind_name(
         }
         LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor => {
             "adapter_event_publication_cursor"
+        }
+    }
+}
+
+pub const fn input_callback_transport_bookmark_kind_name(
+    kind: LanguageInputCallbackTransportBookmarkKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportBookmarkKind::CallbackRunnerHandoffBookmark => {
+            "callback_runner_handoff_bookmark"
+        }
+        LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark => {
+            "adapter_event_publication_bookmark"
         }
     }
 }
@@ -4145,6 +4225,72 @@ pub fn input_callback_transport_cursor_summary(
     }
 }
 
+pub fn input_callback_transport_bookmark_summary(
+    cursor_summary: &LanguageInputCallbackTransportCursorSummary,
+) -> LanguageInputCallbackTransportBookmarkSummary {
+    let bookmark_kind = input_callback_transport_bookmark_kind(cursor_summary.cursor_kind);
+
+    LanguageInputCallbackTransportBookmarkSummary {
+        endpoint: cursor_summary.endpoint.clone(),
+        connection_label: cursor_summary.connection_label.clone(),
+        bookmark_label: input_callback_transport_bookmark_label(cursor_summary, bookmark_kind),
+        bookmark_kind,
+        bookmark_name: input_callback_transport_bookmark_kind_name(bookmark_kind).to_owned(),
+        cursor_kind: cursor_summary.cursor_kind,
+        cursor_name: cursor_summary.cursor_name.clone(),
+        marker_kind: cursor_summary.marker_kind,
+        marker_name: cursor_summary.marker_name.clone(),
+        checkpoint_kind: cursor_summary.checkpoint_kind,
+        checkpoint_name: cursor_summary.checkpoint_name.clone(),
+        snapshot_kind: cursor_summary.snapshot_kind,
+        snapshot_name: cursor_summary.snapshot_name.clone(),
+        archive_kind: cursor_summary.archive_kind,
+        archive_name: cursor_summary.archive_name.clone(),
+        journal_kind: cursor_summary.journal_kind,
+        journal_name: cursor_summary.journal_name.clone(),
+        log_kind: cursor_summary.log_kind,
+        log_name: cursor_summary.log_name.clone(),
+        audit_kind: cursor_summary.audit_kind,
+        audit_name: cursor_summary.audit_name.clone(),
+        trace_kind: cursor_summary.trace_kind,
+        trace_name: cursor_summary.trace_name.clone(),
+        outcome_kind: cursor_summary.outcome_kind,
+        outcome_name: cursor_summary.outcome_name.clone(),
+        receipt_kind: cursor_summary.receipt_kind,
+        receipt_name: cursor_summary.receipt_name.clone(),
+        acknowledgement_kind: cursor_summary.acknowledgement_kind,
+        acknowledgement_name: cursor_summary.acknowledgement_name.clone(),
+        delivery_route: cursor_summary.delivery_route,
+        delivery_route_name: cursor_summary.delivery_route_name.clone(),
+        event_kind: cursor_summary.event_kind,
+        event_name: cursor_summary.event_name.clone(),
+        report_kind: cursor_summary.report_kind,
+        report_name: cursor_summary.report_name.clone(),
+        action: cursor_summary.action,
+        action_name: cursor_summary.action_name.clone(),
+        callback_runner_handoff: cursor_summary.callback_runner_handoff,
+        adapter_event_published: cursor_summary.adapter_event_published,
+        delivery_acknowledged: cursor_summary.delivery_acknowledged,
+        receipt_recorded: cursor_summary.receipt_recorded,
+        outcome_recorded: cursor_summary.outcome_recorded,
+        trace_recorded: cursor_summary.trace_recorded,
+        audit_recorded: cursor_summary.audit_recorded,
+        log_recorded: cursor_summary.log_recorded,
+        journal_recorded: cursor_summary.journal_recorded,
+        archive_recorded: cursor_summary.archive_recorded,
+        snapshot_recorded: cursor_summary.snapshot_recorded,
+        checkpoint_recorded: cursor_summary.checkpoint_recorded,
+        marker_recorded: cursor_summary.marker_recorded,
+        cursor_recorded: cursor_summary.cursor_recorded,
+        bookmark_recorded: true,
+        terminal: cursor_summary.terminal,
+        retryable: cursor_summary.retryable,
+        queue_depth_after_bookmark: cursor_summary.queue_depth_after_cursor,
+        message: input_callback_transport_bookmark_message(bookmark_kind).to_owned(),
+        cursor_summary: cursor_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -5923,6 +6069,44 @@ fn input_callback_transport_cursor_message(
         }
         LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor => {
             "Transport cursor should point at the adapter event publication marker."
+        }
+    }
+}
+
+fn input_callback_transport_bookmark_kind(
+    cursor_kind: LanguageInputCallbackTransportCursorKind,
+) -> LanguageInputCallbackTransportBookmarkKind {
+    match cursor_kind {
+        LanguageInputCallbackTransportCursorKind::CallbackRunnerHandoffCursor => {
+            LanguageInputCallbackTransportBookmarkKind::CallbackRunnerHandoffBookmark
+        }
+        LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor => {
+            LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark
+        }
+    }
+}
+
+fn input_callback_transport_bookmark_label(
+    cursor_summary: &LanguageInputCallbackTransportCursorSummary,
+    bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+) -> String {
+    format!(
+        "{} transport_bookmark={} bookmark_recorded=true queue_depth_after_bookmark={}",
+        cursor_summary.cursor_label,
+        input_callback_transport_bookmark_kind_name(bookmark_kind),
+        cursor_summary.queue_depth_after_cursor
+    )
+}
+
+fn input_callback_transport_bookmark_message(
+    bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+) -> &'static str {
+    match bookmark_kind {
+        LanguageInputCallbackTransportBookmarkKind::CallbackRunnerHandoffBookmark => {
+            "Transport bookmark should save the callback-runner handoff cursor."
+        }
+        LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark => {
+            "Transport bookmark should save the adapter event publication cursor."
         }
     }
 }
@@ -14602,6 +14786,269 @@ mod tests {
             )
         );
         assert_eq!(dropped.marker_summary, dropped_marker);
+    }
+
+    #[test]
+    fn input_callback_transport_bookmarks_are_owned_by_rust_language_core() {
+        fn cursor_for_lifecycle(
+            lifecycle: &LanguageInputCallbackSessionLifecycleSummary,
+        ) -> LanguageInputCallbackTransportCursorSummary {
+            let action = input_callback_transport_action_summary(lifecycle);
+            let effect = input_callback_transport_effect_summary(&action);
+            let report = input_callback_transport_report_summary(&effect);
+            let event = input_callback_transport_event_summary(&report);
+            let delivery = input_callback_transport_delivery_summary(&event);
+            let acknowledgement = input_callback_transport_acknowledgement_summary(&delivery);
+            let receipt = input_callback_transport_receipt_summary(&acknowledgement);
+            let outcome = input_callback_transport_outcome_summary(&receipt);
+            let trace = input_callback_transport_trace_summary(&outcome);
+            let audit = input_callback_transport_audit_summary(&trace);
+            let log = input_callback_transport_log_summary(&audit);
+            let journal = input_callback_transport_journal_summary(&log);
+            let archive = input_callback_transport_archive_summary(&journal);
+            let snapshot = input_callback_transport_snapshot_summary(&archive);
+            let checkpoint = input_callback_transport_checkpoint_summary(&snapshot);
+            let marker = input_callback_transport_marker_summary(&checkpoint);
+            input_callback_transport_cursor_summary(&marker)
+        }
+
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_cursor = cursor_for_lifecycle(&completed_lifecycle);
+        let completed = input_callback_transport_bookmark_summary(&completed_cursor);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.bookmark_kind,
+            LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark
+        );
+        assert_eq!(
+            completed.bookmark_name,
+            "adapter_event_publication_bookmark"
+        );
+        assert_eq!(
+            completed.cursor_kind,
+            LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor
+        );
+        assert_eq!(completed.cursor_name, "adapter_event_publication_cursor");
+        assert_eq!(
+            completed.marker_kind,
+            LanguageInputCallbackTransportMarkerKind::AdapterEventPublicationMarker
+        );
+        assert_eq!(
+            completed.checkpoint_kind,
+            LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint
+        );
+        assert_eq!(
+            completed.snapshot_kind,
+            LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot
+        );
+        assert_eq!(
+            completed.archive_kind,
+            LanguageInputCallbackTransportArchiveKind::AdapterEventPublicationArchive
+        );
+        assert_eq!(
+            completed.journal_kind,
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        );
+        assert_eq!(
+            completed.log_kind,
+            LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog
+        );
+        assert_eq!(
+            completed.audit_kind,
+            LanguageInputCallbackTransportAuditKind::AdapterEventPublicationAudit
+        );
+        assert_eq!(
+            completed.trace_kind,
+            LanguageInputCallbackTransportTraceKind::AdapterEventPublicationTrace
+        );
+        assert_eq!(
+            completed.outcome_kind,
+            LanguageInputCallbackTransportOutcomeKind::AdapterEventPublicationRecorded
+        );
+        assert_eq!(
+            completed.receipt_kind,
+            LanguageInputCallbackTransportReceiptKind::AdapterEventPublication
+        );
+        assert_eq!(
+            completed.acknowledgement_kind,
+            LanguageInputCallbackTransportAcknowledgementKind::AdapterEventPublished
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.marker_recorded);
+        assert!(completed.cursor_recorded);
+        assert!(completed.bookmark_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_bookmark, 2);
+        assert_eq!(
+            completed.bookmark_label,
+            format!(
+                "{} transport_bookmark=adapter_event_publication_bookmark bookmark_recorded=true queue_depth_after_bookmark=2",
+                completed_cursor.cursor_label
+            )
+        );
+        assert_eq!(
+            completed.message,
+            "Transport bookmark should save the adapter event publication cursor."
+        );
+        assert_eq!(completed.cursor_summary, completed_cursor);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_cursor = cursor_for_lifecycle(&pending_lifecycle);
+        let pending = input_callback_transport_bookmark_summary(&pending_cursor);
+
+        assert_eq!(
+            pending.bookmark_kind,
+            LanguageInputCallbackTransportBookmarkKind::CallbackRunnerHandoffBookmark
+        );
+        assert_eq!(pending.bookmark_name, "callback_runner_handoff_bookmark");
+        assert_eq!(
+            pending.cursor_kind,
+            LanguageInputCallbackTransportCursorKind::CallbackRunnerHandoffCursor
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(pending.archive_recorded);
+        assert!(pending.snapshot_recorded);
+        assert!(pending.checkpoint_recorded);
+        assert!(pending.marker_recorded);
+        assert!(pending.cursor_recorded);
+        assert!(pending.bookmark_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_bookmark, 3);
+        assert_eq!(
+            pending.bookmark_label,
+            format!(
+                "{} transport_bookmark=callback_runner_handoff_bookmark bookmark_recorded=true queue_depth_after_bookmark=3",
+                pending_cursor.cursor_label
+            )
+        );
+        assert_eq!(
+            pending.message,
+            "Transport bookmark should save the callback-runner handoff cursor."
+        );
+        assert_eq!(pending.cursor_summary, pending_cursor);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_cursor = cursor_for_lifecycle(&dropped_lifecycle);
+        let dropped = input_callback_transport_bookmark_summary(&dropped_cursor);
+
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.bookmark_kind,
+            LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.marker_recorded);
+        assert!(dropped.cursor_recorded);
+        assert!(dropped.bookmark_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_bookmark, 1);
+        assert_eq!(
+            dropped.bookmark_label,
+            format!(
+                "{} transport_bookmark=adapter_event_publication_bookmark bookmark_recorded=true queue_depth_after_bookmark=1",
+                dropped_cursor.cursor_label
+            )
+        );
+        assert_eq!(dropped.cursor_summary, dropped_cursor);
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Add Rust-owned input callback transport bookmark kinds, names, labels, queue-depth metadata, and summary records layered over transport cursors.
- Carry the transport action/report/event/delivery/acknowledgement/receipt/outcome/trace/audit/log/journal/archive/snapshot/checkpoint/marker/cursor chain into bookmark summaries so language frontends can stay thin.
- Document the bookmark summary API in board-vm-language-core and cover callback-runner handoff plus adapter-event publication paths.

Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-bookmark cargo test -p board-vm-language-core
- bash BUILD (in code/packages/rust/board-vm-language-core)
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-bookmark cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Notes
- Started from origin/main 52e0fe6482b11852d986b5f65f734ffd6f3a2afc before committing.
- Removed generated code/packages/rust/Cargo.lock, code/packages/rust/build-plan.json, and build-plan.json before committing if present.
- The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.