### PR TITLE
spice: route options into engine calls

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Route selected `.options` keys into engine-call helpers:
+  `dc_op_kwargs()` for DC Newton options and `transient_kwargs()` for
+  transient method/adaptive-step options.
 - Parse SPICE `.four <frequency> <V(node)|I(source)>...` Fourier-analysis
   cards.
 - Parse SPICE `.print <analysis> <V(node)|I(source)>...` and

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -31,3 +31,5 @@ expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
 `.temp`, `.print`, `.plot`, `.four`, and `.options` analysis cards. Transient
 cards can carry `method=euler|trap|gear2`; when omitted,
 `netlist.transient_method()` falls back to `.options method=<...>` if present.
+Selected `.options` keys can also be turned into engine-call arguments with
+`netlist.dc_op_kwargs()` and `netlist.transient_kwargs()`.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -265,6 +265,60 @@ class ParsedNetlist:
                 return _parse_transient_method(value, ".options method")
         return None
 
+    def dc_op_kwargs(self) -> dict[str, object]:
+        """Return selected `.options` values as :func:`spice_engine.dc_op` kwargs."""
+
+        values = _merged_options(self.options_cards())
+        kwargs: dict[str, object] = {}
+        tol = _option_number(values, ("reltol", "tol"))
+        if tol is not None:
+            kwargs["tol"] = tol
+        max_iterations = _option_int(values, ("itl1", "maxiter", "maxiters", "max_iterations"))
+        if max_iterations is not None:
+            kwargs["max_iterations"] = max_iterations
+        gmin = _option_number(values, ("gmin",))
+        if gmin is not None:
+            kwargs["pseudo_transient_shunt_conductance"] = gmin
+        pseudo_steps = _option_int(values, ("srcsteps", "pseudo_transient_steps"))
+        if pseudo_steps is not None:
+            kwargs["pseudo_transient_steps"] = pseudo_steps
+        pseudo_iterations = _option_int(values, ("itl6", "pseudo_transient_max_iterations"))
+        if pseudo_iterations is not None:
+            kwargs["pseudo_transient_max_iterations"] = pseudo_iterations
+        return kwargs
+
+    def transient_kwargs(
+        self,
+        tran: TranAnalysis | None = None,
+        *,
+        adaptive: bool = False,
+    ) -> dict[str, object]:
+        """Return selected `.options` values as :func:`spice_engine.transient` kwargs."""
+
+        values = _merged_options(self.options_cards())
+        kwargs: dict[str, object] = {}
+        method = self.transient_method(tran)
+        if method is not None:
+            kwargs["method"] = method
+        tol = _option_number(values, ("reltol", "tol"))
+        if tol is not None:
+            kwargs["tol"] = tol
+        tol_lte = _option_number(values, ("trtol", "lte", "tol_lte"))
+        if tol_lte is not None:
+            kwargs["tol_lte"] = tol_lte
+        min_step = _option_number(values, ("minstep", "tmin", "min_step"))
+        if min_step is not None:
+            kwargs["min_step"] = min_step
+        max_step = _option_number(values, ("maxstep", "tmax", "max_step"))
+        if max_step is not None:
+            kwargs["max_step"] = max_step
+        max_iterations = _option_int(values, ("itl4", "maxiter", "maxiters", "max_iterations"))
+        if max_iterations is not None:
+            kwargs["max_iterations"] = max_iterations
+        if adaptive:
+            kwargs["adaptive"] = True
+        return kwargs
+
 
 _VALUE_RE = re.compile(
     r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)([a-zA-Zµ]*)\s*$"
@@ -282,6 +336,34 @@ _SUFFIXES = {
     "p": 1.0e-12,
     "f": 1.0e-15,
 }
