### PR TITLE
Expose embedded resource metadata in HTML parser browser projections

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -260,7 +260,7 @@ def check_browser_expected_lists(
         resource_path = f"{case_path}.expected.resources[{index}]"
         require_string(resource_path, resource, "kind", errors)
         require_string(resource_path, resource, "url", errors)
-        for field in ("resolved_url", "rel", "type_hint", "media", "title"):
+        for field in ("resolved_url", "rel", "type_hint", "media", "title", "width", "height"):
             require_optional_nullable_string(resource_path, resource, field, errors)
         require_boolean(resource_path, resource, "async_script", errors)
         require_boolean(resource_path, resource, "defer_script", errors)
@@ -357,6 +357,11 @@ def check_browser_content_node(
         "src",
         "resolved_src",
         "alt",
+        "resource_kind",
+        "width",
+        "height",
+        "type_hint",
+        "media",
         "control_type",
         "value",
     ):
@@ -420,6 +425,11 @@ def check_browser_render_node(
         "src",
         "resolved_src",
         "alt",
+        "resource_kind",
+        "width",
+        "height",
+        "type_hint",
+        "media",
         "control_type",
         "value",
     ):

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -197,6 +197,10 @@ documented in this file.
   identity and language metadata, including document/body `lang` and `dir`,
   body `id`/classes, and node-level `id`, tokenized `class`, `title`, `lang`,
   and `dir` values for selector matching and browser UI policy.
+- Browser-facing document, content-tree, and render-tree projections now carry
+  embedded resource metadata for frames, objects, embeds, media, and images,
+  including resolved source URLs, resource kind, type hints, media attributes,
+  and authored dimensions for fetch and layout planning.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -74,6 +74,9 @@ The current parser surface includes:
 - browser-facing identity and language metadata for document/body fields plus
   renderable content nodes, including `id`, tokenized `class`, `title`, `lang`,
   and `dir` values for selector matching, UI policy, and early layout
+- browser-facing embedded resource metadata for replaced content such as
+  `iframe`, `object`, `embed`, `audio`, and `video`, including resolved source
+  URLs, resource kind, type hints, media attributes, and authored dimensions
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -853,6 +853,8 @@ pub struct BrowserResource {
     pub type_hint: Option<String>,
     pub media: Option<String>,
     pub title: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
     pub async_script: bool,
     pub defer_script: bool,
 }
@@ -884,6 +886,11 @@ pub struct BrowserContentNode {
     pub src: Option<String>,
     pub resolved_src: Option<String>,
     pub alt: Option<String>,
+    pub resource_kind: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
     pub control_type: Option<String>,
     pub value: Option<String>,
     pub disabled: bool,
@@ -914,6 +921,11 @@ pub struct BrowserRenderNode {
     pub src: Option<String>,
     pub resolved_src: Option<String>,
     pub alt: Option<String>,
+    pub resource_kind: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
     pub control_type: Option<String>,
     pub value: Option<String>,
     pub disabled: bool,
@@ -1087,6 +1099,11 @@ impl BrowserRenderNode {
             src: content_node.src.clone(),
             resolved_src: content_node.resolved_src.clone(),
             alt: content_node.alt.clone(),
+            resource_kind: content_node.resource_kind.clone(),
+            width: content_node.width.clone(),
+            height: content_node.height.clone(),
+            type_hint: content_node.type_hint.clone(),
+            media: content_node.media.clone(),
             control_type: content_node.control_type.clone(),
             value: content_node.value.clone(),
             disabled: content_node.disabled,
@@ -8093,6 +8110,8 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         type_hint: element.attribute("type").map(ToOwned::to_owned),
                         media: element.attribute("media").map(ToOwned::to_owned),
                         title: element.attribute("title").map(ToOwned::to_owned),
+                        width: None,
+                        height: None,
                         async_script: false,
                         defer_script: false,
                     });
@@ -8108,6 +8127,8 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         type_hint: element.attribute("type").map(ToOwned::to_owned),
                         media: None,
                         title: None,
+                        width: None,
+                        height: None,
                         async_script: element.attribute("async").is_some(),
                         defer_script: element.attribute("defer").is_some(),
                     });
@@ -8147,6 +8168,8 @@ fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
         title: element.attribute("title").map(ToOwned::to_owned),
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
         async_script: element.name == "script" && element.attribute("async").is_some(),
         defer_script: element.name == "script" && element.attribute("defer").is_some(),
     });
@@ -8362,6 +8385,11 @@ fn collect_browser_content_nodes(
                         src: None,
                         resolved_src: None,
                         alt: None,
+                        resource_kind: None,
+                        width: None,
+                        height: None,
+                        type_hint: None,
+                        media: None,
                         control_type: None,
                         value: None,
                         disabled: false,
@@ -8425,6 +8453,11 @@ fn browser_content_node_for_element(
             .and_then(|src| resolve_browser_url(src, base_href)),
         src,
         alt: element.attribute("alt").map(ToOwned::to_owned),
+        resource_kind: browser_content_resource_kind(element),
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
         control_type: browser_content_control_type(element),
         value: browser_content_value(element),
         disabled: element.attribute("disabled").is_some(),
@@ -8442,6 +8475,11 @@ fn browser_content_role(name: &str) -> Option<&'static str> {
         }
         "a" => Some("link"),
         "img" => Some("image"),
+        "iframe" | "frame" => Some("frame"),
+        "embed" => Some("embed"),
+        "object" => Some("object"),
+        "audio" | "video" => Some("media"),
+        "canvas" => Some("canvas"),
         "br" | "wbr" => Some("line_break"),
         "form" => Some("form"),
         "fieldset" => Some("form_group"),
@@ -8470,6 +8508,9 @@ fn should_collect_browser_content_children(name: &str) -> bool {
             | "base"
             | "br"
             | "button"
+            | "embed"
+            | "frame"
+            | "iframe"
             | "img"
             | "input"
             | "link"
@@ -8500,6 +8541,18 @@ fn browser_content_src(element: &Element) -> Option<String> {
     match element.name.as_str() {
         "object" => element.attribute("data").map(ToOwned::to_owned),
         _ => element.attribute("src").map(ToOwned::to_owned),
+    }
+}
+
+fn browser_content_resource_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "img" => Some("image".to_string()),
+        "iframe" | "frame" => Some("frame".to_string()),
+        "embed" => Some("embed".to_string()),
+        "object" => Some("object".to_string()),
+        "audio" | "video" => Some(element.name.clone()),
+        "canvas" => Some("canvas".to_string()),
+        _ => None,
     }
 }
 
