### PR TITLE
feat(ui31): UI31-G/R — add HostTable sibling primitives to kernel rosters

### DIFF
--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -111,6 +111,17 @@ pub const KERNEL_PRIMITIVES: &[&str] = &[
     "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
     "HostCheckbox", "HostRadio",
     "HostLink", "HostTooltip", "HostNumberInput",
+    // UI31 — `HostTable` sibling primitives. The structural sub-tags
+    // (HostTableColGroup / HostTableHead / HostTableBody /
+    // HostTableFoot) plus the cell-defining `Col` lower together with
+    // HostTable into a real semantic-HTML `<table>` (and the matching
+    // native widgets on every other backend). Pre-UI31 these were
+    // recognised only by the React emitter's HostTable dispatcher and
+    // sat outside KERNEL_PRIMITIVES — UI31 makes them first-class so
+    // future backends don't need to special-case them and so
+    // package-resolver-driven validation accepts them at parse time.
+    "HostTableColGroup", "HostTableHead", "HostTableBody", "HostTableFoot",
+    "Col",
 ];
 
 // ---------------------------------------------------------------------------
@@ -668,12 +679,13 @@ version = "1"
 
     #[test]
     fn kernel_set_covers_ui29_section_2_1() {
-        // The twenty-one primitives — fifteen from UI29 §2.1, plus
+        // The twenty-six primitives — fifteen from UI29 §2.1, plus
         // HostDialog added in UI29-1 (#3846), plus HostCheckbox and
         // HostRadio added in UI29-2 (#3978), plus HostLink,
-        // HostTooltip, and HostNumberInput added in UI29-4 (this
-        // batch).
-        let expected_21 = [
+        // HostTooltip, and HostNumberInput added in UI29-4, plus the
+        // five UI31 HostTable structural sub-tags (HostTableColGroup,
+        // HostTableHead, HostTableBody, HostTableFoot, Col).
+        let expected_26 = [
             "Box", "Row", "Column", "Stack", "Text", "Image",
             "Spacer", "Divider", "Icon",
             "If", "For",
@@ -681,8 +693,10 @@ version = "1"
             "HostDialog",
             "HostCheckbox", "HostRadio",
             "HostLink", "HostTooltip", "HostNumberInput",
+            "HostTableColGroup", "HostTableHead", "HostTableBody",
+            "HostTableFoot", "Col",
         ];
-        for name in &expected_21 {
+        for name in &expected_26 {
             assert!(
                 KERNEL_PRIMITIVES.contains(name),
                 "kernel must include `{name}`"

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -126,6 +126,14 @@ const PRIMITIVES: &[&str] = &[
     "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
     "HostCheckbox", "HostRadio",
     "HostLink", "HostTooltip", "HostNumberInput",
+    // UI31 — `HostTable` sibling primitives. Recognised by the React
+    // emitter's HostTable dispatcher pre-UI31; promoting to PRIMITIVES
+    // here so the parser stops routing them through the unknown-
+    // component-reference fallback path and so future backends'
+    // emitters can match on them directly. See
+    // `code/specs/UI31-host-table.md` §2 for the structural shape.
+    "HostTableColGroup", "HostTableHead", "HostTableBody", "HostTableFoot",
+    "Col",
 ];
 
 fn is_primitive(tag: &str) -> bool {
@@ -2139,6 +2147,27 @@ mod tests {
         assert!(
             PRIMITIVES.contains(&"HostNumberInput"),
             "UI29-4 added HostNumberInput as the 21st kernel primitive"
+        );
+        // UI31 — HostTable family structural sub-tags.
+        assert!(
+            PRIMITIVES.contains(&"HostTableColGroup"),
+            "UI31 added HostTableColGroup as a HostTable structural sub-tag"
+        );
+        assert!(
+            PRIMITIVES.contains(&"HostTableHead"),
+            "UI31 added HostTableHead as a HostTable structural sub-tag"
+        );
+        assert!(
+            PRIMITIVES.contains(&"HostTableBody"),
+            "UI31 added HostTableBody as a HostTable structural sub-tag"
+        );
+        assert!(
+            PRIMITIVES.contains(&"HostTableFoot"),
+            "UI31 added HostTableFoot as a HostTable structural sub-tag"
+        );
+        assert!(
+            PRIMITIVES.contains(&"Col"),
+            "UI31 added Col as the cell-definition sub-tag inside HostTableColGroup"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes plan item [L3]. Adds the 5 HostTable structural sub-tags (\`HostTableColGroup\`, \`HostTableHead\`, \`HostTableBody\`, \`HostTableFoot\`, \`Col\`) to both kernel allow-lists.

Kernel grows **21 → 26** primitives. The React emitter has recognised these sub-tags since UI29 §2.1 (where HostTable was introduced); this PR makes them first-class so future backends' emitters can match on them directly without special-casing each name.

**Naming reconciliation note** (for the user's earlier A/B/C question on spec/emitter drift): the spec on \`main\` (post-#4143 amendment) and the shipped React emitter both use the \`HostTableHead/Body/Foot/ColGroup\` + \`Row\` + auto-wrapped cell shape. This PR uses those names — the drift is resolved.

## Test plan

- [x] \`cargo build -p moslayout-compiler -p mosaic-package-resolver\` clean
- [x] \`cargo test\` passing (55 + 13 tests)
- [x] Kernel-size test updated: \`expected_21\` → \`expected_26\` with the 5 new entries
- [x] \`host_dialog_and_friends_in_primitives\` test gains 5 new assertions
- [x] Security review passed (allow-list expansion is monotonic; no new attack surface)
- [ ] CI green (await babysit)
- [ ] User review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)