+
+
+def _merged_options(options_cards: list[OptionsAnalysis]) -> dict[str, OptionValue]:
+    values: dict[str, OptionValue] = {}
+    for options in options_cards:
+        values.update(options.values)
+    return values
+
+
+def _option_number(
+    values: dict[str, OptionValue],
+    keys: tuple[str, ...],
+) -> float | None:
+    for key in keys:
+        value = values.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (float, int)):
+            return float(value)
+    return None
+
+
+def _option_int(
+    values: dict[str, OptionValue],
+    keys: tuple[str, ...],
+) -> int | None:
+    value = _option_number(values, keys)
+    return None if value is None else int(value)
 
 
 def parse_netlist(text: str) -> ParsedNetlist:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -25,6 +25,7 @@ from spice_engine import (
     noise_ac,
     sens_dc,
     tf,
+    transient,
 )
 
 from spice_netlist_parser import (
@@ -196,6 +197,46 @@ def test_parse_options_analysis_card() -> None:
         )
     ]
     assert parsed.options_cards() == parsed.analyses
+
+
+def test_options_cards_build_engine_call_kwargs() -> None:
+    parsed = parse_netlist(
+        """
+V1 vin 0 DC 10
+R1 vin mid 1k
+R2 mid 0 1k
+.options reltol=1u itl1=7 gmin=1p method=gear2 trtol=2m minstep=1n maxstep=5n itl4=9
+.op
+.tran 1n 2n
+"""
+    )
+    tran = parsed.tran_cards()[0]
+
+    assert parsed.dc_op_kwargs() == {
+        "tol": 1.0e-6,
+        "max_iterations": 7,
+        "pseudo_transient_shunt_conductance": 1.0e-12,
+    }
+    result = dc_op(parsed.circuit, **parsed.dc_op_kwargs())
+    assert isclose(result.node_voltages["mid"], 5.0, abs_tol=1.0e-9)
+
+    assert parsed.transient_kwargs(tran, adaptive=True) == {
+        "method": "gear2",
+        "tol": 1.0e-6,
+        "tol_lte": 2.0e-3,
+        "min_step": 1.0e-9,
+        "max_step": 5.0e-9,
+        "max_iterations": 9,
+        "adaptive": True,
+    }
+    transient_result = transient(
+        parsed.circuit,
+        t_stop=tran.t_stop,
+        t_step=tran.t_step,
+        **parsed.transient_kwargs(tran, adaptive=True),
+    )
+    assert transient_result.converged
+    assert transient_result.method == "gear2"
 
 
 def test_parse_temp_analysis_card() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Route selected `.options` keys into engine-call helpers:
+  `dc_op_options()` for DC Newton options and `adaptive_transient_options()`
+  for adaptive transient options.
 - Parse SPICE `.four <frequency> <V(node)|I(source)>...` Fourier-analysis
   cards.
 - Parse SPICE `.print <analysis> <V(node)|I(source)>...` and

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -33,3 +33,5 @@ expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,
 Transient cards can carry `method=euler|trap|gear2`; when omitted,
 `parsed.transient_method(None)?` falls back to `.options method=<...>` if
 present.
+Selected `.options` keys can also be turned into engine-call options with
+`parsed.dc_op_options()?` and `parsed.adaptive_transient_options(None)?`.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, fmt};
 
 use spice_engine::{
-    Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource, Diode, Element, ExpWaveform,
-    Inductor, Jfet, JfetPolarity, Mosfet, MosfetLevel1Params, MosfetType, MutualInductor,
-    PulseWaveform, PwlWaveform, Resistor, SinWaveform, TransientMethod, TransmissionLine, Vccs,
-    Vcvs, VoltageSource, Waveform,
+    AdaptiveTransientOptions, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource,
+    DcOpOptions, Diode, Element, ExpWaveform, Inductor, Jfet, JfetPolarity, Mosfet,
+    MosfetLevel1Params, MosfetType, MutualInductor, PulseWaveform, PwlWaveform, Resistor,
+    SinWaveform, TransientMethod, TransmissionLine, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -300,6 +300,95 @@ impl ParsedNetlist {
         }
         Ok(None)
     }
