### PR TITLE
Expose table metadata in HTML parser browser projections

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -308,7 +308,13 @@ def check_browser_expected_lists(
     for index, table in enumerate(object_list_items(expected, "tables")):
         table_path = f"{case_path}.expected.tables[{index}]"
         require_optional_nullable_string(table_path, table, "caption", errors)
-        for field in ("row_count", "cell_count", "header_cell_count"):
+        for field in (
+            "row_count",
+            "column_count",
+            "column_hint_count",
+            "cell_count",
+            "header_cell_count",
+        ):
             require_integer(table_path, table, field, errors)
 
 
@@ -364,9 +370,16 @@ def check_browser_content_node(
         "media",
         "control_type",
         "value",
+        "table_section_kind",
+        "colspan",
+        "rowspan",
+        "span",
+        "scope",
+        "abbr",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "classes", errors)
+    require_optional_string_list(node_path, node, "headers", errors)
     for field in ("disabled", "checked", "selected"):
         require_optional_boolean(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "options", errors)
@@ -432,9 +445,16 @@ def check_browser_render_node(
         "media",
         "control_type",
         "value",
+        "table_section_kind",
+        "colspan",
+        "rowspan",
+        "span",
+        "scope",
+        "abbr",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "classes", errors)
+    require_optional_string_list(node_path, node, "headers", errors)
     for field in ("disabled", "checked", "selected"):
         require_optional_boolean(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "options", errors)

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -201,6 +201,10 @@ documented in this file.
   embedded resource metadata for frames, objects, embeds, media, and images,
   including resolved source URLs, resource kind, type hints, media attributes,
   and authored dimensions for fetch and layout planning.
+- Browser-facing table summaries and tree projections now carry table layout and
+  accessibility metadata, including effective column counts, column hints,
+  row-group identity, column and cell spans, header associations, scopes, and
+  abbreviated header labels.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -77,6 +77,9 @@ The current parser surface includes:
 - browser-facing embedded resource metadata for replaced content such as
   `iframe`, `object`, `embed`, `audio`, and `video`, including resolved source
   URLs, resource kind, type hints, media attributes, and authored dimensions
+- browser-facing table layout and accessibility metadata, including effective
+  column counts, column hints, row-group identity, column spans, cell spans,
+  header associations, scopes, and abbreviated header labels
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -897,6 +897,13 @@ pub struct BrowserContentNode {
     pub checked: bool,
     pub selected: bool,
     pub options: Vec<String>,
+    pub table_section_kind: Option<String>,
+    pub colspan: Option<String>,
+    pub rowspan: Option<String>,
+    pub span: Option<String>,
+    pub scope: Option<String>,
+    pub headers: Vec<String>,
+    pub abbr: Option<String>,
     pub children: Vec<BrowserContentNode>,
 }
 
@@ -932,6 +939,13 @@ pub struct BrowserRenderNode {
     pub checked: bool,
     pub selected: bool,
     pub options: Vec<String>,
+    pub table_section_kind: Option<String>,
+    pub colspan: Option<String>,
+    pub rowspan: Option<String>,
+    pub span: Option<String>,
+    pub scope: Option<String>,
+    pub headers: Vec<String>,
+    pub abbr: Option<String>,
     pub children: Vec<BrowserRenderNode>,
 }
 
@@ -986,6 +1000,8 @@ pub struct BrowserFormControl {
 pub struct BrowserTable {
     pub caption: Option<String>,
     pub row_count: usize,
+    pub column_count: usize,
+    pub column_hint_count: usize,
     pub cell_count: usize,
     pub header_cell_count: usize,
 }
@@ -1110,6 +1126,13 @@ impl BrowserRenderNode {
             checked: content_node.checked,
             selected: content_node.selected,
             options: content_node.options.clone(),
+            table_section_kind: content_node.table_section_kind.clone(),
+            colspan: content_node.colspan.clone(),
+            rowspan: content_node.rowspan.clone(),
+            span: content_node.span.clone(),
+            scope: content_node.scope.clone(),
+            headers: content_node.headers.clone(),
+            abbr: content_node.abbr.clone(),
             children: content_node
                 .children
                 .iter()
@@ -8069,11 +8092,11 @@ fn collect_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             "table" => summary.tables.push(BrowserTable {
                 caption: find_first_element_in_nodes(&element.children, "caption")
                     .map(element_text),
-                row_count: count_elements_named(&element.children, "tr"),
-                cell_count: count_elements_matching(&element.children, |element| {
-                    matches!(element.name.as_str(), "td" | "th")
-                }),
-                header_cell_count: count_elements_named(&element.children, "th"),
+                row_count: browser_table_rows(element).len(),
+                column_count: browser_table_column_count(element),
+                column_hint_count: browser_table_column_hint_count(element),
+                cell_count: browser_table_cell_count(element),
+                header_cell_count: browser_table_header_cell_count(element),
             }),
             name if heading_level(name).is_some() => summary.headings.push(BrowserHeading {
                 level: heading_level(name).expect("heading level was checked above"),
@@ -8396,6 +8419,13 @@ fn collect_browser_content_nodes(
                         checked: false,
                         selected: false,
                         options: Vec::new(),
+                        table_section_kind: None,
+                        colspan: None,
+                        rowspan: None,
+                        span: None,
+                        scope: None,
+                        headers: Vec::new(),
+                        abbr: None,
                         children: Vec::new(),
                     });
                 }
@@ -8464,6 +8494,16 @@ fn browser_content_node_for_element(
         checked: element.attribute("checked").is_some(),
         selected: element.attribute("selected").is_some(),
         options: browser_content_options(element),
+        table_section_kind: browser_table_section_kind(element),
+        colspan: element.attribute("colspan").map(ToOwned::to_owned),
+        rowspan: element.attribute("rowspan").map(ToOwned::to_owned),
+        span: element.attribute("span").map(ToOwned::to_owned),
+        scope: element.attribute("scope").map(ToOwned::to_owned),
+        headers: element
+            .attribute("headers")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        abbr: element.attribute("abbr").map(ToOwned::to_owned),
         children,
     })
 }
@@ -8492,6 +8532,8 @@ fn browser_content_role(name: &str) -> Option<&'static str> {
         "li" | "dt" | "dd" => Some("list_item"),
         "table" => Some("table"),
         "caption" => Some("table_caption"),
+        "colgroup" => Some("table_column_group"),
+        "col" => Some("table_column"),
         "tbody" | "thead" | "tfoot" => Some("table_section"),
         "tr" => Some("table_row"),
         "td" | "th" => Some("table_cell"),
@@ -8508,6 +8550,7 @@ fn should_collect_browser_content_children(name: &str) -> bool {
             | "base"
             | "br"
             | "button"
+            | "col"
             | "embed"
             | "frame"
             | "iframe"
@@ -8552,6 +8595,13 @@ fn browser_content_resource_kind(element: &Element) -> Option<String> {
         "object" => Some("object".to_string()),
         "audio" | "video" => Some(element.name.clone()),
         "canvas" => Some("canvas".to_string()),
+        _ => None,
+    }
+}
+
+fn browser_table_section_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "thead" | "tbody" | "tfoot" => Some(element.name.clone()),
         _ => None,
     }
 }
