### PR TITLE
feat(sql-parser,mini-sqlite): LIMIT signed counts + MySQL-style offset,count

### DIFF
--- a/code/grammars/sql.grammar
+++ b/code/grammars/sql.grammar
@@ -136,7 +136,22 @@ order_clause      = "ORDER" "BY" order_item { "," order_item } ;
 # (case-insensitive).
 order_item        = expr [ "COLLATE" NAME ] [ "ASC" | "DESC" ]
                     [ "NULLS" NAME ] ;
-limit_clause      = "LIMIT" NUMBER [ "OFFSET" NUMBER ] ;
+limit_clause      = "LIMIT" signed_number
+                    [ "OFFSET" signed_number
+                    | "," signed_number ] ;
+# ``signed_number`` is an optional ``-`` prefix followed by a NUMBER
+# token.  SQLite documents a *negative* LIMIT as "no limit"
+# (unbounded), useful for ``LIMIT -1 OFFSET N`` to mean "skip N rows
+# and return the rest".  The lexer emits the sign as a separate
+# MINUS token, so the grammar reads it explicitly here.
+#
+# The trailing ``, signed_number`` alternative is SQLite's
+# MySQL-compatible shorthand: ``LIMIT m, n`` means ``LIMIT n OFFSET
+# m`` — the FIRST number is the offset and the SECOND is the count
+# (note the reversed argument order vs the ``OFFSET`` form).  This
+# syntax exists for compatibility with MySQL queries and is the only
+# place in the language where the count/offset ordering swaps.
+signed_number     = [ "-" ] NUMBER ;
 
 # ── INSERT / UPDATE / DELETE ─────────────────────────────────────────────────
 #

--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [2.8.0] - 2026-05-23
+
+### Added
+
+- ``LIMIT`` clause now supports SQLite's two non-standard extensions:
+
+  * **Negative count** means "no limit" (unbounded).  ``SELECT v FROM
+    t LIMIT -1`` returns all rows; ``LIMIT -1 OFFSET 10`` returns
+    everything from row 11 onwards — the canonical "skip N, take
+    rest" idiom.
+
+  * **MySQL-compatible ``LIMIT m, n``** is now accepted as a synonym
+    for ``LIMIT n OFFSET m``.  Note the reversed argument order: the
+    FIRST number is the offset, the SECOND is the count.  This is the
+    only place in SQL where the order swaps.
+
+  * **Negative offset** is treated as zero (matches SQLite).  ``LIMIT
+    5 OFFSET -3`` returns the first five rows with no skip.
+
+  Previously all three raised ``Parse error … Expected NUMBER, got
+  '-'`` or ``Unexpected token: ','`` because the grammar only
+  accepted ``LIMIT NUMBER [ OFFSET NUMBER ]``.
+
+  Implementation: new grammar rule ``signed_number = [ "-" ] NUMBER``
+  used in both ``LIMIT`` slots, plus a comma-form alternative in the
+  trailing position.  The adapter detects the comma form by the
+  presence of a COMMA token and swaps the argument interpretation.
+  Negative counts map to ``Limit.count=None`` so the planner / codegen
+  paths that already understand "no limit" don't need any changes.
+
 ## [2.7.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.7.0"
+version = "2.8.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/adapter.py
@@ -1010,26 +1010,79 @@ def _order_item(node: ASTNode, state: _PlaceholderCounter) -> SortKey:
     )
 
 
