### PR TITLE
[codex] Add Board VM input callback transport decisions

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -217,6 +217,10 @@ without rebuilding bookmark policy.
 transport logic records with Rust-owned logic names, labels, queue-depth
 metadata, and messages, so frontends can follow callback transport decisions
 without rebuilding reference policy.
+`input_callback_transport_decision_summary` chooses those logic records as
+stable transport decision records with Rust-owned decision names, labels,
+queue-depth metadata, and messages, so frontends can present callback transport
+choices without rebuilding logic policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -1833,6 +1833,82 @@ pub struct LanguageInputCallbackTransportLogicSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportDecisionKind {
+    CallbackRunnerHandoffDecision,
+    AdapterEventPublicationDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportDecisionSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub decision_label: String,
+    pub decision_kind: LanguageInputCallbackTransportDecisionKind,
+    pub decision_name: String,
+    pub logic_kind: LanguageInputCallbackTransportLogicKind,
+    pub logic_name: String,
+    pub reference_kind: LanguageInputCallbackTransportReferenceKind,
+    pub reference_name: String,
+    pub bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+    pub bookmark_name: String,
+    pub cursor_kind: LanguageInputCallbackTransportCursorKind,
+    pub cursor_name: String,
+    pub marker_kind: LanguageInputCallbackTransportMarkerKind,
+    pub marker_name: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub marker_recorded: bool,
+    pub cursor_recorded: bool,
+    pub bookmark_recorded: bool,
+    pub reference_recorded: bool,
+    pub logic_recorded: bool,
+    pub decision_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_decision: u8,
+    pub message: String,
+    pub logic_summary: LanguageInputCallbackTransportLogicSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -2528,6 +2604,19 @@ pub const fn input_callback_transport_logic_kind_name(
         }
         LanguageInputCallbackTransportLogicKind::AdapterEventPublicationLogic => {
             "adapter_event_publication_logic"
+        }
+    }
+}
+
+pub const fn input_callback_transport_decision_kind_name(
+    kind: LanguageInputCallbackTransportDecisionKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportDecisionKind::CallbackRunnerHandoffDecision => {
+            "callback_runner_handoff_decision"
+        }
+        LanguageInputCallbackTransportDecisionKind::AdapterEventPublicationDecision => {
+            "adapter_event_publication_decision"
         }
     }
 }
@@ -4601,6 +4690,81 @@ pub fn input_callback_transport_logic_summary(
     }
 }
 
