### PR TITLE
Carry browser identity metadata through HTML parser projections

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -229,6 +229,9 @@ def check_browser_readiness_case(
     require_optional_nullable_string(case_path, expected, "title", errors)
     require_optional_nullable_string(case_path, expected, "base_href", errors)
     require_optional_nullable_string(case_path, expected, "base_target", errors)
+    for field in ("document_lang", "document_dir", "body_id", "body_lang", "body_dir"):
+        require_optional_nullable_string(case_path, expected, field, errors)
+    require_optional_string_list(case_path, expected, "body_classes", errors)
     require_string(f"{case_path}.expected", expected, "body_text", errors)
     require_object_list(f"{case_path}.expected", expected, "metas", errors)
     require_object_list(f"{case_path}.expected", expected, "resources", errors)
@@ -344,6 +347,10 @@ def check_browser_content_node(
     require_string(node_path, node, "role", errors)
     for field in (
         "name",
+        "id",
+        "title",
+        "lang",
+        "dir",
         "text",
         "href",
         "resolved_href",
@@ -354,6 +361,7 @@ def check_browser_content_node(
         "value",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
+    require_optional_string_list(node_path, node, "classes", errors)
     for field in ("disabled", "checked", "selected"):
         require_optional_boolean(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "options", errors)
@@ -402,6 +410,10 @@ def check_browser_render_node(
     require_string(node_path, node, "role", errors)
     for field in (
         "name",
+        "id",
+        "title",
+        "lang",
+        "dir",
         "text",
         "href",
         "resolved_href",
@@ -412,6 +424,7 @@ def check_browser_render_node(
         "value",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
+    require_optional_string_list(node_path, node, "classes", errors)
     for field in ("disabled", "checked", "selected"):
         require_optional_boolean(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "options", errors)

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -193,6 +193,10 @@ documented in this file.
   resolved URL metadata for links, resources, images, and form actions using
   the document `base` href when available, while preserving raw authored
   attributes for downstream policy decisions.
+- Browser-facing document, content-tree, and render-tree projections now carry
+  identity and language metadata, including document/body `lang` and `dir`,
+  body `id`/classes, and node-level `id`, tokenized `class`, `title`, `lang`,
+  and `dir` values for selector matching and browser UI policy.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -71,6 +71,9 @@ The current parser surface includes:
 - browser-facing URL resolution metadata for links, loadable resources, images,
   and form actions using the document `base` href when available, while keeping
   raw authored URLs available to browser policy code
+- browser-facing identity and language metadata for document/body fields plus
+  renderable content nodes, including `id`, tokenized `class`, `title`, `lang`,
+  and `dir` values for selector matching, UI policy, and early layout
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -818,6 +818,12 @@ pub struct BrowserDocument {
     pub title: Option<String>,
     pub base_href: Option<String>,
     pub base_target: Option<String>,
+    pub document_lang: Option<String>,
+    pub document_dir: Option<String>,
+    pub body_id: Option<String>,
+    pub body_classes: Vec<String>,
+    pub body_lang: Option<String>,
+    pub body_dir: Option<String>,
     pub body_text: String,
     pub metas: Vec<BrowserMeta>,
     pub resources: Vec<BrowserResource>,
@@ -867,6 +873,11 @@ pub struct BrowserContentTree {
 pub struct BrowserContentNode {
     pub role: String,
     pub name: Option<String>,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub title: Option<String>,
+    pub lang: Option<String>,
+    pub dir: Option<String>,
     pub text: Option<String>,
     pub href: Option<String>,
     pub resolved_href: Option<String>,
@@ -892,6 +903,11 @@ pub struct BrowserRenderNode {
     pub display: String,
     pub role: String,
     pub name: Option<String>,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub title: Option<String>,
+    pub lang: Option<String>,
+    pub dir: Option<String>,
     pub text: Option<String>,
     pub href: Option<String>,
     pub resolved_href: Option<String>,
@@ -964,6 +980,7 @@ pub struct BrowserTable {
 
 impl BrowserDocument {
     pub fn from_document(document: &Document) -> Self {
+        let html = find_first_element_in_nodes(&document.children, "html");
         let head = find_first_element_in_nodes(&document.children, "head");
         let body = find_first_element_in_nodes(&document.children, "body");
         let body_children = body
@@ -981,6 +998,25 @@ impl BrowserDocument {
             base_target: head
                 .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
                 .and_then(|element| element.attribute("target"))
+                .map(ToOwned::to_owned),
+            document_lang: html
+                .and_then(|element| element.attribute("lang"))
+                .map(ToOwned::to_owned),
+            document_dir: html
+                .and_then(|element| element.attribute("dir"))
+                .map(ToOwned::to_owned),
+            body_id: body
+                .and_then(|element| element.attribute("id"))
+                .map(ToOwned::to_owned),
+            body_classes: body
+                .and_then(|element| element.attribute("class"))
+                .map(split_html_classes)
+                .unwrap_or_default(),
+            body_lang: body
+                .and_then(|element| element.attribute("lang"))
+                .map(ToOwned::to_owned),
+            body_dir: body
+                .and_then(|element| element.attribute("dir"))
                 .map(ToOwned::to_owned),
             body_text: visible_text_for_nodes(body_children),
             ..Self::default()
@@ -1040,6 +1076,11 @@ impl BrowserRenderNode {
             display: browser_render_display(&content_node.role).to_string(),
             role: content_node.role.clone(),
             name: content_node.name.clone(),
+            id: content_node.id.clone(),
+            classes: content_node.classes.clone(),
+            title: content_node.title.clone(),
+            lang: content_node.lang.clone(),
+            dir: content_node.dir.clone(),
             text: content_node.text.clone(),
             href: content_node.href.clone(),
             resolved_href: content_node.resolved_href.clone(),
@@ -8310,6 +8351,11 @@ fn collect_browser_content_nodes(
                     output.push(BrowserContentNode {
                         role: "text".to_string(),
                         name: None,
+                        id: None,
+                        classes: Vec::new(),
+                        title: None,
+                        lang: None,
+                        dir: None,
                         text: Some(text),
                         href: None,
                         resolved_href: None,
@@ -8361,6 +8407,14 @@ fn browser_content_node_for_element(
     Some(BrowserContentNode {
         role: role.to_string(),
         name: Some(element.name.clone()),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        lang: element.attribute("lang").map(ToOwned::to_owned),
+        dir: element.attribute("dir").map(ToOwned::to_owned),
         text,
         resolved_href: href
             .as_deref()
@@ -8447,6 +8501,13 @@ fn browser_content_src(element: &Element) -> Option<String> {
         "object" => element.attribute("data").map(ToOwned::to_owned),
         _ => element.attribute("src").map(ToOwned::to_owned),
     }
+}
+
+fn split_html_classes(value: &str) -> Vec<String> {
+    value
+        .split_ascii_whitespace()
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 fn browser_content_control_type(element: &Element) -> Option<String> {
@@ -8852,6 +8913,29 @@ mod tests {
             resolve_browser_url("relative.html", Some("/local/base/")),
             None
         );
+    }
+
+    #[test]
+    fn browser_identity_metadata_tracks_language_direction_and_classes() {
+        let document = parse_html(
+            "<html lang=en dir=ltr><body id=main class=\"page legacy\" lang=en-US>\
+             <p id=intro class=\"lede print\" title=\"Intro\" dir=auto>Hello</p>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.document_lang.as_deref(), Some("en"));
+        assert_eq!(summary.document_dir.as_deref(), Some("ltr"));
+        assert_eq!(summary.body_id.as_deref(), Some("main"));
+        assert_eq!(summary.body_classes, vec!["page", "legacy"]);
+        assert_eq!(summary.body_lang.as_deref(), Some("en-US"));
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        let paragraph = &content_tree.children[0];
+        assert_eq!(paragraph.id.as_deref(), Some("intro"));
+        assert_eq!(paragraph.classes, vec!["lede", "print"]);
+        assert_eq!(paragraph.title.as_deref(), Some("Intro"));
+        assert_eq!(paragraph.dir.as_deref(), Some("auto"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -28,6 +28,16 @@ struct ExpectedContentTree {
 struct ExpectedContentNode {
     role: String,
     name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    lang: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
     text: Option<String>,
     href: Option<String>,
     #[serde(default)]
@@ -89,6 +99,11 @@ impl ExpectedContentNode {
         BrowserContentNode {
             role: self.role,
             name: self.name,
+            id: self.id,
+            classes: self.classes,
+            title: self.title,
+            lang: self.lang,
+            dir: self.dir,
             text: self.text,
             href: self.href,
             resolved_href: self.resolved_href,

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -25,6 +25,18 @@ struct ExpectedBrowserDocument {
     title: Option<String>,
     base_href: Option<String>,
     base_target: Option<String>,
+    #[serde(default)]
+    document_lang: Option<String>,
+    #[serde(default)]
+    document_dir: Option<String>,
+    #[serde(default)]
+    body_id: Option<String>,
+    #[serde(default)]
+    body_classes: Vec<String>,
+    #[serde(default)]
+    body_lang: Option<String>,
+    #[serde(default)]
+    body_dir: Option<String>,
     body_text: String,
     metas: Vec<ExpectedMeta>,
     resources: Vec<ExpectedResource>,
@@ -148,6 +160,12 @@ impl ExpectedBrowserDocument {
             title: self.title,
             base_href: self.base_href,
             base_target: self.base_target,
+            document_lang: self.document_lang,
+            document_dir: self.document_dir,
+            body_id: self.body_id,
+            body_classes: self.body_classes,
+            body_lang: self.body_lang,
+            body_dir: self.body_dir,
             body_text: self.body_text,
             metas: self
                 .metas

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -29,6 +29,16 @@ struct ExpectedRenderNode {
     display: String,
     role: String,
     name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    lang: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
     text: Option<String>,
     href: Option<String>,
     #[serde(default)]
@@ -91,6 +101,11 @@ impl ExpectedRenderNode {
             display: self.display,
             role: self.role,
             name: self.name,
+            id: self.id,
+            classes: self.classes,
+            title: self.title,
+            lang: self.lang,
+            dir: self.dir,
             text: self.text,
             href: self.href,
             resolved_href: self.resolved_href,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -14,7 +14,9 @@ browser-facing extraction. It verifies that broad HTML documents produce stable
 title, base URL/target, metadata, resource, anchor, body text, heading, link,
 image, form, and table facts that a browser pipeline can consume before layout
 and Paint VM rendering. The fixture also pins resolved URL metadata derived
-from `base` hrefs while preserving raw authored link and resource attributes.
+from `base` hrefs while preserving raw authored link and resource attributes,
+and document/body identity and language metadata such as `lang`, `dir`, body
+`id`, and tokenized body classes.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body
@@ -22,7 +24,9 @@ content can be filtered into renderable structural nodes such as headings,
 blocks, inline runs, links, images, form controls, lists, and tables while
 skipping parser shell, head metadata, comments, scripts, styles, and templates.
 Where a document base is present, link and replaced-resource nodes also expose
-resolved URL fields for downstream navigation and fetch planning.
+resolved URL fields for downstream navigation and fetch planning. Renderable
+nodes may also pin `id`, tokenized `class`, `title`, `lang`, and `dir`
+metadata for selector matching and UI policy.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
@@ -30,7 +34,8 @@ is converted into stable default display categories such as block, inline,
 inline-replaced, list-item, and table display nodes for early layout work. The
 browser-facing fixture set also pins control metadata such as value,
 disabled/checked/selected state, select option labels, textarea values, and
-resolved URL metadata for link and replaced nodes.
+resolved URL metadata for link and replaced nodes, plus render-node identity
+metadata that layout and styling code can carry forward.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -6,12 +6,17 @@
     {
       "id": "classic-document-flow",
       "description": "Head metadata is skipped while headings, paragraphs, base-resolved links, images, line breaks, and lists stay renderable.",
-      "input": "<!doctype html><title>Example</title><base href=\"https://example.test/docs/\"><link rel=stylesheet href=style.css><h1 id=top>Example Directory</h1><p>Welcome to <a href=intro.html>Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
+      "input": "<!doctype html><title>Example</title><base href=\"https://example.test/docs/\"><link rel=stylesheet href=style.css><h1 id=top class=\"headline primary\" title=\"Directory\" lang=en dir=ltr>Example Directory</h1><p class=lede>Welcome to <a id=intro-link class=nav href=intro.html title=\"Read intro\">Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
       "expected": {
         "children": [
           {
             "role": "heading",
             "name": "h1",
+            "id": "top",
+            "classes": ["headline", "primary"],
+            "title": "Directory",
+            "lang": "en",
+            "dir": "ltr",
             "text": "Example Directory",
             "href": null,
             "src": null,
@@ -24,6 +29,7 @@
           {
             "role": "block",
             "name": "p",
+            "classes": ["lede"],
             "text": null,
             "href": null,
             "src": null,
@@ -34,6 +40,9 @@
               {
                 "role": "link",
                 "name": "a",
+                "id": "intro-link",
+                "classes": ["nav"],
+                "title": "Read intro",
                 "text": "Venture HTML",
                 "href": "intro.html",
                 "resolved_href": "https://example.test/docs/intro.html",

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -38,11 +38,17 @@
     {
       "id": "catalog-form-table-page",
       "description": "Form controls, select options, textarea text, button text, and table summaries.",
-      "input": "<html><head><title>Search</title><meta http-equiv=refresh content=\"30; url=/next\"></head><body><h2>Catalog</h2><form action=\"/search\" method=POST enctype=\"multipart/form-data\" target=results><input name=q value=\"rust html\"><input type=hidden name=page value=1><input type=checkbox name=in_stock value=yes checked><input type=text name=disabled value=no disabled><select name=section><option value=books>Books<option value=manuals selected>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
+      "input": "<html lang=en dir=ltr><head><title>Search</title><meta http-equiv=refresh content=\"30; url=/next\"></head><body id=catalog class=\"browser page\" lang=en-US dir=ltr><h2>Catalog</h2><form action=\"/search\" method=POST enctype=\"multipart/form-data\" target=results><input name=q value=\"rust html\"><input type=hidden name=page value=1><input type=checkbox name=in_stock value=yes checked><input type=text name=disabled value=no disabled><select name=section><option value=books>Books<option value=manuals selected>Manuals</select><textarea name=notes>Line one\nLine two</textarea><button name=go>Search</button></form><table><caption>Results</caption><tr><th>Name<th>Kind<tr><td>Mosaic<td>Browser</table>",
       "expected": {
         "title": "Search",
         "base_href": null,
         "base_target": null,
+        "document_lang": "en",
+        "document_dir": "ltr",
+        "body_id": "catalog",
+        "body_classes": ["browser", "page"],
+        "body_lang": "en-US",
+        "body_dir": "ltr",
         "body_text": "Catalog Books Manuals Line one Line two Search Results Name Kind Mosaic Browser",
         "metas": [
           { "name": null, "http_equiv": "refresh", "property": null, "charset": null, "content": "30; url=/next" }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -6,13 +6,15 @@
     {
       "id": "flow-inline-and-replaced",
       "description": "Headings and paragraphs become block layout inputs while base-resolved text, links, images, and line breaks keep inline display categories.",
-      "input": "<base href=\"https://example.test/pages/current.html\"><body><h1>Example</h1><p>Hello <a href=next.html>Next</a><img src=../assets/logo.gif alt=Logo><br>Tail</p>",
+      "input": "<base href=\"https://example.test/pages/current.html\"><body><h1 id=page-title class=hero>Example</h1><p id=intro class=\"lede print\" title=\"Intro paragraph\">Hello <a href=next.html class=next lang=en>Next</a><img src=../assets/logo.gif alt=Logo><br>Tail</p>",
       "expected": {
         "children": [
           {
             "display": "block",
             "role": "heading",
             "name": "h1",
+            "id": "page-title",
+            "classes": ["hero"],
             "text": "Example",
             "href": null,
             "src": null,
@@ -26,6 +28,9 @@
             "display": "block",
             "role": "block",
             "name": "p",
+            "id": "intro",
+            "classes": ["lede", "print"],
+            "title": "Intro paragraph",
             "text": null,
             "href": null,
             "src": null,
@@ -37,6 +42,8 @@
                 "display": "inline",
                 "role": "link",
                 "name": "a",
+                "classes": ["next"],
+                "lang": "en",
                 "text": "Next",
                 "href": "next.html",
                 "resolved_href": "https://example.test/pages/next.html",


### PR DESCRIPTION
## Summary
- add browser document/body identity and language metadata: document lang/dir, body id/classes/lang/dir
- carry node-level id, tokenized class, title, lang, and dir through BrowserContentTree and BrowserRenderTree
- extend browser fixture schemas, fixtures, docs, and focused parser tests for the new metadata

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser