### PR TITLE
feat(mini-sqlite): recognise PRAGMA writable_schema

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.9.0] - 2026-05-23
+
+### Added
+
+- ``PRAGMA writable_schema`` is now recognised as a read/write
+  boolean PRAGMA with the SQLite-compatible default of ``0`` (off).
+  Reads return the current integer (0 or 1); writes accept any of
+  ``1``/``0``/``ON``/``OFF``/``TRUE``/``FALSE``/``YES``/``NO`` and
+  the value persists for the lifetime of the connection.  It is also
+  now advertised in ``PRAGMA pragma_list``.
+
+  Mini-sqlite synthesises ``sqlite_master`` on every read (no backing
+  table), so honouring writes through the catalog is a much larger
+  change.  This PR fills only the read/write round-trip surface so
+  defensive callers (ORMs, migration tools, database-repair flows)
+  that toggle the PRAGMA before deciding whether to attempt a fix
+  see the expected value instead of an empty result or a "unknown
+  PRAGMA" error.
+
+  Previously: ``PRAGMA writable_schema`` returned ``[]`` instead of
+  the documented ``[(0,)]`` and writes were silently dropped.
+
 ## [2.8.0] - 2026-05-23
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.8.0"
+version = "2.9.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -820,6 +820,13 @@ _PRAGMA_DEFAULTS: dict[str, tuple[object, str]] = {
     "wal_autocheckpoint": (1000,           "integer"),  # pages between autocheckpoints
     "journal_size_limit": (-1,             "integer"),  # bytes; -1 = no limit
     "threads":          (0,                "integer"),  # worker threads in sort/index
+    # writable_schema — when ON, SQLite allows direct UPDATE/INSERT/DELETE
+    # against sqlite_master, which lets you rename/repair the schema.
+    # Mini-sqlite synthesises sqlite_master on-the-fly and does not honour
+    # writes to it, but we still round-trip the PRAGMA's value so ORMs and
+    # migration tools that toggle it during repair flows don't trip on
+    # unrecognised PRAGMA.
+    "writable_schema":  (0,                "integer"),  # bool; off by default
 }
 
 # Per-connection PRAGMA state.  Keyed by the backend object's id() so each
@@ -1253,6 +1260,12 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
         "reverse_unordered_selects",  # planner hint, no scrambling implemented
         "cell_size_check",            # btree integrity flag, no btree in mini
         "fullfsync",                  # fsync mode, no disk I/O in mini
