### PR TITLE
feat(cas-summation): Phase 56 — bounded × Sqrt(diverging) (TS+Rust port, 1.4.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.4.0 — 2026-05-23
+
+**Phase 56 — Bounded × Sqrt(diverging) numerator pattern (Rust port).**
+
+Ports Python ``cas-summation`` 1.4.0 (PR #4167).  Bounded × sqrt
+analogue of Phase 55's bounded × log.
+
+### Added
+
+- **`bounded_times_sqrt_inner_deg(node, k) -> Option<i64>`** —
+  returns ``deg(P)`` (×2 half-degree to stay in i64 arithmetic) for
+  ``Mul`` of exactly one ``Sqrt(positive-poly)`` factor and rest
+  bounded.  Returns ``None`` for the no-Sqrt case, two-Sqrt case
+  (conservative), or unrecognised factors.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds Phase 56 branch after Phase 55,
+  comparing ``2 * den_deg > deg(P)`` for polynomial denominators or
+  short-circuiting on non-polynomial divergence.
+
+### Tests
+
+3 new ``phase56_*`` cases.  Full suite: **69 passed** (was 66; +3).
+
 ## 1.3.0 — 2026-05-23
 
 **Phase 55 — Bounded×Log(diverging) numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1171,6 +1171,41 @@ fn is_bounded_times_log_in_k(node: &IRNode, k: &IRNode) -> bool {
     log_count == 1
 }
 
+/// Phase 56 (Rust port): Return the ``Sqrt`` inner polynomial degree
+/// (×2 to stay exact) when ``node`` is a ``Mul`` with exactly one
+/// ``Sqrt(positive-leading polynomial)`` factor and all remaining
+/// factors bounded in ``k``; ``None`` otherwise.
+///
+/// Mirror of ``is_bounded_times_log_in_k`` for sqrt instead of log.
+/// Returns ``deg(P)`` (= 2 × half-degree) so callers can compare with
+/// ``2 * den_deg`` in integer arithmetic.
+fn bounded_times_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut sqrt_inner_deg: Option<i64> = None;
+    for arg in &apply_node.args {
+        if let Some(deg) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_inner_deg.is_some() {
+                // Two Sqrt factors — refuse (conservative).
+                return None;
+            }
+            sqrt_inner_deg = Some(deg);
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Neither Sqrt(positive-poly) nor bounded → unrecognised.
+        return None;
+    }
+    sqrt_inner_deg
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1247,6 +1282,19 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     // the numerator's effective polynomial degree is 0 (no polynomial factor).
     if is_bounded_times_log_in_k(num, k) && h_diverges_at_infinity(den, k) {
         return true;
+    }
+    // Phase 56: Mul(bounded, Sqrt(positive-poly)) numerator pattern.
+    // Effective growth ``deg(P)/2``; closes when:
+    //   - polynomial denominator with ``2 * den_deg > deg(P)``, OR
+    //   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+    if let Some(sqrt_inner_deg) = bounded_times_sqrt_inner_deg(num, k) {
+        if let Some(den_deg_bs) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_bs > sqrt_inner_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1346,3 +1346,63 @@ fn phase55_bounded_times_log_constant_denominator_stays() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 56 (Rust port): bounded × Sqrt(diverging) numerator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase56_sin_times_sqrt_k_over_k_squared_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase56_sin_times_sqrt_k_cubed_over_exponential_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1_3]);
+    // Denominator is 2^k — exponential, dominates polynomial of any degree.
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase56_sin_times_sqrt_k_cubed_over_k_refused() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k.clone()]),
+        apply(sym(DIV), vec![num_kp1, kp1]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    // 3/2 > 1 → does not vanish.
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.4.0 — 2026-05-23
+
+**Phase 56 — Bounded × Sqrt(diverging) numerator pattern (TypeScript port).**
+
+Ports Python ``cas-summation`` 1.4.0 (PR #4167).  Bounded × sqrt
+analogue of Phase 55's bounded × log.  Effective growth degree is
+``deg(P)/2``; quotient vanishes when ``denDeg > deg(P)/2``
+(polynomial) or denominator is non-polynomial diverging.
+
+### Added
+
+- **`boundedTimesSqrtHalfDegree(node, k)`** — returns ``deg(P)/2``
+  (half-degree) for ``Mul`` of exactly one ``Sqrt(positive-poly)``
+  factor and rest bounded.  Returns ``undefined`` for the no-Sqrt
+  case, two-Sqrt case (conservative), or unrecognised factors.
+
+### Changed
+
+- ``gVanishesAtInfinity`` adds Phase 56 branch after Phase 55, with
+  two denominator sub-cases (polynomial ``denDeg > halfDeg`` OR
+  non-polynomial diverging dominates).
+
+### Tests
+
+3 new ``summation: Phase 56 bounded × sqrt numerator`` cases.
+Full suite: **69 passed** (was 66; +3).
+
 ## 1.3.0 — 2026-05-23
 
 **Phase 55 — Bounded×Log(diverging) numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -869,6 +869,49 @@ function isBoundedTimesLogInK(node: IRNode, k: IRNode): boolean {
   return logCount === 1;
 }
 
+/**
+ * Phase 56 (TypeScript port): Return the ``Sqrt`` inner half-degree
+ * when ``node`` is a ``Mul`` with exactly one
+ * ``Sqrt(positive-leading polynomial)`` factor and all remaining
+ * factors bounded in ``k``; ``undefined`` otherwise.
+ *
+ * Mirror of :func:`isBoundedTimesLogInK` but for sqrt instead of log.
+ * Returns the half-degree directly (Phase 51's
+ * ``sqrtEffectiveHalfDegree`` already returns the half value in TS),
+ * so the caller compares ``denDeg > sqrtHalfDeg`` directly.
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Sqrt(positive-leading polynomial)`` → record its half-deg;
+ *        refuse if a second sqrt appears.
+ *      - ``bounded`` → accept.
+ *      - otherwise → return undefined.
+ *   3. Require exactly one sqrt factor.
+ */
+function boundedTimesSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  for (const arg of node.args) {
+    const deg = sqrtEffectiveHalfDegree(arg, k);
+    if (deg !== undefined) {
+      if (sqrtHalfDeg !== undefined) {
+        // Two Sqrt factors — refuse (conservative, would need
+        // combined growth-rate logic).
+        return undefined;
+      }
+      sqrtHalfDeg = deg;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Neither Sqrt(positive-poly) nor bounded → unrecognised.
+    return undefined;
+  }
+  return sqrtHalfDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -937,6 +980,22 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   // but log itself is dominated by any polynomial or faster-growing denominator).
   if (isBoundedTimesLogInK(num, k) && hDivergesAtInfinity(den, k)) {
     return true;
+  }
+  // Phase 56: Mul(bounded, Sqrt(positive-poly)) numerator pattern.
+  // Effective growth degree is deg(P)/2.  Vanishes when:
+  //   - denominator is polynomial with deg(den) > deg(P)/2, OR
+  //   - denominator is non-polynomial diverging (Exp / Pow / Log×poly)
+  //     which dominates any sub-polynomial sqrt growth automatically.
+  const sqrtBoundedHalfDeg = boundedTimesSqrtHalfDegree(num, k);
+  if (sqrtBoundedHalfDeg !== undefined) {
+    const denDegBs = polynomialDegreeInK(den, k);
+    if (denDegBs !== undefined) {
+      if (denDegBs > sqrtBoundedHalfDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1067,3 +1067,61 @@ describe("summation: Phase 55 Bounded×Log(diverging) numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 56 (TS port): bounded × Sqrt(diverging) numerator.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 56 bounded × sqrt numerator", () => {
+  it("∑ [sin(k)·sqrt(k)/k² − ...] closes (1/2 < 2)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, sqrtK]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·sqrt(k³)/2^k − ...] closes (sqrt < exp)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin(k)·sqrt(k³)/k stays unevaluated (3/2 > 1)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, k]),
+      app(DIV, [numKp1, kp1]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // 3/2 > 1 → does not vanish.
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Phase 56 fix (PR #4167) to TypeScript and Rust.
Bounded × sqrt analogue of Phase 55's bounded × log.  Numerator
``Mul(bounded, Sqrt(P(k)))`` has effective polynomial degree
``deg(P)/2``; quotient vanishes when denominator grows strictly
faster (polynomial or transcendental).

Bumps:
- ``@coding-adventures/cas-summation`` 1.3.0 → 1.4.0
- ``cas-summation`` (Rust)             1.3.0 → 1.4.0

### Added (both languages)

| Language | Function | Returns |
|---|---|---|
| TS | ``boundedTimesSqrtHalfDegree`` | ``deg(P)/2`` as ``number`` (already half-degree from Phase 51's ``sqrtEffectiveHalfDegree``) |
| Rust | ``bounded_times_sqrt_inner_deg`` | ``deg(P)`` (×2 half-degree) as ``Option<i64>`` for exact integer comparison |

### Test plan

- [x] TS: ``npm test`` → 69 passed (was 66; +3)
- [x] Rust: ``cargo test`` → 69 passed (was 66; +3)
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)