### PR TITLE
feat(mosaic-pkg-toolkit): v0.5 — Pagination on UI29-4 HostLink

### DIFF
--- a/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-toolkit/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — mosaic-pkg-toolkit
 
+## [Unreleased] — v0.5 — Pagination
+
+### Added
+
+**`Pagination`** — Bootstrap's page-navigation row: `« prev | 1 2 3
+| next »`. Composition: `Row[pagination] { HostLink[pagination-prev],
+For (each: pages, as: page) { HostLink[pagination-page] (label: page,
+onActivate: onPageSelect) }, HostLink[pagination-next] }`. Slots:
+`pages: list<text>`, `prev-label`, `next-label`, `active-index`.
+Emits: `onPrev`, `onNext`, `onPageSelect(index: number)`.
+
+Like Nav and Breadcrumb (v0.4), every chip wraps the UI29-4
+`HostLink` kernel primitive. Bootstrap's real-world DOM uses `<a>`
+tags for the same elements — `role="link"` semantics + Tab/Enter
+keyboard activation come from the kernel for free. `href: "#"` +
+`external: false` mirror the Nav/Breadcrumb conventions.
+
+### Tests
+
+`tests/package_compiles.rs` grew to 17 (was 16): one more interface
+test (`pagination_interface_matches_spec`) plus the new component
+in the `COMPONENTS` array. All pass.
+
 ## [0.4.0] — UI29-4 — HostLink wires Breadcrumb + Nav; Tooltip + NumberInput added
 
 UI29-4 added three new kernel primitives (`HostLink`, `HostTooltip`,

--- a/code/packages/mosaic-pkg-toolkit/README.md
+++ b/code/packages/mosaic-pkg-toolkit/README.md
@@ -46,6 +46,11 @@ for the architecture, component catalog, and phasing plan.
   `If open { Box[toast] { Column { Row[toast-header],
   Box[toast-body] } } }`. Slots: `title`, `message`, `variant`,
   `open`. Emit: `onClose`.
+- **`Pagination`** — Bootstrap's page-navigation row («prev | 1 2
+  3 | next »). Each chip wraps the UI29-4 `HostLink` primitive
+  (same convention as Nav/Breadcrumb). Slots: `pages: list<text>`,
+  `prev-label`, `next-label`, `active-index`. Emits: `onPrev`,
+  `onNext`, `onPageSelect(index: number)`.
 
 Every component ships `.light.msl` and `.dark.msl` themes.
 

--- a/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-toolkit/mosaic-package.toml
@@ -15,7 +15,7 @@
 
 [package]
 name        = "mosaic-pkg-toolkit"
-version     = "0.4.0"
+version     = "0.5.0"
 description = "Bootstrap-shaped Mosaic UI component library — ready-made components composed purely from UI29 kernel primitives"
 license     = "MIT OR Apache-2.0"
 
@@ -27,12 +27,13 @@ license     = "MIT OR Apache-2.0"
 # v0.1 PR-5: Field (label + HostInput + help/error).
 # v0.2 PR-6: Tier-2 batch 1 — Nav, ButtonGroup, Breadcrumb.
 # v0.4 UI29-4: Tooltip, NumberInput (new) + Breadcrumb/Nav rewrites.
+# v0.5: Pagination (HostLink-based, matching Nav/Breadcrumb).
 # Remaining Tier-1 (Card, Container) blocked on UI29-2 children
 # pass-through spec; ship when that lands.
 exports = [
   "Alert", "Badge", "Breadcrumb", "Button", "ButtonGroup",
   "Checkbox", "Field", "Input", "ListGroup", "Modal", "Nav",
-  "NumberInput", "Radio", "Spinner", "Toast", "Tooltip",
+  "NumberInput", "Pagination", "Radio", "Spinner", "Toast", "Tooltip",
 ]
 
 [dependencies]

--- a/code/packages/mosaic-pkg-toolkit/src/Pagination.dark.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Pagination.dark.msl
@@ -1,0 +1,34 @@
+// Pagination.dark.msl — dark-theme styling.
+
+style Pagination {
+  part pagination {
+    padding : 0 ;
+  }
+  part pagination-prev {
+    padding       : 8 ;
+    background    : "#1f2937" ;
+    color         : "#60a5fa" ;
+    border-width  : 1 ;
+    border-color  : "#374151" ;
+    font-size     : 14 ;
+    border-radius : 0 ;
+  }
+  part pagination-page {
+    padding       : 8 ;
+    background    : "#1f2937" ;
+    color         : "#60a5fa" ;
+    border-width  : 1 ;
+    border-color  : "#374151" ;
+    font-size     : 14 ;
+    border-radius : 0 ;
+  }
+  part pagination-next {
+    padding       : 8 ;
+    background    : "#1f2937" ;
+    color         : "#60a5fa" ;
+    border-width  : 1 ;
+    border-color  : "#374151" ;
+    font-size     : 14 ;
+    border-radius : 0 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Pagination.light.msl
+++ b/code/packages/mosaic-pkg-toolkit/src/Pagination.light.msl
@@ -1,0 +1,34 @@
+// Pagination.light.msl — default light-theme styling.
+
+style Pagination {
+  part pagination {
+    padding : 0 ;
+  }
+  part pagination-prev {
+    padding       : 8 ;
+    background    : "#ffffff" ;
+    color         : "#0d6efd" ;
+    border-width  : 1 ;
+    border-color  : "#dee2e6" ;
+    font-size     : 14 ;
+    border-radius : 0 ;
+  }
+  part pagination-page {
+    padding       : 8 ;
+    background    : "#ffffff" ;
+    color         : "#0d6efd" ;
+    border-width  : 1 ;
+    border-color  : "#dee2e6" ;
+    font-size     : 14 ;
+    border-radius : 0 ;
+  }
+  part pagination-next {
+    padding       : 8 ;
+    background    : "#ffffff" ;
+    color         : "#0d6efd" ;
+    border-width  : 1 ;
+    border-color  : "#dee2e6" ;
+    font-size     : 14 ;
+    border-radius : 0 ;
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Pagination.mil
+++ b/code/packages/mosaic-pkg-toolkit/src/Pagination.mil
@@ -1,0 +1,40 @@
+// Pagination.mil — interface for the toolkit's Pagination (v0.5).
+//
+// Page navigation control: « prev | 1 2 3 ... | next ». Bootstrap's
+// `<ul class="pagination">` equivalent. Tracks the current page via
+// a slot the host owns; clicks fire onPageChange with the new index.
+//
+// Like Nav and Breadcrumb (v0.4), Pagination wraps the UI29-4
+// `HostLink` kernel primitive for every page-number / prev / next
+// chip. Bootstrap's real-world DOM renders these as `<a>` tags too —
+// `role="link"` + browser-native keyboard semantics (Tab + Enter)
+// come from the kernel for free.
+//
+// v0.5 takes a flat list<text> of visible page labels — the host
+// decides what to show ("1, 2, 3, 4, 5", "1, 2, ..., 99, 100", etc).
+// A future PR may add a `total-pages: number` slot + compute the
+// visible window from the current page in the .mll.
+
+component Pagination {
+  // The visible page-label strings in order. Each becomes a chip.
+  // Typically these are "1", "2", "3" etc. but any text works
+  // (e.g. an ellipsis "..." that doesn't navigate anywhere).
+  slot pages : list<text> ;
+
+  // Label for the "previous" chip. Default: "←".
+  slot prev-label : text ;
+
+  // Label for the "next" chip. Default: "→".
+  slot next-label : text ;
+
+  // Index of the currently-active page (or -1). Drives active-state
+  // styling once the variant sub-part syntax lands.
+  slot active-index : number ;
+
+  // Fired when prev is activated.
+  emit onPrev ;
+  // Fired when next is activated.
+  emit onNext ;
+  // Fired when a page-number chip is activated. Payload: index.
+  emit onPageSelect ( index : number ) ;
+}

--- a/code/packages/mosaic-pkg-toolkit/src/Pagination.mll
+++ b/code/packages/mosaic-pkg-toolkit/src/Pagination.mll
@@ -1,0 +1,51 @@
+// Pagination.mll — layout for the Pagination control (v0.5).
+//
+//   Row [ pagination ]
+//     HostLink [ pagination-prev ] (
+//       href: "#", external: false,
+//       label: slot: prev-label, onActivate: emit: onPrev
+//     )
+//     For (each: slot: pages, as: page, index: i)
+//       HostLink [ pagination-page ] (
+//         href: "#", external: false,
+//         label: page, onActivate: emit: onPageSelect
+//       )
+//     HostLink [ pagination-next ] (
+//       href: "#", external: false,
+//       label: slot: next-label, onActivate: emit: onNext
+//     )
+//
+// All three chip families (prev / pages / next) share the same Row.
+// The .msl flat-styles them as connected button-styled anchors with
+// shared borders.
+//
+// `external: false` + `href: "#"`: matches the Nav/Breadcrumb
+// convention — toolkit owns layout, host routes via the onActivate
+// payload. The inert href keeps right-click → Copy Link and middle-
+// click → open-in-new-tab from doing useless things; a future PR
+// could thread per-page hrefs through a list<text> slot.
+
+layout Pagination {
+  Row [ pagination ] {
+    HostLink [ pagination-prev ] (
+      href : "#" ,
+      external : false ,
+      label : slot: prev-label ,
+      onActivate : emit: onPrev
+    )
+    For ( each: slot: pages , as: page , index: i ) {
+      HostLink [ pagination-page ] (
+        href : "#" ,
+        external : false ,
+        label : page ,
+        onActivate : emit: onPageSelect
+      )
+    }
+    HostLink [ pagination-next ] (
+      href : "#" ,
+      external : false ,
+      label : slot: next-label ,
+      onActivate : emit: onNext
+    )
+  }
+}

--- a/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-toolkit/tests/package_compiles.rs
@@ -37,7 +37,7 @@ use std::path::PathBuf;
 const COMPONENTS: &[&str] = &[
     "Alert", "Badge", "Breadcrumb", "Button", "ButtonGroup",
     "Checkbox", "Field", "Input", "ListGroup", "Modal", "Nav",
-    "NumberInput", "Radio", "Spinner", "Toast", "Tooltip",
+    "NumberInput", "Pagination", "Radio", "Spinner", "Toast", "Tooltip",
 ];
 
 /// Themes shipped per component. Both must compile.
@@ -82,8 +82,8 @@ fn manifest_declares_expected_exports() {
         .and_then(|v| v.as_str())
         .expect("[package].version must be set");
     assert_eq!(
-        version, "0.4.0",
-        "[package].version must be 0.4.0 for the UI29-4 HostLink + Tooltip + NumberInput release"
+        version, "0.5.0",
+        "[package].version must be 0.5.0 for the Pagination release"
     );
 
     let exports = value
@@ -366,4 +366,20 @@ fn breadcrumb_interface_matches_spec() {
     assert_eq!(slot_names, vec!["crumbs"]);
     let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
     assert_eq!(emit_names, vec!["onSelect"]);
+}
+
+/// Pagination — « prev | 1 2 3 | next » row of HostLink chips. Three
+/// emits: onPrev, onNext (no payload), onPageSelect(index).
+#[test]
+fn pagination_interface_matches_spec() {
+    let mil_src = read_source("Pagination.mil");
+    let out = mosmodel_compiler::compile(&mil_src).unwrap();
+    let c = &out.component;
+    let slot_names: Vec<&str> = c.slots.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        slot_names,
+        vec!["pages", "prev-label", "next-label", "active-index"]
+    );
+    let emit_names: Vec<&str> = c.emits.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(emit_names, vec!["onPrev", "onNext", "onPageSelect"]);
 }


### PR DESCRIPTION
## Summary

Bootstrap's page-navigation row («prev | 1 2 3 | next ») as a new
toolkit component, sitting on the same UI29-4 \`HostLink\` primitive
that Nav and Breadcrumb migrated to in v0.4.

- **\`Pagination.mil\`** — slots \`pages: list<text>\`, \`prev-label\`,
  \`next-label\`, \`active-index\`. Emits \`onPrev\`, \`onNext\`,
  \`onPageSelect(index)\`.
- **\`Pagination.mll\`** — \`Row[pagination]\` containing prev
  \`HostLink\`, a \`For\` over \`pages\` emitting
  \`HostLink[pagination-page]\` per chip, and a next \`HostLink\`.
  Every chip uses \`href: \"#\"\` + \`external: false\` to match
  the Nav/Breadcrumb routing convention.
- **\`Pagination.light.msl\` / \`.dark.msl\`** — Bootstrap-style
  flat row of shared-border chips, themed for both palettes.

## Files changed

- Added: \`src/Pagination.{mil,mll,light.msl,dark.msl}\`.
- Modified: \`mosaic-package.toml\` (version 0.4.0 → 0.5.0; exports
  list extended), \`tests/package_compiles.rs\` (\`COMPONENTS\` array
  + new \`pagination_interface_matches_spec\` test + version
  assertion), \`CHANGELOG.md\`, \`README.md\`.

## Context

This PR replaces closed PR #3959, rebased onto current
\`origin/main\` and adopts the v0.4 \`HostLink\` convention.
InputGroup and Accordion (the other two batch-2 candidates from
#3959) ship in follow-up PRs once Pagination lands cleanly.

## Test plan

- [x] \`cargo test\` under \`code/packages/mosaic-pkg-toolkit\`
  passes — 17 tests (was 16): manifest + 15 prior interface tests
  + \`every_exported_component_round_trips\` + new
  \`pagination_interface_matches_spec\`.
- [ ] CI: detect + build (ubuntu-latest)
- [ ] No backend changes — every emitter regenerates Pagination
  from kernel primitives via the existing pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)