+def _signed_number(node: ASTNode) -> int:
+    """Resolve a ``signed_number = [ "-" ] NUMBER`` node to a Python int.
+
+    NUMBER tokens carry the raw source text; hex literals (``0x1F``)
+    reach us as the original ``0x1F`` string, so we route through
+    ``_parse_number`` which handles both decimal and hex spellings.
+    Floats in LIMIT/OFFSET are rejected by SQLite at runtime, but the
+    parser lets them through; we coerce to int and let the engine
+    raise the same error sqlite3 would.
+
+    SQLite documents a negative count as "no limit" — the meaning of
+    the sign is preserved here and the caller (``_limit_clause``)
+    translates a negative count to ``Limit.count=None`` (unbounded).
+    """
+    negative = False
+    raw: str | None = None
+    for c in node.children:
+        if isinstance(c, Token):
+            t = _token_type(c)
+            if t == "MINUS":
+                negative = True
+            elif t == "NUMBER":
+                raw = c.value
+    if raw is None:
+        raise ProgrammingError("signed_number missing NUMBER token")
+    value = int(_parse_number(raw))
+    return -value if negative else value
+
+
 def _limit_clause(node: ASTNode | None) -> Limit | None:
     if node is None:
         return None
-    # limit_clause = "LIMIT" NUMBER [ "OFFSET" NUMBER ]
-    # NUMBER tokens carry the raw source text; hex literals (``0x1F``)
-    # reach us as the original ``0x1F`` string, so we route through
-    # ``_parse_number`` which handles both decimal and hex spellings.
-    # (Floats in LIMIT/OFFSET are rejected by SQLite at runtime, but the
-    # parser allows them through; we coerce to int and let the engine
-    # raise the same error sqlite3 would.)
-    numbers: list[int] = []
-    has_offset_keyword = False
-    for c in node.children:
-        if isinstance(c, Token):
-            if _token_type(c) == "NUMBER":
-                numbers.append(int(_parse_number(c.value)))
-            elif _token_type(c) == "KEYWORD" and c.value.upper() == "OFFSET":
-                has_offset_keyword = True
-    count = numbers[0] if numbers else None
-    offset = numbers[1] if has_offset_keyword and len(numbers) > 1 else None
+    # limit_clause = "LIMIT" signed_number
+    #                [ "OFFSET" signed_number | "," signed_number ]
+    #
+    # Two trailing forms:
+    #   * ``OFFSET N``  — count first, offset second (SQL standard)
+    #   * ``, N``       — offset first, count second (MySQL-compatible)
+    # We detect the comma form by the presence of a COMMA token and
+    # swap the argument interpretation accordingly.
+    signed_nums = [
+        _signed_number(c)
+        for c in node.children
+        if isinstance(c, ASTNode) and c.rule_name == "signed_number"
+    ]
+    has_comma = any(
+        isinstance(c, Token) and _token_type(c) == "COMMA" for c in node.children
+    )
+
+    if not signed_nums:
+        return None
+
+    if has_comma and len(signed_nums) == 2:
+        # MySQL form: ``LIMIT offset, count``.  Swap so ``count`` and
+        # ``offset`` carry their SQL-standard meaning downstream.
+        offset_val, count_val = signed_nums[0], signed_nums[1]
+    else:
+        count_val = signed_nums[0]
+        offset_val = signed_nums[1] if len(signed_nums) > 1 else None
+
+    # SQLite: a negative count means "no limit" (unbounded).  Map that
+    # to ``Limit.count=None`` which the planner/codegen already treat
+    # as "do not emit LimitResult".
+    count: int | None = None if count_val < 0 else count_val
+    # Negative offsets are silently treated as zero in SQLite — match
+    # that behaviour rather than passing the negative value through.
+    offset: int | None
+    if offset_val is None:
+        offset = None
+    elif offset_val < 0:
+        offset = 0
+    else:
+        offset = offset_val
     return Limit(count=count, offset=offset)
 
 

