### PR TITLE
[codex] Add Board VM input callback transport references

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -209,6 +209,10 @@ rebuilding marker policy.
 transport bookmark records with Rust-owned bookmark names, labels, queue-depth
 metadata, and messages, so frontends can restore callback transport positions
 without rebuilding cursor policy.
+`input_callback_transport_reference_summary` binds those bookmarks as stable
+transport reference records with Rust-owned reference names, labels, queue-depth
+metadata, and messages, so frontends can reuse callback transport bookmarks
+without rebuilding bookmark policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -1690,6 +1690,76 @@ pub struct LanguageInputCallbackTransportBookmarkSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportReferenceKind {
+    CallbackRunnerHandoffReference,
+    AdapterEventPublicationReference,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportReferenceSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub reference_label: String,
+    pub reference_kind: LanguageInputCallbackTransportReferenceKind,
+    pub reference_name: String,
+    pub bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+    pub bookmark_name: String,
+    pub cursor_kind: LanguageInputCallbackTransportCursorKind,
+    pub cursor_name: String,
+    pub marker_kind: LanguageInputCallbackTransportMarkerKind,
+    pub marker_name: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub marker_recorded: bool,
+    pub cursor_recorded: bool,
+    pub bookmark_recorded: bool,
+    pub reference_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_reference: u8,
+    pub message: String,
+    pub bookmark_summary: LanguageInputCallbackTransportBookmarkSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -2359,6 +2429,19 @@ pub const fn input_callback_transport_bookmark_kind_name(
         }
         LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark => {
             "adapter_event_publication_bookmark"
+        }
+    }
+}
+
+pub const fn input_callback_transport_reference_kind_name(
+    kind: LanguageInputCallbackTransportReferenceKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportReferenceKind::CallbackRunnerHandoffReference => {
+            "callback_runner_handoff_reference"
+        }
+        LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference => {
+            "adapter_event_publication_reference"
         }
     }
 }
@@ -4291,6 +4374,75 @@ pub fn input_callback_transport_bookmark_summary(
     }
 }
 
+pub fn input_callback_transport_reference_summary(
+    bookmark_summary: &LanguageInputCallbackTransportBookmarkSummary,
+) -> LanguageInputCallbackTransportReferenceSummary {
+    let reference_kind = input_callback_transport_reference_kind(bookmark_summary.bookmark_kind);
+
+    LanguageInputCallbackTransportReferenceSummary {
+        endpoint: bookmark_summary.endpoint.clone(),
+        connection_label: bookmark_summary.connection_label.clone(),
+        reference_label: input_callback_transport_reference_label(bookmark_summary, reference_kind),
+        reference_kind,
+        reference_name: input_callback_transport_reference_kind_name(reference_kind).to_owned(),
+        bookmark_kind: bookmark_summary.bookmark_kind,
+        bookmark_name: bookmark_summary.bookmark_name.clone(),
+        cursor_kind: bookmark_summary.cursor_kind,
+        cursor_name: bookmark_summary.cursor_name.clone(),
+        marker_kind: bookmark_summary.marker_kind,
+        marker_name: bookmark_summary.marker_name.clone(),
+        checkpoint_kind: bookmark_summary.checkpoint_kind,
+        checkpoint_name: bookmark_summary.checkpoint_name.clone(),
+        snapshot_kind: bookmark_summary.snapshot_kind,
+        snapshot_name: bookmark_summary.snapshot_name.clone(),
+        archive_kind: bookmark_summary.archive_kind,
+        archive_name: bookmark_summary.archive_name.clone(),
+        journal_kind: bookmark_summary.journal_kind,
+        journal_name: bookmark_summary.journal_name.clone(),
+        log_kind: bookmark_summary.log_kind,
+        log_name: bookmark_summary.log_name.clone(),
+        audit_kind: bookmark_summary.audit_kind,
+        audit_name: bookmark_summary.audit_name.clone(),
+        trace_kind: bookmark_summary.trace_kind,
+        trace_name: bookmark_summary.trace_name.clone(),
+        outcome_kind: bookmark_summary.outcome_kind,
+        outcome_name: bookmark_summary.outcome_name.clone(),
+        receipt_kind: bookmark_summary.receipt_kind,
+        receipt_name: bookmark_summary.receipt_name.clone(),
+        acknowledgement_kind: bookmark_summary.acknowledgement_kind,
+        acknowledgement_name: bookmark_summary.acknowledgement_name.clone(),
+        delivery_route: bookmark_summary.delivery_route,
+        delivery_route_name: bookmark_summary.delivery_route_name.clone(),
+        event_kind: bookmark_summary.event_kind,
+        event_name: bookmark_summary.event_name.clone(),
+        report_kind: bookmark_summary.report_kind,
+        report_name: bookmark_summary.report_name.clone(),
+        action: bookmark_summary.action,
+        action_name: bookmark_summary.action_name.clone(),
+        callback_runner_handoff: bookmark_summary.callback_runner_handoff,
+        adapter_event_published: bookmark_summary.adapter_event_published,
+        delivery_acknowledged: bookmark_summary.delivery_acknowledged,
+        receipt_recorded: bookmark_summary.receipt_recorded,
+        outcome_recorded: bookmark_summary.outcome_recorded,
+        trace_recorded: bookmark_summary.trace_recorded,
+        audit_recorded: bookmark_summary.audit_recorded,
+        log_recorded: bookmark_summary.log_recorded,
+        journal_recorded: bookmark_summary.journal_recorded,
+        archive_recorded: bookmark_summary.archive_recorded,
+        snapshot_recorded: bookmark_summary.snapshot_recorded,
+        checkpoint_recorded: bookmark_summary.checkpoint_recorded,
+        marker_recorded: bookmark_summary.marker_recorded,
+        cursor_recorded: bookmark_summary.cursor_recorded,
+        bookmark_recorded: bookmark_summary.bookmark_recorded,
+        reference_recorded: true,
+        terminal: bookmark_summary.terminal,
+        retryable: bookmark_summary.retryable,
+        queue_depth_after_reference: bookmark_summary.queue_depth_after_bookmark,
+        message: input_callback_transport_reference_message(reference_kind).to_owned(),
+        bookmark_summary: bookmark_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -6107,6 +6259,44 @@ fn input_callback_transport_bookmark_message(
         }
         LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark => {
             "Transport bookmark should save the adapter event publication cursor."
+        }
+    }
+}
+
+fn input_callback_transport_reference_kind(
+    bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+) -> LanguageInputCallbackTransportReferenceKind {
+    match bookmark_kind {
+        LanguageInputCallbackTransportBookmarkKind::CallbackRunnerHandoffBookmark => {
+            LanguageInputCallbackTransportReferenceKind::CallbackRunnerHandoffReference
+        }
+        LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark => {
+            LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference
+        }
+    }
+}
+
+fn input_callback_transport_reference_label(
+    bookmark_summary: &LanguageInputCallbackTransportBookmarkSummary,
+    reference_kind: LanguageInputCallbackTransportReferenceKind,
+) -> String {
+    format!(
+        "{} transport_reference={} reference_recorded=true queue_depth_after_reference={}",
+        bookmark_summary.bookmark_label,
+        input_callback_transport_reference_kind_name(reference_kind),
+        bookmark_summary.queue_depth_after_bookmark
+    )
+}
+
+fn input_callback_transport_reference_message(
+    reference_kind: LanguageInputCallbackTransportReferenceKind,
+) -> &'static str {
+    match reference_kind {
+        LanguageInputCallbackTransportReferenceKind::CallbackRunnerHandoffReference => {
+            "Transport reference should bind the callback-runner handoff bookmark."
+        }
+        LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference => {
+            "Transport reference should bind the adapter event publication bookmark."
         }
     }
 }
@@ -15049,6 +15239,280 @@ mod tests {
             )
         );
         assert_eq!(dropped.cursor_summary, dropped_cursor);
+    }
+
+    #[test]
+    fn input_callback_transport_references_are_owned_by_rust_language_core() {
+        fn bookmark_for_lifecycle(
+            lifecycle: &LanguageInputCallbackSessionLifecycleSummary,
+        ) -> LanguageInputCallbackTransportBookmarkSummary {
+            let action = input_callback_transport_action_summary(lifecycle);
+            let effect = input_callback_transport_effect_summary(&action);
+            let report = input_callback_transport_report_summary(&effect);
+            let event = input_callback_transport_event_summary(&report);
+            let delivery = input_callback_transport_delivery_summary(&event);
+            let acknowledgement = input_callback_transport_acknowledgement_summary(&delivery);
+            let receipt = input_callback_transport_receipt_summary(&acknowledgement);
+            let outcome = input_callback_transport_outcome_summary(&receipt);
+            let trace = input_callback_transport_trace_summary(&outcome);
+            let audit = input_callback_transport_audit_summary(&trace);
+            let log = input_callback_transport_log_summary(&audit);
+            let journal = input_callback_transport_journal_summary(&log);
+            let archive = input_callback_transport_archive_summary(&journal);
+            let snapshot = input_callback_transport_snapshot_summary(&archive);
+            let checkpoint = input_callback_transport_checkpoint_summary(&snapshot);
+            let marker = input_callback_transport_marker_summary(&checkpoint);
+            let cursor = input_callback_transport_cursor_summary(&marker);
+            input_callback_transport_bookmark_summary(&cursor)
+        }
+
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_bookmark = bookmark_for_lifecycle(&completed_lifecycle);
+        let completed = input_callback_transport_reference_summary(&completed_bookmark);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.reference_kind,
+            LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference
+        );
+        assert_eq!(
+            completed.reference_name,
+            "adapter_event_publication_reference"
+        );
+        assert_eq!(
+            completed.bookmark_kind,
+            LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark
+        );
+        assert_eq!(
+            completed.bookmark_name,
+            "adapter_event_publication_bookmark"
+        );
+        assert_eq!(
+            completed.cursor_kind,
+            LanguageInputCallbackTransportCursorKind::AdapterEventPublicationCursor
+        );
+        assert_eq!(
+            completed.marker_kind,
+            LanguageInputCallbackTransportMarkerKind::AdapterEventPublicationMarker
+        );
+        assert_eq!(
+            completed.checkpoint_kind,
+            LanguageInputCallbackTransportCheckpointKind::AdapterEventPublicationCheckpoint
+        );
+        assert_eq!(
+            completed.snapshot_kind,
+            LanguageInputCallbackTransportSnapshotKind::AdapterEventPublicationSnapshot
+        );
+        assert_eq!(
+            completed.archive_kind,
+            LanguageInputCallbackTransportArchiveKind::AdapterEventPublicationArchive
+        );
+        assert_eq!(
+            completed.journal_kind,
+            LanguageInputCallbackTransportJournalKind::AdapterEventPublicationJournal
+        );
+        assert_eq!(
+            completed.log_kind,
+            LanguageInputCallbackTransportLogKind::AdapterEventPublicationLog
+        );
+        assert_eq!(
+            completed.audit_kind,
+            LanguageInputCallbackTransportAuditKind::AdapterEventPublicationAudit
+        );
+        assert_eq!(
+            completed.trace_kind,
+            LanguageInputCallbackTransportTraceKind::AdapterEventPublicationTrace
+        );
+        assert_eq!(
+            completed.outcome_kind,
+            LanguageInputCallbackTransportOutcomeKind::AdapterEventPublicationRecorded
+        );
+        assert_eq!(
+            completed.receipt_kind,
+            LanguageInputCallbackTransportReceiptKind::AdapterEventPublication
+        );
+        assert_eq!(
+            completed.acknowledgement_kind,
+            LanguageInputCallbackTransportAcknowledgementKind::AdapterEventPublished
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.marker_recorded);
+        assert!(completed.cursor_recorded);
+        assert!(completed.bookmark_recorded);
+        assert!(completed.reference_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_reference, 2);
+        assert_eq!(
+            completed.reference_label,
+            format!(
+                "{} transport_reference=adapter_event_publication_reference reference_recorded=true queue_depth_after_reference=2",
+                completed_bookmark.bookmark_label
+            )
+        );
+        assert_eq!(
+            completed.message,
+            "Transport reference should bind the adapter event publication bookmark."
+        );
+        assert_eq!(completed.bookmark_summary, completed_bookmark);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_bookmark = bookmark_for_lifecycle(&pending_lifecycle);
+        let pending = input_callback_transport_reference_summary(&pending_bookmark);
+
+        assert_eq!(
+            pending.reference_kind,
+            LanguageInputCallbackTransportReferenceKind::CallbackRunnerHandoffReference
+        );
+        assert_eq!(pending.reference_name, "callback_runner_handoff_reference");
+        assert_eq!(
+            pending.bookmark_kind,
+            LanguageInputCallbackTransportBookmarkKind::CallbackRunnerHandoffBookmark
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(pending.archive_recorded);
+        assert!(pending.snapshot_recorded);
+        assert!(pending.checkpoint_recorded);
+        assert!(pending.marker_recorded);
+        assert!(pending.cursor_recorded);
+        assert!(pending.bookmark_recorded);
+        assert!(pending.reference_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_reference, 3);
+        assert_eq!(
+            pending.reference_label,
+            format!(
+                "{} transport_reference=callback_runner_handoff_reference reference_recorded=true queue_depth_after_reference=3",
+                pending_bookmark.bookmark_label
+            )
+        );
+        assert_eq!(
+            pending.message,
+            "Transport reference should bind the callback-runner handoff bookmark."
+        );
+        assert_eq!(pending.bookmark_summary, pending_bookmark);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_bookmark = bookmark_for_lifecycle(&dropped_lifecycle);
+        let dropped = input_callback_transport_reference_summary(&dropped_bookmark);
+
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.reference_kind,
+            LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.marker_recorded);
+        assert!(dropped.cursor_recorded);
+        assert!(dropped.bookmark_recorded);
+        assert!(dropped.reference_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_reference, 1);
+        assert_eq!(
+            dropped.reference_label,
+            format!(
+                "{} transport_reference=adapter_event_publication_reference reference_recorded=true queue_depth_after_reference=1",
+                dropped_bookmark.bookmark_label
+            )
+        );
+        assert_eq!(dropped.bookmark_summary, dropped_bookmark);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned input callback transport reference kinds and summaries above transport bookmarks
- preserve the full transport chain and embedded bookmark summary for frontend consumers
- document the new `input_callback_transport_reference_summary` helper in language-core README

## Validation
- `cargo fmt -p board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-reference cargo test -p board-vm-language-core`
- `bash BUILD` in `code/packages/rust/board-vm-language-core`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-reference cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `git diff --cached --check`

The external `/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool` path remains unavailable, so detector validation could not run from this worktree.