+
+    pub fn dc_op_options(&self) -> Result<DcOpOptions, NetlistParseError> {
+        let values = self.merged_options();
+        let mut options = DcOpOptions::default();
+        if let Some(tolerance) = option_number(&values, &["reltol", "tol"])? {
+            options.tolerance = tolerance;
+        }
+        if let Some(max_iterations) =
+            option_usize(&values, &["itl1", "maxiter", "maxiters", "maxiterations"])?
+        {
+            options.max_iterations = max_iterations;
+        }
+        if let Some(gmin) = option_number(&values, &["gmin"])? {
+            options.pseudo_transient_conductance = gmin;
+        }
+        if let Some(pseudo_steps) = option_usize(&values, &["srcsteps", "pseudotransientsteps"])? {
+            options.pseudo_transient_steps = pseudo_steps;
+        }
+        if let Some(pseudo_iterations) =
+            option_usize(&values, &["itl6", "pseudotransientmaxiterations"])?
+        {
+            options.pseudo_transient_max_iterations = pseudo_iterations;
+        }
+        Ok(options)
+    }
+
+    pub fn adaptive_transient_options(
+        &self,
+        tran: Option<&TranAnalysis>,
+    ) -> Result<AdaptiveTransientOptions, NetlistParseError> {
+        let values = self.merged_options();
+        let mut options = AdaptiveTransientOptions::default();
+        if let Some(method) = self.transient_method(tran)? {
+            options.method = method;
+        }
+        if let Some(tolerance) = option_number(&values, &["trtol", "lte", "tollte"])? {
+            options.tolerance = tolerance;
+        }
+        if let Some(min_step) = option_number(&values, &["minstep", "tmin"])? {
+            options.min_step = Some(min_step);
+        }
+        if let Some(max_step) = option_number(&values, &["maxstep", "tmax"])? {
+            options.max_step = Some(max_step);
+        }
+        Ok(options)
+    }
+
+    fn merged_options(&self) -> HashMap<String, OptionValue> {
+        let mut values = HashMap::new();
+        for options in self.options_cards() {
+            values.extend(options.values.clone());
+        }
+        values
+    }
+}
+
+fn option_number(
+    values: &HashMap<String, OptionValue>,
+    keys: &[&str],
+) -> Result<Option<f64>, NetlistParseError> {
+    for key in keys {
+        if let Some(value) = values.get(*key) {
+            return match value {
+                OptionValue::Number(value) => Ok(Some(*value)),
+                OptionValue::Text(value) => Err(NetlistParseError::new(format!(
+                    ".options {key:?} must be numeric, got {value:?}"
+                ))),
+                OptionValue::Flag(_) => Err(NetlistParseError::new(format!(
+                    ".options {key:?} requires a numeric value"
+                ))),
+            };
+        }
+    }
+    Ok(None)
+}
+
+fn option_usize(
+    values: &HashMap<String, OptionValue>,
+    keys: &[&str],
+) -> Result<Option<usize>, NetlistParseError> {
+    let Some(value) = option_number(values, keys)? else {
+        return Ok(None);
+    };
+    if !value.is_finite() || value < 0.0 {
+        return Err(NetlistParseError::new(
+            ".options iteration counts must be finite and non-negative",
+        ));
+    }
+    Ok(Some(value.trunc() as usize))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    ac_sweep, dc_op, mc_dc, noise_ac, sens_dc, tf, BjtPolarity, Element, JfetPolarity,
-    McDistribution, McOptions, MosfetType, TransientMethod,
+    ac_sweep, dc_op, dc_op_with_options, mc_dc, noise_ac, sens_dc, tf, transient_adaptive,
+    BjtPolarity, Element, JfetPolarity, McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
     parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, FourAnalysis, McAnalysis,
@@ -226,6 +226,44 @@ fn parses_options_analysis_cards() {
     );
     assert_eq!(card.values.get("noopiter"), Some(&OptionValue::Flag(true)));
     assert!(matches!(parsed.analyses.as_slice(), [Analysis::Options(_)]));
+}
+
+#[test]
+fn options_cards_build_engine_call_options() {
+    let parsed = parse_netlist(
+        r#"
+V1 vin 0 DC 10
+R1 vin mid 1k
+R2 mid 0 1k
+.options reltol=1u itl1=7 gmin=1p method=gear2 trtol=2m minstep=1n maxstep=5n
+.op
+.tran 1n 2n
+"#,
+    )
+    .unwrap();
+    let tran = parsed.tran_cards()[0];
+
+    let dc_options = parsed.dc_op_options().unwrap();
+    assert_eq!(dc_options.max_iterations, 7);
+    assert_close(dc_options.tolerance, 1.0e-6);
+    assert_close(dc_options.pseudo_transient_conductance, 1.0e-12);
+    let result = dc_op_with_options(&parsed.circuit, dc_options).unwrap();
+    assert_close(result.voltage("mid").unwrap(), 5.0);
+
+    let transient_options = parsed.adaptive_transient_options(Some(tran)).unwrap();
+    assert_eq!(transient_options.method, TransientMethod::Gear2);
+    assert_close(transient_options.tolerance, 2.0e-3);
+    assert_close(transient_options.min_step.unwrap(), 1.0e-9);
+    assert_close(transient_options.max_step.unwrap(), 5.0e-9);
+    let transient = transient_adaptive(
+        &parsed.circuit,
+        tran.time_step,
+        tran.stop_time,
+        transient_options,
+    )
+    .unwrap();
+    assert!(transient.converged);
+    assert_eq!(transient.method, TransientMethod::Gear2);
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Route selected `.options` keys into engine-call helpers:
+  `dcOpOptions()` for DC Newton options and `adaptiveTransientOptions()` for
+  adaptive transient options.
 - Parse SPICE `.four <frequency> <V(node)|I(source)>...` Fourier-analysis
   cards.
 - Parse SPICE `.print <analysis> <V(node)|I(source)>...` and

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -35,3 +35,5 @@ SPICE engineering suffixes, PWL/PULSE/SIN/EXP source forms, comments, `.end`,
 analysis cards. Transient cards can carry `method=euler|trap|gear2`; when
 omitted, `netlist.transientMethod()` falls back to `.options method=<...>` if
 present.
+Selected `.options` keys can also be turned into engine-call options with
+`netlist.dcOpOptions()` and `netlist.adaptiveTransientOptions()`.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -24,6 +24,8 @@ import {
   voltageSource,
   voltageSourceWithAc,
   voltageSourceWithWaveform,
+  type AdaptiveTransientOptions,
+  type DcOpOptions,
   type Element,
   type JfetPolarity,
   type MosfetLevel1Params,
@@ -223,6 +225,96 @@ export class ParsedNetlist {
     }
     return undefined;
   }
+
+  dcOpOptions(): DcOpOptions {
+    const values = this.mergedOptions();
+    const options: {
+      maxIterations?: number;
+      tolerance?: number;
+      pseudoTransientConductance?: number;
+      pseudoTransientSteps?: number;
+      pseudoTransientMaxIterations?: number;
+    } = {};
+    const tolerance = optionNumber(values, ["reltol", "tol"]);
+    if (tolerance !== undefined) {
+      options.tolerance = tolerance;
+    }
+    const maxIterations = optionInteger(values, ["itl1", "maxiter", "maxiters", "maxiterations"]);
+    if (maxIterations !== undefined) {
+      options.maxIterations = maxIterations;
+    }
+    const gmin = optionNumber(values, ["gmin"]);
+    if (gmin !== undefined) {
+      options.pseudoTransientConductance = gmin;
+    }
+    const pseudoSteps = optionInteger(values, ["srcsteps", "pseudotransientsteps"]);
+    if (pseudoSteps !== undefined) {
+      options.pseudoTransientSteps = pseudoSteps;
+    }
+    const pseudoIterations = optionInteger(values, ["itl6", "pseudotransientmaxiterations"]);
+    if (pseudoIterations !== undefined) {
+      options.pseudoTransientMaxIterations = pseudoIterations;
+    }
+    return options;
+  }
+
+  adaptiveTransientOptions(tran?: TranAnalysis): AdaptiveTransientOptions {
+    const values = this.mergedOptions();
+    const options: {
+      method?: TransientMethod;
+      tolerance?: number;
+      minStep?: number;
+      maxStep?: number;
+    } = {};
+    const method = this.transientMethod(tran);
+    if (method !== undefined) {
+      options.method = method;
+    }
+    const tolerance = optionNumber(values, ["trtol", "lte", "tollte"]);
+    if (tolerance !== undefined) {
+      options.tolerance = tolerance;
+    }
+    const minStep = optionNumber(values, ["minstep", "tmin"]);
+    if (minStep !== undefined) {
+      options.minStep = minStep;
+    }
+    const maxStep = optionNumber(values, ["maxstep", "tmax"]);
+    if (maxStep !== undefined) {
+      options.maxStep = maxStep;
+    }
+    return options;
+  }
+
+  private mergedOptions(): Map<string, OptionValue> {
+    const values = new Map<string, OptionValue>();
+    for (const options of this.optionsCards()) {
+      for (const [key, value] of options.values) {
+        values.set(key, value);
+      }
+    }
+    return values;
+  }
+}
+
+function optionNumber(
+  values: ReadonlyMap<string, OptionValue>,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = values.get(key);
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function optionInteger(
+  values: ReadonlyMap<string, OptionValue>,
+  keys: readonly string[],
+): number | undefined {
+  const value = optionNumber(values, keys);
+  return value === undefined ? undefined : Math.trunc(value);
 }
 
 interface Statement {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1,4 +1,12 @@
-import { acSweep, dcOp, mcDc, noiseAc, sensDc, tf } from "@coding-adventures/spice-engine";
+import {
+  acSweep,
+  dcOp,
+  mcDc,
+  noiseAc,
+  sensDc,
+  tf,
+  transientAdaptive,
+} from "@coding-adventures/spice-engine";
 import { describe, expect, it } from "vitest";
 import {
   NetlistParseError,
@@ -145,6 +153,41 @@ Tdelay in 0 out 0 Z0=50 TD=1n
     };
     expect(parsed.analyses).toEqual([card]);
     expect(parsed.optionsCards()).toEqual([card]);
+  });
+
+  it("builds engine call options from .options cards", () => {
+    const parsed = parseNetlist(`
+V1 vin 0 DC 10
+R1 vin mid 1k
+R2 mid 0 1k
+.options reltol=1u itl1=7 gmin=1p method=gear2 trtol=2m minstep=1n maxstep=5n
+.op
+.tran 1n 2n
+`);
+    const tran = parsed.tranCards()[0];
+
+    expect(parsed.dcOpOptions()).toEqual({
+      tolerance: 1.0e-6,
+      maxIterations: 7,
+      pseudoTransientConductance: 1.0e-12,
+    });
+    const result = dcOp(parsed.circuit, parsed.dcOpOptions());
+    expect(result.voltage("mid")).toBeCloseTo(5.0, 9);
+
+    expect(parsed.adaptiveTransientOptions(tran)).toEqual({
+      method: "gear2",
+      tolerance: 2.0e-3,
+      minStep: 1.0e-9,
+      maxStep: 5.0e-9,
+    });
+    const transient = transientAdaptive(
+      parsed.circuit,
+      tran.timeStep,
+      tran.stopTime,
+      parsed.adaptiveTransientOptions(tran),
+    );
+    expect(transient.converged).toBe(true);
+    expect(transient.method).toBe("gear2");
   });
 
   it("parses .temp analysis cards", () => {

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -258,6 +258,9 @@ Status:
 - Stable text-output helpers for DC operating points and transient samples are
   implemented across Python, TypeScript, and Rust, with snapshot tests covering
   node-voltage and branch-current ordering.
+- Selected `.options` keys are wired into engine-call helpers across Python,
+  TypeScript, and Rust, covering DC solver tolerances/iteration limits and
+  transient method/adaptive-step options.
 
 ### Phase 8 - Small-Signal Distortion and Pole-Zero
 


### PR DESCRIPTION
## Summary

- add cross-language helpers that turn selected `.options` keys into engine-call options
- route DC solver tolerances/iteration knobs and transient method/adaptive-step knobs in Python, TypeScript, and Rust
- cover the helpers with parser tests that pass parsed options into engine calls, and update Phase 7 docs/status

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-options-engine-routing PYTHONPATH=src:../spice-engine/src:../device-physics/src:../mosfet-models/src python -m pytest tests/test_spice_netlist_parser.py -q`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-options-engine-routing npm install && MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-options-engine-routing npm run build && MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-options-engine-routing npm test -- --run`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-options-engine-routing cargo fmt -p spice-netlist-parser --check && MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-options-engine-routing cargo test -p spice-netlist-parser`
- `git diff --check`