--- a/code/packages/python/mini-sqlite/tests/test_tier3_limit_extensions.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_limit_extensions.py
@@ -1,0 +1,100 @@
+"""Tests for SQLite's ``LIMIT`` extensions: signed counts + MySQL-style ``offset, count``.
+
+SQLite supports two non-standard ``LIMIT`` shapes beyond the basic
+``LIMIT N`` / ``LIMIT N OFFSET M`` forms:
+
+* **Negative count means "no limit".**  ``LIMIT -1`` is a documented
+  idiom for "unbounded".  Combined with ``OFFSET N`` (``LIMIT -1
+  OFFSET 10``) it gives "skip 10, return the rest" — useful in
+  paged queries when you want everything from a given row onwards.
+
+* **Comma syntax: ``LIMIT m, n``.**  MySQL-compatible shorthand for
+  ``LIMIT n OFFSET m``.  Note the reversed argument order — the
+  FIRST number is the offset, the SECOND is the count.  This is the
+  only place in SQL where the order swaps.
+
+* **Negative offset is treated as zero.**  ``LIMIT 5 OFFSET -3``
+  returns the first 5 rows (no skip).
+
+Mini-sqlite previously parse-errored on every one of these because
+the grammar only accepted ``LIMIT NUMBER [ OFFSET NUMBER ]`` (no
+sign, no comma form).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(*stmts: str, query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for s in stmts:
+            c.execute(s)
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+_SOURCE = (
+    "CREATE TABLE t (v INT)",
+    "INSERT INTO t VALUES (1), (2), (3), (4), (5)",
+)
+
+
+class TestNegativeLimit:
+    def test_limit_neg_one_returns_all(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT -1")
+
+    def test_limit_neg_one_with_offset(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT -1 OFFSET 2")
+
+    def test_limit_minus_large(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT -999")
+
+
+class TestMySQLCommaSyntax:
+    def test_limit_offset_count(self) -> None:
+        # LIMIT 1, 2  ≡  LIMIT 2 OFFSET 1  → rows 2 and 3
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 1, 2")
+
+    def test_limit_zero_count(self) -> None:
+        # LIMIT 0, 2  ≡  LIMIT 2 OFFSET 0  → rows 1 and 2
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 0, 2")
+
+    def test_limit_large_offset(self) -> None:
+        # LIMIT 3, 10 ≡  LIMIT 10 OFFSET 3 → rows 4 and 5
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 3, 10")
+
+    def test_limit_offset_beyond_end(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 99, 5")
+
+
+class TestNegativeOffset:
+    def test_negative_offset_treated_as_zero(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 3 OFFSET -2")
+
+
+class TestUnchangedBehaviour:
+    """Regression: the existing LIMIT / LIMIT N OFFSET M paths must still work."""
+
+    def test_plain_limit(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 2")
+
+    def test_limit_zero(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 0")
+
+    def test_limit_with_offset(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 2 OFFSET 1")
+
+    def test_limit_exceeds_rows(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t LIMIT 100")
+
+
+class TestOrderByLimitInteraction:
+    def test_neg_limit_with_order_by(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t ORDER BY v DESC LIMIT -1 OFFSET 1")
+
+    def test_comma_limit_with_order_by(self) -> None:
+        _both_match(*_SOURCE, query="SELECT v FROM t ORDER BY v DESC LIMIT 1, 2")

--- a/code/packages/python/sql-execution-engine/src/sql_execution_engine/executor.py
+++ b/code/packages/python/sql-execution-engine/src/sql_execution_engine/executor.py
@@ -655,31 +655,77 @@ def _extract_order_item(item: ASTNode) -> tuple[ASTNode | Token, bool]:
 # ---------------------------------------------------------------------------
 
 
+def _signed_number_value(node: ASTNode) -> int:
+    """Resolve a ``signed_number = [ "-" ] NUMBER`` AST node to an int.
+
+    The grammar now wraps each LIMIT number in a ``signed_number``
+    rule so a leading ``-`` can be parsed without ambiguity.  We walk
+    the children: collect the optional MINUS sign, then parse the
+    NUMBER token.
+    """
+    negative = False
+    number_text: str | None = None
+    for c in node.children:
+        if isinstance(c, Token):
+            if c.value == "-":
+                negative = True
+            elif c.value.isdigit() or c.value.startswith("0x") or c.value.startswith("0X"):
+                number_text = c.value
+            else:
+                # Fallback: any non-empty numeric-looking value.
+                number_text = c.value
+    if number_text is None:
+        return 0
+    value = int(number_text, 0) if number_text.startswith(("0x", "0X")) else int(number_text)
+    return -value if negative else value
+
+
 def _apply_limit(
     rows: list[dict[str, Any]],
     limit_clause: ASTNode,
 ) -> list[dict[str, Any]]:
     """Apply LIMIT and optional OFFSET to the row list.
 
