### PR TITLE
Expand HTML parser browser form controls

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -341,8 +341,11 @@ def check_browser_content_node(
     errors: list[str],
 ) -> None:
     require_string(node_path, node, "role", errors)
-    for field in ("name", "text", "href", "src", "alt", "control_type"):
+    for field in ("name", "text", "href", "src", "alt", "control_type", "value"):
         require_optional_nullable_string(node_path, node, field, errors)
+    for field in ("disabled", "checked", "selected"):
+        require_optional_boolean(node_path, node, field, errors)
+    require_optional_string_list(node_path, node, "options", errors)
     require_object_list(node_path, node, "children", errors)
     for child_index, child in enumerate(object_list_items(node, "children")):
         check_browser_content_node(
@@ -386,8 +389,11 @@ def check_browser_render_node(
 ) -> None:
     require_string(node_path, node, "display", errors)
     require_string(node_path, node, "role", errors)
-    for field in ("name", "text", "href", "src", "alt", "control_type"):
+    for field in ("name", "text", "href", "src", "alt", "control_type", "value"):
         require_optional_nullable_string(node_path, node, field, errors)
+    for field in ("disabled", "checked", "selected"):
+        require_optional_boolean(node_path, node, field, errors)
+    require_optional_string_list(node_path, node, "options", errors)
     require_object_list(node_path, node, "children", errors)
     for child_index, child in enumerate(object_list_items(node, "children")):
         check_browser_render_node(
@@ -491,6 +497,16 @@ def require_boolean(
         errors.append(f"{path}.{field} must be a boolean")
 
 
+def require_optional_boolean(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    if field in data:
+        require_boolean(path, data, field, errors)
+
+
 def require_string_list(
     path: str,
     data: dict[str, Any],
@@ -500,6 +516,16 @@ def require_string_list(
     value = data.get(field)
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         errors.append(f"{path}.{field} must be a list of strings")
+
+
+def require_optional_string_list(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    if field in data:
+        require_string_list(path, data, field, errors)
 
 
 def require_object_list(

--- a/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
@@ -83,6 +83,11 @@ class HtmlFixtureSchemasTest(unittest.TestCase):
                                     "src": None,
                                     "alt": None,
                                     "control_type": None,
+                                    "value": None,
+                                    "disabled": False,
+                                    "checked": False,
+                                    "selected": False,
+                                    "options": [],
                                     "children": [],
                                 }
                             ],
@@ -122,6 +127,11 @@ class HtmlFixtureSchemasTest(unittest.TestCase):
                                     "src": None,
                                     "alt": None,
                                     "control_type": None,
+                                    "value": None,
+                                    "disabled": False,
+                                    "checked": False,
+                                    "selected": False,
+                                    "options": [],
                                     "children": [],
                                 }
                             ],

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -186,6 +186,9 @@ documented in this file.
   CSS-independent structural nodes for early browser rendering pipelines.
 - Browser-facing render tree input extraction now maps parsed body structure
   into stable default display categories for early layout pipelines.
+- Browser-facing document, content-tree, and render-tree projections now carry
+  richer form control metadata including values, checked/selected state,
+  disabled state, select options, and textarea values.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -65,6 +65,9 @@ The current parser surface includes:
   invisible nodes into a CSS-independent body structure for early rendering
 - browser-facing render tree input extraction that maps renderable content
   nodes into stable default display categories for early layout
+- browser-facing form control metadata for input values, disabled/checked/
+  selected state, select options, and textarea values across document,
+  content-tree, and render-tree projections
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources
@@ -347,6 +350,14 @@ assert_eq!(content_tree.children[1].role, "block");
 let render_tree = parse_browser_render_tree("<p>Hello <img src=logo.gif alt=Logo>").unwrap();
 assert_eq!(render_tree.children[0].display, "block");
 assert_eq!(render_tree.children[0].children[1].display, "inline-replaced");
+
+let form_tree = parse_browser_render_tree(
+    "<form><select><option value=one>One<option selected>Two</select></form>"
+).unwrap();
+let select = &form_tree.children[0].children[0];
+assert_eq!(select.control_type.as_deref(), Some("select"));
+assert_eq!(select.value.as_deref(), Some("Two"));
+assert_eq!(select.options, vec!["One".to_string(), "Two".to_string()]);
 
 match &document.children[0] {
     Node::Element(element) => assert_eq!(element.name, "html"),

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -871,6 +871,11 @@ pub struct BrowserContentNode {
     pub src: Option<String>,
     pub alt: Option<String>,
     pub control_type: Option<String>,
+    pub value: Option<String>,
+    pub disabled: bool,
+    pub checked: bool,
+    pub selected: bool,
+    pub options: Vec<String>,
     pub children: Vec<BrowserContentNode>,
 }
 
@@ -889,6 +894,11 @@ pub struct BrowserRenderNode {
     pub src: Option<String>,
     pub alt: Option<String>,
     pub control_type: Option<String>,
+    pub value: Option<String>,
+    pub disabled: bool,
+    pub checked: bool,
+    pub selected: bool,
+    pub options: Vec<String>,
     pub children: Vec<BrowserRenderNode>,
 }
 
@@ -1019,6 +1029,11 @@ impl BrowserRenderNode {
             src: content_node.src.clone(),
             alt: content_node.alt.clone(),
             control_type: content_node.control_type.clone(),
+            value: content_node.value.clone(),
+            disabled: content_node.disabled,
+            checked: content_node.checked,
+            selected: content_node.selected,
+            options: content_node.options.clone(),
             children: content_node
                 .children
                 .iter()
@@ -8126,6 +8141,11 @@ fn collect_browser_content_nodes(nodes: &[Node], output: &mut Vec<BrowserContent
                         src: None,
                         alt: None,
                         control_type: None,
+                        value: None,
+                        disabled: false,
+                        checked: false,
+                        selected: false,
+                        options: Vec::new(),
                         children: Vec::new(),
                     });
                 }
@@ -8164,6 +8184,11 @@ fn browser_content_node_for_element(element: &Element) -> Option<BrowserContentN
         src: browser_content_src(element),
         alt: element.attribute("alt").map(ToOwned::to_owned),
         control_type: browser_content_control_type(element),
+        value: browser_content_value(element),
+        disabled: element.attribute("disabled").is_some(),
+        checked: element.attribute("checked").is_some(),
+        selected: element.attribute("selected").is_some(),
+        options: browser_content_options(element),
         children,
     })
 }
@@ -8177,7 +8202,12 @@ fn browser_content_role(name: &str) -> Option<&'static str> {
         "img" => Some("image"),
         "br" | "wbr" => Some("line_break"),
         "form" => Some("form"),
+        "fieldset" => Some("form_group"),
+        "label" => Some("label"),
+        "legend" => Some("legend"),
         "input" | "button" | "select" | "textarea" => Some("control"),
+        "optgroup" => Some("option_group"),
+        "option" => Some("option"),
         "ul" | "ol" | "menu" | "dir" => Some("list"),
         "li" | "dt" | "dd" => Some("list_item"),
         "table" => Some("table"),
@@ -8203,7 +8233,6 @@ fn should_collect_browser_content_children(name: &str) -> bool {
             | "link"
             | "meta"
             | "param"
-            | "select"
             | "textarea"
             | "wbr"
     )
@@ -8211,10 +8240,9 @@ fn should_collect_browser_content_children(name: &str) -> bool {
 
 fn browser_content_text(element: &Element, role: &str) -> Option<String> {
     let text = match role {
-        "control" if element.name == "input" => {
-            element.attribute("value").unwrap_or_default().to_string()
-        }
-        "control" | "heading" | "link" | "table_caption" => {
+        "control" if element.name == "input" => browser_input_display_value(element),
+        "option" => browser_option_display_text(element),
+        "control" | "heading" | "label" | "legend" | "link" | "table_caption" => {
             visible_text_for_nodes(&element.children)
         }
         _ => String::new(),
@@ -8250,6 +8278,87 @@ fn browser_content_control_type(element: &Element) -> Option<String> {
         "select" | "textarea" => Some(element.name.clone()),
         _ => None,
     }
+}
+
+fn browser_content_value(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "button" => element.attribute("value").map(ToOwned::to_owned),
+        "input" => browser_input_value(element),
+        "option" => Some(browser_option_value(element)),
+        "select" => selected_option_value(&element.children),
+        "textarea" => Some(element_text(element)),
+        _ => None,
+    }
+}
+
+fn browser_content_options(element: &Element) -> Vec<String> {
+    match element.name.as_str() {
+        "select" => collect_select_options(&element.children),
+        _ => Vec::new(),
+    }
+}
+
+fn selected_option_value(nodes: &[Node]) -> Option<String> {
+    let mut first = None;
+    selected_option_value_in(nodes, &mut first).or(first)
+}
+
+fn selected_option_value_in(nodes: &[Node], first: &mut Option<String>) -> Option<String> {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if element.name == "option" {
+            let value = browser_option_value(element);
+            if first.is_none() {
+                *first = Some(value.clone());
+            }
+            if element.attribute("selected").is_some() {
+                return Some(value);
+            }
+        } else if let Some(value) = selected_option_value_in(&element.children, first) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn browser_input_display_value(element: &Element) -> String {
+    match element
+        .attribute("type")
+        .map(|input_type| input_type.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("checkbox" | "hidden" | "password" | "radio") => String::new(),
+        _ => element.attribute("value").unwrap_or_default().to_string(),
+    }
+}
+
+fn browser_input_value(element: &Element) -> Option<String> {
+    match element
+        .attribute("type")
+        .map(|input_type| input_type.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("checkbox" | "radio") => Some(element.attribute("value").unwrap_or("on").to_string()),
+        _ => element.attribute("value").map(ToOwned::to_owned),
+    }
+}
+
+fn browser_option_display_text(element: &Element) -> String {
+    let text = visible_text_for_nodes(&element.children);
+    if text.is_empty() {
+        element.attribute("label").unwrap_or_default().to_string()
+    } else {
+        text
+    }
+}
+
+fn browser_option_value(element: &Element) -> String {
+    element
+        .attribute("value")
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| browser_option_display_text(element))
 }
 
 fn is_browser_block_element(name: &str) -> bool {
@@ -8290,7 +8399,8 @@ fn browser_render_display(role: &str) -> &'static str {
         "inline" | "link" => "inline",
         "image" | "control" => "inline-replaced",
         "line_break" => "line-break",
-        "heading" | "block" | "form" | "list" => "block",
+        "heading" | "block" | "form" | "form_group" | "legend" | "list" => "block",
+        "label" | "option" | "option_group" => "inline",
         "list_item" => "list-item",
         "table" => "table",
         "table_caption" => "table-caption",
@@ -8320,7 +8430,7 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
                     .map(|input_type| input_type.to_ascii_lowercase())
                     .unwrap_or_else(|| "text".to_string()),
                 name: element.attribute("name").map(ToOwned::to_owned),
-                value: element.attribute("value").map(ToOwned::to_owned),
+                value: browser_input_value(element),
                 disabled: element.attribute("disabled").is_some(),
                 checked: element.attribute("checked").is_some(),
                 text: String::new(),
@@ -8341,7 +8451,7 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
             "select" => controls.push(BrowserFormControl {
                 control_type: "select".to_string(),
                 name: element.attribute("name").map(ToOwned::to_owned),
-                value: None,
+                value: selected_option_value(&element.children),
                 disabled: element.attribute("disabled").is_some(),
                 checked: false,
                 text: visible_text_for_nodes(&element.children),
@@ -8350,7 +8460,7 @@ fn collect_form_controls_into(nodes: &[Node], controls: &mut Vec<BrowserFormCont
             "textarea" => controls.push(BrowserFormControl {
                 control_type: "textarea".to_string(),
                 name: element.attribute("name").map(ToOwned::to_owned),
-                value: None,
+                value: Some(element_text(element)),
                 disabled: element.attribute("disabled").is_some(),
                 checked: false,
                 text: element_text(element),

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -33,6 +33,16 @@ struct ExpectedContentNode {
     src: Option<String>,
     alt: Option<String>,
     control_type: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    checked: bool,
+    #[serde(default)]
+    selected: bool,
+    #[serde(default)]
+    options: Vec<String>,
     children: Vec<ExpectedContentNode>,
 }
 
@@ -80,6 +90,11 @@ impl ExpectedContentNode {
             src: self.src,
             alt: self.alt,
             control_type: self.control_type,
+            value: self.value,
+            disabled: self.disabled,
+            checked: self.checked,
+            selected: self.selected,
+            options: self.options,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -34,6 +34,16 @@ struct ExpectedRenderNode {
     src: Option<String>,
     alt: Option<String>,
     control_type: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    checked: bool,
+    #[serde(default)]
+    selected: bool,
+    #[serde(default)]
+    options: Vec<String>,
     children: Vec<ExpectedRenderNode>,
 }
 
@@ -82,6 +92,11 @@ impl ExpectedRenderNode {
             src: self.src,
             alt: self.alt,
             control_type: self.control_type,
+            value: self.value,
+            disabled: self.disabled,
+            checked: self.checked,
+            selected: self.selected,
+            options: self.options,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -24,7 +24,9 @@ skipping parser shell, head metadata, comments, scripts, styles, and templates.
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
 is converted into stable default display categories such as block, inline,
-inline-replaced, list-item, and table display nodes for early layout work.
+inline-replaced, list-item, and table display nodes for early layout work. The
+browser-facing fixture set also pins control metadata such as value,
+disabled/checked/selected state, select option labels, and textarea values.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -113,8 +113,22 @@
             "alt": null,
             "control_type": null,
             "children": [
-              { "role": "control", "name": "input", "text": "html", "href": null, "src": null, "alt": null, "control_type": "text", "children": [] },
-              { "role": "control", "name": "select", "text": "Books Manuals", "href": null, "src": null, "alt": null, "control_type": "select", "children": [] },
+              { "role": "control", "name": "input", "text": "html", "href": null, "src": null, "alt": null, "control_type": "text", "value": "html", "children": [] },
+              {
+                "role": "control",
+                "name": "select",
+                "text": "Books Manuals",
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": "select",
+                "value": "Books",
+                "options": ["Books", "Manuals"],
+                "children": [
+                  { "role": "option", "name": "option", "text": "Books", "href": null, "src": null, "alt": null, "control_type": null, "value": "Books", "children": [{ "role": "text", "name": null, "text": "Books", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                  { "role": "option", "name": "option", "text": "Manuals", "href": null, "src": null, "alt": null, "control_type": null, "value": "Manuals", "children": [{ "role": "text", "name": null, "text": "Manuals", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                ]
+              },
               { "role": "control", "name": "button", "text": "Search", "href": null, "src": null, "alt": null, "control_type": "submit", "children": [] }
             ]
           },

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -38,7 +38,7 @@
     {
       "id": "catalog-form-table-page",
       "description": "Form controls, select options, textarea text, button text, and table summaries.",
-      "input": "<html><head><title>Search</title><meta http-equiv=refresh content=\"30; url=/next\"></head><body><h2>Catalog</h2><form action=\"/search\" method=POST enctype=\"multipart/form-data\" target=results><input name=q value=\"rust html\"><input type=hidden name=page value=1><input type=checkbox name=in_stock value=yes checked><input type=text name=disabled value=no disabled><select name=section><option>Books<option>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
+      "input": "<html><head><title>Search</title><meta http-equiv=refresh content=\"30; url=/next\"></head><body><h2>Catalog</h2><form action=\"/search\" method=POST enctype=\"multipart/form-data\" target=results><input name=q value=\"rust html\"><input type=hidden name=page value=1><input type=checkbox name=in_stock value=yes checked><input type=text name=disabled value=no disabled><select name=section><option value=books>Books<option value=manuals selected>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
       "expected": {
         "title": "Search",
         "base_href": null,
@@ -65,8 +65,8 @@
               { "control_type": "hidden", "name": "page", "value": "1", "disabled": false, "checked": false, "text": "", "options": [] },
               { "control_type": "checkbox", "name": "in_stock", "value": "yes", "disabled": false, "checked": true, "text": "", "options": [] },
               { "control_type": "text", "name": "disabled", "value": "no", "disabled": true, "checked": false, "text": "", "options": [] },
-              { "control_type": "select", "name": "section", "value": null, "disabled": false, "checked": false, "text": "Books Manuals", "options": ["Books", "Manuals"] },
-              { "control_type": "textarea", "name": "notes", "value": null, "disabled": false, "checked": false, "text": "Line one Line two", "options": [] },
+              { "control_type": "select", "name": "section", "value": "manuals", "disabled": false, "checked": false, "text": "Books Manuals", "options": ["Books", "Manuals"] },
+              { "control_type": "textarea", "name": "notes", "value": "Line one Line two", "disabled": false, "checked": false, "text": "Line one Line two", "options": [] },
               { "control_type": "submit", "name": "go", "value": null, "disabled": false, "checked": false, "text": "Search", "options": [] }
             ]
           }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -56,8 +56,8 @@
     },
     {
       "id": "form-and-table-display",
-      "description": "Form controls become inline replaced boxes, and parser-implied table sections become table row group inputs.",
-      "input": "<body><form><input value=query><button>Go</button></form><table><tr><td>A<td>B</table>",
+      "description": "Form controls become inline replaced boxes with stable control metadata, and parser-implied table sections become table row group inputs.",
+      "input": "<body><form><input value=query><select name=section><option value=books>Books<option selected>Manuals</select><textarea>Notes</textarea><button>Go</button></form><table><tr><td>A<td>B</table>",
       "expected": {
         "children": [
           {
@@ -70,7 +70,51 @@
             "alt": null,
             "control_type": null,
             "children": [
-              { "display": "inline-replaced", "role": "control", "name": "input", "text": "query", "href": null, "src": null, "alt": null, "control_type": "text", "children": [] },
+              { "display": "inline-replaced", "role": "control", "name": "input", "text": "query", "href": null, "src": null, "alt": null, "control_type": "text", "value": "query", "children": [] },
+              {
+                "display": "inline-replaced",
+                "role": "control",
+                "name": "select",
+                "text": "Books Manuals",
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": "select",
+                "value": "Manuals",
+                "options": ["Books", "Manuals"],
+                "children": [
+                  {
+                    "display": "inline",
+                    "role": "option",
+                    "name": "option",
+                    "text": "Books",
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "value": "books",
+                    "children": [
+                      { "display": "inline-text", "role": "text", "name": null, "text": "Books", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                    ]
+                  },
+                  {
+                    "display": "inline",
+                    "role": "option",
+                    "name": "option",
+                    "text": "Manuals",
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "value": "Manuals",
+                    "selected": true,
+                    "children": [
+                      { "display": "inline-text", "role": "text", "name": null, "text": "Manuals", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                    ]
+                  }
+                ]
+              },
+              { "display": "inline-replaced", "role": "control", "name": "textarea", "text": "Notes", "href": null, "src": null, "alt": null, "control_type": "textarea", "value": "Notes", "children": [] },
               { "display": "inline-replaced", "role": "control", "name": "button", "text": "Go", "href": null, "src": null, "alt": null, "control_type": "submit", "children": [] }
             ]
           },


### PR DESCRIPTION
## Summary
- carry richer form control metadata through browser document, content-tree, and render-tree projections
- expose select option values/labels, selected state, textarea values, input checked/disabled state, and option child nodes for browser layout/input consumers
- update browser-facing fixtures, schema checks, docs, and changelog to pin the broader contract

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser