### PR TITLE
feat(twig-ir-compiler): typed make_nil → const ref<LispyPair> (Path A 6a)

### DIFF
--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog — twig-ir-compiler
 
+## [0.20.0] — 2026-05-23 (Path A increment 6a — typed `make_nil`)
+
+### Added — `nil` literal emits `const 0 [ref<LispyPair>]`
+
+Increment 6a of the Twig → IIR-to-* end-to-end story.  Replaces
+every `call_builtin "make_nil" [any]` emission site with a typed
+`const 0 [ref<LispyPair>]`, matching the Phase 2 heap-lowering
+convention used by the IIR-to-{wasm,jvm,clr,beam} backends.
+
+Nil is encoded as the null `LispyPair` reference — represented as
+`0` — which is exactly how `iir-builtin-lowering/src/heap.rs:288`
+produces it from the legacy `call_builtin "make_nil"` form.  Every
+backend already accepts the typed const for `ref<*>` types.
+
+#### Sites converted (5 total)
+
+| Site                                | Function                       | Where                                |
+|-------------------------------------|--------------------------------|--------------------------------------|
+| Empty program return-nil            | `compile_program`              | Implicit `nil` when no final expr    |
+| `nil` literal                       | `compile_expr_inner`           | `Expr::NilLit` match arm             |
+| `match` fallthrough init            | `compile_match`                | Initial `result` register value      |
+| Record constructor cons-chain tail  | `compile_record_constructor`   | Fold-right base for record fields    |
+| Union variant cons-chain tail       | `compile_record_constructor`   | Fold-right base for variant fields   |
+
+#### What this unlocks
+
+- `nil` literal flows through every backend (new test
+  `twig_nil_literal_accepted_by_every_backend`).
+- Empty Twig program flows through every backend (new test
+  `twig_empty_program_accepted_by_every_backend`).
+- `match` programs whose arms all have known types now have a
+  typed fallthrough register, removing the last untyped `mov`
+  source in `compile_match`.
+
+#### twig-vm dispatch wrapper (companion change)
+
+twig-vm's `exec_const` now special-cases `const … [ref<LispyPair>]`
+with `Operand::Int(0)` to produce `LispyValue::NIL` (instead of the
+plain `LispyValue::int(0)` it would otherwise emit).  Without this,
+HOF builtins like `map` / `filter` / `fold-*` would see `Int(0)`
+where they expect the NIL sentinel and bail out with
+`"list tail 0 is not a cons cell"`.
+
+This is the symmetric companion to the increment 2 dispatch wrapper
+that synthesised `call_builtin "+"` from typed `add`.
+
+#### What's not in this PR
+
+Still pending for increment 6:
+
+- `cons` → typed `alloc` + `field_store` (increment 6b, 3 sites)
+- `car` / `cdr` → typed `field_load` (increment 6c, 8 sites)
+
+After 6b and 6c, no list-handling op in twig-ir-compiler emits an
+untyped `call_builtin`, and Twig programs that build / traverse
+lists flow end-to-end through every backend.
+
+#### Tests
+
+- 2 new backend acceptance tests (`nil`, empty program).
+- Lib test `nil_literal_emits_make_nil_builtin` renamed to
+  `nil_literal_emits_typed_const_ref_lispy_pair` and updated.
+- Lib test `empty_program_returns_nil` renamed to
+  `empty_program_returns_typed_nil_const` and updated.
+- All 73 lib + 12 backend e2e + 179 twig-vm tests pass.
+
 ## [0.19.0] — 2026-05-22 (Path A — typed `match` arm merges)
 
 ### Added — Typed `mov` for the 7 remaining `compile_match` sites

