### PR TITLE
feat(sql-parser,mini-sqlite): SQLite IS / IS NOT as NULL-safe equality

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -353,7 +353,16 @@ comparison        = collated [ cmp_op collated
                   | "IS" "NULL"
                   | "IS" "NOT" "NULL"
                   | "IS" "DISTINCT" "FROM" collated
-                  | "IS" "NOT" "DISTINCT" "FROM" collated ] ;
+                  | "IS" "NOT" "DISTINCT" "FROM" collated
+                  | "IS" "NOT" collated
+                  | "IS" collated ] ;
+# The last two alternatives implement SQLite's NULL-safe equality
+# operator.  ``x IS y`` is equivalent to ``x IS NOT DISTINCT FROM y``
+# (NULLs compare equal to each other, never to anything else); ``x IS
+# NOT y`` is the negation.  Order matters in this PEG grammar: the
+# more specific ``IS NULL`` / ``IS NOT NULL`` / ``IS [NOT] DISTINCT
+# FROM`` alternatives must precede the general ``IS [NOT] collated``
+# forms so they get the first shot at matching their keyword tails.
 
 # in_expr: a subquery takes priority (starts with SELECT); otherwise a
 # comma-separated value list is used.

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [2.7.0] - 2026-05-23
+
+### Added
+
+- SQLite's NULL-safe equality operators ``x IS y`` and ``x IS NOT y``
+  (general RHS form, beyond the existing ``IS NULL`` /
+  ``IS NOT NULL`` / ``IS DISTINCT FROM …`` shapes) are now supported.
+  ``IS`` is equivalent to ``IS NOT DISTINCT FROM`` (true iff both
+  sides are equal *or* both are NULL); ``IS NOT`` is the negation.
+
+  Examples that previously raised ``Parse error … Expected "NULL" or
+  "NOT" or "DISTINCT", got '1'``::
+
+      SELECT 1 IS 1                ⟶  1
+      SELECT NULL IS NULL          ⟶  1
+      SELECT NULL IS 1             ⟶  0
+      SELECT 'a' IS 'a'            ⟶  1
+      SELECT 1 IS NOT 2            ⟶  1
+      WHERE a IS b                 (NULL-safe column comparison)
+
+  Implementation: two new grammar alternatives — ``"IS" collated``
+  and ``"IS" "NOT" collated`` — at the end of the IS family (PEG
+  order: the more specific ``NULL`` / ``DISTINCT`` forms still get
+  the first shot at matching).  The adapter detects the bare-RHS
+  form by the count of ``collated`` children (one child = ``IS
+  NULL`` shape; two = ``IS <expr>`` shape) and routes through the
+  existing ``IS_[NOT_]DISTINCT_FROM`` planner/codegen/VM paths.
+
 ## [2.6.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.6.0"
+version = "2.7.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -2102,7 +2102,7 @@ def _comparison(node: ASTNode, state: _PlaceholderCounter) -> Expr:
             return UnaryExpr(op=UnaryOp.NOT, operand=glob_call)
         return glob_call
 
-    # IS NULL / IS NOT NULL / IS DISTINCT FROM / IS NOT DISTINCT FROM.
+    # IS NULL / IS NOT NULL / IS [NOT] DISTINCT FROM / IS [NOT] <expr>.
     if _has_keyword_child(node, "IS"):
         if _has_keyword_child(node, "DISTINCT"):
             # "IS [NOT] DISTINCT FROM collated"
@@ -2114,9 +2114,25 @@ def _comparison(node: ASTNode, state: _PlaceholderCounter) -> Expr:
             if _has_keyword_child(node, "NOT"):
                 return BinaryExpr(op=BinaryOp.IS_NOT_DISTINCT_FROM, left=left, right=right)
             return BinaryExpr(op=BinaryOp.IS_DISTINCT_FROM, left=left, right=right)
+        # ``IS NULL`` / ``IS NOT NULL`` — detect by the presence of NULL in
+        # the keyword tail.  The bare-RHS form (``IS <expr>``) has exactly
+        # two ``collated`` children; the NULL form has only one.
+        if len(collateds) == 1:
+            if _has_keyword_child(node, "NOT"):
+                return IsNotNull(operand=left)
+            return IsNull(operand=left)
+        # ``x IS y`` / ``x IS NOT y`` for arbitrary RHS — SQLite's NULL-safe
+        # equality.  ``IS`` ≡ ``IS NOT DISTINCT FROM`` and ``IS NOT`` ≡
+        # ``IS DISTINCT FROM``.  Routed through the existing IS_[NOT_]DISTINCT_FROM
+        # planner/codegen/VM paths so no downstream changes are needed.
+        right, right_coll = _collated(collateds[1], state)
+        coll = left_coll if left_coll is not None else right_coll
+        if coll is not None:
+            left = _collation_transform(left, coll)
+            right = _collation_transform(right, coll)
         if _has_keyword_child(node, "NOT"):