+        # ``writable_schema`` round-trips but mini-sqlite ignores it on the
+        # write side — the schema catalog is synthesised at query time, not
+        # stored in a writable sqlite_master table.  Tools that read this
+        # PRAGMA defensively (e.g. to skip a repair flow) still see the
+        # expected value.
+        "writable_schema",
     }
     _INT_PRAGMAS = {
         "temp_store",

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_writable_schema.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_writable_schema.py
@@ -1,0 +1,106 @@
+"""Tests for ``PRAGMA writable_schema``.
+
+SQLite's ``writable_schema`` PRAGMA controls whether direct
+UPDATE/INSERT/DELETE statements against ``sqlite_master`` are allowed
+— used by repair tools and migration frameworks to rename tables or
+fix corrupted catalog rows.  Default is OFF (0).
+
+Mini-sqlite synthesises ``sqlite_master`` on every read (it's not a
+real table backed by storage), so honouring writes through it would
+be a much larger change.  We instead accept and *round-trip* the
+PRAGMA value per connection — defensive callers that read the
+PRAGMA before deciding whether to run a repair flow see the
+expected value, and migrations that just toggle it without using
+the writability don't trip on ``unrecognised PRAGMA``.
+
+This brings the PRAGMA's surface behaviour in line with sqlite3
+(read returns the current int, write accepts ON/OFF/0/1/TRUE/FALSE,
+the value persists for the lifetime of the connection).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match_pragma(*pragmas: str, final_read: str) -> None:
+    """Run a sequence of PRAGMA statements then a final read; compare oracles."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for p in pragmas:
+            c.execute(p)
+    assert mini.execute(final_read).fetchall() == ref.execute(final_read).fetchall()
+
+
+class TestDefault:
+    def test_default_is_zero(self) -> None:
+        _both_match_pragma(final_read="PRAGMA writable_schema")
+
+
+class TestSetIntegers:
+    def test_set_one(self) -> None:
+        _both_match_pragma(
+            "PRAGMA writable_schema = 1",
+            final_read="PRAGMA writable_schema",
+        )
+
+    def test_set_zero(self) -> None:
+        _both_match_pragma(
+            "PRAGMA writable_schema = 1",
+            "PRAGMA writable_schema = 0",
+            final_read="PRAGMA writable_schema",
+        )
+
+
+class TestSetBoolKeywords:
+    """SQLite accepts ON/OFF/TRUE/FALSE/YES/NO as boolean PRAGMA values."""
+
+    def test_set_on(self) -> None:
+        _both_match_pragma(
+            "PRAGMA writable_schema = ON",
+            final_read="PRAGMA writable_schema",
+        )
+
+    def test_set_off(self) -> None:
+        _both_match_pragma(
+            "PRAGMA writable_schema = ON",
+            "PRAGMA writable_schema = OFF",
+            final_read="PRAGMA writable_schema",
+        )
+
+    def test_set_true(self) -> None:
+        _both_match_pragma(
+            "PRAGMA writable_schema = TRUE",
+            final_read="PRAGMA writable_schema",
+        )
+
+    def test_set_false(self) -> None:
+        _both_match_pragma(
+            "PRAGMA writable_schema = TRUE",
+            "PRAGMA writable_schema = FALSE",
+            final_read="PRAGMA writable_schema",
+        )
+
+
+class TestPragmaListContainsWritableSchema:
+    """PRAGMA pragma_list must advertise writable_schema as supported."""
+
+    def test_writable_schema_in_pragma_list(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        names = {r[0] for r in m.execute("PRAGMA pragma_list").fetchall()}
+        assert "writable_schema" in names
+
+
+class TestConnectionIsolation:
+    """Two connections each carry their own writable_schema state."""
+
+    def test_independent_state(self) -> None:
+        a = mini_sqlite.connect(":memory:")
+        b = mini_sqlite.connect(":memory:")
+        a.execute("PRAGMA writable_schema = 1")
+        # Connection ``b`` must still see the default.
+        assert b.execute("PRAGMA writable_schema").fetchall() == [(0,)]
+        assert a.execute("PRAGMA writable_schema").fetchall() == [(1,)]


### PR DESCRIPTION
## Summary

- Adds `PRAGMA writable_schema` as a recognized boolean PRAGMA (default `0`, settable to `0`/`1`/`ON`/`OFF`/`TRUE`/`FALSE`).
- Previously returned `[]` instead of `[(0,)]` and silently dropped writes.
- One entry in `_PRAGMA_DEFAULTS` + one in `_BOOL_PRAGMAS` — the existing scalar-PRAGMA handler covers everything else, and `pragma_list` auto-picks it up.

## Scope limit

Mini-sqlite synthesises `sqlite_master` on read (no backing table), so honouring writes through it would be a much larger change. This PR fills only the read/write *round-trip* surface — defensive callers (ORMs, migration tools) see the expected value; tools that actually try to UPDATE sqlite_master will still find the catalog read-only. CHANGELOG and inline comment make this explicit.

## Version bump

- `mini-sqlite`: 2.8 → 2.9

## Test plan

- [x] 9 new oracle tests pass (default, integer set/get, ON/OFF/TRUE/FALSE keyword set/get, pragma_list inclusion, per-connection isolation)
- [x] mini-sqlite suite (2262 tests) clean
- [x] Ruff clean
- [x] Security review passed (no catalog-modification capability introduced; pure round-trip flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)