### PR TITLE
fix(sql-vm): CAST(bool AS TEXT) yields '1'/'0' not Python 'True'/'False'

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2.12.0] - 2026-05-24
+
+### Fixed
+
+- ``CAST(TRUE AS TEXT)`` / ``CAST(FALSE AS TEXT)`` (and the
+  ``VARCHAR`` / ``CHAR`` / ``NVARCHAR`` aliases) now return ``'1'``
+  / ``'0'`` instead of Python's ``'True'`` / ``'False'``.  Matches
+  SQLite — see the sql-vm 1.57 entry for the scalar-function-level
+  fix.
+
+  Common idioms that the bug used to corrupt::
+
+      SELECT 'is_active=' || CAST(is_active AS TEXT) FROM users;
+      WHERE CAST(flag AS TEXT) = '1'
+
+  Now both sides agree with sqlite3.
+
 ## [2.11.0] - 2026-05-24
 
 ### Changed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.11.0"
+version = "2.12.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_cast_bool_to_text.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_cast_bool_to_text.py
@@ -1,0 +1,83 @@
+"""Tests for ``CAST(<bool> AS TEXT)`` matching SQLite's "no native bool" rule.
+
+SQLite has no native boolean type — the ``TRUE`` and ``FALSE``
+keywords are aliases for the integers ``1`` and ``0``.  Casting them
+to TEXT therefore yields ``'1'`` and ``'0'``, not the strings
+``'True'`` and ``'False'``.
+
+Mini-sqlite's CAST handler used to call ``str(x)`` on the value
+directly.  Python's ``str(True)`` returns ``'True'``, which leaked
+the Python-level boolean repr into SQL output and broke any oracle
+test that compared against sqlite3's ``'1'`` / ``'0'``.  The fix
+detects ``bool`` before the generic str path (mirroring the
+INTEGER-affinity path, which already special-cases bool) and
+returns ``str(int(x))``.
+
+These tests pin the corrected behaviour so a future refactor of the
+CAST handler can't silently regress it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestBoolToText:
+    def test_cast_true_as_text(self) -> None:
+        _both_match("SELECT CAST(TRUE AS TEXT)")
+
+    def test_cast_false_as_text(self) -> None:
+        _both_match("SELECT CAST(FALSE AS TEXT)")
+
+    def test_cast_true_as_varchar(self) -> None:
+        _both_match("SELECT CAST(TRUE AS VARCHAR)")
+
+    def test_cast_false_as_char(self) -> None:
+        _both_match("SELECT CAST(FALSE AS CHAR)")
+
+
+class TestRegressionIntegerPaths:
+    """The INTEGER affinity path already handled bool — pin it so a
+    refactor that touches the TEXT branch doesn't accidentally regress
+    the INTEGER one."""
+
+    def test_cast_true_as_integer(self) -> None:
+        _both_match("SELECT CAST(TRUE AS INTEGER)")
+
+    def test_cast_false_as_integer(self) -> None:
+        _both_match("SELECT CAST(FALSE AS INTEGER)")
+
+    def test_cast_true_as_real(self) -> None:
+        _both_match("SELECT CAST(TRUE AS REAL)")
+
+
+class TestPlainStringConversionStillWorks:
+    """Regression: non-bool values keep their str() rendering."""
+
+    def test_cast_int_as_text(self) -> None:
+        _both_match("SELECT CAST(42 AS TEXT)")
+
+    def test_cast_float_as_text(self) -> None:
+        _both_match("SELECT CAST(3.14 AS TEXT)")
+
+    def test_cast_null_as_text(self) -> None:
+        _both_match("SELECT CAST(NULL AS TEXT)")
+
+
+class TestInExpressionContext:
+    def test_bool_text_in_concat(self) -> None:
+        # Building a label that includes a boolean flag — common idiom.
+        _both_match("SELECT 'is_active=' || CAST(TRUE AS TEXT)")
+
+    def test_bool_text_in_where(self) -> None:
+        _both_match(
+            "SELECT 1 WHERE CAST(TRUE AS TEXT) = '1'",
+        )

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.57.0 — 2026-05-24
+
+### Fixed
+
+- ``CAST(<bool> AS TEXT)`` now yields ``'1'`` / ``'0'`` instead of
+  Python's ``'True'`` / ``'False'``.  SQLite has no native boolean
+  type — TRUE and FALSE are aliases for the integers 1 and 0 — so
+  the textual rendering of a cast boolean must match the integer
+  string.  The previous implementation called ``str(x)`` directly,
+  which leaked Python's ``bool`` repr into SQL output.
+
+  Fix in ``_cast_fn``: the TEXT-affinity branch now special-cases
+  ``isinstance(x, bool)`` before the generic ``str`` path
+  (mirroring the existing INTEGER-affinity bool handling) and
+  returns ``str(int(x))``.
+
 ## 1.56.0 — 2026-05-24
 
 ### Changed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.56.0"
+version = "1.57.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -351,6 +351,14 @@ def _cast_fn(x: SqlValue, target_type: SqlValue) -> SqlValue:
                  "clob"):
             if isinstance(x, bytes):
                 return x.hex()
+            # SQLite has no native boolean type — TRUE / FALSE round-trip
+            # as integers 1 / 0.  ``CAST(TRUE AS TEXT)`` must therefore
+            # yield ``'1'``, not Python's ``'True'``.  Check ``bool``
+            # before the generic ``str`` path because ``bool`` is a
+            # subclass of ``int`` and would otherwise be caught by it
+            # under the existing INTEGER affinity path.
+            if isinstance(x, bool):
+                return str(int(x))
             return str(x)
         if t in ("blob", "none"):
             if isinstance(x, bytes):


### PR DESCRIPTION
## Summary

- `CAST(TRUE AS TEXT)` / `CAST(FALSE AS TEXT)` now return `'1'` / `'0'` (matching SQLite) instead of Python's `'True'` / `'False'`.
- Root cause: the TEXT-affinity branch of `_cast_fn` called `str(x)` directly. For Python `bool` that returns the host-language repr; the INTEGER-affinity branch had the right special-case already, but TEXT didn't.
- One special-case added before the generic `str` path — 7 lines total.

## Version bumps

- `sql-vm`: 1.56 → 1.57
- `mini-sqlite`: 2.11 → 2.12

## Test plan

- [x] 12 new oracle tests pass (TRUE/FALSE → TEXT/VARCHAR/CHAR, INTEGER/REAL regression pins, plain int/float/NULL TEXT regression, expression-context use)
- [x] sql-vm suite (921 tests) clean
- [x] mini-sqlite suite (2283 tests) clean
- [x] Ruff clean
- [x] Security review passed (pure value-coercion fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)