+pub fn input_callback_transport_decision_summary(
+    logic_summary: &LanguageInputCallbackTransportLogicSummary,
+) -> LanguageInputCallbackTransportDecisionSummary {
+    let decision_kind = input_callback_transport_decision_kind(logic_summary.logic_kind);
+
+    LanguageInputCallbackTransportDecisionSummary {
+        endpoint: logic_summary.endpoint.clone(),
+        connection_label: logic_summary.connection_label.clone(),
+        decision_label: input_callback_transport_decision_label(logic_summary, decision_kind),
+        decision_kind,
+        decision_name: input_callback_transport_decision_kind_name(decision_kind).to_owned(),
+        logic_kind: logic_summary.logic_kind,
+        logic_name: logic_summary.logic_name.clone(),
+        reference_kind: logic_summary.reference_kind,
+        reference_name: logic_summary.reference_name.clone(),
+        bookmark_kind: logic_summary.bookmark_kind,
+        bookmark_name: logic_summary.bookmark_name.clone(),
+        cursor_kind: logic_summary.cursor_kind,
+        cursor_name: logic_summary.cursor_name.clone(),
+        marker_kind: logic_summary.marker_kind,
+        marker_name: logic_summary.marker_name.clone(),
+        checkpoint_kind: logic_summary.checkpoint_kind,
+        checkpoint_name: logic_summary.checkpoint_name.clone(),
+        snapshot_kind: logic_summary.snapshot_kind,
+        snapshot_name: logic_summary.snapshot_name.clone(),
+        archive_kind: logic_summary.archive_kind,
+        archive_name: logic_summary.archive_name.clone(),
+        journal_kind: logic_summary.journal_kind,
+        journal_name: logic_summary.journal_name.clone(),
+        log_kind: logic_summary.log_kind,
+        log_name: logic_summary.log_name.clone(),
+        audit_kind: logic_summary.audit_kind,
+        audit_name: logic_summary.audit_name.clone(),
+        trace_kind: logic_summary.trace_kind,
+        trace_name: logic_summary.trace_name.clone(),
+        outcome_kind: logic_summary.outcome_kind,
+        outcome_name: logic_summary.outcome_name.clone(),
+        receipt_kind: logic_summary.receipt_kind,
+        receipt_name: logic_summary.receipt_name.clone(),
+        acknowledgement_kind: logic_summary.acknowledgement_kind,
+        acknowledgement_name: logic_summary.acknowledgement_name.clone(),
+        delivery_route: logic_summary.delivery_route,
+        delivery_route_name: logic_summary.delivery_route_name.clone(),
+        event_kind: logic_summary.event_kind,
+        event_name: logic_summary.event_name.clone(),
+        report_kind: logic_summary.report_kind,
+        report_name: logic_summary.report_name.clone(),
+        action: logic_summary.action,
+        action_name: logic_summary.action_name.clone(),
+        callback_runner_handoff: logic_summary.callback_runner_handoff,
+        adapter_event_published: logic_summary.adapter_event_published,
+        delivery_acknowledged: logic_summary.delivery_acknowledged,
+        receipt_recorded: logic_summary.receipt_recorded,
+        outcome_recorded: logic_summary.outcome_recorded,
+        trace_recorded: logic_summary.trace_recorded,
+        audit_recorded: logic_summary.audit_recorded,
+        log_recorded: logic_summary.log_recorded,
+        journal_recorded: logic_summary.journal_recorded,
+        archive_recorded: logic_summary.archive_recorded,
+        snapshot_recorded: logic_summary.snapshot_recorded,
+        checkpoint_recorded: logic_summary.checkpoint_recorded,
+        marker_recorded: logic_summary.marker_recorded,
+        cursor_recorded: logic_summary.cursor_recorded,
+        bookmark_recorded: logic_summary.bookmark_recorded,
+        reference_recorded: logic_summary.reference_recorded,
+        logic_recorded: logic_summary.logic_recorded,
+        decision_recorded: true,
+        terminal: logic_summary.terminal,
+        retryable: logic_summary.retryable,
+        queue_depth_after_decision: logic_summary.queue_depth_after_logic,
+        message: input_callback_transport_decision_message(decision_kind).to_owned(),
+        logic_summary: logic_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -6493,6 +6657,44 @@ fn input_callback_transport_logic_message(
         }
         LanguageInputCallbackTransportLogicKind::AdapterEventPublicationLogic => {
             "Transport logic should route the adapter event publication reference."
+        }
+    }
+}
+
+fn input_callback_transport_decision_kind(
+    logic_kind: LanguageInputCallbackTransportLogicKind,
+) -> LanguageInputCallbackTransportDecisionKind {
+    match logic_kind {
+        LanguageInputCallbackTransportLogicKind::CallbackRunnerHandoffLogic => {
+            LanguageInputCallbackTransportDecisionKind::CallbackRunnerHandoffDecision
+        }
+        LanguageInputCallbackTransportLogicKind::AdapterEventPublicationLogic => {
+            LanguageInputCallbackTransportDecisionKind::AdapterEventPublicationDecision
+        }
+    }
+}
+
+fn input_callback_transport_decision_label(
+    logic_summary: &LanguageInputCallbackTransportLogicSummary,
+    decision_kind: LanguageInputCallbackTransportDecisionKind,
+) -> String {
+    format!(
+        "{} transport_decision={} decision_recorded=true queue_depth_after_decision={}",
+        logic_summary.logic_label,
+        input_callback_transport_decision_kind_name(decision_kind),
+        logic_summary.queue_depth_after_logic
+    )
+}
+
+fn input_callback_transport_decision_message(
+    decision_kind: LanguageInputCallbackTransportDecisionKind,
+) -> &'static str {
+    match decision_kind {
+        LanguageInputCallbackTransportDecisionKind::CallbackRunnerHandoffDecision => {
+            "Transport decision should choose the callback-runner handoff logic."
+        }
+        LanguageInputCallbackTransportDecisionKind::AdapterEventPublicationDecision => {
+            "Transport decision should choose the adapter event publication logic."
         }
     }
 }
@@ -15988,6 +16190,253 @@ mod tests {
             )
         );
         assert_eq!(dropped.reference_summary, dropped_reference);
