### PR TITLE
Add shared textured GPU paint profiles

### DIFF
--- a/code/packages/rust/paint-vm-gpu-core/CHANGELOG.md
+++ b/code/packages/rust/paint-vm-gpu-core/CHANGELOG.md
@@ -12,3 +12,5 @@
   backends that support texture sampling.
 - Added radial gradient 2D textures with radial UV lowering for GPU backends
   that support sampled gradient textures.
+- Added a shared Tier 1 textured backend profile for GPU/compute backends that
+  accept image, linear-gradient, and radial-gradient texture plans.

--- a/code/packages/rust/paint-vm-gpu-core/src/lib.rs
+++ b/code/packages/rust/paint-vm-gpu-core/src/lib.rs
@@ -204,6 +204,29 @@ impl GpuBackendProfile {
             accepts_degraded_solid_gradients: true,
         }
     }
+
+    pub const fn tier1_textured(
+        id: &'static str,
+        family: GpuApiFamily,
+        render_path: GpuRenderPath,
+        shader_model: &'static str,
+        readback: GpuReadbackStrategy,
+    ) -> Self {
+        Self {
+            id,
+            family,
+            render_path,
+            shader_model,
+            readback,
+            supports_indexed_meshes: true,
+            supports_scissor_clips: true,
+            supports_texture_sampling: true,
+            supports_linear_gradients: true,
+            supports_radial_gradients: true,
+            supports_glyph_atlas: false,
+            accepts_degraded_solid_gradients: true,
+        }
+    }
 }
 
 impl Default for GpuPlanOptions {
@@ -1789,6 +1812,118 @@ mod tests {
         let unsupported = unsupported_plan_features(profile, &plan);
 
         assert_eq!(unsupported, vec!["gradient.radial"]);
+    }
+
+    #[test]
+    fn tier1_textured_profile_accepts_images_and_gradient_textures() {
+        let mut pixels = PixelContainer::new(1, 1);
+        pixels.set_pixel(0, 0, 12, 34, 56, 255);
+        let mut scene = PaintScene::new(24.0, 12.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("linear".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 12.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ff0000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#0000ff".to_string(),
+                    },
+                ],
+            }));
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("radial".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Radial {
+                    cx: 18.0,
+                    cy: 6.0,
+                    r: 6.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ffffff".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#000000".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 8.0,
+            height: 12.0,
+            fill: Some("url(#linear)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 8.0,
+            y: 0.0,
+            width: 8.0,
+            height: 12.0,
+            fill: Some("url(#radial)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+        scene.instructions.push(PaintInstruction::Image(PaintImage {
+            base: PaintBase::default(),
+            x: 16.0,
+            y: 0.0,
+            width: 8.0,
+            height: 12.0,
+            src: ImageSrc::Pixels(pixels),
+            opacity: None,
+        }));
+        let profile = GpuBackendProfile::tier1_textured(
+            "paint-vm-test-gpu",
+            GpuApiFamily::Wgpu,
+            GpuRenderPath::GraphicsPipeline,
+            "test-shader",
+            GpuReadbackStrategy::TextureCopyToBuffer,
+        );
+
+        let plan = plan_scene(&scene);
+        let unsupported = unsupported_plan_features(profile, &plan);
+
+        assert_eq!(
+            plan.images
+                .iter()
+                .map(|image| image.kind)
+                .collect::<Vec<_>>(),
+            vec![
+                GpuTextureKind::LinearGradient,
+                GpuTextureKind::RadialGradient,
+                GpuTextureKind::Image
+            ]
+        );
+        assert!(unsupported.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/paint-vm-mesa/src/lib.rs
+++ b/code/packages/rust/paint-vm-mesa/src/lib.rs
@@ -3,7 +3,8 @@
 //! Mesa is not a single drawing API; it supplies software and driver-backed
 //! implementations for OpenGL and Vulkan. This crate gives the runtime a
 //! first-class place to model Mesa profiles such as llvmpipe and lavapipe while
-//! sharing the same GPU render plan as WGPU, Vulkan, OpenGL, and OpenCL.
+//! sharing the same GPU render plan as WGPU, Vulkan, OpenGL, and OpenCL,
+//! including image and gradient texture plans.
 
 use paint_instructions::{PaintScene, PixelContainer};
 use paint_vm_gpu_core::{
@@ -31,7 +32,7 @@ pub fn descriptor() -> PaintBackendDescriptor {
 }
 
 pub fn profile() -> GpuBackendProfile {
-    GpuBackendProfile::tier1_solid(
+    GpuBackendProfile::tier1_textured(
         "paint-vm-mesa",
         GpuApiFamily::Mesa,
         GpuRenderPath::DriverProfile,
@@ -86,7 +87,11 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_instructions::{
+        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
+        PaintText,
+    };
+    use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
 
     #[test]
@@ -104,6 +109,9 @@ mod tests {
         assert_eq!(profile.family, GpuApiFamily::Mesa);
         assert_eq!(profile.render_path, GpuRenderPath::DriverProfile);
         assert_eq!(profile.readback, GpuReadbackStrategy::DelegatedToProfile);
+        assert!(profile.supports_texture_sampling);
+        assert!(profile.supports_linear_gradients);
+        assert!(profile.supports_radial_gradients);
     }
 
     #[test]
@@ -119,6 +127,91 @@ mod tests {
 
         assert_eq!((plan.width, plan.height), (16, 16));
         assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_gradient_textures_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("linear".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 10.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ff0000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#0000ff".to_string(),
+                    },
+                ],
+            }));
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("radial".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Radial {
+                    cx: 15.0,
+                    cy: 5.0,
+                    r: 5.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ffffff".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#000000".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#linear)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 10.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#radial)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 2);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
+        assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-opencl/src/lib.rs
+++ b/code/packages/rust/paint-vm-opencl/src/lib.rs
@@ -1,6 +1,8 @@
 //! OpenCL compute backend profile and plan adapter for the Paint VM runtime.
 //!
 //! OpenCL is treated as a compute raster path rather than a native vector API.
+//! Its shared plan adapter still accepts the same image and gradient texture
+//! plans as the graphics GPU backends.
 
 use paint_instructions::{PaintScene, PixelContainer};
 use paint_vm_gpu_core::{
@@ -28,7 +30,7 @@ pub fn descriptor() -> PaintBackendDescriptor {
 }
 
 pub fn profile() -> GpuBackendProfile {
-    GpuBackendProfile::tier1_solid(
+    GpuBackendProfile::tier1_textured(
         "paint-vm-opencl",
         GpuApiFamily::OpenCl,
         GpuRenderPath::ComputeRaster,
@@ -84,7 +86,11 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_instructions::{
+        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
+        PaintText,
+    };
+    use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
 
     #[test]
@@ -102,6 +108,9 @@ mod tests {
         assert_eq!(profile.family, GpuApiFamily::OpenCl);
         assert_eq!(profile.render_path, GpuRenderPath::ComputeRaster);
         assert_eq!(profile.readback, GpuReadbackStrategy::StorageBufferReadback);
+        assert!(profile.supports_texture_sampling);
+        assert!(profile.supports_linear_gradients);
+        assert!(profile.supports_radial_gradients);
     }
 
     #[test]
@@ -117,6 +126,91 @@ mod tests {
 
         assert_eq!((plan.width, plan.height), (16, 16));
         assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_gradient_textures_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("linear".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 10.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ff0000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#0000ff".to_string(),
+                    },
+                ],
+            }));
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("radial".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Radial {
+                    cx: 15.0,
+                    cy: 5.0,
+                    r: 5.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ffffff".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#000000".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#linear)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 10.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#radial)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 2);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
+        assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-opengl/src/lib.rs
+++ b/code/packages/rust/paint-vm-opengl/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate still needs an actual context/framebuffer implementation before
 //! it can render pixels. The shared GPU-plan adapter is present now so OpenGL
 //! converges with WGPU, Vulkan, Mesa, and OpenCL on the same PaintScene
-//! lowering contract.
+//! lowering contract, including image and gradient texture plans.
 
 use paint_instructions::{PaintScene, PixelContainer};
 use paint_vm_gpu_core::{
@@ -31,7 +31,7 @@ pub fn descriptor() -> PaintBackendDescriptor {
 }
 
 pub fn profile() -> GpuBackendProfile {
-    GpuBackendProfile::tier1_solid(
+    GpuBackendProfile::tier1_textured(
         "paint-vm-opengl",
         GpuApiFamily::OpenGl,
         GpuRenderPath::GraphicsPipeline,
@@ -86,7 +86,11 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_instructions::{
+        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
+        PaintText,
+    };
+    use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
 
     #[test]
@@ -104,6 +108,9 @@ mod tests {
         assert_eq!(profile.family, GpuApiFamily::OpenGl);
         assert_eq!(profile.render_path, GpuRenderPath::GraphicsPipeline);
         assert_eq!(profile.readback, GpuReadbackStrategy::FramebufferReadPixels);
+        assert!(profile.supports_texture_sampling);
+        assert!(profile.supports_linear_gradients);
+        assert!(profile.supports_radial_gradients);
     }
 
     #[test]
@@ -119,6 +126,91 @@ mod tests {
 
         assert_eq!((plan.width, plan.height), (16, 16));
         assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_gradient_textures_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("linear".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 10.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ff0000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#0000ff".to_string(),
+                    },
+                ],
+            }));
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("radial".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Radial {
+                    cx: 15.0,
+                    cy: 5.0,
+                    r: 5.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ffffff".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#000000".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#linear)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 10.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#radial)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 2);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
+        assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-vulkan/src/lib.rs
+++ b/code/packages/rust/paint-vm-vulkan/src/lib.rs
@@ -3,7 +3,8 @@
 //! This crate still needs a native Vulkan instance/device/render-pass
 //! implementation before it can render pixels. The shared GPU-plan adapter is
 //! present now so Vulkan converges with WGPU, OpenGL, Mesa, and OpenCL on the
-//! same PaintScene lowering contract.
+//! same PaintScene lowering contract, including image and gradient texture
+//! plans.
 
 use paint_instructions::{PaintScene, PixelContainer};
 use paint_vm_gpu_core::{
@@ -31,7 +32,7 @@ pub fn descriptor() -> PaintBackendDescriptor {
 }
 
 pub fn profile() -> GpuBackendProfile {
-    GpuBackendProfile::tier1_solid(
+    GpuBackendProfile::tier1_textured(
         "paint-vm-vulkan",
         GpuApiFamily::Vulkan,
         GpuRenderPath::GraphicsPipeline,
@@ -86,7 +87,11 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paint_instructions::{PaintInstruction, PaintRect, PaintText};
+    use paint_instructions::{
+        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
+        PaintText,
+    };
+    use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
 
     #[test]
@@ -104,6 +109,9 @@ mod tests {
         assert_eq!(profile.family, GpuApiFamily::Vulkan);
         assert_eq!(profile.render_path, GpuRenderPath::GraphicsPipeline);
         assert_eq!(profile.readback, GpuReadbackStrategy::TextureCopyToBuffer);
+        assert!(profile.supports_texture_sampling);
+        assert!(profile.supports_linear_gradients);
+        assert!(profile.supports_radial_gradients);
     }
 
     #[test]
@@ -119,6 +127,91 @@ mod tests {
 
         assert_eq!((plan.width, plan.height), (16, 16));
         assert_eq!(plan.meshes.len(), 1);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_gradient_textures_with_shared_gpu_core() {
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("linear".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Linear {
+                    x1: 0.0,
+                    y1: 0.0,
+                    x2: 10.0,
+                    y2: 0.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ff0000".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#0000ff".to_string(),
+                    },
+                ],
+            }));
+        scene
+            .instructions
+            .push(PaintInstruction::Gradient(PaintGradient {
+                base: PaintBase {
+                    id: Some("radial".to_string()),
+                    metadata: None,
+                },
+                kind: GradientKind::Radial {
+                    cx: 15.0,
+                    cy: 5.0,
+                    r: 5.0,
+                },
+                stops: vec![
+                    GradientStop {
+                        offset: 0.0,
+                        color: "#ffffff".to_string(),
+                    },
+                    GradientStop {
+                        offset: 1.0,
+                        color: "#000000".to_string(),
+                    },
+                ],
+            }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 0.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#linear)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+        scene.instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: 10.0,
+            y: 0.0,
+            width: 10.0,
+            height: 10.0,
+            fill: Some("url(#radial)".to_string()),
+            stroke: None,
+            stroke_width: None,
+            corner_radius: None,
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 2);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
+        assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-wgpu/src/lib.rs
+++ b/code/packages/rust/paint-vm-wgpu/src/lib.rs
@@ -59,17 +59,13 @@ pub fn descriptor() -> PaintBackendDescriptor {
 }
 
 pub fn profile() -> GpuBackendProfile {
-    let mut profile = GpuBackendProfile::tier1_solid(
+    GpuBackendProfile::tier1_textured(
         "paint-vm-wgpu",
         GpuApiFamily::Wgpu,
         GpuRenderPath::GraphicsPipeline,
         "WGSL",
         GpuReadbackStrategy::TextureCopyToBuffer,
-    );
-    profile.supports_texture_sampling = true;
-    profile.supports_linear_gradients = true;
-    profile.supports_radial_gradients = true;
-    profile
+    )
 }
 
 pub fn renderer() -> WgpuPaintBackend {


### PR DESCRIPTION
## Summary
- add a shared tier1_textured GPU backend profile for image and gradient texture plans
- switch WGPU to the shared textured profile instead of mutating tier1_solid
- let Vulkan, OpenGL, OpenCL, and Mesa plan adapters accept linear/radial gradient texture plans through paint-vm-gpu-core

## Tests
- cargo test -p paint-vm-gpu-core -p paint-vm-vulkan -p paint-vm-opengl -p paint-vm-opencl -p paint-vm-mesa --offline
- cargo test -p paint-vm-wgpu --offline