@@ -8646,7 +8699,9 @@ fn browser_render_display(role: &str) -> &'static str {
     match role {
         "text" => "inline-text",
         "inline" | "link" => "inline",
-        "image" | "control" => "inline-replaced",
+        "canvas" | "embed" | "frame" | "image" | "media" | "object" | "control" => {
+            "inline-replaced"
+        }
         "line_break" => "line-break",
         "heading" | "block" | "form" | "form_group" | "legend" | "list" => "block",
         "label" | "option" | "option_group" => "inline",
@@ -8936,6 +8991,40 @@ mod tests {
         assert_eq!(paragraph.classes, vec!["lede", "print"]);
         assert_eq!(paragraph.title.as_deref(), Some("Intro"));
         assert_eq!(paragraph.dir.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn browser_embedded_resource_metadata_tracks_fetch_and_layout_fields() {
+        let document = parse_html(
+            "<base href=\"https://example.test/media/index.html\">\
+             <iframe src=frame.html width=320 height=200 title=Frame></iframe>\
+             <object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.resources[0].kind, "frame");
+        assert_eq!(
+            summary.resources[0].resolved_url.as_deref(),
+            Some("https://example.test/media/frame.html")
+        );
+        assert_eq!(summary.resources[0].width.as_deref(), Some("320"));
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        assert_eq!(content_tree.children[0].role, "frame");
+        assert_eq!(
+            content_tree.children[0].resource_kind.as_deref(),
+            Some("frame")
+        );
+        assert_eq!(content_tree.children[1].role, "object");
+        assert_eq!(
+            content_tree.children[1].type_hint.as_deref(),
+            Some("application/x-shockwave-flash")
+        );
+
+        let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
+        assert_eq!(render_tree.children[0].display, "inline-replaced");
+        assert_eq!(render_tree.children[1].display, "inline-replaced");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -46,6 +46,16 @@ struct ExpectedContentNode {
     #[serde(default)]
     resolved_src: Option<String>,
     alt: Option<String>,
+    #[serde(default)]
+    resource_kind: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
     control_type: Option<String>,
     #[serde(default)]
     value: Option<String>,
@@ -110,6 +120,11 @@ impl ExpectedContentNode {
             src: self.src,
             resolved_src: self.resolved_src,
             alt: self.alt,
+            resource_kind: self.resource_kind,
+            width: self.width,
+            height: self.height,
+            type_hint: self.type_hint,
+            media: self.media,
             control_type: self.control_type,
             value: self.value,
             disabled: self.disabled,

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -66,6 +66,10 @@ struct ExpectedResource {
     type_hint: Option<String>,
     media: Option<String>,
     title: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
     async_script: bool,
     defer_script: bool,
 }
@@ -233,6 +237,8 @@ impl ExpectedResource {
             type_hint: self.type_hint,
             media: self.media,
             title: self.title,
+            width: self.width,
+            height: self.height,
             async_script: self.async_script,
             defer_script: self.defer_script,
         }

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -47,6 +47,16 @@ struct ExpectedRenderNode {
     #[serde(default)]
     resolved_src: Option<String>,
     alt: Option<String>,
+    #[serde(default)]
+    resource_kind: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
     control_type: Option<String>,
     #[serde(default)]
     value: Option<String>,
@@ -112,6 +122,11 @@ impl ExpectedRenderNode {
             src: self.src,
             resolved_src: self.resolved_src,
             alt: self.alt,
+            resource_kind: self.resource_kind,
+            width: self.width,
+            height: self.height,
+            type_hint: self.type_hint,
+            media: self.media,
             control_type: self.control_type,
             value: self.value,
             disabled: self.disabled,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -26,7 +26,9 @@ skipping parser shell, head metadata, comments, scripts, styles, and templates.
 Where a document base is present, link and replaced-resource nodes also expose
 resolved URL fields for downstream navigation and fetch planning. Renderable
 nodes may also pin `id`, tokenized `class`, `title`, `lang`, and `dir`
-metadata for selector matching and UI policy.
+metadata for selector matching and UI policy. Embedded and replaced resources
+such as frames, objects, embeds, and media elements also carry resource kind,
+resolved source, type hints, media attributes, and authored dimensions.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
@@ -35,7 +37,9 @@ inline-replaced, list-item, and table display nodes for early layout work. The
 browser-facing fixture set also pins control metadata such as value,
 disabled/checked/selected state, select option labels, textarea values, and
 resolved URL metadata for link and replaced nodes, plus render-node identity
-metadata that layout and styling code can carry forward.
+metadata that layout and styling code can carry forward. Replaced resource
+nodes are pinned as inline-replaced render inputs with their fetch and
+dimension metadata intact.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -55,7 +55,7 @@
               },
               { "role": "text", "name": null, "text": ".", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
               { "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
-              { "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "control_type": null, "children": [] }
+              { "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "resource_kind": "image", "control_type": null, "children": [] }
             ]
           },
           {
@@ -226,6 +226,19 @@
               { "role": "text", "name": null, "text": "tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
             ]
           }
+        ]
+      }
+    },
+    {
+      "id": "embedded-resource-nodes",
+      "description": "Embedded resources become explicit content nodes with resolved sources and layout/fetch metadata.",
+      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120>",
+      "expected": {
+        "children": [
+          { "role": "frame", "name": "iframe", "title": "Frame", "text": null, "href": null, "src": "frame.html", "resolved_src": "https://example.test/media/frame.html", "alt": null, "resource_kind": "frame", "width": "320", "height": "200", "control_type": null, "children": [] },
+          { "role": "object", "name": "object", "text": null, "href": null, "src": "movie.swf", "resolved_src": "https://example.test/media/movie.swf", "alt": null, "resource_kind": "object", "width": "400", "height": "300", "type_hint": "application/x-shockwave-flash", "control_type": null, "children": [] },
+          { "role": "media", "name": "video", "text": null, "href": null, "src": "movie.mp4", "resolved_src": "https://example.test/media/movie.mp4", "alt": null, "resource_kind": "video", "width": "640", "height": "360", "control_type": null, "children": [] },
+          { "role": "embed", "name": "embed", "text": null, "href": null, "src": "legacy.mov", "resolved_src": "https://example.test/media/legacy.mov", "alt": null, "resource_kind": "embed", "width": "160", "height": "120", "type_hint": "video/quicktime", "control_type": null, "children": [] }
         ]
       }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -17,7 +17,7 @@
         ],
         "resources": [
           { "kind": "stylesheet", "url": "style.css", "resolved_url": "https://example.test/docs/style.css", "rel": "stylesheet", "type_hint": null, "media": "screen", "title": "default", "async_script": false, "defer_script": false },
-          { "kind": "image", "url": "logo.gif", "resolved_url": "https://example.test/docs/logo.gif", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false }
+          { "kind": "image", "url": "logo.gif", "resolved_url": "https://example.test/docs/logo.gif", "rel": null, "type_hint": null, "media": null, "title": null, "width": "88", "height": "31", "async_script": false, "defer_script": false }
         ],
         "anchors": [
           { "id": "index", "name": null, "text": "Example Directory" }
@@ -106,6 +106,30 @@
           { "href": null, "resolved_href": null, "name": "top", "target": null, "rel": null, "title": null, "text": "" },
           { "href": "#top", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Back" }
         ],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "embedded-resource-page",
+      "description": "Body resource inventory preserves embedded frame, object, video, and embed metadata for fetch and layout planning.",
+      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/media/index.html",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "frame", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "rel": null, "type_hint": null, "media": null, "title": "Frame", "width": "320", "height": "200", "async_script": false, "defer_script": false },
+          { "kind": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "rel": null, "type_hint": "application/x-shockwave-flash", "media": null, "title": null, "width": "400", "height": "300", "async_script": false, "defer_script": false },
+          { "kind": "video", "url": "movie.mp4", "resolved_url": "https://example.test/media/movie.mp4", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "async_script": false, "defer_script": false },
+          { "kind": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "rel": null, "type_hint": "video/quicktime", "media": null, "title": null, "width": "160", "height": "120", "async_script": false, "defer_script": false }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
         "images": [],
         "forms": [],
         "tables": []

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -54,7 +54,7 @@
                   { "display": "inline-text", "role": "text", "name": null, "text": "Next", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
                 ]
               },
-              { "display": "inline-replaced", "role": "image", "name": "img", "text": null, "href": null, "src": "../assets/logo.gif", "resolved_src": "https://example.test/assets/logo.gif", "alt": "Logo", "control_type": null, "children": [] },
+              { "display": "inline-replaced", "role": "image", "name": "img", "text": null, "href": null, "src": "../assets/logo.gif", "resolved_src": "https://example.test/assets/logo.gif", "alt": "Logo", "resource_kind": "image", "control_type": null, "children": [] },
               { "display": "line-break", "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
               { "display": "inline-text", "role": "text", "name": null, "text": "Tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
             ]
@@ -164,6 +164,19 @@
               }
             ]
           }
+        ]
+      }
+    },
+    {
+      "id": "embedded-resource-display",
+      "description": "Embedded resource content nodes become inline replaced render inputs with preserved fetch and layout metadata.",
+      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120>",
+      "expected": {
+        "children": [
+          { "display": "inline-replaced", "role": "frame", "name": "iframe", "title": "Frame", "text": null, "href": null, "src": "frame.html", "resolved_src": "https://example.test/media/frame.html", "alt": null, "resource_kind": "frame", "width": "320", "height": "200", "control_type": null, "children": [] },
+          { "display": "inline-replaced", "role": "object", "name": "object", "text": null, "href": null, "src": "movie.swf", "resolved_src": "https://example.test/media/movie.swf", "alt": null, "resource_kind": "object", "width": "400", "height": "300", "type_hint": "application/x-shockwave-flash", "control_type": null, "children": [] },
+          { "display": "inline-replaced", "role": "media", "name": "video", "text": null, "href": null, "src": "movie.mp4", "resolved_src": "https://example.test/media/movie.mp4", "alt": null, "resource_kind": "video", "width": "640", "height": "360", "control_type": null, "children": [] },
+          { "display": "inline-replaced", "role": "embed", "name": "embed", "text": null, "href": null, "src": "legacy.mov", "resolved_src": "https://example.test/media/legacy.mov", "alt": null, "resource_kind": "embed", "width": "160", "height": "120", "type_hint": "video/quicktime", "control_type": null, "children": [] }
         ]
       }
     }


### PR DESCRIPTION
## Summary
- add authored width/height to browser resource inventory for body resources
- project iframe/frame/object/embed/audio/video/canvas/image metadata through browser content and render trees
- add fixture schema support, acceptance cases, and docs for embedded/replaced resource fetch and layout metadata

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser