### PR TITLE
html-parser: expose text flow projection metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -376,11 +376,19 @@ def check_browser_content_node(
         "span",
         "scope",
         "abbr",
+        "text_flow",
+        "list_kind",
+        "list_start",
+        "list_marker_type",
+        "list_item_value",
+        "quote_cite",
+        "resolved_quote_cite",
+        "break_kind",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "classes", errors)
     require_optional_string_list(node_path, node, "headers", errors)
-    for field in ("disabled", "checked", "selected"):
+    for field in ("disabled", "checked", "selected", "list_reversed"):
         require_optional_boolean(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "options", errors)
     require_object_list(node_path, node, "children", errors)
@@ -451,11 +459,19 @@ def check_browser_render_node(
         "span",
         "scope",
         "abbr",
+        "text_flow",
+        "list_kind",
+        "list_start",
+        "list_marker_type",
+        "list_item_value",
+        "quote_cite",
+        "resolved_quote_cite",
+        "break_kind",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "classes", errors)
     require_optional_string_list(node_path, node, "headers", errors)
-    for field in ("disabled", "checked", "selected"):
+    for field in ("disabled", "checked", "selected", "list_reversed"):
         require_optional_boolean(node_path, node, field, errors)
     require_optional_string_list(node_path, node, "options", errors)
     require_object_list(node_path, node, "children", errors)

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -205,6 +205,10 @@ documented in this file.
   accessibility metadata, including effective column counts, column hints,
   row-group identity, column and cell spans, header associations, scopes, and
   abbreviated header labels.
+- Browser-facing content-tree and render-tree projections now carry text-flow
+  metadata for paragraphs, preformatted text, ordered and unordered lists, list
+  item values, block and inline quote citations, and line/word/thematic break
+  elements.
 - Void end tags such as `</img>`, `</input>`, and `</hr>` are now ignored with a
   parser diagnostic, while self-closing syntax on void start tags remains
   acknowledged.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -80,6 +80,9 @@ The current parser surface includes:
 - browser-facing table layout and accessibility metadata, including effective
   column counts, column hints, row-group identity, column spans, cell spans,
   header associations, scopes, and abbreviated header labels
+- browser-facing text-flow metadata for paragraphs, preformatted text, ordered
+  and unordered lists, list item values, block/inline quote citations, and
+  line/word/thematic break elements
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -904,6 +904,15 @@ pub struct BrowserContentNode {
     pub scope: Option<String>,
     pub headers: Vec<String>,
     pub abbr: Option<String>,
+    pub text_flow: Option<String>,
+    pub list_kind: Option<String>,
+    pub list_start: Option<String>,
+    pub list_marker_type: Option<String>,
+    pub list_reversed: bool,
+    pub list_item_value: Option<String>,
+    pub quote_cite: Option<String>,
+    pub resolved_quote_cite: Option<String>,
+    pub break_kind: Option<String>,
     pub children: Vec<BrowserContentNode>,
 }
 
@@ -946,6 +955,15 @@ pub struct BrowserRenderNode {
     pub scope: Option<String>,
     pub headers: Vec<String>,
     pub abbr: Option<String>,
+    pub text_flow: Option<String>,
+    pub list_kind: Option<String>,
+    pub list_start: Option<String>,
+    pub list_marker_type: Option<String>,
+    pub list_reversed: bool,
+    pub list_item_value: Option<String>,
+    pub quote_cite: Option<String>,
+    pub resolved_quote_cite: Option<String>,
+    pub break_kind: Option<String>,
     pub children: Vec<BrowserRenderNode>,
 }
 
@@ -1133,6 +1151,15 @@ impl BrowserRenderNode {
             scope: content_node.scope.clone(),
             headers: content_node.headers.clone(),
             abbr: content_node.abbr.clone(),
+            text_flow: content_node.text_flow.clone(),
+            list_kind: content_node.list_kind.clone(),
+            list_start: content_node.list_start.clone(),
+            list_marker_type: content_node.list_marker_type.clone(),
+            list_reversed: content_node.list_reversed,
+            list_item_value: content_node.list_item_value.clone(),
+            quote_cite: content_node.quote_cite.clone(),
+            resolved_quote_cite: content_node.resolved_quote_cite.clone(),
+            break_kind: content_node.break_kind.clone(),
             children: content_node
                 .children
                 .iter()
@@ -8389,10 +8416,23 @@ fn collect_browser_content_nodes(
     output: &mut Vec<BrowserContentNode>,
     base_href: Option<&str>,
 ) {
+    collect_browser_content_nodes_with_mode(nodes, output, base_href, false);
+}
+
+fn collect_browser_content_nodes_with_mode(
+    nodes: &[Node],
+    output: &mut Vec<BrowserContentNode>,
+    base_href: Option<&str>,
+    preserve_whitespace: bool,
+) {
     for node in nodes {
         match node {
             Node::Text(value) => {
-                let text = collapse_html_whitespace(&value.data);
+                let text = if preserve_whitespace {
+                    value.data.clone()
+                } else {
+                    collapse_html_whitespace(&value.data)
+                };
                 if !text.is_empty() {
                     output.push(BrowserContentNode {
                         role: "text".to_string(),
@@ -8426,12 +8466,27 @@ fn collect_browser_content_nodes(
                         scope: None,
                         headers: Vec::new(),
                         abbr: None,
+                        text_flow: if preserve_whitespace {
+                            Some("preformatted".to_string())
+                        } else {
+                            None
+                        },
+                        list_kind: None,
+                        list_start: None,
+                        list_marker_type: None,
+                        list_reversed: false,
+                        list_item_value: None,
+                        quote_cite: None,
+                        resolved_quote_cite: None,
+                        break_kind: None,
                         children: Vec::new(),
                     });
                 }
             }
             Node::Element(element) => {
-                if let Some(content_node) = browser_content_node_for_element(element, base_href) {
+                if let Some(content_node) =
+                    browser_content_node_for_element(element, base_href, preserve_whitespace)
+                {
                     output.push(content_node);
                 }
             }
@@ -8443,6 +8498,7 @@ fn collect_browser_content_nodes(
 fn browser_content_node_for_element(
     element: &Element,
     base_href: Option<&str>,
+    preserve_whitespace: bool,
 ) -> Option<BrowserContentNode> {
     if is_browser_invisible_element(&element.name) {
         return None;
@@ -8451,7 +8507,12 @@ fn browser_content_node_for_element(
     let role = browser_content_role(&element.name)?;
     let mut children = Vec::new();
     if should_collect_browser_content_children(&element.name) {
-        collect_browser_content_nodes(&element.children, &mut children, base_href);
+        collect_browser_content_nodes_with_mode(
+            &element.children,
+            &mut children,
+            base_href,
+            preserve_whitespace || browser_preserves_text_whitespace(&element.name),
+        );
     }
 
     let text = browser_content_text(element, role);
@@ -8461,6 +8522,7 @@ fn browser_content_node_for_element(
 
     let href = element.attribute("href").map(ToOwned::to_owned);
     let src = browser_content_src(element);
+    let quote_cite = browser_quote_cite(element);
 
     Some(BrowserContentNode {
         role: role.to_string(),
@@ -8504,6 +8566,17 @@ fn browser_content_node_for_element(
             .map(split_html_classes)
             .unwrap_or_default(),
         abbr: element.attribute("abbr").map(ToOwned::to_owned),
+        text_flow: browser_text_flow(element, preserve_whitespace),
+        list_kind: browser_list_kind(element),
+        list_start: browser_list_start(element),
+        list_marker_type: browser_list_marker_type(element),
+        list_reversed: element.name == "ol" && element.attribute("reversed").is_some(),
+        list_item_value: browser_list_item_value(element),
+        resolved_quote_cite: quote_cite
+            .as_deref()
+            .and_then(|cite| resolve_browser_url(cite, base_href)),
+        quote_cite,
+        break_kind: browser_break_kind(element),
         children,
     })
 }
@@ -8521,6 +8594,11 @@ fn browser_content_role(name: &str) -> Option<&'static str> {
         "audio" | "video" => Some("media"),
         "canvas" => Some("canvas"),
         "br" | "wbr" => Some("line_break"),
+        "hr" => Some("separator"),
+        "blockquote" => Some("quote_block"),
+        "q" => Some("quote"),
+        "p" => Some("paragraph"),
+        "pre" | "plaintext" | "xmp" | "listing" => Some("preformatted"),
         "form" => Some("form"),
         "fieldset" => Some("form_group"),
         "label" => Some("label"),
@@ -8602,6 +8680,67 @@ fn browser_content_resource_kind(element: &Element) -> Option<String> {
 fn browser_table_section_kind(element: &Element) -> Option<String> {
     match element.name.as_str() {
         "thead" | "tbody" | "tfoot" => Some(element.name.clone()),
+        _ => None,
+    }
+}
+
+fn browser_preserves_text_whitespace(name: &str) -> bool {
+    matches!(name, "pre" | "plaintext" | "xmp" | "listing")
+}
+
+fn browser_text_flow(element: &Element, inherited_preserve_whitespace: bool) -> Option<String> {
+    if browser_preserves_text_whitespace(&element.name) || inherited_preserve_whitespace {
+        Some("preformatted".to_string())
+    } else {
+        None
+    }
+}
+
+fn browser_list_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "ul" => Some("unordered".to_string()),
+        "ol" => Some("ordered".to_string()),
+        "menu" => Some("menu".to_string()),
+        "dir" => Some("directory".to_string()),
+        _ => None,
+    }
+}
+
+fn browser_list_start(element: &Element) -> Option<String> {
+    if element.name == "ol" {
+        element.attribute("start").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_list_marker_type(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "ol" | "ul" | "li" => element.attribute("type").map(ToOwned::to_owned),
+        _ => None,
+    }
+}
+
+fn browser_list_item_value(element: &Element) -> Option<String> {
+    if element.name == "li" {
+        element.attribute("value").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_quote_cite(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "blockquote" | "q" => element.attribute("cite").map(ToOwned::to_owned),
+        _ => None,
+    }
+}
+
+fn browser_break_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "br" => Some("line".to_string()),
+        "wbr" => Some("word".to_string()),
+        "hr" => Some("thematic".to_string()),
         _ => None,
     }
 }
@@ -8753,8 +8892,9 @@ fn browser_render_display(role: &str) -> &'static str {
             "inline-replaced"
         }
         "line_break" => "line-break",
-        "heading" | "block" | "form" | "form_group" | "legend" | "list" => "block",
-        "label" | "option" | "option_group" => "inline",
+        "paragraph" | "preformatted" | "heading" | "block" | "form" | "form_group" | "legend"
+        | "list" | "quote_block" | "separator" => "block",
+        "label" | "option" | "option_group" | "quote" => "inline",
         "list_item" => "list-item",
         "table" => "table",
         "table_caption" => "table-caption",
@@ -9209,12 +9349,70 @@ mod tests {
         );
 
         let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
-        assert_eq!(render_tree.children[0].children[1].display, "table-column-group");
+        assert_eq!(
+            render_tree.children[0].children[1].display,
+            "table-column-group"
+        );
         assert_eq!(
             render_tree.children[0].children[3].children[0].children[1]
                 .colspan
                 .as_deref(),
             Some("2")
+        );
+    }
+
+    #[test]
+    fn browser_text_flow_metadata_tracks_lists_quotes_and_breaks() {
+        let document = parse_html(
+            "<base href=\"https://example.test/docs/page.html\">\
+             <p>Intro<br>line<wbr>word</p><hr>\
+             <ol start=3 reversed type=A><li value=7>Seven<li>Eight</ol>\
+             <pre>  keep\nspace</pre>\
+             <blockquote cite=notes/ref.html><p>Quote <q cite=#part>part</q></p></blockquote>",
+        )
+        .unwrap();
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        let paragraph = &content_tree.children[0];
+        assert_eq!(paragraph.role, "paragraph");
+        assert_eq!(paragraph.children[1].break_kind.as_deref(), Some("line"));
+        assert_eq!(paragraph.children[3].break_kind.as_deref(), Some("word"));
+
+        let separator = &content_tree.children[1];
+        assert_eq!(separator.role, "separator");
+        assert_eq!(separator.break_kind.as_deref(), Some("thematic"));
+
+        let list = &content_tree.children[2];
+        assert_eq!(list.list_kind.as_deref(), Some("ordered"));
+        assert_eq!(list.list_start.as_deref(), Some("3"));
+        assert_eq!(list.list_marker_type.as_deref(), Some("A"));
+        assert!(list.list_reversed);
+        assert_eq!(list.children[0].list_item_value.as_deref(), Some("7"));
+
+        let pre = &content_tree.children[3];
+        assert_eq!(pre.role, "preformatted");
+        assert_eq!(pre.text_flow.as_deref(), Some("preformatted"));
+        assert_eq!(pre.children[0].text.as_deref(), Some("  keep\nspace"));
+
+        let quote = &content_tree.children[4];
+        assert_eq!(quote.role, "quote_block");
+        assert_eq!(quote.quote_cite.as_deref(), Some("notes/ref.html"));
+        assert_eq!(
+            quote.resolved_quote_cite.as_deref(),
+            Some("https://example.test/docs/notes/ref.html")
+        );
+        let inline_quote = &quote.children[0].children[1];
+        assert_eq!(inline_quote.role, "quote");
+        assert_eq!(inline_quote.quote_cite.as_deref(), Some("#part"));
+
+        let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
+        assert_eq!(render_tree.children[0].display, "block");
+        assert_eq!(render_tree.children[0].children[1].display, "line-break");
+        assert_eq!(render_tree.children[1].display, "block");
+        assert_eq!(render_tree.children[2].children[0].display, "list-item");
+        assert_eq!(
+            render_tree.children[4].children[0].children[1].display,
+            "inline"
         );
     }
 

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -81,6 +81,24 @@ struct ExpectedContentNode {
     headers: Vec<String>,
     #[serde(default)]
     abbr: Option<String>,
+    #[serde(default)]
+    text_flow: Option<String>,
+    #[serde(default)]
+    list_kind: Option<String>,
+    #[serde(default)]
+    list_start: Option<String>,
+    #[serde(default)]
+    list_marker_type: Option<String>,
+    #[serde(default)]
+    list_reversed: bool,
+    #[serde(default)]
+    list_item_value: Option<String>,
+    #[serde(default)]
+    quote_cite: Option<String>,
+    #[serde(default)]
+    resolved_quote_cite: Option<String>,
+    #[serde(default)]
+    break_kind: Option<String>,
     children: Vec<ExpectedContentNode>,
 }
 
@@ -152,6 +170,15 @@ impl ExpectedContentNode {
             scope: self.scope,
             headers: self.headers,
             abbr: self.abbr,
+            text_flow: self.text_flow,
+            list_kind: self.list_kind,
+            list_start: self.list_start,
+            list_marker_type: self.list_marker_type,
+            list_reversed: self.list_reversed,
+            list_item_value: self.list_item_value,
+            quote_cite: self.quote_cite,
+            resolved_quote_cite: self.resolved_quote_cite,
+            break_kind: self.break_kind,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -82,6 +82,24 @@ struct ExpectedRenderNode {
     headers: Vec<String>,
     #[serde(default)]
     abbr: Option<String>,
+    #[serde(default)]
+    text_flow: Option<String>,
+    #[serde(default)]
+    list_kind: Option<String>,
+    #[serde(default)]
+    list_start: Option<String>,
+    #[serde(default)]
+    list_marker_type: Option<String>,
+    #[serde(default)]
+    list_reversed: bool,
+    #[serde(default)]
+    list_item_value: Option<String>,
+    #[serde(default)]
+    quote_cite: Option<String>,
+    #[serde(default)]
+    resolved_quote_cite: Option<String>,
+    #[serde(default)]
+    break_kind: Option<String>,
     children: Vec<ExpectedRenderNode>,
 }
 
@@ -154,6 +172,15 @@ impl ExpectedRenderNode {
             scope: self.scope,
             headers: self.headers,
             abbr: self.abbr,
+            text_flow: self.text_flow,
+            list_kind: self.list_kind,
+            list_start: self.list_start,
+            list_marker_type: self.list_marker_type,
+            list_reversed: self.list_reversed,
+            list_item_value: self.list_item_value,
+            quote_cite: self.quote_cite,
+            resolved_quote_cite: self.resolved_quote_cite,
+            break_kind: self.break_kind,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -31,7 +31,9 @@ such as frames, objects, embeds, and media elements also carry resource kind,
 resolved source, type hints, media attributes, and authored dimensions. Table
 nodes preserve row-group identity, column groups/columns, column and cell spans,
 header associations, scopes, and abbreviated header labels for layout and
-accessibility code.
+accessibility code. Text-flow cases also pin paragraph/preformatted roles,
+preserved preformatted text runs, list numbering metadata, quote citations, and
+line/word/thematic break kinds.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
@@ -44,7 +46,9 @@ metadata that layout and styling code can carry forward. Replaced resource
 nodes are pinned as inline-replaced render inputs with their fetch and
 dimension metadata intact. Table render inputs also keep column hints, row-group
 identity, spans, scopes, and header metadata intact while mapping to stable table
-display categories.
+display categories. Text-flow render inputs preserve list markers, quote
+citations, preformatted whitespace policy, and break kinds while mapping to
+stable display categories.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -27,7 +27,7 @@
             ]
           },
           {
-            "role": "block",
+            "role": "paragraph",
             "name": "p",
             "classes": ["lede"],
             "text": null,
@@ -54,7 +54,7 @@
                 ]
               },
               { "role": "text", "name": null, "text": ".", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
-              { "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "break_kind": "line", "control_type": null, "children": [] },
               { "role": "image", "name": "img", "text": null, "href": null, "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "resource_kind": "image", "control_type": null, "children": [] }
             ]
           },
@@ -65,6 +65,7 @@
             "href": null,
             "src": null,
             "alt": null,
+            "list_kind": "unordered",
             "control_type": null,
             "children": [
               {
@@ -213,7 +214,7 @@
       "expected": {
         "children": [
           {
-            "role": "block",
+            "role": "paragraph",
             "name": "p",
             "text": null,
             "href": null,
@@ -318,6 +319,89 @@
                       { "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "colspan": "2", "headers": ["item", "price"], "control_type": null, "children": [{ "role": "text", "name": null, "text": "$1", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                     ]
                   }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "text-flow-list-quote-metadata",
+      "description": "Paragraphs, preformatted text, lists, quotes, and break elements preserve browser layout metadata.",
+      "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Intro<br>line<wbr>word</p><hr><ol start=3 reversed type=A><li value=7>Seven<li>Eight</ol><pre>  keep\nspace</pre><blockquote cite=notes/ref.html><p>Quote <q cite=#part>part</q></p></blockquote>",
+      "expected": {
+        "children": [
+          {
+            "role": "paragraph",
+            "name": "p",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "Intro", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "break_kind": "line", "control_type": null, "children": [] },
+              { "role": "text", "name": null, "text": "line", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "role": "line_break", "name": "wbr", "text": null, "href": null, "src": null, "alt": null, "break_kind": "word", "control_type": null, "children": [] },
+              { "role": "text", "name": null, "text": "word", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          },
+          { "role": "separator", "name": "hr", "text": null, "href": null, "src": null, "alt": null, "break_kind": "thematic", "control_type": null, "children": [] },
+          {
+            "role": "list",
+            "name": "ol",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "list_kind": "ordered",
+            "list_start": "3",
+            "list_marker_type": "A",
+            "type_hint": "A",
+            "list_reversed": true,
+            "control_type": null,
+            "children": [
+              { "role": "list_item", "name": "li", "text": null, "href": null, "src": null, "alt": null, "list_item_value": "7", "control_type": null, "children": [{ "role": "text", "name": null, "text": "Seven", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+              { "role": "list_item", "name": "li", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Eight", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+            ]
+          },
+          {
+            "role": "preformatted",
+            "name": "pre",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "text_flow": "preformatted",
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "  keep\nspace", "href": null, "src": null, "alt": null, "text_flow": "preformatted", "control_type": null, "children": [] }
+            ]
+          },
+          {
+            "role": "quote_block",
+            "name": "blockquote",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "quote_cite": "notes/ref.html",
+            "resolved_quote_cite": "https://example.test/docs/notes/ref.html",
+            "control_type": null,
+            "children": [
+              {
+                "role": "paragraph",
+                "name": "p",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "role": "text", "name": null, "text": "Quote", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+                  { "role": "quote", "name": "q", "text": null, "href": null, "src": null, "alt": null, "quote_cite": "#part", "resolved_quote_cite": "https://example.test/docs/page.html#part", "control_type": null, "children": [{ "role": "text", "name": null, "text": "part", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                 ]
               }
             ]

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -158,6 +158,25 @@
           { "caption": "Prices", "row_count": 2, "column_count": 3, "column_hint_count": 3, "cell_count": 4, "header_cell_count": 3 }
         ]
       }
+    },
+    {
+      "id": "text-flow-list-quote-page",
+      "description": "Browser document facts keep the visible prose around lists, preformatted blocks, quotes, and break elements stable.",
+      "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Intro<br>line<wbr>word</p><hr><ol start=3 reversed type=A><li value=7>Seven<li>Eight</ol><pre>  keep\nspace</pre><blockquote cite=notes/ref.html><p>Quote <q cite=#part>part</q></p></blockquote>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/docs/page.html",
+        "base_target": null,
+        "body_text": "Intro line word Seven Eight keep space Quote part",
+        "metas": [],
+        "resources": [],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
     }
   ]
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -26,7 +26,7 @@
           },
           {
             "display": "block",
-            "role": "block",
+            "role": "paragraph",
             "name": "p",
             "id": "intro",
             "classes": ["lede", "print"],
@@ -55,7 +55,7 @@
                 ]
               },
               { "display": "inline-replaced", "role": "image", "name": "img", "text": null, "href": null, "src": "../assets/logo.gif", "resolved_src": "https://example.test/assets/logo.gif", "alt": "Logo", "resource_kind": "image", "control_type": null, "children": [] },
-              { "display": "line-break", "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "display": "line-break", "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "break_kind": "line", "control_type": null, "children": [] },
               { "display": "inline-text", "role": "text", "name": null, "text": "Tail", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
             ]
           }
@@ -263,6 +263,94 @@
                       { "display": "table-cell", "role": "table_cell", "name": "td", "text": null, "href": null, "src": null, "alt": null, "colspan": "2", "headers": ["item", "price"], "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "$1", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                     ]
                   }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "text-flow-list-quote-display-metadata",
+      "description": "Paragraphs, preformatted text, lists, quotes, and break elements survive render-tree input projection.",
+      "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Intro<br>line<wbr>word</p><hr><ol start=3 reversed type=A><li value=7>Seven<li>Eight</ol><pre>  keep\nspace</pre><blockquote cite=notes/ref.html><p>Quote <q cite=#part>part</q></p></blockquote>",
+      "expected": {
+        "children": [
+          {
+            "display": "block",
+            "role": "paragraph",
+            "name": "p",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "control_type": null,
+            "children": [
+              { "display": "inline-text", "role": "text", "name": null, "text": "Intro", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "display": "line-break", "role": "line_break", "name": "br", "text": null, "href": null, "src": null, "alt": null, "break_kind": "line", "control_type": null, "children": [] },
+              { "display": "inline-text", "role": "text", "name": null, "text": "line", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+              { "display": "line-break", "role": "line_break", "name": "wbr", "text": null, "href": null, "src": null, "alt": null, "break_kind": "word", "control_type": null, "children": [] },
+              { "display": "inline-text", "role": "text", "name": null, "text": "word", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
+            ]
+          },
+          { "display": "block", "role": "separator", "name": "hr", "text": null, "href": null, "src": null, "alt": null, "break_kind": "thematic", "control_type": null, "children": [] },
+          {
+            "display": "block",
+            "role": "list",
+            "name": "ol",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "list_kind": "ordered",
+            "list_start": "3",
+            "list_marker_type": "A",
+            "type_hint": "A",
+            "list_reversed": true,
+            "control_type": null,
+            "children": [
+              { "display": "list-item", "role": "list_item", "name": "li", "text": null, "href": null, "src": null, "alt": null, "list_item_value": "7", "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Seven", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+              { "display": "list-item", "role": "list_item", "name": "li", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Eight", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+            ]
+          },
+          {
+            "display": "block",
+            "role": "preformatted",
+            "name": "pre",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "text_flow": "preformatted",
+            "control_type": null,
+            "children": [
+              { "display": "inline-text", "role": "text", "name": null, "text": "  keep\nspace", "href": null, "src": null, "alt": null, "text_flow": "preformatted", "control_type": null, "children": [] }
+            ]
+          },
+          {
+            "display": "block",
+            "role": "quote_block",
+            "name": "blockquote",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "quote_cite": "notes/ref.html",
+            "resolved_quote_cite": "https://example.test/docs/notes/ref.html",
+            "control_type": null,
+            "children": [
+              {
+                "display": "block",
+                "role": "paragraph",
+                "name": "p",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "control_type": null,
+                "children": [
+                  { "display": "inline-text", "role": "text", "name": null, "text": "Quote", "href": null, "src": null, "alt": null, "control_type": null, "children": [] },
+                  { "display": "inline", "role": "quote", "name": "q", "text": null, "href": null, "src": null, "alt": null, "quote_cite": "#part", "resolved_quote_cite": "https://example.test/docs/page.html#part", "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "part", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                 ]
               }
             ]


### PR DESCRIPTION
## Summary
- add browser-facing text-flow metadata for paragraphs, preformatted text, lists, list items, quotes, and break/separator nodes
- preserve preformatted text while keeping normal browser body text collapsed
- extend browser readiness/content/render fixtures and schema governance for the new projection fields

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
