### PR TITLE
Expose Hue grouped light state reads

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
   action, and state-projection coverage over typed CLIP v2 snapshots.
 - Hue event-stream summaries for compact retry-hint, record, resource-item, and
   resource-type coverage over parsed Server-Sent Events batches.
+- `HueClient::get_grouped_light_state_updates` for room/zone aggregate-light
+  state reads through the facade.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -30,6 +30,7 @@ Included surfaces:
 - Hue light resource decoding
 - Hue light, grouped-light, motion, and button state update extraction from
   snapshots and event-stream batches
+- grouped-light state update collection reads through the `HueClient` facade
 
 ## Dependencies
 

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -651,6 +651,13 @@ impl<T: HueTransport> HueClient<T> {
         parse_light_state_updates_from_envelope(&envelope)
     }
 
+    pub fn get_grouped_light_state_updates(
+        &mut self,
+    ) -> Result<Vec<HueGroupedLightStateUpdate>, HueClientError> {
+        let envelope = self.get_collection(HueResourceType::GroupedLight)?;
+        parse_grouped_light_state_updates_from_envelope(&envelope)
+    }
+
     pub fn get_motion_state_updates(
         &mut self,
     ) -> Result<Vec<HueMotionStateUpdate>, HueClientError> {
@@ -2097,6 +2104,29 @@ mod tests {
         assert_eq!(grouped_lights.len(), 1);
         assert_eq!(grouped_lights[0].id.as_str(), "grouped-light-1");
         assert_eq!(grouped_lights[0].owner.resource_type, HueResourceType::Room);
+        assert_eq!(transport.requests.len(), 1);
+        assert_eq!(
+            transport.requests[0].path,
+            "/clip/v2/resource/grouped_light"
+        );
+    }
+
+    #[test]
+    fn client_reads_grouped_light_state_updates_through_injected_transport() {
+        let transport = RecordingTransport::with_response(
+            r#"{"data":[{"id":"grouped-light-1","type":"grouped_light","metadata":{"name":"Kitchen"},"owner":{"rid":"room-1","rtype":"room"},"on":{"on":true},"dimming":{"brightness":84}}],"errors":[]}"#,
+        );
+        let mut client = HueClient::new(HueClientConfig::paired("app-key"), transport);
+
+        let updates = client.get_grouped_light_state_updates().unwrap();
+        let transport = client.into_transport();
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].id.as_str(), "grouped-light-1");
+        assert_eq!(updates[0].name.as_deref(), Some("Kitchen"));
+        assert_eq!(updates[0].on, Some(true));
+        assert_eq!(updates[0].brightness, Some(84));
+        assert_eq!(updates[0].state_deltas().len(), 2);
         assert_eq!(transport.requests.len(), 1);
         assert_eq!(
             transport.requests[0].path,


### PR DESCRIPTION
## Summary
- add HueClient::get_grouped_light_state_updates for grouped-light collection state reads
- cover the facade through injected transport and existing grouped-light state delta projection
- document the grouped-light state read surface

## Tests
- $env:CARGO_TARGET_DIR='C:\tmp\codex-hue-client-target'; cargo test -p hue-client -- --nocapture
- git diff --check