### PR TITLE
Add HTML parser browser navigation URL metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -257,7 +257,7 @@ def check_browser_expected_lists(
         resource_path = f"{case_path}.expected.resources[{index}]"
         require_string(resource_path, resource, "kind", errors)
         require_string(resource_path, resource, "url", errors)
-        for field in ("rel", "type_hint", "media", "title"):
+        for field in ("resolved_url", "rel", "type_hint", "media", "title"):
             require_optional_nullable_string(resource_path, resource, field, errors)
         require_boolean(resource_path, resource, "async_script", errors)
         require_boolean(resource_path, resource, "defer_script", errors)
@@ -275,18 +275,19 @@ def check_browser_expected_lists(
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"
-        for field in ("href", "name", "target", "rel", "title"):
+        for field in ("href", "resolved_href", "name", "target", "rel", "title"):
             require_optional_nullable_string(link_path, link, field, errors)
         require_string(link_path, link, "text", errors)
 
     for index, image in enumerate(object_list_items(expected, "images")):
         image_path = f"{case_path}.expected.images[{index}]"
-        for field in ("src", "alt", "width", "height"):
+        for field in ("src", "resolved_src", "alt", "width", "height"):
             require_optional_nullable_string(image_path, image, field, errors)
 
     for index, form in enumerate(object_list_items(expected, "forms")):
         form_path = f"{case_path}.expected.forms[{index}]"
         require_optional_nullable_string(form_path, form, "action", errors)
+        require_optional_nullable_string(form_path, form, "resolved_action", errors)
         require_string(form_path, form, "method", errors)
         require_optional_nullable_string(form_path, form, "enctype", errors)
         require_optional_nullable_string(form_path, form, "target", errors)
@@ -341,7 +342,17 @@ def check_browser_content_node(
     errors: list[str],
 ) -> None:
     require_string(node_path, node, "role", errors)
-    for field in ("name", "text", "href", "src", "alt", "control_type", "value"):
+    for field in (
+        "name",
+        "text",
+        "href",
+        "resolved_href",
+        "src",
+        "resolved_src",
+        "alt",
+        "control_type",
+        "value",
+    ):
         require_optional_nullable_string(node_path, node, field, errors)
     for field in ("disabled", "checked", "selected"):
         require_optional_boolean(node_path, node, field, errors)
@@ -389,7 +400,17 @@ def check_browser_render_node(
 ) -> None:
     require_string(node_path, node, "display", errors)
     require_string(node_path, node, "role", errors)
-    for field in ("name", "text", "href", "src", "alt", "control_type", "value"):
+    for field in (
+        "name",
+        "text",
+        "href",
+        "resolved_href",
+        "src",
+        "resolved_src",
+        "alt",
+        "control_type",
+        "value",
+    ):
         require_optional_nullable_string(node_path, node, field, errors)
     for field in ("disabled", "checked", "selected"):
         require_optional_boolean(node_path, node, field, errors)

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -189,6 +189,10 @@ documented in this file.
 - Browser-facing document, content-tree, and render-tree projections now carry
   richer form control metadata including values, checked/selected state,
   disabled state, select options, and textarea values.
+- Browser-facing document, content-tree, and render-tree projections now carry
+  resolved URL metadata for links, resources, images, and form actions using
+  the document `base` href when available, while preserving raw authored
+  attributes for downstream policy decisions.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -68,6 +68,9 @@ The current parser surface includes:
 - browser-facing form control metadata for input values, disabled/checked/
   selected state, select options, and textarea values across document,
   content-tree, and render-tree projections
+- browser-facing URL resolution metadata for links, loadable resources, images,
+  and form actions using the document `base` href when available, while keeping
+  raw authored URLs available to browser policy code
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -842,6 +842,7 @@ pub struct BrowserMeta {
 pub struct BrowserResource {
     pub kind: String,
     pub url: String,
+    pub resolved_url: Option<String>,
     pub rel: Option<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
@@ -868,7 +869,9 @@ pub struct BrowserContentNode {
     pub name: Option<String>,
     pub text: Option<String>,
     pub href: Option<String>,
+    pub resolved_href: Option<String>,
     pub src: Option<String>,
+    pub resolved_src: Option<String>,
     pub alt: Option<String>,
     pub control_type: Option<String>,
     pub value: Option<String>,
@@ -891,7 +894,9 @@ pub struct BrowserRenderNode {
     pub name: Option<String>,
     pub text: Option<String>,
     pub href: Option<String>,
+    pub resolved_href: Option<String>,
     pub src: Option<String>,
+    pub resolved_src: Option<String>,
     pub alt: Option<String>,
     pub control_type: Option<String>,
     pub value: Option<String>,
@@ -911,6 +916,7 @@ pub struct BrowserHeading {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserLink {
     pub href: Option<String>,
+    pub resolved_href: Option<String>,
     pub name: Option<String>,
     pub target: Option<String>,
     pub rel: Option<String>,
@@ -921,6 +927,7 @@ pub struct BrowserLink {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserImage {
     pub src: Option<String>,
+    pub resolved_src: Option<String>,
     pub alt: Option<String>,
     pub width: Option<String>,
     pub height: Option<String>,
@@ -929,6 +936,7 @@ pub struct BrowserImage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserForm {
     pub action: Option<String>,
+    pub resolved_action: Option<String>,
     pub method: String,
     pub enctype: Option<String>,
     pub target: Option<String>,
@@ -988,16 +996,24 @@ impl BrowserDocument {
 
 impl BrowserContentTree {
     pub fn from_document(document: &Document) -> Self {
+        let head = find_first_element_in_nodes(&document.children, "head");
+        let base_href = head
+            .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
+            .and_then(|element| element.attribute("href"));
         let body = find_first_element_in_nodes(&document.children, "body");
         let body_children = body
             .map(|element| element.children.as_slice())
             .unwrap_or(document.children.as_slice());
-        Self::from_nodes(body_children)
+        Self::from_nodes_with_base(body_children, base_href)
     }
 
     pub fn from_nodes(nodes: &[Node]) -> Self {
+        Self::from_nodes_with_base(nodes, None)
+    }
+
+    fn from_nodes_with_base(nodes: &[Node], base_href: Option<&str>) -> Self {
         let mut children = Vec::new();
-        collect_browser_content_nodes(nodes, &mut children);
+        collect_browser_content_nodes(nodes, &mut children, base_href);
         Self { children }
     }
 }
@@ -1026,7 +1042,9 @@ impl BrowserRenderNode {
             name: content_node.name.clone(),
             text: content_node.text.clone(),
             href: content_node.href.clone(),
+            resolved_href: content_node.resolved_href.clone(),
             src: content_node.src.clone(),
+            resolved_src: content_node.resolved_src.clone(),
             alt: content_node.alt.clone(),
             control_type: content_node.control_type.clone(),
             value: content_node.value.clone(),
@@ -7959,6 +7977,9 @@ fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
         match element.name.as_str() {
             "a" => summary.links.push(BrowserLink {
                 href: element.attribute("href").map(ToOwned::to_owned),
+                resolved_href: element
+                    .attribute("href")
+                    .and_then(|href| resolve_browser_url(href, summary.base_href.as_deref())),
                 name: element.attribute("name").map(ToOwned::to_owned),
                 target: element.attribute("target").map(ToOwned::to_owned),
                 rel: element.attribute("rel").map(ToOwned::to_owned),
@@ -7967,12 +7988,18 @@ fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             }),
             "img" => summary.images.push(BrowserImage {
                 src: element.attribute("src").map(ToOwned::to_owned),
+                resolved_src: element
+                    .attribute("src")
+                    .and_then(|src| resolve_browser_url(src, summary.base_href.as_deref())),
                 alt: element.attribute("alt").map(ToOwned::to_owned),
                 width: element.attribute("width").map(ToOwned::to_owned),
                 height: element.attribute("height").map(ToOwned::to_owned),
             }),
             "form" => summary.forms.push(BrowserForm {
                 action: element.attribute("action").map(ToOwned::to_owned),
+                resolved_action: element
+                    .attribute("action")
+                    .and_then(|action| resolve_browser_url(action, summary.base_href.as_deref())),
                 method: element
                     .attribute("method")
                     .map(|method| method.to_ascii_lowercase())
@@ -8020,6 +8047,7 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                     summary.resources.push(BrowserResource {
                         kind: link_resource_kind(element.attribute("rel")),
                         url: href.to_string(),
+                        resolved_url: resolve_browser_url(href, summary.base_href.as_deref()),
                         rel: element.attribute("rel").map(ToOwned::to_owned),
                         type_hint: element.attribute("type").map(ToOwned::to_owned),
                         media: element.attribute("media").map(ToOwned::to_owned),
@@ -8034,6 +8062,7 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                     summary.resources.push(BrowserResource {
                         kind: "script".to_string(),
                         url: src.to_string(),
+                        resolved_url: resolve_browser_url(src, summary.base_href.as_deref()),
                         rel: None,
                         type_hint: element.attribute("type").map(ToOwned::to_owned),
                         media: None,
@@ -8071,6 +8100,7 @@ fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
 
     summary.resources.push(BrowserResource {
         kind,
+        resolved_url: resolve_browser_url(&url, summary.base_href.as_deref()),
         url,
         rel: None,
         type_hint: element.attribute("type").map(ToOwned::to_owned),
@@ -8108,6 +8138,146 @@ fn body_resource(element: &Element) -> Option<(String, String)> {
     }
 }
 
+fn resolve_browser_url(url: &str, base_href: Option<&str>) -> Option<String> {
+    let url = url.trim();
+    if url.is_empty() {
+        return None;
+    }
+    if is_absolute_url(url) {
+        return Some(url.to_string());
+    }
+
+    let base_href = base_href?.trim();
+    if !is_absolute_url(base_href) {
+        return None;
+    }
+
+    let (scheme, authority, base_path) = split_hierarchical_url(base_href)?;
+    if url.starts_with("//") {
+        return Some(format!("{scheme}:{url}"));
+    }
+    if let Some(fragment) = url.strip_prefix('#') {
+        return Some(format!(
+            "{scheme}://{authority}{}#{fragment}",
+            strip_fragment(base_path)
+        ));
+    }
+    if let Some(query) = url.strip_prefix('?') {
+        return Some(format!(
+            "{scheme}://{authority}{}?{query}",
+            strip_query_and_fragment(base_path)
+        ));
+    }
+
+    let (relative_path, suffix) = split_url_suffix(url);
+    let resolved_path = if relative_path.starts_with('/') {
+        normalize_browser_path(relative_path)
+    } else {
+        let base_dir = browser_base_directory(strip_query_and_fragment(base_path));
+        normalize_browser_path(&format!("{base_dir}{relative_path}"))
+    };
+
+    Some(format!("{scheme}://{authority}{resolved_path}{suffix}"))
+}
+
+fn is_absolute_url(url: &str) -> bool {
+    let Some(index) = url.find(':') else {
+        return false;
+    };
+    let scheme = &url[..index];
+    !scheme.is_empty()
+        && scheme.as_bytes()[0].is_ascii_alphabetic()
+        && scheme
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+        && !scheme.contains('/')
+        && !scheme.contains('?')
+        && !scheme.contains('#')
+}
+
+fn split_hierarchical_url(url: &str) -> Option<(&str, &str, &str)> {
+    let (scheme, rest) = url.split_once(':')?;
+    let rest = rest.strip_prefix("//")?;
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    if authority.is_empty() {
+        return None;
+    }
+    let path = if authority_end == rest.len() {
+        "/"
+    } else {
+        &rest[authority_end..]
+    };
+    Some((scheme, authority, path))
+}
+
+fn strip_fragment(path: &str) -> &str {
+    path.split_once('#')
+        .map(|(before_fragment, _)| before_fragment)
+        .unwrap_or(path)
+}
+
+fn strip_query_and_fragment(path: &str) -> &str {
+    let query_index = path.find('?');
+    let fragment_index = path.find('#');
+    let end = match (query_index, fragment_index) {
+        (Some(query), Some(fragment)) => query.min(fragment),
+        (Some(query), None) => query,
+        (None, Some(fragment)) => fragment,
+        (None, None) => path.len(),
+    };
+    &path[..end]
+}
+
+fn split_url_suffix(url: &str) -> (&str, &str) {
+    let suffix_index = match (url.find('?'), url.find('#')) {
+        (Some(query), Some(fragment)) => query.min(fragment),
+        (Some(query), None) => query,
+        (None, Some(fragment)) => fragment,
+        (None, None) => url.len(),
+    };
+    (&url[..suffix_index], &url[suffix_index..])
+}
+
+fn browser_base_directory(path: &str) -> String {
+    if path.ends_with('/') {
+        return path.to_string();
+    }
+    match path.rfind('/') {
+        Some(index) => path[..=index].to_string(),
+        None => "/".to_string(),
+    }
+}
+
+fn normalize_browser_path(path: &str) -> String {
+    let absolute = path.starts_with('/');
+    let trailing_slash = path.ends_with('/');
+    let mut segments: Vec<&str> = Vec::new();
+
+    for segment in path.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            _ => segments.push(segment),
+        }
+    }
+
+    let mut normalized = if absolute {
+        format!("/{}", segments.join("/"))
+    } else {
+        segments.join("/")
+    };
+    if normalized.is_empty() {
+        normalized.push('/');
+    }
+    if trailing_slash && !normalized.ends_with('/') {
+        normalized.push('/');
+    }
+    normalized
+}
+
 fn link_resource_kind(rel: Option<&str>) -> String {
     let Some(rel) = rel else {
         return "link".to_string();
@@ -8127,7 +8297,11 @@ fn link_resource_kind(rel: Option<&str>) -> String {
     "link".to_string()
 }
 
-fn collect_browser_content_nodes(nodes: &[Node], output: &mut Vec<BrowserContentNode>) {
+fn collect_browser_content_nodes(
+    nodes: &[Node],
+    output: &mut Vec<BrowserContentNode>,
+    base_href: Option<&str>,
+) {
     for node in nodes {
         match node {
             Node::Text(value) => {
@@ -8138,7 +8312,9 @@ fn collect_browser_content_nodes(nodes: &[Node], output: &mut Vec<BrowserContent
                         name: None,
                         text: Some(text),
                         href: None,
+                        resolved_href: None,
                         src: None,
+                        resolved_src: None,
                         alt: None,
                         control_type: None,
                         value: None,
@@ -8151,7 +8327,7 @@ fn collect_browser_content_nodes(nodes: &[Node], output: &mut Vec<BrowserContent
                 }
             }
             Node::Element(element) => {
-                if let Some(content_node) = browser_content_node_for_element(element) {
+                if let Some(content_node) = browser_content_node_for_element(element, base_href) {
                     output.push(content_node);
                 }
             }
@@ -8160,7 +8336,10 @@ fn collect_browser_content_nodes(nodes: &[Node], output: &mut Vec<BrowserContent
     }
 }
 
-fn browser_content_node_for_element(element: &Element) -> Option<BrowserContentNode> {
+fn browser_content_node_for_element(
+    element: &Element,
+    base_href: Option<&str>,
+) -> Option<BrowserContentNode> {
     if is_browser_invisible_element(&element.name) {
         return None;
     }
@@ -8168,7 +8347,7 @@ fn browser_content_node_for_element(element: &Element) -> Option<BrowserContentN
     let role = browser_content_role(&element.name)?;
     let mut children = Vec::new();
     if should_collect_browser_content_children(&element.name) {
-        collect_browser_content_nodes(&element.children, &mut children);
+        collect_browser_content_nodes(&element.children, &mut children, base_href);
     }
 
     let text = browser_content_text(element, role);
@@ -8176,12 +8355,21 @@ fn browser_content_node_for_element(element: &Element) -> Option<BrowserContentN
         return None;
     }
 
+    let href = element.attribute("href").map(ToOwned::to_owned);
+    let src = browser_content_src(element);
+
     Some(BrowserContentNode {
         role: role.to_string(),
         name: Some(element.name.clone()),
         text,
-        href: element.attribute("href").map(ToOwned::to_owned),
-        src: browser_content_src(element),
+        resolved_href: href
+            .as_deref()
+            .and_then(|href| resolve_browser_url(href, base_href)),
+        href,
+        resolved_src: src
+            .as_deref()
+            .and_then(|src| resolve_browser_url(src, base_href)),
+        src,
         alt: element.attribute("alt").map(ToOwned::to_owned),
         control_type: browser_content_control_type(element),
         value: browser_content_value(element),
@@ -8621,6 +8809,49 @@ mod tests {
 
     fn body(document: &Document) -> &Element {
         element(&html(document).children[1])
+    }
+
+    #[test]
+    fn resolves_browser_urls_against_document_base() {
+        let base = Some("https://example.test/docs/current/page.html?old=1#section");
+
+        assert_eq!(
+            resolve_browser_url("intro.html", base),
+            Some("https://example.test/docs/current/intro.html".to_string())
+        );
+        assert_eq!(
+            resolve_browser_url("../assets/logo.gif", base),
+            Some("https://example.test/docs/assets/logo.gif".to_string())
+        );
+        assert_eq!(
+            resolve_browser_url("/search?q=html#top", base),
+            Some("https://example.test/search?q=html#top".to_string())
+        );
+        assert_eq!(
+            resolve_browser_url("?page=2", base),
+            Some("https://example.test/docs/current/page.html?page=2".to_string())
+        );
+        assert_eq!(
+            resolve_browser_url("#next", base),
+            Some("https://example.test/docs/current/page.html?old=1#next".to_string())
+        );
+        assert_eq!(
+            resolve_browser_url("//cdn.example.test/app.js", base),
+            Some("https://cdn.example.test/app.js".to_string())
+        );
+    }
+
+    #[test]
+    fn browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives() {
+        assert_eq!(
+            resolve_browser_url("mailto:hello@example.test", None),
+            Some("mailto:hello@example.test".to_string())
+        );
+        assert_eq!(resolve_browser_url("relative.html", None), None);
+        assert_eq!(
+            resolve_browser_url("relative.html", Some("/local/base/")),
+            None
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -30,7 +30,11 @@ struct ExpectedContentNode {
     name: Option<String>,
     text: Option<String>,
     href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
     src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
     alt: Option<String>,
     control_type: Option<String>,
     #[serde(default)]
@@ -87,7 +91,9 @@ impl ExpectedContentNode {
             name: self.name,
             text: self.text,
             href: self.href,
+            resolved_href: self.resolved_href,
             src: self.src,
+            resolved_src: self.resolved_src,
             alt: self.alt,
             control_type: self.control_type,
             value: self.value,

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -49,6 +49,7 @@ struct ExpectedMeta {
 struct ExpectedResource {
     kind: String,
     url: String,
+    resolved_url: Option<String>,
     rel: Option<String>,
     type_hint: Option<String>,
     media: Option<String>,
@@ -73,6 +74,7 @@ struct ExpectedHeading {
 #[derive(Debug, Deserialize)]
 struct ExpectedLink {
     href: Option<String>,
+    resolved_href: Option<String>,
     name: Option<String>,
     target: Option<String>,
     rel: Option<String>,
@@ -83,6 +85,7 @@ struct ExpectedLink {
 #[derive(Debug, Deserialize)]
 struct ExpectedImage {
     src: Option<String>,
+    resolved_src: Option<String>,
     alt: Option<String>,
     width: Option<String>,
     height: Option<String>,
@@ -91,6 +94,7 @@ struct ExpectedImage {
 #[derive(Debug, Deserialize)]
 struct ExpectedForm {
     action: Option<String>,
+    resolved_action: Option<String>,
     method: String,
     enctype: Option<String>,
     target: Option<String>,
@@ -206,6 +210,7 @@ impl ExpectedResource {
         BrowserResource {
             kind: self.kind,
             url: self.url,
+            resolved_url: self.resolved_url,
             rel: self.rel,
             type_hint: self.type_hint,
             media: self.media,
@@ -239,6 +244,7 @@ impl ExpectedLink {
     fn into_browser_link(self) -> BrowserLink {
         BrowserLink {
             href: self.href,
+            resolved_href: self.resolved_href,
             name: self.name,
             target: self.target,
             rel: self.rel,
@@ -252,6 +258,7 @@ impl ExpectedImage {
     fn into_browser_image(self) -> BrowserImage {
         BrowserImage {
             src: self.src,
+            resolved_src: self.resolved_src,
             alt: self.alt,
             width: self.width,
             height: self.height,
@@ -263,6 +270,7 @@ impl ExpectedForm {
     fn into_browser_form(self) -> BrowserForm {
         BrowserForm {
             action: self.action,
+            resolved_action: self.resolved_action,
             method: self.method,
             enctype: self.enctype,
             target: self.target,

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -31,7 +31,11 @@ struct ExpectedRenderNode {
     name: Option<String>,
     text: Option<String>,
     href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
     src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
     alt: Option<String>,
     control_type: Option<String>,
     #[serde(default)]
@@ -89,7 +93,9 @@ impl ExpectedRenderNode {
             name: self.name,
             text: self.text,
             href: self.href,
+            resolved_href: self.resolved_href,
             src: self.src,
+            resolved_src: self.resolved_src,
             alt: self.alt,
             control_type: self.control_type,
             value: self.value,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -13,20 +13,24 @@ without inventing a Rust-only test schema.
 browser-facing extraction. It verifies that broad HTML documents produce stable
 title, base URL/target, metadata, resource, anchor, body text, heading, link,
 image, form, and table facts that a browser pipeline can consume before layout
-and Paint VM rendering.
+and Paint VM rendering. The fixture also pins resolved URL metadata derived
+from `base` hrefs while preserving raw authored link and resource attributes.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body
 content can be filtered into renderable structural nodes such as headings,
 blocks, inline runs, links, images, form controls, lists, and tables while
 skipping parser shell, head metadata, comments, scripts, styles, and templates.
+Where a document base is present, link and replaced-resource nodes also expose
+resolved URL fields for downstream navigation and fetch planning.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
 is converted into stable default display categories such as block, inline,
 inline-replaced, list-item, and table display nodes for early layout work. The
 browser-facing fixture set also pins control metadata such as value,
-disabled/checked/selected state, select option labels, and textarea values.
+disabled/checked/selected state, select option labels, textarea values, and
+resolved URL metadata for link and replaced nodes.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -5,8 +5,8 @@
   "cases": [
     {
       "id": "classic-document-flow",
-      "description": "Head metadata is skipped while headings, paragraphs, links, images, line breaks, and lists stay renderable.",
-      "input": "<!doctype html><title>Example</title><link rel=stylesheet href=style.css><h1 id=top>Example Directory</h1><p>Welcome to <a href=intro.html>Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
+      "description": "Head metadata is skipped while headings, paragraphs, base-resolved links, images, line breaks, and lists stay renderable.",
+      "input": "<!doctype html><title>Example</title><base href=\"https://example.test/docs/\"><link rel=stylesheet href=style.css><h1 id=top>Example Directory</h1><p>Welcome to <a href=intro.html>Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
       "expected": {
         "children": [
           {
@@ -36,6 +36,7 @@
                 "name": "a",
                 "text": "Venture HTML",
                 "href": "intro.html",
+                "resolved_href": "https://example.test/docs/intro.html",
                 "src": null,
                 "alt": null,
                 "control_type": null,
@@ -45,7 +46,7 @@
               },
               { "role": "text", "name": null, "text": ".", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
               { "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
-              { "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "alt": "Logo", "control_type": null, "children": [] }
+              { "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "control_type": null, "children": [] }
             ]
           },
           {

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -16,8 +16,8 @@
           { "name": null, "http_equiv": null, "property": null, "charset": "utf-8", "content": null }
         ],
         "resources": [
-          { "kind": "stylesheet", "url": "style.css", "rel": "stylesheet", "type_hint": null, "media": "screen", "title": "default", "async_script": false, "defer_script": false },
-          { "kind": "image", "url": "logo.gif", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false }
+          { "kind": "stylesheet", "url": "style.css", "resolved_url": "https://example.test/docs/style.css", "rel": "stylesheet", "type_hint": null, "media": "screen", "title": "default", "async_script": false, "defer_script": false },
+          { "kind": "image", "url": "logo.gif", "resolved_url": "https://example.test/docs/logo.gif", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false }
         ],
         "anchors": [
           { "id": "index", "name": null, "text": "Example Directory" }
@@ -26,10 +26,10 @@
           { "level": 1, "text": "Example Directory" }
         ],
         "links": [
-          { "href": "intro.html", "name": null, "target": "main", "rel": "next", "title": "Intro", "text": "Venture HTML" }
+          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "rel": "next", "title": "Intro", "text": "Venture HTML" }
         ],
         "images": [
-          { "src": "logo.gif", "alt": "Logo", "width": "88", "height": "31" }
+          { "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "width": "88", "height": "31" }
         ],
         "forms": [],
         "tables": []
@@ -57,6 +57,7 @@
         "forms": [
           {
             "action": "/search",
+            "resolved_action": null,
             "method": "post",
             "enctype": "multipart/form-data",
             "target": "results",
@@ -87,7 +88,7 @@
         "body_text": "Alpha bold Beta italic tail Archive Back spaced text",
         "metas": [],
         "resources": [
-          { "kind": "script", "url": "app.js", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": true, "defer_script": true }
+          { "kind": "script", "url": "app.js", "resolved_url": null, "rel": null, "type_hint": null, "media": null, "title": null, "async_script": true, "defer_script": true }
         ],
         "anchors": [
           { "id": null, "name": "top", "text": "" }
@@ -96,8 +97,8 @@
           { "level": 3, "text": "Archive" }
         ],
         "links": [
-          { "href": null, "name": "top", "target": null, "rel": null, "title": null, "text": "" },
-          { "href": "#top", "name": null, "target": null, "rel": null, "title": null, "text": "Back" }
+          { "href": null, "resolved_href": null, "name": "top", "target": null, "rel": null, "title": null, "text": "" },
+          { "href": "#top", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Back" }
         ],
         "images": [],
         "forms": [],

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -5,8 +5,8 @@
   "cases": [
     {
       "id": "flow-inline-and-replaced",
-      "description": "Headings and paragraphs become block layout inputs while text, links, images, and line breaks keep inline display categories.",
-      "input": "<body><h1>Example</h1><p>Hello <a href=next.html>Next</a><img src=logo.gif alt=Logo><br>Tail</p>",
+      "description": "Headings and paragraphs become block layout inputs while base-resolved text, links, images, and line breaks keep inline display categories.",
+      "input": "<base href=\"https://example.test/pages/current.html\"><body><h1>Example</h1><p>Hello <a href=next.html>Next</a><img src=../assets/logo.gif alt=Logo><br>Tail</p>",
       "expected": {
         "children": [
           {
@@ -39,6 +39,7 @@
                 "name": "a",
                 "text": "Next",
                 "href": "next.html",
+                "resolved_href": "https://example.test/pages/next.html",
                 "src": null,
                 "alt": null,
                 "control_type": null,
@@ -46,7 +47,7 @@
                   { "display": "inline-text", "role": "text", "name": null, "text": "Next", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
                 ]
               },
-              { "display": "inline-replaced", "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "alt": "Logo", "control_type": null, "children": [] },
+              { "display": "inline-replaced", "role": "image", "name": "img", "text": null, "href": null, "src": "../assets/logo.gif", "resolved_src": "https://example.test/assets/logo.gif", "alt": "Logo", "control_type": null, "children": [] },
               { "display": "line-break", "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
               { "display": "inline-text", "role": "text", "name": null, "text": "Tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
             ]


### PR DESCRIPTION
## Summary
- add resolved URL metadata beside raw authored URLs in BrowserDocument resources, links, images, and forms
- thread resolved href/src metadata through BrowserContentTree and BrowserRenderTree using document base href
- extend browser fixture schemas, fixtures, docs, and focused resolver tests

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser