### PR TITLE
feat(sql-parser,mini-sqlite): accept unary + prefix operator

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -369,14 +369,19 @@ cmp_op            = "=" | NOT_EQUALS | "<" | ">" | "<=" | ">=" ;
 #   bitwise:   & | << >>             ← new layer, between additive and cmp
 #   additive:  + - || -> ->>
 #   multiplicative: * / %
-#   unary:     - ~
+#   unary:     - ~ +
 #   primary
 #
 # (Reference: https://sqlite.org/lang_expr.html#operators )
 bitwise           = additive { ( "&" | "|" | "<<" | ">>" ) additive } ;
 additive          = multiplicative { ( "+" | "-" | "||" | JSON_ARROW | JSON_ARROW_TEXT ) multiplicative } ;
 multiplicative    = unary { ( STAR | "/" | "%" ) unary } ;
-unary             = ( "-" | "~" ) unary | primary ;
+# Unary prefix operators.  ``+`` is the no-op identity (``+5`` ≡ ``5``)
+# — matches SQLite, which documents it as "a valid no-op".  ``-`` is
+# arithmetic negation; ``~`` is bitwise NOT (coerces to int64).  All
+# three share the same precedence level so ``-+5`` parses as ``-(+5)``
+# and ``++5`` parses as ``+(+5)``.
+unary             = ( "-" | "~" | "+" ) unary | primary ;
 
 # primary: order matters for PEG backtracking.
 #   1. Simple literals

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.6.0] - 2026-05-23
+
+### Added
+
+- Unary ``+`` prefix operator (e.g. ``SELECT +5``,
+  ``SELECT 1 + +2``, ``SELECT -+5``) is now accepted as the documented
+  SQLite no-op identity.  Previously raised
+  ``ProgrammingError: Parse error … Expected "-" or "~" or NUMBER …,
+  got '+'`` because the grammar's ``unary`` rule only listed ``-`` and
+  ``~`` as prefixes.
+
+  Implementation: one-character grammar change — ``unary = ( "-" | "~"
+  | "+" ) unary | primary`` — plus an adapter pass-through that
+  unwraps the ``+`` without emitting an IR node (the operand value is
+  unchanged, so adding a layer would just be work for the planner and
+  codegen to peel).  Regenerated sql-parser's ``_grammar.py`` cache.
+
+  All combinations work: ``+5.5``, ``+(-3)``, ``-+5``, ``++5``,
+  ``+~5``, ``+a`` in SELECT/WHERE/ORDER BY/CASE/function-argument
+  positions.
+
 ## [2.5.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.5.0"
+version = "2.6.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -2216,18 +2216,29 @@ def _multiplicative(node: ASTNode, state: _PlaceholderCounter) -> Expr:
 
 
 def _unary(node: ASTNode, state: _PlaceholderCounter) -> Expr:
-    # unary = ( "-" | "~" ) unary | primary
+    # unary = ( "-" | "~" | "+" ) unary | primary
     #
-    # SQLite supports two unary prefix operators at the same precedence level:
+    # SQLite supports three unary prefix operators at the same precedence level:
     #   -x   arithmetic negation
     #   ~x   bitwise NOT (coerces x to a 64-bit signed integer, then flips
     #        every bit — equivalent to ``-(x + 1)`` for integers).
+    #   +x   no-op identity — SQLite documents it as a valid prefix that
+    #        evaluates to its operand unchanged.  Useful for symmetry
+    #        when writing signed numeric literals (``+5`` ≡ ``5``) and
+    #        for normalising user-supplied expressions in tools.
     if any(_is_token(c, type_="MINUS") for c in node.children):
         inner = _child_node(node, "unary")
         return UnaryExpr(op=UnaryOp.NEG, operand=_unary(inner, state))
     if any(_is_token(c, type_="BIT_NOT_OP") for c in node.children):
         inner = _child_node(node, "unary")
         return UnaryExpr(op=UnaryOp.BIT_NOT, operand=_unary(inner, state))
+    if any(_is_token(c, type_="PLUS") for c in node.children):
+        # No-op: just return the inner expression unchanged.  We don't
+        # introduce a UnaryOp.POS because the operand is bit-for-bit
+        # identical — wrapping it would only add a useless layer for
+        # the planner / codegen to peel.
+        inner = _child_node(node, "unary")
+        return _unary(inner, state)
     return _primary(_child_node(node, "primary"), state)
 
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_unary_plus.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_unary_plus.py
@@ -1,0 +1,102 @@
+"""Tests for the unary ``+`` prefix operator.
+
+SQLite accepts ``+`` as a unary prefix that is a documented no-op
+identity::
+
+    SELECT +5         ⟶  5
+    SELECT +5.5       ⟶  5.5
+    SELECT +(-3)      ⟶  -3
+    SELECT 1 + +2     ⟶  3
+    SELECT ++5        ⟶  5
+    SELECT -+5        ⟶  -5
+
+Mini-sqlite previously parse-errored on every occurrence of unary
+``+`` because the grammar's ``unary`` rule only accepted ``-`` and
+``~`` as prefixes.  Now ``+`` parses at the same precedence level
+and the adapter unwraps it directly (no IR node is emitted because
+the operand value is unchanged — that would only add a useless layer
+for the planner / codegen to peel).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(*stmts: str, query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestBasic:
+    def test_plus_int_literal(self) -> None:
+        _both_match(query="SELECT +5")
+
+    def test_plus_float_literal(self) -> None:
+        _both_match(query="SELECT +5.5")
+
+    def test_plus_zero(self) -> None:
+        _both_match(query="SELECT +0")
+
+    def test_plus_large_int(self) -> None:
+        _both_match(query="SELECT +9223372036854775807")
+
+
+class TestNestedAndChained:
+    def test_plus_minus(self) -> None:
+        _both_match(query="SELECT -+5")
+
+    def test_double_plus(self) -> None:
+        _both_match(query="SELECT ++5")
+
+    def test_plus_paren_negative(self) -> None:
+        _both_match(query="SELECT +(-3)")
+
+    def test_plus_inside_addition(self) -> None:
+        _both_match(query="SELECT 1 + +2")
+
+    def test_minus_plus_minus(self) -> None:
+        _both_match(query="SELECT -+-5")
+
+    def test_plus_bitnot(self) -> None:
+        _both_match(query="SELECT +~5")
+
+
+class TestOnColumns:
+    def test_plus_column_in_select(self) -> None:
+        _both_match(
+            "CREATE TABLE t (a INT)",
+            "INSERT INTO t VALUES (1), (2), (3)",
+            query="SELECT +a FROM t",
+        )
+
+    def test_plus_column_in_where(self) -> None:
+        _both_match(
+            "CREATE TABLE t (a INT)",
+            "INSERT INTO t VALUES (1), (2), (3)",
+            query="SELECT a FROM t WHERE a = +2",
+        )
+
+    def test_plus_column_in_order_by(self) -> None:
+        _both_match(
+            "CREATE TABLE t (a INT)",
+            "INSERT INTO t VALUES (3), (1), (2)",
+            query="SELECT a FROM t ORDER BY +a",
+        )
+
+
+class TestInExpressionContexts:
+    def test_plus_in_arithmetic(self) -> None:
+        _both_match(query="SELECT 10 - +3")
+
+    def test_plus_in_case_branch(self) -> None:
+        _both_match(query="SELECT CASE WHEN +1 = 1 THEN 'yes' END")
+
+    def test_plus_in_func_arg(self) -> None:
+        _both_match(query="SELECT ABS(+(-7))")

--- a/code/packages/python/sql-parser/CHANGELOG.md
+++ b/code/packages/python/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the SQL parser package will be documented in this file.
 
+## [0.42.0] - 2026-05-23
+
+### Changed
+
+- ``unary`` rule now accepts ``+`` alongside ``-`` and ``~``::
+
+      unary = ( "-" | "~" | "+" ) unary | primary ;
+
+  SQLite documents ``+`` as a valid no-op unary prefix.  Regenerated
+  ``_grammar.py`` cache via ``grammar-tools``.
+
 ## [0.41.0] - 2026-05-23
 
 ### Changed

--- a/code/packages/python/sql-parser/src/sql_parser/_grammar.py
+++ b/code/packages/python/sql-parser/src/sql_parser/_grammar.py
@@ -1,6 +1,6 @@
 # AUTO-GENERATED FILE — DO NOT EDIT
 # ruff: noqa: E501, F401
-# Source: /Users/adhithya/Documents/coding-adventures/.claude/worktrees/nice-wing-09855c/code/grammars/sql.grammar
+# Source: code/grammars/sql.grammar
 # Regenerate with: grammar-tools compile-grammar <source.grammar>
 #
 # This file embeds a ParserGrammar as native Python data structures.
@@ -1380,13 +1380,14 @@ PARSER_GRAMMAR = ParserGrammar(
                         Alternation(choices=[
                             Literal(value='-'),
                             Literal(value='~'),
+                            Literal(value='+'),
                         ]),
                     ),
                     RuleReference(name='unary', is_token=False),
                 ]),
                 RuleReference(name='primary', is_token=False),
             ]),
-            line_number=379,
+            line_number=384,
         ),
         GrammarRule(
             name='primary',
@@ -1420,7 +1421,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value=')'),
                 ]),
             ]),
-            line_number=399,
+            line_number=404,
         ),
         GrammarRule(
             name='column_ref',
@@ -1434,7 +1435,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=409,
+            line_number=414,
         ),
         GrammarRule(
             name='function_call',
@@ -1464,7 +1465,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='filter_clause', is_token=False),
                 ),
             ]),
-            line_number=423,
+            line_number=428,
         ),
         GrammarRule(
             name='filter_clause',
@@ -1476,7 +1477,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='expr', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=427,
+            line_number=432,
         ),
         GrammarRule(
             name='cast_expr',
@@ -1489,7 +1490,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='NAME', is_token=True),
                 Literal(value=')'),
             ]),
-            line_number=433,
+            line_number=438,
         ),
         GrammarRule(
             name='window_func_call',
@@ -1511,7 +1512,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='window_spec', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=462,
+            line_number=467,
         ),
         GrammarRule(
             name='window_spec',
@@ -1527,7 +1528,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_clause', is_token=False),
                 ),
             ]),
-            line_number=463,
+            line_number=468,
         ),
         GrammarRule(
             name='partition_clause',
@@ -1543,7 +1544,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=464,
+            line_number=469,
         ),
         GrammarRule(
             name='value_list',
@@ -1557,7 +1558,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=465,
+            line_number=470,
         ),
         GrammarRule(
             name='frame_clause',
@@ -1575,7 +1576,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_bound', is_token=False),
                 ]),
             ]),
-            line_number=487,
+            line_number=492,
         ),
         GrammarRule(
             name='frame_unit',
@@ -1585,7 +1586,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='RANGE'),
                 Literal(value='GROUPS'),
             ]),
-            line_number=489,
+            line_number=494,
         ),
         GrammarRule(
             name='frame_bound',
@@ -1612,7 +1613,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='FOLLOWING'),
                 ]),
             ]),
-            line_number=490,
+            line_number=495,
         ),
         GrammarRule(
             name='create_trigger_stmt',
@@ -1650,7 +1651,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=516,
+            line_number=521,
         ),
         GrammarRule(
             name='trigger_body_stmt',
@@ -1662,7 +1663,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='delete_stmt', is_token=False),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=521,
+            line_number=526,
         ),
         GrammarRule(
             name='drop_trigger_stmt',
@@ -1678,7 +1679,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=523,
+            line_number=528,
         ),
         GrammarRule(
             name='case_expr',
@@ -1700,13 +1701,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=538,
+            line_number=543,
         ),
         GrammarRule(
             name='case_operand',
             body=
             RuleReference(name='expr', is_token=False),
-            line_number=539,
+            line_number=544,
         ),
         GrammarRule(
             name='case_when',
@@ -1717,7 +1718,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='THEN'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=540,
+            line_number=545,
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- Adds SQLite's documented unary `+` prefix operator (a no-op identity: `+5` ≡ `5`).
- Grammar's `unary` rule extended from `( \"-\" | \"~\" )` to `( \"-\" | \"~\" | \"+\" )`. Regenerated `_grammar.py` cache.
- Adapter unwraps `+` without emitting an IR node (operand value unchanged; wrapping would only add work for the planner/codegen).

## Version bumps

- `sql-parser`: 0.41 → 0.42
- `mini-sqlite`: 2.5 → 2.6

## Test plan

- [x] 16 new oracle tests pass (literals, chained prefixes `-+5` `++5` `+~5`, paren-wrapped operand `+(-3)`, mixed arithmetic `1 + +2`, column refs in SELECT/WHERE/ORDER BY/CASE/function-args)
- [x] mini-sqlite suite (2208 tests) clean
- [x] sql-parser suite (91 tests) clean
- [x] Ruff clean
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)