### PR TITLE
feat(cas-summation): Phase 56 — bounded × Sqrt(diverging) numerator (1.4.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 1.4.0 — 2026-05-23
+
+**Phase 56 — Bounded × Sqrt(diverging) numerator pattern (Python).**
+
+Extends ``_g_vanishes_at_infinity`` with a new branch for
+``Div(Mul(bounded, Sqrt(P(k))), den)`` shapes.  The bounded part is
+uniformly bounded by some constant ``C``; the sqrt part grows like
+``k^{deg(P)/2}``.  The whole numerator therefore has effective
+polynomial degree ``deg(P)/2``, expressed here as ``deg(P)`` (the ×2
+trick used elsewhere) so the comparison ``2 × den_deg > deg(P)``
+stays exact in integer arithmetic.
+
+This is the bounded-times-sqrt analogue of Phase 55 (bounded × log).
+The two phases close the analogous gap between Phase 52 (bounded ×
+polynomial, deg-aware) and the sub-polynomial growth families (log
+and sqrt).
+
+Bumps 1.3.0 → 1.4.0.
+
+### Added
+
+- **``_bounded_times_sqrt_inner_deg(node, k)``** — Phase 56 helper.
+  Returns the ``Sqrt`` inner polynomial degree (×2 to stay exact)
+  when ``node`` is a ``Mul`` with exactly one
+  ``Sqrt(positive-leading polynomial)`` factor and all remaining
+  factors bounded in ``k``.  Returns ``None`` for:
+
+  - non-``Mul`` shapes
+  - ``Mul`` with no ``Sqrt`` factor
+  - ``Mul`` with two or more ``Sqrt`` factors (conservative — would
+    need a combined growth-rate calculation; users can pre-simplify
+    ``sqrt(k)·sqrt(k) = k``)
+  - ``Mul`` with a non-bounded non-``Sqrt`` factor (e.g. bare ``k``)
+  - ``Sqrt`` of a negative-leading polynomial (not real-valued)
+
+- **Phase 56 branch in ``_g_vanishes_at_infinity``** — inserted
+  after Phase 55 and before the Phase 42 polynomial widening.  Two
+  sub-cases by denominator shape:
+
+  1. Polynomial denominator (``_polynomial_degree_in_k`` returns
+     ``int``): require ``2 × den_deg > sqrt_inner_deg``.
+  2. Non-polynomial diverging denominator (Exp / Pow / Log×poly):
+     dominates any sub-polynomial sqrt growth automatically.
+
+- **6 new tests** in ``TestEvaluateSumPhase56BoundedTimesSqrtNumerator``
+  (``test_summation.py``):
+  - ``test_sin_times_sqrt_k_over_k_squared_closes`` — 1/2 < 2
+  - ``test_cos_times_sqrt_k_cubed_over_k_squared_closes`` — 3/2 < 2 (tight margin)
+  - ``test_two_bounded_factors_times_sqrt_closes`` — sin·cos·sqrt(k)/k²
+  - ``test_bounded_times_sqrt_over_exponential_closes`` — sin·sqrt(k³)/2^k
+  - ``test_sin_times_sqrt_k_cubed_over_k_refused`` — 3/2 > 1 (no vanish)
+  - ``test_two_sqrt_factors_refused`` — conservative: two-sqrt patterns refused
+
+Total: **132 tests** (was 126; +6 net new), no regressions.
+
+### Still deferred
+
+- Two-sqrt patterns (``sin(k)·sqrt(k)·sqrt(k+1)``) — would need
+  combined growth-rate logic.
+- Log + Sqrt combinations (``sin(k)·log(k)·sqrt(k)/k³``) — analogous
+  to Phase 55/56 but with both sub-polynomial factors.
+
 ## 1.3.0 — 2026-05-23
 
 **Phase 55 — Bounded×Log(diverging) numerator pattern (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.3.0"
+version = "1.4.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -759,6 +759,27 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     # Any strictly diverging denominator therefore dominates.
     if _is_bounded_times_log_in_k(num, k) and _h_diverges_at_infinity(den, k):
         return True
+    # Phase 56: ``Mul(bounded, Sqrt(diverging))`` numerator pattern.
+    # The bounded part is uniformly bounded; ``Sqrt(P(k))`` grows like
+    # ``k^{deg(P)/2}``.  The whole numerator therefore has effective
+    # growth ``k^{deg(P)/2}``, and the quotient vanishes when the
+    # denominator grows strictly faster.  Stays exact via the ×2 integer
+    # trick already used in Phase 51 / 53: returns
+    # ``sqrt_inner_deg = deg(P)`` (= 2 × half-degree); compare to
+    # ``2 × den_poly_degree``.  When the denominator is non-polynomial
+    # but diverging (Exp / Pow / Log×poly / Mul of these), it dominates
+    # any sub-polynomial sqrt growth automatically.
+    sqrt_inner_deg = _bounded_times_sqrt_inner_deg(num, k)
+    if sqrt_inner_deg is not None:
+        den_deg_bs = _polynomial_degree_in_k(den, k)
+        if den_deg_bs is not None:
+            if 2 * den_deg_bs > sqrt_inner_deg:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            # Non-polynomial diverging denominator dominates ``k^{m/2}``
+            # for any ``m`` since ``Exp / Pow(b>1, …)`` grows faster
+            # than any polynomial, hence faster than any half-degree.
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1066,6 +1087,61 @@ def _is_bounded_times_log_in_k(node: IRNode, k: IRSymbol) -> bool:
         # Factor is neither Log(diverging) nor bounded — unrecognised.
         return False
     return log_count == 1
+
+
+def _bounded_times_sqrt_inner_deg(node: IRNode, k: IRSymbol) -> int | None:
+    """Return the ``Sqrt`` inner polynomial degree (×2) when ``node`` is a
+    ``Mul`` with exactly one ``Sqrt(positive-leading polynomial)`` factor
+    and all remaining factors bounded in ``k``; ``None`` otherwise.
+
+    Phase 56 — bounded × sqrt analogue of Phase 55's bounded × log.
+    Mirrors :func:`_is_bounded_times_log_in_k` but returns the sqrt
+    inner-degree (× 2 to stay exact) so the caller can compare growth
+    rates without floats.
+
+    The bounded part is uniformly bounded by some constant ``C``; the
+    sqrt part grows like ``k^{deg(P)/2}``.  Therefore the numerator's
+    effective polynomial degree is ``deg(P)/2``, expressed here as
+    ``deg(P)`` to be compared against ``2 × den_polynomial_degree``.
+
+    +---------------------------------------+------------------+
+    | Input                                 | Return           |
+    +=======================================+==================+
+    | ``Mul(Sin(k), Sqrt(k))``              | ``1`` (deg P=1)  |
+    | ``Mul(Cos(k), Sqrt(k³))``             | ``3``            |
+    | ``Mul(Sin(k), Cos(k), Sqrt(k+1))``    | ``1``            |
+    | ``Mul(k, Sqrt(k))``                   | ``None`` (k not bounded) |
+    | ``Mul(Sin(k), Sqrt(k), Sqrt(k))``     | ``None`` (two sqrt)      |
+    | ``Sqrt(k)`` (plain, not Mul)          | ``None`` (→ Phase 51)    |
+    | ``Mul(Sin(k), Sqrt(-k))``             | ``None`` (negative poly) |
+    +---------------------------------------+------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - If it is ``Sqrt(positive-leading polynomial)`` → record its
+           ``×2`` degree; refuse if a second sqrt appears.
+         - If it is ``bounded_in_k`` → accept.
+         - Otherwise → return ``None`` (unrecognised factor).
+      3. Require exactly one sqrt factor; zero → ``None``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_inner_deg: int | None = None
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_inner_deg is not None:
+                # Two Sqrt factors — refuse (would need a different
+                # growth-rate calculation we haven't justified yet).
+                return None
+            sqrt_inner_deg = deg_x2
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Neither Sqrt(positive-poly) nor bounded → unrecognised.
+        return None
+    return sqrt_inner_deg
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1758,3 +1758,131 @@ class TestEvaluateSumPhase55BoundedTimesLogNumerator:
         assert isinstance(result, IRApply) and result.head == SUM, (
             f"Phase 55: constant denominator should stay unevaluated; got {result!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 56 — Bounded × Sqrt(diverging) numerator pattern.
+#
+# Mirror of Phase 55 (bounded × Log) with Sqrt instead.  Numerator
+# Mul(bounded, Sqrt(P(k))) has effective polynomial degree deg(P)/2;
+# vanishes against denominators of degree > deg(P)/2 (polynomial) or
+# against any non-polynomial diverging denominator (Exp / Pow / Log×poly).
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase56BoundedTimesSqrtNumerator:
+    def test_sin_times_sqrt_k_over_k_squared_closes(self):
+        """``sin(k)·sqrt(k)/k²``: half-deg 1/2 < deg 2 → vanishes."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 56 should close; got {result!r}"
+        )
+
+    def test_cos_times_sqrt_k_cubed_over_k_squared_closes(self):
+        """``cos(k)·sqrt(k³)/k²``: half-deg 3/2 < 2 → vanishes (tight margin)."""
+        from symbolic_ir import COS, POW, SQRT, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (cos_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (cos_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_bounded_factors_times_sqrt_closes(self):
+        """``sin(k)·cos(k)·sqrt(k)/k²``: two bounded × sqrt(k) → vanishes."""
+        from symbolic_ir import COS, POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        cos_k = IRApply(COS, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, cos_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        cos_kp1 = IRApply(COS, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, cos_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_bounded_times_sqrt_over_exponential_closes(self):
+        """``sin(k)·sqrt(k³)/2^k``: Sqrt sub-polynomial / exponential dominates."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (sin_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1_3))
+        # Denominator is 2^k — exponential, dominates polynomial of any degree.
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_times_sqrt_k_cubed_over_k_refused(self):
+        """``sin(k)·sqrt(k³)/k``: half-deg 3/2 > deg 1 → does NOT vanish.
+        Phase 56 must refuse.
+        """
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (sin_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # half-deg(num) = 3/2 > 1 = deg(den) → does not vanish.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_two_sqrt_factors_refused(self):
+        """``Mul(sin(k), sqrt(k), sqrt(k))/k³`` — two sqrt factors.
+        Phase 56 refuses (would require combining growth rates we
+        haven't justified yet; multiplying sqrt(k)·sqrt(k) = k could
+        be simplified before reaching us, but Phase 56 stays
+        conservative).
+        """
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, sqrt_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Phase 56 conservative: refuses two-sqrt patterns.
+        assert isinstance(result, IRApply) and result.head == SUM


### PR DESCRIPTION
## Summary

Extends ``_g_vanishes_at_infinity`` with a new branch for
``Div(Mul(bounded, Sqrt(P(k))), den)`` shapes — the bounded × sqrt
analogue of Phase 55's bounded × log.

The bounded part is uniformly bounded by some constant ``C``; the
sqrt part grows like ``k^{deg(P)/2}``.  The whole numerator therefore
has effective polynomial degree ``deg(P)/2``, expressed as ``deg(P)``
(×2 integer arithmetic, matching Phase 51/53) so the comparison
``2 × den_deg > deg(P)`` stays exact.

Bumps ``cas-summation`` 1.3.0 → 1.4.0.

### Added

| Function | Returns |
|---|---|
| ``_bounded_times_sqrt_inner_deg`` | ``deg(P)`` for ``Mul(bounded..., Sqrt(positive-poly))`` with exactly one Sqrt factor; ``None`` otherwise |

### Wiring

Inserted after Phase 55, before the Phase 42 polynomial widening.
Two sub-cases by denominator shape:

1. Polynomial denominator: require ``2 × den_deg > sqrt_inner_deg``.
2. Non-polynomial diverging denominator (Exp / Pow / Log×poly):
   dominates any sub-polynomial sqrt growth automatically.

### Test plan

- [x] ``pytest tests/ -k phase56`` → 6 passed
- [x] ``pytest tests/`` → 132 passed (was 126; +6 net new)
- [x] No regressions
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Still deferred

- Two-sqrt patterns (``sin(k)·sqrt(k)·sqrt(k+1)``) — would need
  combined growth-rate logic.
- Log + Sqrt combinations (``sin·log·sqrt/k³``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)