@@ -8708,6 +8758,8 @@ fn browser_render_display(role: &str) -> &'static str {
         "list_item" => "list-item",
         "table" => "table",
         "table_caption" => "table-caption",
+        "table_column_group" => "table-column-group",
+        "table_column" => "table-column",
         "table_section" => "table-row-group",
         "table_row" => "table-row",
         "table_cell" => "table-cell",
@@ -8859,22 +8911,118 @@ fn find_first_element_in_nodes<'a>(nodes: &'a [Node], name: &str) -> Option<&'a 
     None
 }
 
-fn count_elements_named(nodes: &[Node], name: &str) -> usize {
-    count_elements_matching(nodes, |element| element.name == name)
+fn browser_table_rows(table: &Element) -> Vec<&Element> {
+    let mut rows = Vec::new();
+    collect_browser_table_rows(&table.children, &mut rows);
+    rows
 }
 
-fn count_elements_matching(nodes: &[Node], predicate: impl Fn(&Element) -> bool + Copy) -> usize {
-    let mut count = 0;
+fn collect_browser_table_rows<'a>(nodes: &'a [Node], rows: &mut Vec<&'a Element>) {
     for node in nodes {
         let Node::Element(element) = node else {
             continue;
         };
-        if predicate(element) {
-            count += 1;
+        if element.name == "tr" {
+            rows.push(element);
+        } else if element.name != "table" {
+            collect_browser_table_rows(&element.children, rows);
         }
-        count += count_elements_matching(&element.children, predicate);
     }
+}
+
+fn browser_table_column_count(table: &Element) -> usize {
+    browser_table_rows(table)
+        .into_iter()
+        .map(browser_table_row_column_count)
+        .max()
+        .unwrap_or(0)
+}
+
+fn browser_table_row_column_count(row: &Element) -> usize {
+    row.children
+        .iter()
+        .filter_map(|node| match node {
+            Node::Element(element) if matches!(element.name.as_str(), "td" | "th") => {
+                Some(html_positive_integer_attribute(element, "colspan"))
+            }
+            _ => None,
+        })
+        .sum()
+}
+
+fn browser_table_cell_count(table: &Element) -> usize {
+    browser_table_rows(table)
+        .into_iter()
+        .map(|row| {
+            row.children
+                .iter()
+                .filter(|node| {
+                    matches!(
+                        node,
+                        Node::Element(element) if matches!(element.name.as_str(), "td" | "th")
+                    )
+                })
+                .count()
+        })
+        .sum()
+}
+
+fn browser_table_header_cell_count(table: &Element) -> usize {
+    browser_table_rows(table)
+        .into_iter()
+        .map(|row| {
+            row.children
+                .iter()
+                .filter(|node| matches!(node, Node::Element(element) if element.name == "th"))
+                .count()
+        })
+        .sum()
+}
+
+fn browser_table_column_hint_count(table: &Element) -> usize {
+    let mut count = 0;
+    collect_browser_table_column_hints(&table.children, &mut count);
     count
+}
+
+fn collect_browser_table_column_hints(nodes: &[Node], count: &mut usize) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        match element.name.as_str() {
+            "colgroup" => {
+                let column_spans = element
+                    .children
+                    .iter()
+                    .filter_map(|child| match child {
+                        Node::Element(child_element) if child_element.name == "col" => {
+                            Some(html_positive_integer_attribute(child_element, "span"))
+                        }
+                        _ => None,
+                    })
+                    .sum::<usize>();
+                if column_spans == 0 {
+                    *count += html_positive_integer_attribute(element, "span");
+                } else {
+                    *count += column_spans;
+                }
+            }
+            "col" => {
+                *count += html_positive_integer_attribute(element, "span");
+            }
+            "table" => {}
+            _ => collect_browser_table_column_hints(&element.children, count),
+        }
+    }
+}
+
+fn html_positive_integer_attribute(element: &Element, name: &str) -> usize {
+    element
+        .attribute(name)
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(1)
 }
 
 fn heading_level(name: &str) -> Option<u8> {
@@ -9025,6 +9173,49 @@ mod tests {
         let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
         assert_eq!(render_tree.children[0].display, "inline-replaced");
         assert_eq!(render_tree.children[1].display, "inline-replaced");
+    }
+
+    #[test]
+    fn browser_table_metadata_tracks_columns_spans_and_headers() {
+        let document = parse_html(
+            "<table><caption>Prices</caption>\
+             <colgroup><col span=2 width=80><col width=120>\
+             <thead><tr><th id=item scope=col abbr=Item>Name<th id=price scope=col>Price\
+             <tbody><tr><th scope=row headers=item>Basic\
+             <td colspan=2 headers=\"item price\">$1</table>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.tables[0].caption.as_deref(), Some("Prices"));
+        assert_eq!(summary.tables[0].row_count, 2);
+        assert_eq!(summary.tables[0].column_count, 3);
+        assert_eq!(summary.tables[0].column_hint_count, 3);
+        assert_eq!(summary.tables[0].header_cell_count, 3);
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        let table = &content_tree.children[0];
+        assert_eq!(table.children[1].role, "table_column_group");
+        assert_eq!(table.children[1].children[0].span.as_deref(), Some("2"));
+        assert_eq!(
+            table.children[2].table_section_kind.as_deref(),
+            Some("thead")
+        );
+        let body_cell = &table.children[3].children[0].children[1];
+        assert_eq!(body_cell.colspan.as_deref(), Some("2"));
+        assert_eq!(
+            body_cell.headers,
+            vec!["item".to_string(), "price".to_string()]
+        );
+
+        let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
+        assert_eq!(render_tree.children[0].children[1].display, "table-column-group");
+        assert_eq!(
+            render_tree.children[0].children[3].children[0].children[1]
+                .colspan
+                .as_deref(),
+            Some("2")
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -67,6 +67,20 @@ struct ExpectedContentNode {
     selected: bool,
     #[serde(default)]
     options: Vec<String>,
+    #[serde(default)]
+    table_section_kind: Option<String>,
+    #[serde(default)]
+    colspan: Option<String>,
+    #[serde(default)]
+    rowspan: Option<String>,
+    #[serde(default)]
+    span: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    headers: Vec<String>,
+    #[serde(default)]
+    abbr: Option<String>,
     children: Vec<ExpectedContentNode>,
 }
 
@@ -131,6 +145,13 @@ impl ExpectedContentNode {
             checked: self.checked,
             selected: self.selected,
             options: self.options,
+            table_section_kind: self.table_section_kind,
+            colspan: self.colspan,
+            rowspan: self.rowspan,
+            span: self.span,
+            scope: self.scope,
+            headers: self.headers,
+            abbr: self.abbr,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -132,6 +132,10 @@ struct ExpectedFormControl {
 struct ExpectedTable {
     caption: Option<String>,
     row_count: usize,
+    #[serde(default)]
+    column_count: usize,
+    #[serde(default)]
+    column_hint_count: usize,
     cell_count: usize,
     header_cell_count: usize,
 }
@@ -326,6 +330,8 @@ impl ExpectedTable {
         BrowserTable {
             caption: self.caption,
             row_count: self.row_count,
+            column_count: self.column_count,
+            column_hint_count: self.column_hint_count,
             cell_count: self.cell_count,
             header_cell_count: self.header_cell_count,
         }

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -68,6 +68,20 @@ struct ExpectedRenderNode {
     selected: bool,
     #[serde(default)]
     options: Vec<String>,
+    #[serde(default)]
+    table_section_kind: Option<String>,
+    #[serde(default)]
+    colspan: Option<String>,
+    #[serde(default)]
+    rowspan: Option<String>,
+    #[serde(default)]
+    span: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    headers: Vec<String>,
+    #[serde(default)]
+    abbr: Option<String>,
     children: Vec<ExpectedRenderNode>,
 }
 
@@ -133,6 +147,13 @@ impl ExpectedRenderNode {
             checked: self.checked,
             selected: self.selected,
             options: self.options,
+            table_section_kind: self.table_section_kind,
+            colspan: self.colspan,
+            rowspan: self.rowspan,
+            span: self.span,
+            scope: self.scope,
+            headers: self.headers,
+            abbr: self.abbr,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -28,7 +28,10 @@ resolved URL fields for downstream navigation and fetch planning. Renderable
 nodes may also pin `id`, tokenized `class`, `title`, `lang`, and `dir`
 metadata for selector matching and UI policy. Embedded and replaced resources
 such as frames, objects, embeds, and media elements also carry resource kind,
-resolved source, type hints, media attributes, and authored dimensions.
+resolved source, type hints, media attributes, and authored dimensions. Table
+nodes preserve row-group identity, column groups/columns, column and cell spans,
+header associations, scopes, and abbreviated header labels for layout and
+accessibility code.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
@@ -39,7 +42,9 @@ disabled/checked/selected state, select option labels, textarea values, and
 resolved URL metadata for link and replaced nodes, plus render-node identity
 metadata that layout and styling code can carry forward. Replaced resource
 nodes are pinned as inline-replaced render inputs with their fetch and
-dimension metadata intact.
+dimension metadata intact. Table render inputs also keep column hints, row-group
+identity, spans, scopes, and header metadata intact while mapping to stable table
+display categories.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -166,6 +166,7 @@
               {
                 "role": "table_section",
                 "name": "tbody",
+                "table_section_kind": "tbody",
                 "text": null,
                 "href": null,
                 "src": null,
@@ -224,6 +225,101 @@
               { "role": "inline", "name": "b", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "bold", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
               { "role": "inline", "name": "i", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "italic", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
               { "role": "text", "name": null, "text": "tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "table-layout-metadata",
+      "description": "Table column hints, row groups, cell spans, and header metadata are preserved for browser layout and accessibility code.",
+      "input": "<body><table><caption>Prices</caption><colgroup><col span=2 width=80><col width=120><thead><tr><th id=item scope=col abbr=Item>Name<th id=price scope=col>Price<tbody><tr><th scope=row headers=item>Basic<td colspan=2 headers=\"item price\">$1</table>",
+      "expected": {
+        "children": [
+          {
+            "role": "table",
+            "name": "table",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              {
+                "role": "table_caption",
+                "name": "caption",
+                "text": "Prices",
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "text", "name": null, "text": "Prices", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              },
+              {
+                "role": "table_column_group",
+                "name": "colgroup",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "table_column", "name": "col", "text": null, "href": null, "src": null, "alt": null, "width": "80", "span": "2", "control_type": null, "children": [] },
+                  { "role": "table_column", "name": "col", "text": null, "href": null, "src": null, "alt": null, "width": "120", "control_type": null, "children": [] }
+                ]
+              },
+              {
+                "role": "table_section",
+                "name": "thead",
+                "table_section_kind": "thead",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  {
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "role": "table_cell", "name": "th", "id": "item", "text": null, "href": null, "src": null, "alt": null, "scope": "col", "abbr": "Item", "control_type": null, "children": [{ "role": "text", "name": null, "text": "Name", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "role": "table_cell", "name": "th", "id": "price", "text": null, "href": null, "src": null, "alt": null, "scope": "col", "control_type": null, "children": [{ "role": "text", "name": null, "text": "Price", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              },
+              {
+                "role": "table_section",
+                "name": "tbody",
+                "table_section_kind": "tbody",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  {
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "role": "table_cell", "name": "th", "text": null, "href": null, "src": null, "alt": null, "scope": "row", "headers": ["item"], "control_type": null, "children": [{ "role": "text", "name": null, "text": "Basic", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "colspan": "2", "headers": ["item", "price"], "control_type": null, "children": [{ "role": "text", "name": null, "text": "$1", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              }
             ]
           }
         ]

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -79,7 +79,7 @@
           }
         ],
         "tables": [
-          { "caption": "Results", "row_count": 2, "cell_count": 4, "header_cell_count": 2 }
+          { "caption": "Results", "row_count": 2, "column_count": 2, "column_hint_count": 0, "cell_count": 4, "header_cell_count": 2 }
         ]
       }
     },
@@ -133,6 +133,30 @@
         "images": [],
         "forms": [],
         "tables": []
+      }
+    },
+    {
+      "id": "table-layout-metadata-page",
+      "description": "Table summaries expose effective row, column, column hint, cell, and header counts for early layout planning.",
+      "input": "<body><table><caption>Prices</caption><colgroup><col span=2 width=80><col width=120><thead><tr><th id=item scope=col abbr=Item>Name<th id=price scope=col>Price<tbody><tr><th scope=row headers=item>Basic<td colspan=2 headers=\"item price\">$1</table>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Prices Name Price Basic $1",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "item", "name": null, "text": "Name" },
+          { "id": "price", "name": null, "text": "Price" }
+        ],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": [
+          { "caption": "Prices", "row_count": 2, "column_count": 3, "column_hint_count": 3, "cell_count": 4, "header_cell_count": 3 }
+        ]
       }
     }
   ]

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -140,6 +140,7 @@
                 "display": "table-row-group",
                 "role": "table_section",
                 "name": "tbody",
+                "table_section_kind": "tbody",
                 "text": null,
                 "href": null,
                 "src": null,
@@ -158,6 +159,108 @@
                     "children": [
                       { "display": "table-cell", "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "A", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
                       { "display": "table-cell", "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "B", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "table-layout-display-metadata",
+      "description": "Table column hints, row groups, cell spans, and header metadata survive render-tree input projection.",
+      "input": "<body><table><caption>Prices</caption><colgroup><col span=2 width=80><col width=120><thead><tr><th id=item scope=col abbr=Item>Name<th id=price scope=col>Price<tbody><tr><th scope=row headers=item>Basic<td colspan=2 headers=\"item price\">$1</table>",
+      "expected": {
+        "children": [
+          {
+            "display": "table",
+            "role": "table",
+            "name": "table",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              {
+                "display": "table-caption",
+                "role": "table_caption",
+                "name": "caption",
+                "text": "Prices",
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "display": "inline-text", "role": "text", "name": null, "text": "Prices", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+                ]
+              },
+              {
+                "display": "table-column-group",
+                "role": "table_column_group",
+                "name": "colgroup",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "display": "table-column", "role": "table_column", "name": "col", "text": null, "href": null, "src": null, "alt": null, "width": "80", "span": "2", "control_type": null, "children": [] },
+                  { "display": "table-column", "role": "table_column", "name": "col", "text": null, "href": null, "src": null, "alt": null, "width": "120", "control_type": null, "children": [] }
+                ]
+              },
+              {
+                "display": "table-row-group",
+                "role": "table_section",
+                "name": "thead",
+                "table_section_kind": "thead",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  {
+                    "display": "table-row",
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "display": "table-cell", "role": "table_cell", "name": "th", "id": "item", "text": null, "href": null, "src": null, "alt": null, "scope": "col", "abbr": "Item", "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Name", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "display": "table-cell", "role": "table_cell", "name": "th", "id": "price", "text": null, "href": null, "src": null, "alt": null, "scope": "col", "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Price", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              },
+              {
+                "display": "table-row-group",
+                "role": "table_section",
+                "name": "tbody",
+                "table_section_kind": "tbody",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  {
+                    "display": "table-row",
+                    "role": "table_row",
+                    "name": "tr",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "control_type": null,
+                    "children": [
+                      { "display": "table-cell", "role": "table_cell", "name": "th", "text": null, "href": null, "src": null, "alt": null, "scope": "row", "headers": ["item"], "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Basic", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                      { "display": "table-cell", "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "colspan": "2", "headers": ["item", "price"], "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "$1", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                     ]
                   }
                 ]


### PR DESCRIPTION
## Summary
- add effective column and column-hint counts to browser-facing table summaries
- preserve colgroup/col nodes, row-group kind, spans, scopes, headers, and abbr metadata through content/render projections
- extend schema governance, browser fixtures, README, and changelog coverage

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser