### PR TITLE
feat(ruby-parser): Phase 6l — method receiver chains `foo.bar.baz`, `foo.bar(args)`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -51,7 +51,18 @@ unless_statement = "unless" expression { !"else" !"end" statement } [ else_claus
 while_statement = "while" expression { !"end" statement } "end" ;
 until_statement = "until" expression { !"end" statement } "end" ;
 assignment   = NAME EQUALS expression ;
-method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPAREN ;
+# Phase 6l — method receiver chains.  `foo.bar`, `foo.bar.baz`,
+# `foo.bar(args)`, `foo(1).bar`, `foo.bar(args).baz(more)`, etc.
+#
+# Postfix design: a `dot_call` rule captures one `.method[(...)]` step;
+# `{ dot_call }` repetitions appended to both `factor` (so chains work
+# everywhere expressions go) and to `method_call` (so statement-level
+# `foo(1).bar` parses cleanly).
+#
+# Setter calls (`foo.bar = 1`) and bracket access (`arr[0]`) are
+# deliberately out of scope for this chunk — they get their own phases.
+method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPAREN { dot_call } ;
+dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression } ] RPAREN ] ;
 # Phase 6h — paren-less method call.  Idiomatic Ruby allows
 # `puts 1, 2` (no parens) when the call has at least one argument.
 #
@@ -94,7 +105,12 @@ term         = factor { ( STAR | SLASH ) factor } ;
 # so they win first.  Right-recursive: `--5` parses fine.  Precedence:
 # tighter than binary `+ -` (since `unary_minus` lives inside `factor`),
 # so `-5 + 3` parses as `(-5) + 3`.
-factor       = NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ;
+# Phase 6l — `method_call` placed FIRST in factor's atom alternation so
+# `foo(1).bar` in expression position parses as `(foo(1)).bar` instead of
+# leaving `(1).bar` unconsumed.  When no parens follow the name, the
+# method_call alternative fails (requires LPAREN) and we fall through to
+# the bare-NAME branch.
+factor       = ( method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call } ;
 unary_minus  = MINUS factor ;
 symbol_literal = COLON ( NAME | KEYWORD | STRING ) ;
 array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.13.0] - 2026-05-23
+
+### Added (Phase 6l — method receiver chains `foo.bar.baz`, `foo.bar(args)`, `foo(1).bar`)
+
+Grammar additions in `code/grammars/ruby.grammar`:
+- `dot_call = "." ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression } ] RPAREN ] ;` — one step of a receiver chain.
+- `factor`'s atom alternation is wrapped in `( … ) { dot_call }` so chains apply anywhere an expression goes.
+- `method_call` grew a trailing `{ dot_call }` so statement-level `foo(1).bar` works without a parser-position trick.
+- `method_call` was promoted to the **first** atom alternative inside `factor`.  Without this, `foo(1).bar` in expression position (e.g. RHS of an assignment) leaves `(1).bar` unconsumed because the bare-NAME branch only matches `foo`.
+
+### Tests (+5 new, total 59)
+- `test_parse_single_dot_call` — `foo.bar` produces one `dot_call` subnode.
+- `test_parse_chained_dot_calls` — `foo.bar.baz` produces two `dot_call`s.
+- `test_parse_method_call_with_dot_chain` — `foo(1).bar` has a `method_call` head and one `dot_call` tail.
+- `test_parse_dot_call_with_args` — `foo.bar(1, 2)` has two `expression` direct children under the `dot_call`.
+- `test_parse_chain_inside_assignment_rhs` — `x = a.b.c` parses two `dot_call`s in the RHS.
+
+Out of scope for this chunk (will get their own phases):
+- Setter calls `foo.bar = 1` (assignment LHS stays as bare NAME).
+- Bracket access `arr[0]`.
+
 ## [0.12.0] - 2026-05-22
 
 ### Added (Phase 6k — unary minus `-5`, `-x`, `-(1+2)`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -289,8 +289,31 @@ pub fn parser_grammar() -> ParserGrammar {
                             ] }) },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 54,
+            line_number: 64,
+        },
+        GrammarRule {
+            name: r#"dot_call"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"."#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                                    ] }) },
+                            ] }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 65,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -305,12 +328,12 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 68,
+            line_number: 79,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 69,
+            line_number: 80,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
@@ -328,7 +351,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 90,
+            line_number: 101,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -342,7 +365,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 91,
+            line_number: 102,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -356,26 +379,30 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 92,
+            line_number: 103,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
-                GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
-                GrammarElement::RuleReference { name: r#"array_literal"#.to_string() },
-                GrammarElement::RuleReference { name: r#"hash_literal"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
-                    GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-                ] },
-                GrammarElement::RuleReference { name: r#"unary_minus"#.to_string() },
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"array_literal"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"hash_literal"#.to_string() },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                        ] },
+                        GrammarElement::RuleReference { name: r#"unary_minus"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 97,
+            line_number: 113,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -383,7 +410,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 98,
+            line_number: 114,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -395,7 +422,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 99,
+            line_number: 115,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -410,7 +437,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 100,
+            line_number: 116,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -425,7 +452,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 101,
+            line_number: 117,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -441,7 +468,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 102,
+            line_number: 118,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -862,5 +862,79 @@ mod tests {
         }
         assert!(has_plus(&ast));
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6l — method receiver chains `foo.bar.baz`, `foo.bar(args)`
+    // -----------------------------------------------------------------------
+    //
+    // The `factor` rule now wraps its atom alternation with `{ dot_call }`;
+    // `method_call` likewise grew a `{ dot_call }` tail.  These tests pin
+    // that one or more `dot_call` subnodes appear in the parsed tree for
+    // each of the canonical chain shapes.
+
+    fn count_descendants(ast: &GrammarASTNode, rule: &str) -> usize {
+        let mut n = 0;
+        if ast.rule_name == rule {
+            n += 1;
+        }
+        for c in &ast.children {
+            if let ASTNodeOrToken::Node(sub) = c {
+                n += count_descendants(sub, rule);
+            }
+        }
+        n
+    }
+
+    #[test]
+    fn test_parse_single_dot_call() {
+        // `foo.bar` — one dot_call.  Lives inside a `factor` because
+        // it's an expression-position chain (no head call).
+        let ast = parse_ruby("foo.bar");
+        let dot_calls = count_descendants(&ast, "dot_call");
+        assert_eq!(dot_calls, 1, "expected exactly 1 dot_call, got {dot_calls}");
+    }
+
+    #[test]
+    fn test_parse_chained_dot_calls() {
+        // `foo.bar.baz` — two dot_calls in sequence under the same
+        // factor.  Left-to-right chain: `(foo.bar).baz`.
+        let ast = parse_ruby("foo.bar.baz");
+        let dot_calls = count_descendants(&ast, "dot_call");
+        assert_eq!(dot_calls, 2, "expected exactly 2 dot_calls, got {dot_calls}");
+    }
+
+    #[test]
+    fn test_parse_method_call_with_dot_chain() {
+        // `foo(1).bar` — head is a method_call, tail is one dot_call
+        // appended to it.
+        let ast = parse_ruby("foo(1).bar");
+        let dot_calls = count_descendants(&ast, "dot_call");
+        assert_eq!(dot_calls, 1, "expected exactly 1 dot_call, got {dot_calls}");
+        // And the method_call rule fired (head call).
+        assert!(find_descendant(&ast, "method_call").is_some());
+    }
+
+    #[test]
+    fn test_parse_dot_call_with_args() {
+        // `foo.bar(1, 2)` — dot_call's optional arg list is populated.
+        let ast = parse_ruby("foo.bar(1, 2)");
+        let dot = find_descendant(&ast, "dot_call").expect("dot_call expected");
+        // Count `expression` direct children of the dot_call.
+        let arg_count = dot
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression"))
+            .count();
+        assert_eq!(arg_count, 2, "expected 2 dot_call args, got {arg_count}");
+    }
+
+    #[test]
+    fn test_parse_chain_inside_assignment_rhs() {
+        // `x = a.b.c` — chain in expression position parses inside
+        // the RHS of an assignment.
+        let ast = parse_ruby("x = a.b.c");
+        let dot_calls = count_descendants(&ast, "dot_call");
+        assert_eq!(dot_calls, 2, "expected 2 dot_calls, got {dot_calls}");
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.13.0] - 2026-05-23
+
+### Added (Phase 6l — method receiver chains lowering)
+
+Each `.method[(...)]` step in a receiver chain lowers to:
+
+```
+BuiltinCall {
+  name: "__method__",
+  args: [receiver, StrLit(method_name), ...actual_args],
+  effects: PURE,
+}
+```
+
+The receiver stays as a first-class expression so arbitrary nesting works (`a.b.c.d`).  The method name lives as a `StrLit` so backends can dispatch by string.  This avoids growing the shared `semantic-ir::Expr` enum.
+
+**Why BuiltinCall and not DirectCall?**  The validator checks `DirectCall.fn_name` against the module's function table; our synthetic `__method__` envelope is intentionally not a declared function — it's a wire-format tag for backends.  BuiltinCall has no such resolution check.
+
+**Effect set**: defaults to `PURE`.  Receiver-dispatched calls are type-erased at this layer; a later receiver-type analysis pass can widen as needed.
+
+**Feature side-effect**: any dot_call fires `Feature::Strings` (because of the synthesised StrLit).  This is auto-added to the manifest in `lower_program`'s feature-collection pass.
+
+### Lowerer changes
+- New helpers: `apply_dot_chain(atom, factor_node)`, `fold_one_dot_call(receiver, dot_node)`, `head_call_expression_children`.
+- `lower_factor` split into `lower_factor` (atom extraction + dot-chain application) and `lower_factor_atom` (the pre-6l atom logic).
+- `lower_method_call` collects head-call args via `head_call_expression_children` so args inside `dot_call` subtrees don't leak into the head call.
+- `lower_expression` gains a dispatch arm for `method_call` (which can now appear in expression position because it's the first atom alternative in `factor`).
+- `Feature::Strings` added to the manifest-population loop in `lower_program`.
+
+### Tests (+5 new, total 64)
+- `dot_chain_lowers_to_method_builtincall` — `foo.bar` produces `BuiltinCall("__method__", [VarRef(foo), StrLit("bar")])`.
+- `dot_chain_two_steps_nests_outer_recv` — `foo.bar.baz` nests as `__method__(__method__(foo, "bar"), "baz")`.
+- `dot_call_with_args_includes_them_after_method_name` — `obj.add(1, 2)` → `__method__(obj, "add", 1, 2)`.
+- `dot_chain_on_method_call_head` — `puts(1).then_something` keeps the head BuiltinCall("puts") and wraps it in `__method__(_, "then_something")`.
+- `dot_chain_module_passes_sir_validator` — full module with a chain inside a function body validates clean.
+
 ## [0.12.0] - 2026-05-22
 
 ### Added (Phase 6k — unary minus lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1022,4 +1022,159 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6l — method receiver chains lowering
+    // -----------------------------------------------------------------
+    //
+    // SIR encoding: `foo.bar(args)` becomes
+    //   BuiltinCall("__method__", [receiver, StrLit("bar"), ...args])
+    // Receiver-first arg layout is the contract — backends can rely on it.
+    // BuiltinCall (not DirectCall) is used because validator only
+    // checks DirectCall.fn_name against the module's function table.
+
+    #[test]
+    fn dot_chain_lowers_to_method_builtincall() {
+        let m = lower("foo = 1\nx = foo.bar\n");
+        let b = main_body(&m);
+        // Second stmt = `x = foo.bar`
+        match &b.stmts[1] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "x");
+                match value {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "__method__");
+                        assert_eq!(args.len(), 2, "receiver + method-name");
+                        assert!(matches!(
+                            &args[0],
+                            Expr::VarRef { name, .. } if name == "foo"
+                        ));
+                        assert!(matches!(
+                            &args[1],
+                            Expr::StrLit { value, .. } if value == "bar"
+                        ));
+                    }
+                    other => panic!("expected BuiltinCall(__method__, …), got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dot_chain_two_steps_nests_outer_recv() {
+        // `foo.bar.baz` → outer is `.baz` with receiver = inner `.bar`.
+        let m = lower("foo = 1\ny = foo.bar.baz\n");
+        let b = main_body(&m);
+        let value = match &b.stmts[1] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__method__");
+                // Outer = `.baz`; args[0] is the inner `foo.bar` BuiltinCall.
+                assert!(matches!(
+                    &args[1],
+                    Expr::StrLit { value, .. } if value == "baz"
+                ));
+                match &args[0] {
+                    Expr::BuiltinCall { name: inner_name, args: inner_args, .. } => {
+                        assert_eq!(inner_name, "__method__");
+                        assert!(matches!(
+                            &inner_args[0],
+                            Expr::VarRef { name, .. } if name == "foo"
+                        ));
+                        assert!(matches!(
+                            &inner_args[1],
+                            Expr::StrLit { value, .. } if value == "bar"
+                        ));
+                    }
+                    other => panic!("expected inner BuiltinCall, got {:?}", other),
+                }
+            }
+            other => panic!("expected BuiltinCall(__method__, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dot_call_with_args_includes_them_after_method_name() {
+        // `obj.add(1, 2)` → BuiltinCall("__method__", [obj, "add", 1, 2])
+        let m = lower("obj = 1\nr = obj.add(1, 2)\n");
+        let b = main_body(&m);
+        let value = match &b.stmts[1] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__method__");
+                assert_eq!(args.len(), 4, "receiver + method + 2 args");
+                assert!(matches!(
+                    &args[0],
+                    Expr::VarRef { name, .. } if name == "obj"
+                ));
+                assert!(matches!(
+                    &args[1],
+                    Expr::StrLit { value, .. } if value == "add"
+                ));
+                assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&args[3], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected BuiltinCall(__method__, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dot_chain_on_method_call_head() {
+        // `puts(1).then_something` — head is a method_call (puts is a
+        // known builtin → BuiltinCall("puts")), tail is one dot_call.
+        // We use puts so the head call lowers as a recognised builtin
+        // and the validator doesn't trip on an undeclared function.
+        let m = lower("z = puts(1).then_something\n");
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__method__");
+                // Receiver is the inner `puts(1)` BuiltinCall.
+                match &args[0] {
+                    Expr::BuiltinCall { name: inner_name, args: inner_args, .. } => {
+                        assert_eq!(inner_name, "puts");
+                        assert_eq!(inner_args.len(), 1);
+                        assert!(matches!(&inner_args[0], Expr::IntLit { value: 1, .. }));
+                    }
+                    other => panic!("expected inner BuiltinCall(puts, …), got {:?}", other),
+                }
+                assert!(matches!(
+                    &args[1],
+                    Expr::StrLit { value, .. } if value == "then_something"
+                ));
+            }
+            other => panic!("expected outer BuiltinCall(__method__, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dot_chain_module_passes_sir_validator() {
+        // Receiver `a` lives as a function parameter so the validator's
+        // var-ref resolution succeeds; the chain itself uses BuiltinCall
+        // so the unknown-fn check doesn't apply.  Strings feature is
+        // auto-added by the lowerer when any dot_call fires.
+        //
+        // Why a function param (not `a = 1\nx = a.b...`)?  The validator
+        // groups consecutive LetBindings into one parallel-let block —
+        // RHS expressions can't see names bound by sibling LetBindings.
+        // Function params don't have that constraint.
+        let m = lower("def chain(a)\n  a.b.c(42)\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected dot-chain output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -109,6 +109,10 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         Feature::Maps,
         Feature::Symbols,
         Feature::Closures,
+        // Phase 6l — method-call chains synthesise a `StrLit` for the
+        // method name when packing into the `__method__` envelope.
+        // StrLit usage triggers the `Strings` feature.
+        Feature::Strings,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -876,39 +880,73 @@ impl Lowerer {
     // -------------------------------------------------------------------
 
     fn lower_method_call(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
-        // Shape: (NAME | KEYWORD) LPAREN [expression (COMMA expression)*] RPAREN
+        // Shape: (NAME | KEYWORD) LPAREN [expression (COMMA expression)*]
+        //          RPAREN { dot_call }
+        //
+        // Phase 6l: trailing `dot_call` repetitions chain method calls
+        // onto the result.  Args before the first dot_call belong to
+        // the head call; args inside each dot_call belong to that step.
+        // We collect only the direct `expression` children (which are
+        // the head call's args) here, then fold dot_calls via
+        // `apply_dot_chain`.
         let (callee, _callee_span) = self.expect_first_name_token(node)?;
-        // Collect argument expressions: every `expression`-rule child of
-        // this node.
-        let args: Vec<Expr> = node
-            .children
-            .iter()
-            .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
-                _ => None,
-            })
+        // Collect argument expressions belonging to the head call —
+        // these are `expression` nodes that come BEFORE any dot_call
+        // (the dot_call subtree owns its own `expression` children).
+        let args: Vec<Expr> = self
+            .head_call_expression_children(node)
+            .into_iter()
             .map(|n| self.lower_expression(n))
             .collect::<Result<Vec<_>, _>>()?;
 
         let span = self.span_of(node);
-        if let Some(effects) = ruby_builtin_effects(&callee) {
-            Ok(Expr::BuiltinCall {
+        let head: Expr = if let Some(effects) = ruby_builtin_effects(&callee) {
+            Expr::BuiltinCall {
                 name: callee,
                 args,
                 effects,
                 span,
-            })
+            }
         } else {
             // Unrecognised name — fall back to DirectCall.  SIR
             // backends that can't resolve the name will surface a
             // diagnostic; this keeps the lowering total (no panics).
-            Ok(Expr::DirectCall {
+            Expr::DirectCall {
                 fn_name: callee,
                 args,
                 effects: EffectSet::PURE,
                 span,
-            })
+            }
+        };
+        // Phase 6l — apply trailing `.method[(...)]` chain steps, if any.
+        self.apply_dot_chain(head, node)
+    }
+
+    /// Phase 6l helper — return the `expression` Node children of
+    /// `method_call` that belong to the *head* call (i.e. those that
+    /// come before any `dot_call` child).  Without this guard, args
+    /// nested inside `dot_call` subtrees would leak into the head call.
+    ///
+    /// Because `find_node_child` etc. walk only direct children (not
+    /// the full subtree), filtering by parent identity is sufficient —
+    /// we just stop collecting `expression` nodes as soon as a
+    /// `dot_call` node appears in the sibling list.
+    fn head_call_expression_children<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+    ) -> Vec<&'a GrammarASTNode> {
+        let mut out = Vec::new();
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                if n.rule_name == "dot_call" {
+                    break;
+                }
+                if n.rule_name == "expression" {
+                    out.push(n);
+                }
+            }
         }
+        out
     }
 
     // -------------------------------------------------------------------
@@ -1165,6 +1203,11 @@ impl Lowerer {
             "array_literal" => self.lower_array_literal(node),
             "hash_literal" => self.lower_hash_literal(node),
             "symbol_literal" => self.lower_symbol_literal(node),
+            // Phase 6l — `method_call` may now appear in expression
+            // position because it's the first atom alternative inside
+            // `factor`.  Reuse the statement-level lowerer; it handles
+            // the trailing `{ dot_call }` chain transparently.
+            "method_call" => self.lower_method_call(node),
             // The parser sometimes wraps a bare token into an "expression_stmt"
             // when reached as the RHS of an assignment.  Recurse into it.
             "expression_stmt" => {
@@ -1434,7 +1477,24 @@ impl Lowerer {
     }
 
     fn lower_factor(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
-        // factor ::= NUMBER | STRING | NAME | KEYWORD | LPAREN expression RPAREN
+        // factor ::= ( atom ) { dot_call }
+        //
+        // Phase 6l — method receiver chains.  The atom is followed by
+        // zero or more `dot_call` Node children (`.method[(args)]`).
+        // We extract the atom first, then wrap it once per dot_call.
+        //
+        // Atom alternatives: NUMBER | STRING | NAME | KEYWORD |
+        //   symbol_literal | array_literal | hash_literal |
+        //   LPAREN expression RPAREN | unary_minus
+        let atom = self.lower_factor_atom(node)?;
+        self.apply_dot_chain(atom, node)
+    }
+
+    /// Extract the atom expression from a `factor` node, ignoring
+    /// trailing `dot_call` Node children.  This is the pre-Phase-6l
+    /// lowering logic, refactored into its own helper so that
+    /// `lower_factor` can apply the dot-chain postfix on top.
+    fn lower_factor_atom(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         for child in &node.children {
             match child {
                 ASTNodeOrToken::Token(tok) => {
@@ -1500,6 +1560,11 @@ impl Lowerer {
                     }
                 }
                 ASTNodeOrToken::Node(sub) => {
+                    // Skip dot_call children — those are postfix-applied
+                    // by `apply_dot_chain` after the atom is extracted.
+                    if sub.rule_name == "dot_call" {
+                        continue;
+                    }
                     return self.lower_expression(sub);
                 }
             }
@@ -1508,6 +1573,92 @@ impl Lowerer {
             message: "factor node had no recognisable leaf".to_string(),
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6l — dot-call chain postfix
+    // -------------------------------------------------------------------
+
+    /// Walk every `dot_call` Node child of `node` (in source order) and
+    /// fold each one into a method-call expression with the running
+    /// `recv` as receiver.  `foo.bar.baz` becomes:
+    ///
+    /// ```text
+    /// __method__(recv = foo, "bar")    →  inner
+    /// __method__(recv = inner, "baz")  →  outer
+    /// ```
+    ///
+    /// The chosen SIR encoding is `Expr::BuiltinCall { name:
+    /// "__method__", args: [receiver, StrLit(method_name), ...args] }`.
+    /// This keeps the receiver as a first-class expression (preserving
+    /// arbitrary nesting), the method name as data (so backends can
+    /// dispatch by string), and avoids growing the shared SIR Expr enum.
+    ///
+    /// BuiltinCall (not DirectCall) is chosen because the validator
+    /// checks DirectCall.fn_name against the module's function table,
+    /// and our synthetic `__method__` envelope intentionally isn't a
+    /// declared function — it's a wire-format tag for backends.
+    ///
+    /// Effects default to PURE — receiver-dispatched calls are
+    /// type-erased at this layer; a later receiver-type analysis pass
+    /// can widen as needed.  Callers wrapping I/O-flavored chains
+    /// (e.g. `STDOUT.puts(...)`) can post-process.
+    fn apply_dot_chain(
+        &mut self,
+        atom: Expr,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        let mut recv = atom;
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(sub) = child {
+                if sub.rule_name == "dot_call" {
+                    recv = self.fold_one_dot_call(recv, sub)?;
+                }
+            }
+        }
+        Ok(recv)
+    }
+
+    /// Lower a single `dot_call` step.  Grammar shape:
+    ///     dot_call = "." ( NAME | KEYWORD ) [ LPAREN [ expression
+    ///                  { COMMA expression } ] RPAREN ] ;
+    fn fold_one_dot_call(
+        &mut self,
+        receiver: Expr,
+        dot_node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        // First Name/Keyword token under dot_node is the method name.
+        let (method_name, name_span) = self.expect_first_name_token(dot_node)?;
+        // Optional argument expressions (the inner LPAREN…RPAREN).
+        let args: Vec<Expr> = dot_node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .map(|n| self.lower_expression(n))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let span = self.span_of(dot_node);
+        // Pack as BuiltinCall("__method__", [receiver, StrLit(method),
+        // ...args]) — see apply_dot_chain doc for rationale.
+        // The synthetic StrLit triggers the Strings feature, which the
+        // post-pass adds to the manifest unconditionally.
+        self.features_used.insert(Feature::Strings);
+        let mut full_args = Vec::with_capacity(args.len() + 2);
+        full_args.push(receiver);
+        full_args.push(Expr::StrLit {
+            value: method_name,
+            span: name_span,
+        });
+        full_args.extend(args);
+        Ok(Expr::BuiltinCall {
+            name: "__method__".to_string(),
+            args: full_args,
+            effects: EffectSet::PURE,
+            span,
         })
     }
 


### PR DESCRIPTION
## Summary

Adds parser + SIR-lowering support for **method receiver chains** — the next missing piece on the road to Ruby 3.4 parity.

```ruby
foo.bar           # one .method step
foo.bar.baz       # left-associative chain
foo.bar(args)     # dot_call with arg list
foo(1).bar        # head method_call → trailing dot_call
foo.bar(1).baz    # arbitrary nesting
```

## Grammar additions (`code/grammars/ruby.grammar`)

- `dot_call = "." ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression } ] RPAREN ] ;`
- `factor` atom alternation wrapped in `( … ) { dot_call }` (chains apply anywhere expressions go).
- `method_call` gained trailing `{ dot_call }` (statement-level `foo(1).bar`).
- `method_call` is now the **first** atom alternative inside `factor`, so `foo(1).bar` in expression position doesn't leave `(1).bar` unconsumed.

## SIR lowering

Each `.method[(...)]` step becomes:
```
BuiltinCall("__method__", [receiver, StrLit(method_name), ...actual_args], PURE)
```

BuiltinCall (not DirectCall) because the validator checks `DirectCall.fn_name` against the module's function table; `__method__` is a wire-format tag, not a declared function.

`Feature::Strings` is auto-added to the manifest because the synthetic `StrLit` triggers it.

## Out of scope (own phases)

- Setter calls `foo.bar = 1` (assignment LHS stays as bare NAME)
- Bracket access `arr[0]`

## Test plan

- [x] `cargo test -p coding-adventures-ruby-parser` — 59 passed (+5)
- [x] `cargo test -p ruby-to-semantic-ir` — 64 passed (+5)
- [x] `cargo test -p coding-adventures-ruby-lexer` — 124 passed (no regression)
- [x] Security review passed (no vulnerabilities)
- [x] `dot_chain_module_passes_sir_validator` confirms end-to-end validator acceptance

## Prior PRs in the Ruby 3.4 convergence queue

- #4168 — Phase 4i/4j (lexer: `@x`, `@@x`, `$x`)
- #3953 — Phase 6k (parser: unary minus)
- #3951 — Phase 6j (parser: return/break/next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)