-            return IsNotNull(operand=left)
-        return IsNull(operand=left)
+            return BinaryExpr(op=BinaryOp.IS_DISTINCT_FROM, left=left, right=right)
+        return BinaryExpr(op=BinaryOp.IS_NOT_DISTINCT_FROM, left=left, right=right)
 
     return left
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_is_null_safe_equality.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_is_null_safe_equality.py
@@ -1,0 +1,136 @@
+"""Tests for SQLite's NULL-safe equality operator ``IS`` / ``IS NOT``.
+
+SQLite extends the standard ISO SQL ``IS NULL`` / ``IS NOT NULL``
+predicates with a general NULL-safe equality form::
+
+    x IS y          ⟶  true iff x and y are equal OR both are NULL
+                        (equivalent to ``x IS NOT DISTINCT FROM y``)
+    x IS NOT y      ⟶  the negation
+                        (equivalent to ``x IS DISTINCT FROM y``)
+
+This is identical to PostgreSQL's ``IS NOT DISTINCT FROM`` /
+``IS DISTINCT FROM`` operators in semantics but uses SQLite's compact
+``IS`` spelling.  Mini-sqlite previously parse-errored on this form
+because the grammar only accepted ``IS`` followed by ``NULL``,
+``NOT NULL``, ``DISTINCT FROM …``, or ``NOT DISTINCT FROM …``.
+
+The fix adds two grammar alternatives — ``"IS" collated`` and
+``"IS" "NOT" collated`` — at the end of the IS family (after the
+more specific NULL / DISTINCT forms so PEG ordering still works) and
+routes them through the existing IS_[NOT_]DISTINCT_FROM planner/codegen
+paths in the adapter.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(*stmts: str, query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestNullSafeEquality:
+    def test_int_is_int_equal(self) -> None:
+        _both_match(query="SELECT 1 IS 1")
+
+    def test_int_is_int_unequal(self) -> None:
+        _both_match(query="SELECT 1 IS 0")
+
+    def test_null_is_null(self) -> None:
+        _both_match(query="SELECT NULL IS NULL")
+
+    def test_null_is_int(self) -> None:
+        _both_match(query="SELECT NULL IS 1")
+
+    def test_int_is_null(self) -> None:
+        _both_match(query="SELECT 1 IS NULL")
+
+    def test_string_is_string(self) -> None:
+        _both_match(query="SELECT 'a' IS 'a'")
+
+    def test_float_is_float(self) -> None:
+        _both_match(query="SELECT 1.5 IS 1.5")
+
+    def test_float_is_int_equal(self) -> None:
+        # SQLite: 1 IS 1.0 → 1 (NULL-safe equality coerces)
+        _both_match(query="SELECT 1 IS 1.0")
+
+
+class TestNullSafeInequality:
+    def test_int_is_not_int(self) -> None:
+        _both_match(query="SELECT 1 IS NOT 2")
+
+    def test_string_is_not_string(self) -> None:
+        _both_match(query="SELECT 'a' IS NOT 'b'")
+
+    def test_int_is_not_null(self) -> None:
+        # Pre-existing "IS NOT NULL" predicate path — must still work.
+        _both_match(query="SELECT 1 IS NOT NULL")
+
+    def test_null_is_not_null(self) -> None:
+        _both_match(query="SELECT NULL IS NOT NULL")
+
+    def test_null_is_not_int(self) -> None:
+        _both_match(query="SELECT NULL IS NOT 1")
+
+
+class TestExistingFormsStillWork:
+    """Regression: the original IS NULL / IS DISTINCT FROM paths must keep working."""
+
+    def test_is_null(self) -> None:
+        _both_match(query="SELECT 1 IS NULL")
+
+    def test_is_not_null(self) -> None:
+        _both_match(query="SELECT 1 IS NOT NULL")
+
+    def test_is_distinct_from(self) -> None:
+        _both_match(query="SELECT 1 IS DISTINCT FROM 2")
+
+    def test_is_not_distinct_from(self) -> None:
+        _both_match(query="SELECT 1 IS NOT DISTINCT FROM 1")
+
+    def test_is_not_distinct_from_null(self) -> None:
+        _both_match(query="SELECT NULL IS NOT DISTINCT FROM NULL")
+
+
+class TestColumnContext:
+    def test_is_against_column(self) -> None:
+        _both_match(
+            "CREATE TABLE t (a INT, b INT)",
+            "INSERT INTO t VALUES (1, 1), (1, 2), (NULL, NULL), (NULL, 1), (1, NULL)",
+            query="SELECT a, b FROM t WHERE a IS b ORDER BY rowid",
+        )
+
+    def test_is_not_against_column(self) -> None:
+        _both_match(
+            "CREATE TABLE t (a INT, b INT)",
+            "INSERT INTO t VALUES (1, 1), (1, 2), (NULL, NULL), (NULL, 1)",
+            query="SELECT a, b FROM t WHERE a IS NOT b ORDER BY rowid",
+        )
+
+    def test_is_in_where_with_null_match(self) -> None:
+        # NULL-safe: WHERE a IS NULL is *equivalent* to WHERE a IS (literal NULL)
+        _both_match(
+            "CREATE TABLE t (a INT)",
+            "INSERT INTO t VALUES (1), (NULL), (2)",
+            query="SELECT a FROM t WHERE a IS NULL",
+        )
+
+
+class TestExpressionContext:
+    def test_is_in_case_branch(self) -> None:
+        _both_match(query="SELECT CASE WHEN NULL IS NULL THEN 'yes' END")
+
+    def test_is_inside_not(self) -> None:
+        _both_match(query="SELECT NOT (1 IS 2)")
+
+    def test_chained_is_and_and(self) -> None:
+        _both_match(query="SELECT (1 IS 1) AND (2 IS 2)")

--- a/code/packages/python/sql-parser/CHANGELOG.md
+++ b/code/packages/python/sql-parser/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to the SQL parser package will be documented in this file.
 
 ### Changed
 
+- ``comparison`` rule now accepts SQLite's general NULL-safe equality
+  forms ``"IS" collated`` and ``"IS" "NOT" collated`` (in addition
+  to the existing ``"IS" "NULL"`` / ``"IS" "NOT" "NULL"`` /
+  ``"IS" [NOT] "DISTINCT" "FROM" collated`` alternatives).  The new
+  forms are listed *after* the specific NULL / DISTINCT shapes so
+  the PEG parser still matches those first.  Regenerated
+  ``_grammar.py`` cache via ``grammar-tools``.
+
+- Unary ``+`` prefix accepted as a no-op identity in the ``unary``
+  rule (see mini-sqlite CHANGELOG 2.6.0 for the end-to-end change).
+  This was inadvertently omitted from the previous bump; pinning the
+  version here so the parser ships with the matching grammar.
+
+## [0.41.0] - 2026-05-23
+
+### Changed
+
 - ``unary`` rule now accepts ``+`` alongside ``-`` and ``~``::
 
       unary = ( "-" | "~" | "+" ) unary | primary ;

--- a/code/packages/python/sql-parser/pyproject.toml
+++ b/code/packages/python/sql-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-parser"
-version = "0.41.0"
+version = "0.42.0"
 description = "Parses SQL text into ASTs using the grammar-driven parser — a thin wrapper that loads sql.grammar"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-parser/src/sql_parser/_grammar.py
+++ b/code/packages/python/sql-parser/src/sql_parser/_grammar.py
@@ -1281,6 +1281,15 @@ PARSER_GRAMMAR = ParserGrammar(
                             Literal(value='FROM'),
                             RuleReference(name='collated', is_token=False),
                         ]),
+                        Sequence(elements=[
+                            Literal(value='IS'),
+                            Literal(value='NOT'),
+                            RuleReference(name='collated', is_token=False),
+                        ]),
+                        Sequence(elements=[
+                            Literal(value='IS'),
+                            RuleReference(name='collated', is_token=False),
+                        ]),
                     ]),
                 ),
             ]),
@@ -1293,7 +1302,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='query_stmt', is_token=False),
                 RuleReference(name='value_list', is_token=False),
             ]),
-            line_number=360,
+            line_number=369,
         ),
         GrammarRule(
             name='cmp_op',
@@ -1306,7 +1315,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='<='),
                 Literal(value='>='),
             ]),
-            line_number=362,
+            line_number=371,
         ),
         GrammarRule(
             name='bitwise',
@@ -1327,7 +1336,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=376,
+            line_number=385,
         ),
         GrammarRule(
             name='additive',
@@ -1349,7 +1358,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=377,
+            line_number=386,
         ),
         GrammarRule(
             name='multiplicative',
@@ -1369,7 +1378,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=378,
+            line_number=387,
         ),
         GrammarRule(
             name='unary',
@@ -1387,7 +1396,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='primary', is_token=False),
             ]),
-            line_number=384,
+            line_number=393,
         ),
         GrammarRule(
             name='primary',
@@ -1421,7 +1430,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value=')'),
                 ]),
             ]),
-            line_number=404,
+            line_number=413,
         ),
         GrammarRule(
             name='column_ref',
@@ -1435,7 +1444,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=414,
+            line_number=423,
         ),
         GrammarRule(
             name='function_call',
@@ -1465,7 +1474,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='filter_clause', is_token=False),
                 ),
             ]),
-            line_number=428,
+            line_number=437,
         ),
         GrammarRule(
             name='filter_clause',
@@ -1477,7 +1486,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='expr', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=432,
+            line_number=441,
         ),
         GrammarRule(
             name='cast_expr',
@@ -1490,7 +1499,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='NAME', is_token=True),
                 Literal(value=')'),
             ]),
-            line_number=438,
+            line_number=447,
         ),
         GrammarRule(
             name='window_func_call',
@@ -1512,7 +1521,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='window_spec', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=467,
+            line_number=476,
         ),
         GrammarRule(
             name='window_spec',
@@ -1528,7 +1537,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_clause', is_token=False),
                 ),
             ]),
-            line_number=468,
+            line_number=477,
         ),
         GrammarRule(
             name='partition_clause',
@@ -1544,7 +1553,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=469,
+            line_number=478,
         ),
         GrammarRule(
             name='value_list',
@@ -1558,7 +1567,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=470,
+            line_number=479,
         ),
         GrammarRule(
             name='frame_clause',
@@ -1576,7 +1585,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_bound', is_token=False),
                 ]),
             ]),
-            line_number=492,
+            line_number=501,
         ),
         GrammarRule(
             name='frame_unit',
@@ -1586,7 +1595,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='RANGE'),
                 Literal(value='GROUPS'),
             ]),
-            line_number=494,
+            line_number=503,
         ),
         GrammarRule(
             name='frame_bound',
@@ -1613,7 +1622,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='FOLLOWING'),
                 ]),
             ]),
-            line_number=495,
+            line_number=504,
         ),
         GrammarRule(
             name='create_trigger_stmt',
@@ -1651,7 +1660,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=521,
+            line_number=530,
         ),
         GrammarRule(
             name='trigger_body_stmt',
@@ -1663,7 +1672,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='delete_stmt', is_token=False),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=526,
+            line_number=535,
         ),
         GrammarRule(
             name='drop_trigger_stmt',
@@ -1679,7 +1688,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=528,
+            line_number=537,
         ),
         GrammarRule(
             name='case_expr',
@@ -1701,13 +1710,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=543,
+            line_number=552,
         ),
         GrammarRule(
             name='case_operand',
             body=
             RuleReference(name='expr', is_token=False),
-            line_number=544,
+            line_number=553,
         ),
         GrammarRule(
             name='case_when',
@@ -1718,7 +1727,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='THEN'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=545,
+            line_number=554,
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- Adds SQLite's general NULL-safe equality operator: `x IS y` (≡ `IS NOT DISTINCT FROM`) and `x IS NOT y` (≡ `IS DISTINCT FROM`). Previously parse-errored with `Expected \"NULL\" or \"NOT\" or \"DISTINCT\", got '1'`.
- Two new grammar alternatives `\"IS\" collated` and `\"IS\" \"NOT\" collated` at the END of the IS family (PEG order: specific NULL/DISTINCT shapes still match first).
- Adapter disambiguates by counting `collated` children; routes through existing `IS_[NOT_]DISTINCT_FROM` planner/codegen/VM paths.

## Version bumps

- `sql-parser`: 0.41 → 0.42 (also pins the unary `+` change from PR #4151 which missed the bump)
- `mini-sqlite`: 2.6 → 2.7

## Test plan

- [x] 24 new oracle tests pass (int/float/string/NULL combos, IS NOT variants, column context, expression context, regression for existing IS NULL/DISTINCT forms)
- [x] mini-sqlite suite (2224 tests) clean
- [x] sql-parser suite (91 tests) clean
- [x] Ruff clean
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)