--- a/code/packages/rust/twig-ir-compiler/Cargo.toml
+++ b/code/packages/rust/twig-ir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-ir-compiler"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
-description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG52: let*, and/or special forms.  LANG55: HOF builtins.  LANG56: IIRExport from module_info.  LANG57: match jmpif bug fix + string/symbol conversion builtins.  LANG58: string/char builtins for TW05-E.  LANG72: compile_program_with_externs_and_globals for cross-module strict type checking."
+description = "TW00 — Twig (Lisp-precursor) → InterpreterIR (IIR) compiler.  LANG52: let*, and/or special forms.  LANG55: HOF builtins.  LANG56: IIRExport from module_info.  LANG57: match jmpif bug fix + string/symbol conversion builtins.  LANG58: string/char builtins for TW05-E.  LANG72: compile_program_with_externs_and_globals for cross-module strict type checking.  Path A increment 6a: typed make_nil → const 0 [ref<LispyPair>]."
 
 [dependencies]
 twig-parser        = { path = "../twig-parser" }

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -539,18 +539,28 @@ impl Compiler {
             ), SourceLoc::SYNTHETIC);
         } else {
             // No final value-producing expression → return nil.
+            //
+            // Path A increment 6a: emit `const 0 [ref<LispyPair>]`
+            // instead of `call_builtin "make_nil" [any]`.  This matches
+            // the Phase 2 heap-lowering convention already used by the
+            // IIR-to-{wasm,jvm,clr,beam} backends — nil is the null
+            // LispyPair reference (represented as 0).  The typed `const`
+            // is accepted by every backend, so programs whose only
+            // return path is the implicit nil now flow through every
+            // backend without going through the `call_builtin` fallback.
             let nil_var = main_ctx.fresh_var("nil");
             main_ctx.emit(IIRInstr::new(
-                "call_builtin",
+                "const",
                 Some(nil_var.clone()),
-                vec![Operand::Var("make_nil".into())],
-                "any",
+                vec![Operand::Int(0)],
+                "ref<LispyPair>",
             ), SourceLoc::SYNTHETIC);
+            main_ctx.record_type(&nil_var, "ref<LispyPair>");
             main_ctx.emit(IIRInstr::new(
                 "ret",
                 None,
                 vec![Operand::Var(nil_var)],
-                "any",
+                "ref<LispyPair>",
             ), SourceLoc::SYNTHETIC);
         }
 
@@ -841,13 +851,18 @@ impl Compiler {
             }
 
             Expr::NilLit(NilLit { .. }) => {
+                // Path A increment 6a: emit `const 0 [ref<LispyPair>]`
+                // instead of `call_builtin "make_nil" [any]`.  Every
+                // IIR-to-* backend accepts the typed const, and twig-vm
+                // dispatches it as a nil `LispyPair` reference.
                 let v = ctx.fresh_var("nil");
                 ctx.emit(IIRInstr::new(
-                    "call_builtin",
+                    "const",
                     Some(v.clone()),
-                    vec![Operand::Var("make_nil".into())],
-                    "any",
+                    vec![Operand::Int(0)],
+                    "ref<LispyPair>",
                 ), loc);
+                ctx.record_type(&v, "ref<LispyPair>");
                 Ok(v)
             }
 