-    Grammar: ``limit_clause = "LIMIT" NUMBER [ "OFFSET" NUMBER ]``
+    Grammar (updated in sql-parser 0.43)::
+
+        limit_clause  = "LIMIT" signed_number
+                        [ "OFFSET" signed_number | "," signed_number ] ;
+        signed_number = [ "-" ] NUMBER ;
+
+    Semantics:
+    * Negative count → "no limit" (treat as None).
+    * Negative offset → clamp to 0.
+    * Comma form ``LIMIT m, n`` → offset = m, count = n (note swap).
     """
     limit: int | None = None
     offset: int = 0
 
-    children = limit_clause.children
-    i = 0
-    while i < len(children):
-        child = children[i]
-        if isinstance(child, Token):
-            if child.value.upper() == "LIMIT":
-                i += 1
-                if i < len(children):
-                    limit = int(children[i].value)  # type: ignore[union-attr]
-            elif child.value.upper() == "OFFSET":
-                i += 1
-                if i < len(children):
-                    offset = int(children[i].value)  # type: ignore[union-attr]
-        i += 1
+    # Pull out the (in-order) signed_number AST nodes and detect the
+    # comma form by the presence of a COMMA token in the children list.
+    signed_nodes = [
+        c for c in limit_clause.children
+        if isinstance(c, ASTNode) and c.rule_name == "signed_number"
+    ]
+    has_comma = any(
+        isinstance(c, Token) and c.value == "," for c in limit_clause.children
+    )
+
+    if signed_nodes:
+        if has_comma and len(signed_nodes) == 2:
+            # MySQL form: LIMIT offset, count
+            offset = _signed_number_value(signed_nodes[0])
+            limit = _signed_number_value(signed_nodes[1])
+        else:
+            limit = _signed_number_value(signed_nodes[0])
+            if len(signed_nodes) > 1:
+                offset = _signed_number_value(signed_nodes[1])
+
+    # SQLite semantics: negative count means "no limit".
+    if limit is not None and limit < 0:
+        limit = None
+    # Negative offsets clamp to zero.
+    if offset < 0:
+        offset = 0
 
     if limit is None:
         return rows[offset:]

--- a/code/packages/python/sql-parser/CHANGELOG.md
+++ b/code/packages/python/sql-parser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the SQL parser package will be documented in this file.
 
+## [0.43.0] - 2026-05-23
+
+### Changed
+
+- ``limit_clause`` now accepts SQLite's signed counts and
+  MySQL-compatible comma syntax::
+
+      limit_clause  = "LIMIT" signed_number
+                      [ "OFFSET" signed_number | "," signed_number ] ;
+      signed_number = [ "-" ] NUMBER ;
+
+  ``LIMIT -1`` (no limit), ``LIMIT 5 OFFSET -2`` (negative offset
+  treated as zero), and ``LIMIT m, n`` (≡ ``LIMIT n OFFSET m``)
+  now parse cleanly.  Regenerated ``_grammar.py`` cache via
+  ``grammar-tools``.
+
 ## [0.42.0] - 2026-05-23
 
 ### Changed

--- a/code/packages/python/sql-parser/pyproject.toml
+++ b/code/packages/python/sql-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-parser"
-version = "0.42.0"
+version = "0.43.0"
 description = "Parses SQL text into ASTs using the grammar-driven parser — a thin wrapper that loads sql.grammar"
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-parser/src/sql_parser/_grammar.py
+++ b/code/packages/python/sql-parser/src/sql_parser/_grammar.py
@@ -500,15 +500,32 @@ PARSER_GRAMMAR = ParserGrammar(
             body=
             Sequence(elements=[
                 Literal(value='LIMIT'),
-                RuleReference(name='NUMBER', is_token=True),
+                RuleReference(name='signed_number', is_token=False),
                 Optional(element=
-                    Sequence(elements=[
-                        Literal(value='OFFSET'),
-                        RuleReference(name='NUMBER', is_token=True),
+                    Alternation(choices=[
+                        Sequence(elements=[
+                            Literal(value='OFFSET'),
+                            RuleReference(name='signed_number', is_token=False),
+                        ]),
+                        Sequence(elements=[
+                            Literal(value=','),
+                            RuleReference(name='signed_number', is_token=False),
+                        ]),
                     ]),
                 ),
             ]),
             line_number=139,
+        ),
+        GrammarRule(
+            name='signed_number',
+            body=
+            Sequence(elements=[
+                Optional(element=
+                    Literal(value='-'),
+                ),
+                RuleReference(name='NUMBER', is_token=True),
+            ]),
+            line_number=154,
         ),
         GrammarRule(
             name='conflict_clause',
@@ -525,7 +542,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=161,
+            line_number=176,
         ),
         GrammarRule(
             name='insert_stmt',
@@ -558,7 +575,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=163,
+            line_number=178,
         ),
         GrammarRule(
             name='upsert_clause',
@@ -603,7 +620,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=180,
+            line_number=195,
         ),
         GrammarRule(
             name='upsert_assignment',
@@ -613,7 +630,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='='),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=186,
+            line_number=201,
         ),
         GrammarRule(
             name='replace_stmt',
@@ -640,7 +657,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=187,
+            line_number=202,
         ),
         GrammarRule(
             name='insert_body',
@@ -662,7 +679,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=191,
+            line_number=206,
         ),
         GrammarRule(
             name='row_value',
@@ -678,7 +695,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value=')'),
             ]),
-            line_number=198,
+            line_number=213,
         ),
         GrammarRule(
             name='update_stmt',
@@ -701,7 +718,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=200,
+            line_number=215,
         ),
         GrammarRule(
             name='assignment',
@@ -711,7 +728,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='='),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=202,
+            line_number=217,
         ),
         GrammarRule(
             name='delete_stmt',
@@ -727,7 +744,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='returning_clause', is_token=False),
                 ),
             ]),
-            line_number=204,
+            line_number=219,
         ),
         GrammarRule(
             name='returning_clause',
@@ -742,7 +759,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=206,
+            line_number=221,
         ),
         GrammarRule(
             name='returning_item',
@@ -751,7 +768,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='*'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=210,
+            line_number=225,
         ),
         GrammarRule(
             name='create_table_stmt',
@@ -780,7 +797,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='table_options', is_token=False),
                 ),
             ]),
-            line_number=214,
+            line_number=229,
         ),
         GrammarRule(
             name='table_options',
@@ -794,7 +811,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=223,
+            line_number=238,
         ),
         GrammarRule(
             name='table_option',
@@ -806,7 +823,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='NAME', is_token=True),
                 ]),
             ]),
-            line_number=224,
+            line_number=239,
         ),
         GrammarRule(
             name='col_def',
@@ -818,7 +835,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='col_constraint', is_token=False),
                 ),
             ]),
-            line_number=229,
+            line_number=244,
         ),
         GrammarRule(
             name='col_type',
@@ -839,7 +856,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=233,
+            line_number=248,
         ),
         GrammarRule(
             name='col_constraint',
@@ -896,7 +913,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=234,
+            line_number=249,
         ),
         GrammarRule(
             name='drop_table_stmt',
@@ -912,7 +929,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=245,
+            line_number=260,
         ),
         GrammarRule(
             name='alter_table_stmt',
@@ -954,7 +971,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=254,
+            line_number=269,
         ),
         GrammarRule(
             name='create_index_stmt',
@@ -988,7 +1005,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='where_clause', is_token=False),
                 ),
             ]),
-            line_number=268,
+            line_number=283,
         ),
         GrammarRule(
             name='index_col',
@@ -1008,7 +1025,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=285,
+            line_number=300,
         ),
         GrammarRule(
             name='drop_index_stmt',
@@ -1024,7 +1041,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=287,
+            line_number=302,
         ),
         GrammarRule(
             name='create_view_stmt',
@@ -1043,7 +1060,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='AS'),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=295,
+            line_number=310,
         ),
         GrammarRule(
             name='drop_view_stmt',
@@ -1059,7 +1076,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=297,
+            line_number=312,
         ),
         GrammarRule(
             name='begin_stmt',
@@ -1070,7 +1087,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=303,
+            line_number=318,
         ),
         GrammarRule(
             name='commit_stmt',
@@ -1081,7 +1098,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=304,
+            line_number=319,
         ),
         GrammarRule(
             name='rollback_stmt',
@@ -1092,7 +1109,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='TRANSACTION'),
                 ),
             ]),
-            line_number=305,
+            line_number=320,
         ),
         GrammarRule(
             name='savepoint_stmt',
@@ -1101,7 +1118,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='SAVEPOINT'),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=321,
+            line_number=336,
         ),
         GrammarRule(
             name='release_stmt',
@@ -1113,7 +1130,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=322,
+            line_number=337,
         ),
         GrammarRule(
             name='rollback_to_stmt',
@@ -1126,13 +1143,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=323,
+            line_number=338,
         ),
         GrammarRule(
             name='expr',
             body=
             RuleReference(name='or_expr', is_token=False),
-            line_number=327,
+            line_number=342,
         ),
         GrammarRule(
             name='or_expr',
@@ -1146,7 +1163,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=328,
+            line_number=343,
         ),
         GrammarRule(
             name='and_expr',
@@ -1160,7 +1177,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=329,
+            line_number=344,
         ),
         GrammarRule(
             name='not_expr',
@@ -1172,7 +1189,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='comparison', is_token=False),
             ]),
-            line_number=330,
+            line_number=345,
         ),
         GrammarRule(
             name='collated',
@@ -1186,7 +1203,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=343,
+            line_number=358,
         ),
         GrammarRule(
             name='comparison',
@@ -1293,7 +1310,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=344,
+            line_number=359,
         ),
         GrammarRule(
             name='in_expr',
@@ -1302,7 +1319,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='query_stmt', is_token=False),
                 RuleReference(name='value_list', is_token=False),
             ]),
-            line_number=369,
+            line_number=384,
         ),
         GrammarRule(
             name='cmp_op',
@@ -1315,7 +1332,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='<='),
                 Literal(value='>='),
             ]),
-            line_number=371,
+            line_number=386,
         ),
         GrammarRule(
             name='bitwise',
@@ -1336,7 +1353,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=385,
+            line_number=400,
         ),
         GrammarRule(
             name='additive',
@@ -1358,7 +1375,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=386,
+            line_number=401,
         ),
         GrammarRule(
             name='multiplicative',
@@ -1378,7 +1395,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=387,
+            line_number=402,
         ),
         GrammarRule(
             name='unary',
@@ -1396,7 +1413,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ]),
                 RuleReference(name='primary', is_token=False),
             ]),
-            line_number=393,
+            line_number=408,
         ),
         GrammarRule(
             name='primary',
@@ -1430,7 +1447,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value=')'),
                 ]),
             ]),
-            line_number=413,
+            line_number=428,
         ),
         GrammarRule(
             name='column_ref',
@@ -1444,7 +1461,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=423,
+            line_number=438,
         ),
         GrammarRule(
             name='function_call',
@@ -1474,7 +1491,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='filter_clause', is_token=False),
                 ),
             ]),
-            line_number=437,
+            line_number=452,
         ),
         GrammarRule(
             name='filter_clause',
@@ -1486,7 +1503,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='expr', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=441,
+            line_number=456,
         ),
         GrammarRule(
             name='cast_expr',
@@ -1499,7 +1516,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='NAME', is_token=True),
                 Literal(value=')'),
             ]),
-            line_number=447,
+            line_number=462,
         ),
         GrammarRule(
             name='window_func_call',
@@ -1521,7 +1538,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='window_spec', is_token=False),
                 Literal(value=')'),
             ]),
-            line_number=476,
+            line_number=491,
         ),
         GrammarRule(
             name='window_spec',
@@ -1537,7 +1554,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_clause', is_token=False),
                 ),
             ]),
-            line_number=477,
+            line_number=492,
         ),
         GrammarRule(
             name='partition_clause',
@@ -1553,7 +1570,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=478,
+            line_number=493,
         ),
         GrammarRule(
             name='value_list',
@@ -1567,7 +1584,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     ]),
                 ),
             ]),
-            line_number=479,
+            line_number=494,
         ),
         GrammarRule(
             name='frame_clause',
@@ -1585,7 +1602,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     RuleReference(name='frame_bound', is_token=False),
                 ]),
             ]),
-            line_number=501,
+            line_number=516,
         ),
         GrammarRule(
             name='frame_unit',
@@ -1595,7 +1612,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='RANGE'),
                 Literal(value='GROUPS'),
             ]),
-            line_number=503,
+            line_number=518,
         ),
         GrammarRule(
             name='frame_bound',
@@ -1622,7 +1639,7 @@ PARSER_GRAMMAR = ParserGrammar(
                     Literal(value='FOLLOWING'),
                 ]),
             ]),
-            line_number=504,
+            line_number=519,
         ),
         GrammarRule(
             name='create_trigger_stmt',
@@ -1660,7 +1677,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=530,
+            line_number=545,
         ),
         GrammarRule(
             name='trigger_body_stmt',
@@ -1672,7 +1689,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 RuleReference(name='delete_stmt', is_token=False),
                 RuleReference(name='query_stmt', is_token=False),
             ]),
-            line_number=535,
+            line_number=550,
         ),
         GrammarRule(
             name='drop_trigger_stmt',
@@ -1688,7 +1705,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 RuleReference(name='NAME', is_token=True),
             ]),
-            line_number=537,
+            line_number=552,
         ),
         GrammarRule(
             name='case_expr',
@@ -1710,13 +1727,13 @@ PARSER_GRAMMAR = ParserGrammar(
                 ),
                 Literal(value='END'),
             ]),
-            line_number=552,
+            line_number=567,
         ),
         GrammarRule(
             name='case_operand',
             body=
             RuleReference(name='expr', is_token=False),
-            line_number=553,
+            line_number=568,
         ),
         GrammarRule(
             name='case_when',
@@ -1727,7 +1744,7 @@ PARSER_GRAMMAR = ParserGrammar(
                 Literal(value='THEN'),
                 RuleReference(name='expr', is_token=False),
             ]),
-            line_number=554,
+            line_number=569,
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- Adds SQLite's two non-standard LIMIT extensions: negative count means "no limit" (`LIMIT -1` = unbounded) and MySQL-compatible `LIMIT m, n` (≡ `LIMIT n OFFSET m`, note reversed order).
- Negative offset is clamped to 0 (matches SQLite).
- Grammar: new `signed_number = [ \"-\" ] NUMBER` rule + comma-form alternative on `limit_clause`.
- Adapter: detects comma form via COMMA token presence, swaps count/offset interpretation. Negative count maps to `Limit.count=None` (no planner/codegen changes needed).

## Version bumps

- `sql-parser`: 0.42 → 0.43
- `mini-sqlite`: 2.7 → 2.8

## Test plan

- [x] 14 new oracle tests pass (negative count, comma syntax, negative offset, regression on existing LIMIT forms, ORDER BY interaction)
- [x] mini-sqlite suite (2248 tests) clean
- [x] sql-parser suite (91 tests) clean
- [x] Ruff clean
- [x] Security review passed (no new DoS surface; `LIMIT -1` ≡ omitting LIMIT entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)