### PR TITLE
spice: parse fourier control cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse SPICE `.four <frequency> <V(node)|I(source)>...` Fourier-analysis
+  cards.
 - Parse SPICE `.print <analysis> <V(node)|I(source)>...` and
   `.plot <analysis> <V(node)|I(source)>...` output cards.
 - Parse SPICE `.temp <celsius> [celsius ...]` operating-temperature cards.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -28,6 +28,6 @@ MOSFET parameters (`NMOS`/`PMOS`, `VT0`/`VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 and inductor `IC=<current>` initial conditions, SPICE engineering suffixes,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
-`.temp`, `.print`, `.plot`, and `.options` analysis cards. Transient cards can carry
-`method=euler|trap|gear2`; when omitted, `netlist.transient_method()` falls
-back to `.options method=<...>` if present.
+`.temp`, `.print`, `.plot`, `.four`, and `.options` analysis cards. Transient
+cards can carry `method=euler|trap|gear2`; when omitted,
+`netlist.transient_method()` falls back to `.options method=<...>` if present.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -3,6 +3,7 @@
 from spice_netlist_parser.parser import (
     AcAnalysis,
     DcAnalysis,
+    FourAnalysis,
     McAnalysis,
     ModelCard,
     NetlistParseError,
@@ -28,6 +29,7 @@ __version__ = "0.1.6"
 __all__ = [
     "AcAnalysis",
     "DcAnalysis",
+    "FourAnalysis",
     "McAnalysis",
     "ModelCard",
     "NetlistParseError",

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -140,6 +140,14 @@ class PlotAnalysis:
     probes: tuple[OutputProbe, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class FourAnalysis:
+    """A `.four <frequency> <V(node)|I(source)>...` Fourier-analysis card."""
+
+    frequency_hz: float
+    probes: tuple[OutputProbe, ...]
+
+
 type OptionValue = float | str | bool
 type TransientMethod = Literal["euler", "trap", "gear2"]
 
@@ -163,6 +171,7 @@ type Analysis = (
     | TempAnalysis
     | PrintAnalysis
     | PlotAnalysis
+    | FourAnalysis
     | OptionsAnalysis
 )
 
@@ -238,6 +247,9 @@ class ParsedNetlist:
 
     def plot_cards(self) -> list[PlotAnalysis]:
         return [analysis for analysis in self.analyses if isinstance(analysis, PlotAnalysis)]
+
+    def four_cards(self) -> list[FourAnalysis]:
+        return [analysis for analysis in self.analyses if isinstance(analysis, FourAnalysis)]
 
     def options_cards(self) -> list[OptionsAnalysis]:
         return [analysis for analysis in self.analyses if isinstance(analysis, OptionsAnalysis)]
@@ -869,6 +881,12 @@ def _parse_directive(fields: list[str]) -> Analysis:
         return PlotAnalysis(
             analysis=fields[1].lower(),
             probes=tuple(_parse_output_probe(token, ".plot") for token in fields[2:]),
+        )
+    if directive == ".four":
+        _require_min_fields(fields, 3, ".four")
+        return FourAnalysis(
+            frequency_hz=parse_value(fields[1]),
+            probes=tuple(_parse_output_probe(token, ".four") for token in fields[2:]),
         )
     if directive == ".options":
         _require_min_fields(fields, 2, ".options")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -30,6 +30,7 @@ from spice_engine import (
 from spice_netlist_parser import (
     AcAnalysis,
     DcAnalysis,
+    FourAnalysis,
     McAnalysis,
     ModelCard,
     NetlistParseError,
@@ -242,6 +243,28 @@ def test_output_cards_reject_missing_or_unknown_probes() -> None:
         parse_netlist(".print tran")
     with pytest.raises(NetlistParseError, match=r"\.plot probe must be V\(node\) or I\(source\)"):
         parse_netlist(".plot tran P(out)")
+
+
+def test_parse_four_analysis_card() -> None:
+    parsed = parse_netlist(".four 1k V(out) I(Vin)")
+
+    assert parsed.analyses == [
+        FourAnalysis(
+            1.0e3,
+            (
+                OutputProbe("voltage", "out"),
+                OutputProbe("current", "Vin"),
+            ),
+        )
+    ]
+    assert parsed.four_cards() == parsed.analyses
+
+
+def test_four_card_rejects_missing_or_unknown_probes() -> None:
+    with pytest.raises(NetlistParseError, match=r"\.four expects at least 3 fields"):
+        parse_netlist(".four 1k")
+    with pytest.raises(NetlistParseError, match=r"\.four probe must be V\(node\) or I\(source\)"):
+        parse_netlist(".four 1k P(out)")
 
 
 def test_parse_transient_method_from_tran_card() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse SPICE `.four <frequency> <V(node)|I(source)>...` Fourier-analysis
+  cards.
 - Parse SPICE `.print <analysis> <V(node)|I(source)>...` and
   `.plot <analysis> <V(node)|I(source)>...` output cards.
 - Parse SPICE `.temp <celsius> [celsius ...]` operating-temperature cards.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -29,7 +29,7 @@ suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
-`.temp`, `.print`, `.plot`, and `.options` analysis cards.
+`.temp`, `.print`, `.plot`, `.four`, and `.options` analysis cards.
 Transient cards can carry `method=euler|trap|gear2`; when omitted,
 `parsed.transient_method(None)?` falls back to `.options method=<...>` if
 present.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -106,6 +106,12 @@ pub struct PlotAnalysis {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct FourAnalysis {
+    pub frequency_hz: f64,
+    pub probes: Vec<OutputProbe>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum OptionValue {
     Number(f64),
     Text(String),
@@ -130,6 +136,7 @@ pub enum Analysis {
     Temp(TempAnalysis),
     Print(PrintAnalysis),
     Plot(PlotAnalysis),
+    Four(FourAnalysis),
     Options(OptionsAnalysis),
 }
 
@@ -264,6 +271,16 @@ impl ParsedNetlist {
             .iter()
             .filter_map(|analysis| match analysis {
                 Analysis::Plot(card) => Some(card),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn four_cards(&self) -> Vec<&FourAnalysis> {
+        self.analyses
+            .iter()
+            .filter_map(|analysis| match analysis {
+                Analysis::Four(card) => Some(card),
                 _ => None,
             })
             .collect()
@@ -1418,6 +1435,13 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
             Ok(Analysis::Plot(PlotAnalysis {
                 analysis: fields[1].to_ascii_lowercase(),
                 probes: parse_output_probes(&fields[2..], ".plot")?,
+            }))
+        }
+        ".four" => {
+            require_min_fields(fields, 3, ".four")?;
+            Ok(Analysis::Four(FourAnalysis {
+                frequency_hz: parse_value(&fields[1])?,
+                probes: parse_output_probes(&fields[2..], ".four")?,
             }))
         }
         ".options" => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -3,9 +3,9 @@ use spice_engine::{
     McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
-    parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, McAnalysis, NetlistParseError,
-    NoiseAnalysis, OpAnalysis, OptionValue, OutputProbe, PlotAnalysis, PrintAnalysis, SensAnalysis,
-    TempAnalysis, TfAnalysis, TranAnalysis,
+    parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, FourAnalysis, McAnalysis,
+    NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue, OutputProbe, PlotAnalysis,
+    PrintAnalysis, SensAnalysis, TempAnalysis, TfAnalysis, TranAnalysis,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -306,6 +306,40 @@ fn rejects_output_cards_with_missing_or_unknown_probes() {
     assert!(probe_error
         .to_string()
         .contains(".plot probe must be V(node) or I(source)"));
+}
+
+#[test]
+fn parses_four_analysis_cards() {
+    let parsed = parse_netlist(".four 1k V(out) I(Vin)").unwrap();
+
+    assert_eq!(
+        parsed.analyses,
+        vec![Analysis::Four(FourAnalysis {
+            frequency_hz: 1.0e3,
+            probes: vec![
+                OutputProbe::Voltage {
+                    node: "out".to_string()
+                },
+                OutputProbe::Current {
+                    source_name: "Vin".to_string()
+                },
+            ],
+        })]
+    );
+    assert!(matches!(parsed.four_cards().as_slice(), [_]));
+}
+
+#[test]
+fn rejects_four_cards_with_missing_or_unknown_probes() {
+    let missing_error = parse_netlist(".four 1k").unwrap_err();
+    assert!(missing_error
+        .to_string()
+        .contains(".four expects at least 3 fields"));
+
+    let probe_error = parse_netlist(".four 1k P(out)").unwrap_err();
+    assert!(probe_error
+        .to_string()
+        .contains(".four probe must be V(node) or I(source)"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse SPICE `.four <frequency> <V(node)|I(source)>...` Fourier-analysis
+  cards.
 - Parse SPICE `.print <analysis> <V(node)|I(source)>...` and
   `.plot <analysis> <V(node)|I(source)>...` output cards.
 - Parse SPICE `.temp <celsius> [celsius ...]` operating-temperature cards.

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -31,6 +31,7 @@ elements, `.model <name> D(...)` diode cards with `IS` and `VT` parameters,
 initial conditions,
 SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 `.subckt` / `X` instance expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`,
-`.sens`, `.mc`, `.noise`, `.temp`, `.print`, `.plot`, and `.options` analysis
-cards. Transient cards can carry `method=euler|trap|gear2`; when omitted,
-`netlist.transientMethod()` falls back to `.options method=<...>` if present.
+`.sens`, `.mc`, `.noise`, `.temp`, `.print`, `.plot`, `.four`, and `.options`
+analysis cards. Transient cards can carry `method=euler|trap|gear2`; when
+omitted, `netlist.transientMethod()` falls back to `.options method=<...>` if
+present.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -115,6 +115,12 @@ export interface PlotAnalysis {
   readonly probes: readonly OutputProbe[];
 }
 
+export interface FourAnalysis {
+  readonly kind: "four";
+  readonly frequencyHz: number;
+  readonly probes: readonly OutputProbe[];
+}
+
 export type OptionValue = number | string | boolean;
 
 export interface OptionsAnalysis {
@@ -134,6 +140,7 @@ export type Analysis =
   | TempAnalysis
   | PrintAnalysis
   | PlotAnalysis
+  | FourAnalysis
   | OptionsAnalysis;
 
 export interface ModelCard {
@@ -198,6 +205,10 @@ export class ParsedNetlist {
 
   plotCards(): PlotAnalysis[] {
     return this.analyses.filter((analysis): analysis is PlotAnalysis => analysis.kind === "plot");
+  }
+
+  fourCards(): FourAnalysis[] {
+    return this.analyses.filter((analysis): analysis is FourAnalysis => analysis.kind === "four");
   }
 
   transientMethod(tran?: TranAnalysis): TransientMethod | undefined {
@@ -1134,6 +1145,14 @@ function parseDirective(fields: readonly string[]): Analysis {
       kind: "plot",
       analysis: fields[1].toLowerCase(),
       probes: fields.slice(2).map((token) => parseOutputProbe(token, ".plot")),
+    };
+  }
+  if (directive === ".four") {
+    requireMinFields(fields, 3, ".four");
+    return {
+      kind: "four",
+      frequencyHz: parseValue(fields[1]),
+      probes: fields.slice(2).map((token) => parseOutputProbe(token, ".four")),
     };
   }
   if (directive === ".options") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -193,6 +193,28 @@ Tdelay in 0 out 0 Z0=50 TD=1n
     );
   });
 
+  it("parses .four analysis cards", () => {
+    const parsed = parseNetlist(".four 1k V(out) I(Vin)");
+    const card = {
+      kind: "four",
+      frequencyHz: 1000,
+      probes: [
+        { kind: "voltage", target: "out" },
+        { kind: "current", target: "Vin" },
+      ],
+    };
+
+    expect(parsed.analyses).toEqual([card]);
+    expect(parsed.fourCards()).toEqual([card]);
+  });
+
+  it("rejects .four cards with missing or unknown probes", () => {
+    expect(() => parseNetlist(".four 1k")).toThrow(/\.four expects at least 3 fields/);
+    expect(() => parseNetlist(".four 1k P(out)")).toThrow(
+      /\.four probe must be V\(node\) or I\(source\)/,
+    );
+  });
+
   it("parses transient methods from .tran cards", () => {
     const parsed = parseNetlist(".tran 1n 20n method=gear2");
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -250,6 +250,8 @@ Status:
 - `.print <analysis> <V(node)|I(source)>...` and
   `.plot <analysis> <V(node)|I(source)>...` parser/control-card records are
   implemented across Python, TypeScript, and Rust.
+- `.four <frequency> <V(node)|I(source)>...` parser/control-card records are
+  implemented across Python, TypeScript, and Rust.
 
 ### Phase 8 - Small-Signal Distortion and Pole-Zero
 


### PR DESCRIPTION
## Summary

- add `.four <frequency> <V(node)|I(source)>...` records to the Python, TypeScript, and Rust SPICE netlist parsers
- reuse output-probe records and expose `four_cards()` / `fourCards()` helpers across languages
- cover valid voltage/current probes and invalid/missing `.four` forms, and update parser docs/changelogs plus the Phase 7 compatibility status

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-four-parser PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `npm install && npm run build && npm test -- --run`
- `cargo fmt -p spice-netlist-parser && cargo test -p spice-netlist-parser`
- `git diff --check`