+    }
+
+    #[test]
+    fn input_callback_transport_decision_is_owned_by_rust_language_core() {
+        fn logic_for_lifecycle(
+            lifecycle: &LanguageInputCallbackSessionLifecycleSummary,
+        ) -> LanguageInputCallbackTransportLogicSummary {
+            let action = input_callback_transport_action_summary(lifecycle);
+            let effect = input_callback_transport_effect_summary(&action);
+            let report = input_callback_transport_report_summary(&effect);
+            let event = input_callback_transport_event_summary(&report);
+            let delivery = input_callback_transport_delivery_summary(&event);
+            let acknowledgement = input_callback_transport_acknowledgement_summary(&delivery);
+            let receipt = input_callback_transport_receipt_summary(&acknowledgement);
+            let outcome = input_callback_transport_outcome_summary(&receipt);
+            let trace = input_callback_transport_trace_summary(&outcome);
+            let audit = input_callback_transport_audit_summary(&trace);
+            let log = input_callback_transport_log_summary(&audit);
+            let journal = input_callback_transport_journal_summary(&log);
+            let archive = input_callback_transport_archive_summary(&journal);
+            let snapshot = input_callback_transport_snapshot_summary(&archive);
+            let checkpoint = input_callback_transport_checkpoint_summary(&snapshot);
+            let marker = input_callback_transport_marker_summary(&checkpoint);
+            let cursor = input_callback_transport_cursor_summary(&marker);
+            let bookmark = input_callback_transport_bookmark_summary(&cursor);
+            let reference = input_callback_transport_reference_summary(&bookmark);
+            input_callback_transport_logic_summary(&reference)
+        }
+
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_logic = logic_for_lifecycle(&completed_lifecycle);
+        let completed = input_callback_transport_decision_summary(&completed_logic);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.connection_label,
+            "endpoint=serial:///dev/cu.usbmodem1101 baud=57600"
+        );
+        assert_eq!(
+            completed.decision_kind,
+            LanguageInputCallbackTransportDecisionKind::AdapterEventPublicationDecision
+        );
+        assert_eq!(
+            completed.decision_name,
+            "adapter_event_publication_decision"
+        );
+        assert_eq!(
+            completed.logic_kind,
+            LanguageInputCallbackTransportLogicKind::AdapterEventPublicationLogic
+        );
+        assert_eq!(completed.logic_name, "adapter_event_publication_logic");
+        assert_eq!(
+            completed.reference_kind,
+            LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference
+        );
+        assert_eq!(
+            completed.bookmark_kind,
+            LanguageInputCallbackTransportBookmarkKind::AdapterEventPublicationBookmark
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.report_kind,
+            LanguageInputCallbackTransportReportKind::Completion
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.marker_recorded);
+        assert!(completed.cursor_recorded);
+        assert!(completed.bookmark_recorded);
+        assert!(completed.reference_recorded);
+        assert!(completed.logic_recorded);
+        assert!(completed.decision_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_decision, 2);
+        assert_eq!(
+            completed.decision_label,
+            format!(
+                "{} transport_decision=adapter_event_publication_decision decision_recorded=true queue_depth_after_decision=2",
+                completed_logic.logic_label
+            )
+        );
+        assert_eq!(
+            completed.message,
+            "Transport decision should choose the adapter event publication logic."
+        );
+        assert_eq!(completed.logic_summary, completed_logic);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_logic = logic_for_lifecycle(&pending_lifecycle);
+        let pending = input_callback_transport_decision_summary(&pending_logic);
+
+        assert_eq!(
+            pending.decision_kind,
+            LanguageInputCallbackTransportDecisionKind::CallbackRunnerHandoffDecision
+        );
+        assert_eq!(pending.decision_name, "callback_runner_handoff_decision");
+        assert_eq!(
+            pending.logic_kind,
+            LanguageInputCallbackTransportLogicKind::CallbackRunnerHandoffLogic
+        );
+        assert_eq!(
+            pending.reference_kind,
+            LanguageInputCallbackTransportReferenceKind::CallbackRunnerHandoffReference
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(pending.archive_recorded);
+        assert!(pending.snapshot_recorded);
+        assert!(pending.checkpoint_recorded);
+        assert!(pending.marker_recorded);
+        assert!(pending.cursor_recorded);
+        assert!(pending.bookmark_recorded);
+        assert!(pending.reference_recorded);
+        assert!(pending.logic_recorded);
+        assert!(pending.decision_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_decision, 3);
+        assert_eq!(
+            pending.decision_label,
+            format!(
+                "{} transport_decision=callback_runner_handoff_decision decision_recorded=true queue_depth_after_decision=3",
+                pending_logic.logic_label
+            )
+        );
+        assert_eq!(
+            pending.message,
+            "Transport decision should choose the callback-runner handoff logic."
+        );
+        assert_eq!(pending.logic_summary, pending_logic);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_logic = logic_for_lifecycle(&dropped_lifecycle);
+        let dropped = input_callback_transport_decision_summary(&dropped_logic);
+
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.decision_kind,
+            LanguageInputCallbackTransportDecisionKind::AdapterEventPublicationDecision
+        );
+        assert_eq!(
+            dropped.logic_kind,
+            LanguageInputCallbackTransportLogicKind::AdapterEventPublicationLogic
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.marker_recorded);
+        assert!(dropped.cursor_recorded);
+        assert!(dropped.bookmark_recorded);
+        assert!(dropped.reference_recorded);
+        assert!(dropped.logic_recorded);
+        assert!(dropped.decision_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_decision, 1);
+        assert_eq!(
+            dropped.decision_label,
+            format!(
+                "{} transport_decision=adapter_event_publication_decision decision_recorded=true queue_depth_after_decision=1",
+                dropped_logic.logic_label
+            )
+        );
+        assert_eq!(dropped.logic_summary, dropped_logic);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned input callback transport decision kinds, names, labels, and messages on top of transport logic summaries
- preserve the full callback transport chain through decisions for callback-runner handoff and adapter-event publication paths
- document the new decision summary surface for thin language frontends

## Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-decision cargo test -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-decision cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Note: the external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.