@@ -1439,13 +1454,19 @@ impl Compiler {
         // Result register — each arm writes its value here.
         let result = ctx.fresh_var("match_result");
         // Initialise to nil (fallthrough value).
+        //
+        // Path A increment 6a: emit typed `const 0 [ref<LispyPair>]`
+        // instead of `call_builtin "make_nil" [any]`.  emit_move then
+        // propagates the `ref<LispyPair>` type onto `result`, so the
+        // match expression's fallthrough is also typed.
         let nil_init = ctx.fresh_var("nil");
         ctx.emit(IIRInstr::new(
-            "call_builtin",
+            "const",
             Some(nil_init.clone()),
-            vec![Operand::Var("make_nil".into())],
-            "any",
+            vec![Operand::Int(0)],
+            "ref<LispyPair>",
         ), loc);
+        ctx.record_type(&nil_init, "ref<LispyPair>");
         ctx.emit_move(&result, &nil_init, loc);
 
         // Generate labels for the chain.
@@ -1684,13 +1705,20 @@ impl Compiler {
             }
 
             // Start from the nil end and fold right.
+            //
+            // Path A increment 6a: typed `const 0 [ref<LispyPair>]`
+            // initial tail.  The subsequent `cons` cells (still
+            // emitted as `call_builtin "cons"`) consume `tail` as a
+            // `ref<LispyPair>` srcs operand — increment 6b will
+            // convert the cons emission too.
             let nil_r = ctx.fresh_var("nil");
             ctx.emit(IIRInstr::new(
-                "call_builtin",
+                "const",
                 Some(nil_r.clone()),
-                vec![Operand::Var("make_nil".into())],
-                "any",
+                vec![Operand::Int(0)],
+                "ref<LispyPair>",
             ), loc);
+            ctx.record_type(&nil_r, "ref<LispyPair>");
 
             let mut tail = nil_r;
             for field_name in params.iter().rev() {
@@ -1818,13 +1846,17 @@ impl Compiler {
                 }
 
                 // Start from nil, fold right over fields.
+                //
+                // Path A increment 6a: typed `const 0 [ref<LispyPair>]`
+                // initial tail for the variant's cons chain.
                 let nil_r = ctx.fresh_var("nil");
                 ctx.emit(IIRInstr::new(
-                    "call_builtin",
+                    "const",
                     Some(nil_r.clone()),
-                    vec![Operand::Var("make_nil".into())],
-                    "any",
+                    vec![Operand::Int(0)],
+                    "ref<LispyPair>",
                 ), loc);
+                ctx.record_type(&nil_r, "ref<LispyPair>");
 
                 let mut tail = nil_r;
                 for field_name in params.iter().rev() {

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -544,19 +544,24 @@ mod tests {
     // ---- Module-level invariants -----------------------------------------
 
     #[test]
-    fn empty_program_returns_nil() {
+    fn empty_program_returns_typed_nil_const() {
+        // Path A increment 6a: the empty-program implicit nil return
+        // is emitted as a typed `const 0 [ref<LispyPair>]` instead of
+        // `call_builtin "make_nil" [any]`.  This matches the convention
+        // used by the IIR-to-{wasm,jvm,clr,beam} backends and the
+        // Phase 2 heap-lowering pass — nil is the null `LispyPair`
+        // reference, represented as 0.
         let m = module("");
         assert_eq!(m.entry_point.as_deref(), Some("main"));
         assert_eq!(m.language, "twig");
         assert_eq!(m.functions.len(), 1);
         let main = &m.functions[0];
         assert_eq!(main.name, "main");
-        // make_nil + ret is the empty-program shape.
-        assert_eq!(op_names(&main.instructions), vec!["call_builtin", "ret"]);
-        match &main.instructions[0].srcs[0] {
-            Operand::Var(s) => assert_eq!(s, "make_nil"),
-            other => panic!("expected Var(\"make_nil\"), got {other:?}"),
-        }
+        // const 0 [ref<LispyPair>] + ret is the empty-program shape.
+        assert_eq!(op_names(&main.instructions), vec!["const", "ret"]);
+        assert_eq!(main.instructions[0].srcs[0], Operand::Int(0));
+        assert_eq!(main.instructions[0].type_hint, "ref<LispyPair>");
+        assert_eq!(main.instructions[1].type_hint, "ref<LispyPair>");
     }
 
     #[test]
@@ -633,10 +638,14 @@ mod tests {
     }
 
     #[test]
-    fn nil_literal_emits_make_nil_builtin() {
+    fn nil_literal_emits_typed_const_ref_lispy_pair() {
+        // Path A increment 6a: `nil` now emits `const 0 [ref<LispyPair>]`
+        // (matching iir-builtin-lowering's Phase 2 convention) instead
+        // of `call_builtin "make_nil" [any]`.
         let i = main_instrs("nil");
-        assert_eq!(i[0].op, "call_builtin");
-        assert_eq!(i[0].srcs[0], Operand::Var("make_nil".into()));
+        assert_eq!(i[0].op, "const");
+        assert_eq!(i[0].srcs[0], Operand::Int(0));
+        assert_eq!(i[0].type_hint, "ref<LispyPair>");
     }
 
     #[test]

--- a/code/packages/rust/twig-ir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/twig-ir-compiler/tests/backend_compat.rs
@@ -279,6 +279,70 @@ fn twig_typed_match_wildcard_accepted_by_every_backend() {
     // is deferred to the next increment.
 }
 
+/// Path-A increment 6a: `nil` literal and the implicit "empty
+/// program returns nil" path now emit `const 0 [ref<LispyPair>]`
+/// instead of `call_builtin "make_nil"`.  Every IIR-to-* backend
+/// accepts the typed const (Phase 2 heap-lowering convention), so
+/// these two minimal shapes flow through every backend.
+#[test]
+fn twig_nil_literal_accepted_by_every_backend() {
+    let m = compile_source("nil", "compat").expect("Twig must compile");
+
+    // The nil literal must emit `const 0 [ref<LispyPair>]`, not the
+    // legacy `call_builtin "make_nil"`.
+    let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+    assert!(
+        main.instructions.iter().any(|i|
+            i.op == "const" && i.type_hint == "ref<LispyPair>"
+                && i.srcs[0] == Operand::Int(0)
+        ),
+        "increment 6a: `nil` must emit `const 0 [ref<LispyPair>]`; \
+         got: {:?}", main.instructions,
+    );
+    assert!(
+        !main.instructions.iter().any(|i|
+            i.op == "call_builtin"
+                && matches!(&i.srcs[0], Operand::Var(s) if s == "make_nil")
+        ),
+        "increment 6a: legacy `call_builtin \"make_nil\"` must be gone; \
+         got: {:?}", main.instructions,
+    );
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] validator should accept Twig `nil` after path-A \
+             increment 6a; got {} error(s): {errs:?}",
+            errs.len());
+    }
+}
+
+/// Path-A increment 6a: the empty-program shape — no expressions, so
+/// the compiler synthesises an implicit nil return — also flows
+/// through every backend.
+#[test]
+fn twig_empty_program_accepted_by_every_backend() {
+    let m = compile_source("", "compat").expect("Twig must compile");
+    let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.return_type, "ref<LispyPair>",
+        "empty program's main should return ref<LispyPair> (the nil tail)");
+
+    for (name, errs) in [
+        ("wasm", iir_to_wasm::validate::validate_for_wasm(&m)),
+        ("jvm",  iir_to_jvm_class_file::validate::validate_for_jvm(&m)),
+        ("clr",  iir_to_cil_bytecode::validate::validate_iir_for_clr(&m)),
+        ("beam", iir_to_beam::validate::validate_for_beam(&m)),
+    ] {
+        assert!(errs.is_empty(),
+            "[{name}] validator should accept empty Twig program; \
+             got {} error(s): {errs:?}", errs.len());
+    }
+}
+
 /// Pin the *current* boundary: arithmetic where at least one operand
 /// has a dynamic type (comes from a `call_builtin` like `car`) still
 /// emits `call_builtin "+"` and gets rejected by every backend.  When

--- a/code/packages/rust/twig-to-beam/tests/test_pipeline.rs
+++ b/code/packages/rust/twig-to-beam/tests/test_pipeline.rs
@@ -251,27 +251,28 @@ fn unbalanced_parens_produce_compile_error() {
 // cannot handle.
 // ---------------------------------------------------------------------------
 
-// Test 3.1 — empty program emits make_nil which BEAM cannot handle
+// Test 3.1 — empty program now compiles cleanly (Path A increment 6a)
+//
+// Before increment 6a, empty programs emitted `call_builtin make_nil` which
+// the BEAM validator rejected.  After 6a, `twig-ir-compiler` emits a typed
+// `const 0 [ref<LispyPair>]` for the implicit nil return — and the BEAM
+// backend accepts typed const for `ref<*>` types via the Phase 2 heap-
+// lowering convention.  This test flipped from a BeamError expectation
+// to an Ok expectation.
 #[test]
-fn empty_program_is_beam_error() {
-    // An empty Twig program compiles to: `call_builtin make_nil` + `ret`.
-    // `make_nil` survives builtin-lowering (not in the arithmetic table),
-    // so the BEAM validator sees a `call_builtin` instruction and rejects it.
-    let err = compile_err("");
-    assert!(
-        matches!(err, TwigToBeamError::BeamError(_)),
-        "empty program should produce BeamError (call_builtin make_nil); got: {err}"
-    );
+fn empty_program_compiles() {
+    let bytes = compile_ok("");
+    assert!(!bytes.is_empty(), "empty program should produce a non-empty BEAM blob");
 }
 
-// Test 3.2 — nil literal produces call_builtin which BEAM cannot lower
+// Test 3.2 — nil literal now compiles cleanly (Path A increment 6a)
+//
+// Same flip as empty_program_compiles: `nil` now lowers to
+// `const 0 [ref<LispyPair>]`, accepted by every backend.
 #[test]
-fn nil_literal_is_beam_error() {
-    let err = compile_err("nil");
-    assert!(
-        matches!(err, TwigToBeamError::BeamError(_)),
-        "nil literal should produce BeamError; got: {err}"
-    );
+fn nil_literal_compiles() {
+    let bytes = compile_ok("nil");
+    assert!(!bytes.is_empty(), "nil literal should produce a non-empty BEAM blob");
 }
 
 // Test 3.3 — boolean constant compiles to a valid BEAM binary

--- a/code/packages/rust/twig-to-wasm/tests/test_pipeline.rs
+++ b/code/packages/rust/twig-to-wasm/tests/test_pipeline.rs
@@ -250,27 +250,31 @@ fn unbalanced_parens_produce_compile_error() {
 // cannot handle.
 // ---------------------------------------------------------------------------
 
-// Test 3.1 — empty program emits make_nil which WASM cannot handle
+// Test 3.1 — empty program now compiles cleanly (Path A increment 6a)
+//
+// Before increment 6a, empty programs emitted `call_builtin make_nil` which
+// the WASM validator rejected.  After 6a, `twig-ir-compiler` emits a typed
+// `const 0 [ref<LispyPair>]` for the implicit nil return — and the WASM
+// backend accepts typed const for `ref<*>` types via the Phase 2 heap-
+// lowering convention.  This test flipped from a WasmError expectation
+// to an Ok expectation.
 #[test]
-fn empty_program_is_wasm_error() {
-    // An empty Twig program compiles to: `call_builtin make_nil` + `ret`.
-    // `make_nil` survives builtin-lowering (not in the arithmetic table),
-    // so the WASM validator sees a `call_builtin` instruction and rejects it.
-    let err = compile_err("");
-    assert!(
-        matches!(err, TwigToWasmError::WasmError(_)),
-        "empty program should produce WasmError (call_builtin make_nil); got: {err}"
-    );
+fn empty_program_compiles() {
+    let bytes = compile_ok("");
+    assert!(bytes.starts_with(b"\x00asm"),
+        "empty program should produce a valid WASM module header");
+    assert!(bytes.len() > 8, "WASM module must contain at least a header + minimal sections");
 }
 
-// Test 3.2 — nil literal produces call_builtin which WASM cannot lower
+// Test 3.2 — nil literal now compiles cleanly (Path A increment 6a)
+//
+// Same flip as empty_program_compiles: `nil` now lowers to
+// `const 0 [ref<LispyPair>]`, accepted by every backend.
 #[test]
-fn nil_literal_is_wasm_error() {
-    let err = compile_err("nil");
-    assert!(
-        matches!(err, TwigToWasmError::WasmError(_)),
-        "nil literal should produce WasmError; got: {err}"
-    );
+fn nil_literal_compiles() {
+    let bytes = compile_ok("nil");
+    assert!(bytes.starts_with(b"\x00asm"),
+        "nil literal should produce a valid WASM module header");
 }
 
 // Test 3.3 — boolean constant: either compiles or is a WASM error, never panics

--- a/code/packages/rust/twig-vm/CHANGELOG.md
+++ b/code/packages/rust/twig-vm/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — twig-vm
 
+## [0.20.0] — 2026-05-23 (Dispatch: typed `const … [ref<LispyPair>]` → NIL)
+
+### Added — `exec_const` produces `LispyValue::NIL` for the nil-ref shape
+
+Companion change to twig-ir-compiler 0.20.0's increment 6a, which
+now emits `const 0 [ref<LispyPair>]` instead of `call_builtin
+"make_nil"`.  Without a matching dispatch update, `exec_const`
+would produce `LispyValue::int(0)` — which HOF builtins like `map`
+/ `filter` / `fold-*` reject with `"list tail 0 is not a cons cell"`.
+
+The new arm at the top of `exec_const` recognises the
+`(type_hint == "ref<LispyPair>", srcs[0] == Int(0))` shape and
+writes `LispyValue::NIL` to the destination register.  All other
+shapes (plain `Int`, `Bool`, `Var`, `Str`) flow through the
+existing code unchanged.
+
+This is the symmetric companion to the 0.19.0 dispatch wrappers
+that synthesised `call_builtin "+"` from typed `add` (and the
+other arithmetic / comparison / mov opcodes).
+
+### Tests
+
+All 179 twig-vm lib tests pass.  The 4 previously-failing HOF
+tests (`map_empty_list`, `filter_empty_input`, `fold_left_empty`,
+`fold_right_cons_identity`) now pass because the nil sentinel is
+restored.
+
 ## [0.19.0] — 2026-05-22 (Dispatch: typed CIR mnemonics — path A regression fix)
 
 ### Added — Dispatch handlers for typed CIR mnemonics

--- a/code/packages/rust/twig-vm/Cargo.toml
+++ b/code/packages/rust/twig-vm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-vm"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
-description = "LANG47 + LANG52 + LANG55 + LANG56 + LANG57 + LANG62 + LANG64 + LANG66 — string heap objects, builtins, host I/O, higher-order list ops, multi-file entry points, record/union/match runtime smoke tests; MAX_DISPATCH_DEPTH 256→4096 (LANG62), 4096→65536 (LANG64), 65536→131072 (LANG66) for self-hosted compiler pipeline"
+description = "LANG47 + LANG52 + LANG55 + LANG56 + LANG57 + LANG62 + LANG64 + LANG66 — string heap objects, builtins, host I/O, higher-order list ops, multi-file entry points, record/union/match runtime smoke tests; MAX_DISPATCH_DEPTH 256→4096 (LANG62), 4096→65536 (LANG64), 65536→131072 (LANG66) for self-hosted compiler pipeline.  Path A increment 6a: exec_const dispatches `const 0 [ref<LispyPair>]` to LispyValue::NIL."
 
 [dependencies]
 twig-ir-compiler   = { path = "../twig-ir-compiler" }

--- a/code/packages/rust/twig-vm/src/dispatch.rs
+++ b/code/packages/rust/twig-vm/src/dispatch.rs
@@ -1272,6 +1272,27 @@ fn exec_const(instr: &IIRInstr, frame: &mut Frame) -> Result<(), RunError> {
     let src = instr.srcs.first().ok_or_else(|| {
         RunError::MalformedInstruction("const requires srcs[0]".into())
     })?;
+    // ── Path A increment 6a (twig-vm dispatch wrapper) ──────────────
+    //
+    // The twig-ir-compiler now emits `const 0 [ref<LispyPair>]` for
+    // every `(make_nil)` / `nil` site (matching the IIR-to-{wasm,jvm,
+    // clr,beam} backends' Phase 2 heap-lowering convention).  Under
+    // the plain `Operand::Int(0)` path that would produce
+    // `LispyValue::int(0)` — but the runtime semantic is "the empty
+    // list", which is `LispyValue::NIL`.  Fix: special-case the
+    // typed-const-of-zero into NIL when `type_hint == "ref<LispyPair>"`.
+    //
+    // This is the symmetric companion to the increment 2 dispatch
+    // wrapper that synthesised `call_builtin "+"` from typed `add`.
+    // Without this, HOF builtins like `map` / `filter` / `fold-*`
+    // see Int(0) where they expect a NIL sentinel and bail out with
+    // `"list tail 0 is not a cons cell"`.
+    if instr.type_hint == "ref<LispyPair>" {
+        if let Operand::Int(0) = src {
+            frame.set(dest.clone(), LispyValue::NIL)?;
+            return Ok(());
+        }
+    }
     let value = match src {
         Operand::Int(n) => {
             // Same range check as operand_to_value — keep behaviour


### PR DESCRIPTION
## Summary

Path A increment 6a of the Twig → IIR-to-* end-to-end story.  Replaces every `call_builtin \"make_nil\" [any]` emission site with a typed `const 0 [ref<LispyPair>]`, matching the Phase 2 heap-lowering convention used by the IIR-to-{wasm,jvm,clr,beam} backends.

- 5 emission sites converted in `twig-ir-compiler/src/compiler.rs`
- `nil` literal and empty Twig programs now flow through every backend
- Companion `twig-vm 0.20.0` dispatch wrapper: `exec_const` maps the typed nil-ref shape to `LispyValue::NIL`

## What this unlocks

| Program  | wasm | jvm | clr | beam |
|----------|------|-----|-----|------|
| `nil`    | ✅ (was ❌) | ✅ | ✅ | ✅ |
| empty Twig program | ✅ (was ❌) | ✅ | ✅ | ✅ |

## What's still pending for increment 6

- `cons` → typed `alloc` + `field_store` (6b, 3 sites)
- `car` / `cdr` → typed `field_load` (6c, 8 sites)

After 6b and 6c, no list-handling op in twig-ir-compiler emits an untyped `call_builtin`.

## Test plan

- [x] 73 lib tests in twig-ir-compiler pass
- [x] 12 backend e2e tests pass (2 new: `nil`, empty program)
- [x] 179 twig-vm lib tests pass (4 previously failing HOF tests now pass)
- [x] cargo build of twig-ir-compiler, twig-vm, iir-to-{wasm,jvm,clr,beam}, twig-aot succeeds
- [x] Security review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)