### PR TITLE
Cover raw GPU image paint plans

### DIFF
--- a/code/packages/rust/paint-vm-mesa/README.md
+++ b/code/packages/rust/paint-vm-mesa/README.md
@@ -7,8 +7,9 @@ Mesa backend profile and shared GPU-plan adapter for the Paint VM runtime.
 Mesa is a driver stack rather than one drawing API. This crate models Mesa as a
 first-class runtime profile for software and driver-backed execution paths such
 as llvmpipe and lavapipe. It now consumes `paint-vm-gpu-core` plans for the Tier
-1 solid-vector slice while keeping runtime rendering unavailable until routing
-to an OpenGL or Vulkan Mesa profile exists.
+1 textured slice, including indexed meshes, clips, pixel-image uploads, and
+generated linear/radial gradient textures. Runtime rendering remains unavailable
+until routing to an OpenGL or Vulkan Mesa profile exists.
 
 The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
 selection does not pick Mesa before it can execute pixels. Use `profile()` and
@@ -28,5 +29,6 @@ PaintScene
 
 - Detect available Mesa profiles on Linux/WSL.
 - Route llvmpipe through the OpenGL backend or lavapipe through Vulkan.
+- Forward image and gradient texture plans to the selected Mesa-backed API.
 - Keep deterministic software execution selectable when native GPU drivers are
   unavailable.

--- a/code/packages/rust/paint-vm-mesa/src/lib.rs
+++ b/code/packages/rust/paint-vm-mesa/src/lib.rs
@@ -88,8 +88,8 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 mod tests {
     use super::*;
     use paint_instructions::{
-        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
-        PaintText,
+        GradientKind, GradientStop, ImageSrc, PaintBase, PaintGradient, PaintImage,
+        PaintInstruction, PaintRect, PaintText, PixelContainer,
     };
     use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
@@ -212,6 +212,31 @@ mod tests {
         assert_eq!(plan.images.len(), 2);
         assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
         assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_pixel_images_with_shared_gpu_core() {
+        let mut pixels = PixelContainer::new(2, 1);
+        pixels.set_pixel(0, 0, 255, 0, 0, 255);
+        pixels.set_pixel(1, 0, 0, 0, 255, 255);
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene.instructions.push(PaintInstruction::Image(PaintImage {
+            base: PaintBase::default(),
+            x: 2.0,
+            y: 3.0,
+            width: 16.0,
+            height: 4.0,
+            src: ImageSrc::Pixels(pixels),
+            opacity: Some(0.5),
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 1);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::Image);
+        assert_eq!(plan.meshes[0].texture_id, Some(0));
+        assert_eq!(plan.meshes[0].vertices[0].color.a, 0.5);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-opencl/README.md
+++ b/code/packages/rust/paint-vm-opencl/README.md
@@ -6,9 +6,10 @@ runtime.
 ## Status
 
 OpenCL is modeled as a compute raster path rather than a native vector API. This
-crate now consumes `paint-vm-gpu-core` plans for the Tier 1 solid-vector slice
-while keeping runtime rendering unavailable until an OpenCL context, kernels,
-buffers, and readback path lands.
+crate now consumes `paint-vm-gpu-core` plans for the Tier 1 textured slice:
+indexed meshes, scissor clips, pixel-image uploads, and generated linear/radial
+gradient textures. Runtime rendering remains unavailable until an OpenCL
+context, kernels, buffers, and readback path lands.
 
 The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
 selection does not pick OpenCL before it can execute pixels. Use `profile()` and
@@ -28,5 +29,5 @@ PaintScene
 
 - Build a kernel-side triangle coverage rasterizer for solid meshes.
 - Add buffer upload/readback and device fallback selection.
-- Add texture sampling for `PaintImage`.
+- Execute texture sampling for `PaintImage` and generated gradients.
 - Add glyph atlas buffers once the shared text shaping path is ready.

--- a/code/packages/rust/paint-vm-opencl/src/lib.rs
+++ b/code/packages/rust/paint-vm-opencl/src/lib.rs
@@ -87,8 +87,8 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 mod tests {
     use super::*;
     use paint_instructions::{
-        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
-        PaintText,
+        GradientKind, GradientStop, ImageSrc, PaintBase, PaintGradient, PaintImage,
+        PaintInstruction, PaintRect, PaintText, PixelContainer,
     };
     use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
@@ -211,6 +211,31 @@ mod tests {
         assert_eq!(plan.images.len(), 2);
         assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
         assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_pixel_images_with_shared_gpu_core() {
+        let mut pixels = PixelContainer::new(2, 1);
+        pixels.set_pixel(0, 0, 255, 0, 0, 255);
+        pixels.set_pixel(1, 0, 0, 0, 255, 255);
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene.instructions.push(PaintInstruction::Image(PaintImage {
+            base: PaintBase::default(),
+            x: 2.0,
+            y: 3.0,
+            width: 16.0,
+            height: 4.0,
+            src: ImageSrc::Pixels(pixels),
+            opacity: Some(0.5),
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 1);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::Image);
+        assert_eq!(plan.meshes[0].texture_id, Some(0));
+        assert_eq!(plan.meshes[0].vertices[0].color.a, 0.5);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-opengl/README.md
+++ b/code/packages/rust/paint-vm-opengl/README.md
@@ -4,11 +4,11 @@ OpenGL backend profile and shared GPU-plan adapter for the Paint VM runtime.
 
 ## Status
 
-This crate now consumes `paint-vm-gpu-core` plans for the Tier 1 solid-vector
-slice: indexed meshes, scissor clips, group/layer transform lowering, opacity
-folding, and degraded solid-gradient fallback. The runtime renderer still
-returns `BackendUnavailable` until a real OpenGL context, framebuffer, shader,
-and readback path lands.
+This crate now consumes `paint-vm-gpu-core` plans for the Tier 1 textured slice:
+indexed meshes, scissor clips, group/layer transform lowering, opacity folding,
+pixel-image uploads, and generated linear/radial gradient textures. The runtime
+renderer still returns `BackendUnavailable` until a real OpenGL context,
+framebuffer, shader, and readback path lands.
 
 The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
 selection does not pick OpenGL before it can execute pixels. Use `profile()` and
@@ -30,5 +30,5 @@ PaintScene
 
 - Create platform-specific headless GL contexts.
 - Upload shared meshes to VBO/IBO buffers and draw them with GLSL.
-- Add texture upload/sampling for `PaintImage`.
+- Execute texture upload/sampling for `PaintImage` and generated gradients.
 - Add glyph atlas sampling once the shared text shaping path is ready.

--- a/code/packages/rust/paint-vm-opengl/src/lib.rs
+++ b/code/packages/rust/paint-vm-opengl/src/lib.rs
@@ -87,8 +87,8 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 mod tests {
     use super::*;
     use paint_instructions::{
-        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
-        PaintText,
+        GradientKind, GradientStop, ImageSrc, PaintBase, PaintGradient, PaintImage,
+        PaintInstruction, PaintRect, PaintText, PixelContainer,
     };
     use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
@@ -211,6 +211,31 @@ mod tests {
         assert_eq!(plan.images.len(), 2);
         assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
         assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_pixel_images_with_shared_gpu_core() {
+        let mut pixels = PixelContainer::new(2, 1);
+        pixels.set_pixel(0, 0, 255, 0, 0, 255);
+        pixels.set_pixel(1, 0, 0, 0, 255, 255);
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene.instructions.push(PaintInstruction::Image(PaintImage {
+            base: PaintBase::default(),
+            x: 2.0,
+            y: 3.0,
+            width: 16.0,
+            height: 4.0,
+            src: ImageSrc::Pixels(pixels),
+            opacity: Some(0.5),
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 1);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::Image);
+        assert_eq!(plan.meshes[0].texture_id, Some(0));
+        assert_eq!(plan.meshes[0].vertices[0].color.a, 0.5);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 

--- a/code/packages/rust/paint-vm-vulkan/README.md
+++ b/code/packages/rust/paint-vm-vulkan/README.md
@@ -4,11 +4,11 @@ Vulkan backend profile and shared GPU-plan adapter for the Paint VM runtime.
 
 ## Status
 
-This crate now consumes `paint-vm-gpu-core` plans for the Tier 1 solid-vector
-slice: indexed meshes, scissor clips, group/layer transform lowering, opacity
-folding, and degraded solid-gradient fallback. The runtime renderer still
-returns `BackendUnavailable` until a Vulkan instance, device, render pass,
-pipeline, and readback path lands.
+This crate now consumes `paint-vm-gpu-core` plans for the Tier 1 textured slice:
+indexed meshes, scissor clips, group/layer transform lowering, opacity folding,
+pixel-image uploads, and generated linear/radial gradient textures. The runtime
+renderer still returns `BackendUnavailable` until a Vulkan instance, device,
+render pass, pipeline, and readback path lands.
 
 The `descriptor()` intentionally remains a Tier 0 scaffold so automatic runtime
 selection does not pick Vulkan before it can execute pixels. Use `profile()` and
@@ -30,5 +30,5 @@ PaintScene
 
 - Create instance/device/queue selection with headless surfaces avoided.
 - Upload shared meshes to vertex/index buffers.
-- Add render-pass and pipeline creation for solid-color meshes.
-- Add sampled image textures and glyph atlas textures.
+- Add render-pass and pipeline creation for solid-color and textured meshes.
+- Execute sampled image/gradient textures and add glyph atlas textures.

--- a/code/packages/rust/paint-vm-vulkan/src/lib.rs
+++ b/code/packages/rust/paint-vm-vulkan/src/lib.rs
@@ -88,8 +88,8 @@ fn reject_unsupported_plan(plan: &GpuPaintPlan) -> Result<(), PaintRenderError> 
 mod tests {
     use super::*;
     use paint_instructions::{
-        GradientKind, GradientStop, PaintBase, PaintGradient, PaintInstruction, PaintRect,
-        PaintText,
+        GradientKind, GradientStop, ImageSrc, PaintBase, PaintGradient, PaintImage,
+        PaintInstruction, PaintRect, PaintText, PixelContainer,
     };
     use paint_vm_gpu_core::GpuTextureKind;
     use paint_vm_runtime::PaintBackendTier;
@@ -212,6 +212,31 @@ mod tests {
         assert_eq!(plan.images.len(), 2);
         assert_eq!(plan.images[0].kind, GpuTextureKind::LinearGradient);
         assert_eq!(plan.images[1].kind, GpuTextureKind::RadialGradient);
+        assert!(unsupported_plan_features(profile(), &plan).is_empty());
+    }
+
+    #[test]
+    fn plans_pixel_images_with_shared_gpu_core() {
+        let mut pixels = PixelContainer::new(2, 1);
+        pixels.set_pixel(0, 0, 255, 0, 0, 255);
+        pixels.set_pixel(1, 0, 0, 0, 255, 255);
+        let mut scene = PaintScene::new(20.0, 10.0);
+        scene.instructions.push(PaintInstruction::Image(PaintImage {
+            base: PaintBase::default(),
+            x: 2.0,
+            y: 3.0,
+            width: 16.0,
+            height: 4.0,
+            src: ImageSrc::Pixels(pixels),
+            opacity: Some(0.5),
+        }));
+
+        let plan = plan(&scene).unwrap();
+
+        assert_eq!(plan.images.len(), 1);
+        assert_eq!(plan.images[0].kind, GpuTextureKind::Image);
+        assert_eq!(plan.meshes[0].texture_id, Some(0));
+        assert_eq!(plan.meshes[0].vertices[0].color.a, 0.5);
         assert!(unsupported_plan_features(profile(), &plan).is_empty());
     }
 


### PR DESCRIPTION
## Summary
- add pixel-image plan coverage for Vulkan, OpenGL, OpenCL, and Mesa Paint VM adapters
- verify image uploads are accepted by the shared textured GPU profile and preserve opacity/texture IDs
- update raw GPU backend READMEs to describe the Tier 1 textured plan contract

## Tests
- cargo test -p paint-vm-vulkan -p paint-vm-opengl -p paint-vm-opencl -p paint-vm-mesa --offline