### PR TITLE
html-parser: expose document outline projection metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -384,8 +384,11 @@ def check_browser_content_node(
         "quote_cite",
         "resolved_quote_cite",
         "break_kind",
+        "section_kind",
+        "landmark_kind",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
+    require_optional_integer(node_path, node, "heading_level", errors)
     require_optional_string_list(node_path, node, "classes", errors)
     require_optional_string_list(node_path, node, "headers", errors)
     for field in ("disabled", "checked", "selected", "list_reversed"):
@@ -467,8 +470,11 @@ def check_browser_render_node(
         "quote_cite",
         "resolved_quote_cite",
         "break_kind",
+        "section_kind",
+        "landmark_kind",
     ):
         require_optional_nullable_string(node_path, node, field, errors)
+    require_optional_integer(node_path, node, "heading_level", errors)
     require_optional_string_list(node_path, node, "classes", errors)
     require_optional_string_list(node_path, node, "headers", errors)
     for field in ("disabled", "checked", "selected", "list_reversed"):
@@ -565,6 +571,16 @@ def require_integer(
 ) -> None:
     if not isinstance(data.get(field), int):
         errors.append(f"{path}.{field} must be an integer")
+
+
+def require_optional_integer(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    if field in data:
+        require_integer(path, data, field, errors)
 
 
 def require_boolean(

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -138,6 +138,9 @@ documented in this file.
 - Parser-approved initial tokenizer contexts now include seeded text/RCDATA
   character-reference continuation substates, carrying temporary buffers and
   return states through named, numeric, decimal, and hexadecimal recovery paths.
+- Browser-facing content and render projections now expose document outline
+  metadata for heading levels, sectioning elements, and landmark-like regions
+  such as `main`, `nav`, `aside`, `header`, and `footer`.
 - Initial table tree-construction recovery for omitted `tbody`/`tr` structure,
   including implicit row groups for bare rows/cells and section closure when a
   new table section starts.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -83,6 +83,9 @@ The current parser surface includes:
 - browser-facing text-flow metadata for paragraphs, preformatted text, ordered
   and unordered lists, list item values, block/inline quote citations, and
   line/word/thematic break elements
+- browser-facing document outline metadata for heading levels, sectioning
+  elements, and landmark-like regions such as `main`, `nav`, `aside`,
+  `header`, and `footer`
 
 The checked-in html5lib tree-construction smoke corpus now covers every case in
 the currently audited upstream `html5lib-tests/tree-construction/*.dat` sources

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -913,6 +913,9 @@ pub struct BrowserContentNode {
     pub quote_cite: Option<String>,
     pub resolved_quote_cite: Option<String>,
     pub break_kind: Option<String>,
+    pub heading_level: Option<u8>,
+    pub section_kind: Option<String>,
+    pub landmark_kind: Option<String>,
     pub children: Vec<BrowserContentNode>,
 }
 
@@ -964,6 +967,9 @@ pub struct BrowserRenderNode {
     pub quote_cite: Option<String>,
     pub resolved_quote_cite: Option<String>,
     pub break_kind: Option<String>,
+    pub heading_level: Option<u8>,
+    pub section_kind: Option<String>,
+    pub landmark_kind: Option<String>,
     pub children: Vec<BrowserRenderNode>,
 }
 
@@ -1160,6 +1166,9 @@ impl BrowserRenderNode {
             quote_cite: content_node.quote_cite.clone(),
             resolved_quote_cite: content_node.resolved_quote_cite.clone(),
             break_kind: content_node.break_kind.clone(),
+            heading_level: content_node.heading_level,
+            section_kind: content_node.section_kind.clone(),
+            landmark_kind: content_node.landmark_kind.clone(),
             children: content_node
                 .children
                 .iter()
@@ -8479,6 +8488,9 @@ fn collect_browser_content_nodes_with_mode(
                         quote_cite: None,
                         resolved_quote_cite: None,
                         break_kind: None,
+                        heading_level: None,
+                        section_kind: None,
+                        landmark_kind: None,
                         children: Vec::new(),
                     });
                 }
@@ -8577,6 +8589,9 @@ fn browser_content_node_for_element(
             .and_then(|cite| resolve_browser_url(cite, base_href)),
         quote_cite,
         break_kind: browser_break_kind(element),
+        heading_level: heading_level(&element.name),
+        section_kind: browser_section_kind(element),
+        landmark_kind: browser_landmark_kind(element),
         children,
     })
 }
@@ -8599,6 +8614,14 @@ fn browser_content_role(name: &str) -> Option<&'static str> {
         "q" => Some("quote"),
         "p" => Some("paragraph"),
         "pre" | "plaintext" | "xmp" | "listing" => Some("preformatted"),
+        "article" => Some("article"),
+        "aside" => Some("aside"),
+        "footer" => Some("footer"),
+        "header" => Some("header"),
+        "hgroup" => Some("heading_group"),
+        "main" => Some("main"),
+        "nav" => Some("navigation"),
+        "section" => Some("section"),
         "form" => Some("form"),
         "fieldset" => Some("form_group"),
         "label" => Some("label"),
@@ -8741,6 +8764,31 @@ fn browser_break_kind(element: &Element) -> Option<String> {
         "br" => Some("line".to_string()),
         "wbr" => Some("word".to_string()),
         "hr" => Some("thematic".to_string()),
+        _ => None,
+    }
+}
+
+fn browser_section_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "article" => Some("article".to_string()),
+        "aside" => Some("aside".to_string()),
+        "footer" => Some("footer".to_string()),
+        "header" => Some("header".to_string()),
+        "hgroup" => Some("heading_group".to_string()),
+        "main" => Some("main".to_string()),
+        "nav" => Some("navigation".to_string()),
+        "section" => Some("section".to_string()),
+        _ => None,
+    }
+}
+
+fn browser_landmark_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "aside" => Some("complementary".to_string()),
+        "footer" => Some("footer".to_string()),
+        "header" => Some("header".to_string()),
+        "main" => Some("main".to_string()),
+        "nav" => Some("navigation".to_string()),
         _ => None,
     }
 }
@@ -8892,8 +8940,9 @@ fn browser_render_display(role: &str) -> &'static str {
             "inline-replaced"
         }
         "line_break" => "line-break",
-        "paragraph" | "preformatted" | "heading" | "block" | "form" | "form_group" | "legend"
-        | "list" | "quote_block" | "separator" => "block",
+        "article" | "aside" | "footer" | "header" | "heading" | "heading_group" | "main"
+        | "navigation" | "paragraph" | "preformatted" | "section" | "block" | "form"
+        | "form_group" | "legend" | "list" | "quote_block" | "separator" => "block",
         "label" | "option" | "option_group" | "quote" => "inline",
         "list_item" => "list-item",
         "table" => "table",
@@ -9413,6 +9462,59 @@ mod tests {
         assert_eq!(
             render_tree.children[4].children[0].children[1].display,
             "inline"
+        );
+    }
+
+    #[test]
+    fn browser_outline_metadata_tracks_sections_landmarks_and_heading_levels() {
+        let document = parse_html(
+            "<body><header><h1>Site</h1></header>\
+             <nav><h2>Nav</h2><a href=/home>Home</a></nav>\
+             <main><article id=post><h2>Post</h2><section aria-label=Chapter><h3>Chapter</h3></section></article>\
+             <aside><h2>Related</h2></aside></main><footer>Fine print</footer>",
+        )
+        .unwrap();
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        let header = &content_tree.children[0];
+        assert_eq!(header.role, "header");
+        assert_eq!(header.section_kind.as_deref(), Some("header"));
+        assert_eq!(header.landmark_kind.as_deref(), Some("header"));
+        assert_eq!(header.children[0].heading_level, Some(1));
+
+        let navigation = &content_tree.children[1];
+        assert_eq!(navigation.role, "navigation");
+        assert_eq!(navigation.section_kind.as_deref(), Some("navigation"));
+        assert_eq!(navigation.landmark_kind.as_deref(), Some("navigation"));
+        assert_eq!(navigation.children[0].heading_level, Some(2));
+
+        let main = &content_tree.children[2];
+        assert_eq!(main.role, "main");
+        assert_eq!(main.landmark_kind.as_deref(), Some("main"));
+        let article = &main.children[0];
+        assert_eq!(article.role, "article");
+        assert_eq!(article.section_kind.as_deref(), Some("article"));
+        assert_eq!(article.children[0].heading_level, Some(2));
+        let section = &article.children[1];
+        assert_eq!(section.role, "section");
+        assert_eq!(section.section_kind.as_deref(), Some("section"));
+        assert_eq!(section.children[0].heading_level, Some(3));
+
+        let aside = &main.children[1];
+        assert_eq!(aside.role, "aside");
+        assert_eq!(aside.landmark_kind.as_deref(), Some("complementary"));
+
+        let footer = &content_tree.children[3];
+        assert_eq!(footer.role, "footer");
+        assert_eq!(footer.landmark_kind.as_deref(), Some("footer"));
+
+        let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
+        assert_eq!(render_tree.children[0].display, "block");
+        assert_eq!(render_tree.children[1].display, "block");
+        assert_eq!(render_tree.children[2].children[0].display, "block");
+        assert_eq!(
+            render_tree.children[2].children[0].children[1].children[0].heading_level,
+            Some(3)
         );
     }
 

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -99,6 +99,12 @@ struct ExpectedContentNode {
     resolved_quote_cite: Option<String>,
     #[serde(default)]
     break_kind: Option<String>,
+    #[serde(default)]
+    heading_level: Option<u8>,
+    #[serde(default)]
+    section_kind: Option<String>,
+    #[serde(default)]
+    landmark_kind: Option<String>,
     children: Vec<ExpectedContentNode>,
 }
 
@@ -179,6 +185,9 @@ impl ExpectedContentNode {
             quote_cite: self.quote_cite,
             resolved_quote_cite: self.resolved_quote_cite,
             break_kind: self.break_kind,
+            heading_level: self.heading_level,
+            section_kind: self.section_kind,
+            landmark_kind: self.landmark_kind,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -100,6 +100,12 @@ struct ExpectedRenderNode {
     resolved_quote_cite: Option<String>,
     #[serde(default)]
     break_kind: Option<String>,
+    #[serde(default)]
+    heading_level: Option<u8>,
+    #[serde(default)]
+    section_kind: Option<String>,
+    #[serde(default)]
+    landmark_kind: Option<String>,
     children: Vec<ExpectedRenderNode>,
 }
 
@@ -181,6 +187,9 @@ impl ExpectedRenderNode {
             quote_cite: self.quote_cite,
             resolved_quote_cite: self.resolved_quote_cite,
             break_kind: self.break_kind,
+            heading_level: self.heading_level,
+            section_kind: self.section_kind,
+            landmark_kind: self.landmark_kind,
             children: self
                 .children
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -33,7 +33,9 @@ nodes preserve row-group identity, column groups/columns, column and cell spans,
 header associations, scopes, and abbreviated header labels for layout and
 accessibility code. Text-flow cases also pin paragraph/preformatted roles,
 preserved preformatted text runs, list numbering metadata, quote citations, and
-line/word/thematic break kinds.
+line/word/thematic break kinds. Document-outline cases pin heading levels,
+sectioning roles, and landmark-like regions such as `main`, `nav`, `aside`,
+`header`, and `footer`.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
@@ -48,7 +50,9 @@ dimension metadata intact. Table render inputs also keep column hints, row-group
 identity, spans, scopes, and header metadata intact while mapping to stable table
 display categories. Text-flow render inputs preserve list markers, quote
 citations, preformatted whitespace policy, and break kinds while mapping to
-stable display categories.
+stable display categories. Document-outline render inputs keep heading levels
+and section/landmark metadata while mapping those structural regions to block
+display categories.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -12,6 +12,7 @@
           {
             "role": "heading",
             "name": "h1",
+            "heading_level": 1,
             "id": "top",
             "classes": ["headline", "primary"],
             "title": "Directory",
@@ -106,6 +107,7 @@
           {
             "role": "heading",
             "name": "h2",
+            "heading_level": 2,
             "text": "Catalog",
             "href": null,
             "src": null,
@@ -404,6 +406,112 @@
                   { "role": "quote", "name": "q", "text": null, "href": null, "src": null, "alt": null, "quote_cite": "#part", "resolved_quote_cite": "https://example.test/docs/page.html#part", "control_type": null, "children": [{ "role": "text", "name": null, "text": "part", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                 ]
               }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "document-outline-landmark-metadata",
+      "description": "Sectioning and landmark elements carry stable browser outline metadata alongside heading levels.",
+      "input": "<body><header><h1>Site</h1></header><nav><h2>Nav</h2><a href=/home>Home</a></nav><main><article id=post><h2>Post</h2><section aria-label=Chapter><h3>Chapter</h3></section></article><aside><h2>Related</h2></aside></main><footer>Fine print</footer>",
+      "expected": {
+        "children": [
+          {
+            "role": "header",
+            "name": "header",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "header",
+            "landmark_kind": "header",
+            "control_type": null,
+            "children": [
+              { "role": "heading", "name": "h1", "heading_level": 1, "text": "Site", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Site", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+            ]
+          },
+          {
+            "role": "navigation",
+            "name": "nav",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "navigation",
+            "landmark_kind": "navigation",
+            "control_type": null,
+            "children": [
+              { "role": "heading", "name": "h2", "heading_level": 2, "text": "Nav", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Nav", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+              { "role": "link", "name": "a", "text": "Home", "href": "/home", "resolved_href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Home", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+            ]
+          },
+          {
+            "role": "main",
+            "name": "main",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "main",
+            "landmark_kind": "main",
+            "control_type": null,
+            "children": [
+              {
+                "role": "article",
+                "name": "article",
+                "id": "post",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "section_kind": "article",
+                "control_type": null,
+                "children": [
+                  { "role": "heading", "name": "h2", "heading_level": 2, "text": "Post", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Post", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                  {
+                    "role": "section",
+                    "name": "section",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "section_kind": "section",
+                    "control_type": null,
+                    "children": [
+                      { "role": "heading", "name": "h3", "heading_level": 3, "text": "Chapter", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Chapter", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              },
+              {
+                "role": "aside",
+                "name": "aside",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "section_kind": "aside",
+                "landmark_kind": "complementary",
+                "control_type": null,
+                "children": [
+                  { "role": "heading", "name": "h2", "heading_level": 2, "text": "Related", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Related", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                ]
+              }
+            ]
+          },
+          {
+            "role": "footer",
+            "name": "footer",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "footer",
+            "landmark_kind": "footer",
+            "control_type": null,
+            "children": [
+              { "role": "text", "name": null, "text": "Fine print", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
             ]
           }
         ]

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -160,6 +160,35 @@
       }
     },
     {
+      "id": "document-outline-landmark-page",
+      "description": "Browser document summaries keep heading order across sectioning and landmark elements.",
+      "input": "<body><header><h1>Site</h1></header><nav><h2>Nav</h2><a href=/home>Home</a></nav><main><article id=post><h2>Post</h2><section aria-label=Chapter><h3>Chapter</h3></section></article><aside><h2>Related</h2></aside></main><footer>Fine print</footer>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Site Nav Home Post Chapter Related Fine print",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "post", "name": null, "text": "Post Chapter" }
+        ],
+        "headings": [
+          { "level": 1, "text": "Site" },
+          { "level": 2, "text": "Nav" },
+          { "level": 2, "text": "Post" },
+          { "level": 3, "text": "Chapter" },
+          { "level": 2, "text": "Related" }
+        ],
+        "links": [
+          { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
+        ],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "text-flow-list-quote-page",
       "description": "Browser document facts keep the visible prose around lists, preformatted blocks, quotes, and break elements stable.",
       "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Intro<br>line<wbr>word</p><hr><ol start=3 reversed type=A><li value=7>Seven<li>Eight</ol><pre>  keep\nspace</pre><blockquote cite=notes/ref.html><p>Quote <q cite=#part>part</q></p></blockquote>",

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -13,6 +13,7 @@
             "display": "block",
             "role": "heading",
             "name": "h1",
+            "heading_level": 1,
             "id": "page-title",
             "classes": ["hero"],
             "text": "Example",
@@ -265,6 +266,119 @@
                   }
                 ]
               }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "document-outline-landmark-display-metadata",
+      "description": "Sectioning and landmark elements stay block-level render inputs with explicit outline metadata.",
+      "input": "<body><header><h1>Site</h1></header><nav><h2>Nav</h2><a href=/home>Home</a></nav><main><article id=post><h2>Post</h2><section aria-label=Chapter><h3>Chapter</h3></section></article><aside><h2>Related</h2></aside></main><footer>Fine print</footer>",
+      "expected": {
+        "children": [
+          {
+            "display": "block",
+            "role": "header",
+            "name": "header",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "header",
+            "landmark_kind": "header",
+            "control_type": null,
+            "children": [
+              { "display": "block", "role": "heading", "name": "h1", "heading_level": 1, "text": "Site", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Site", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+            ]
+          },
+          {
+            "display": "block",
+            "role": "navigation",
+            "name": "nav",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "navigation",
+            "landmark_kind": "navigation",
+            "control_type": null,
+            "children": [
+              { "display": "block", "role": "heading", "name": "h2", "heading_level": 2, "text": "Nav", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Nav", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+              { "display": "inline", "role": "link", "name": "a", "text": "Home", "href": "/home", "resolved_href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Home", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+            ]
+          },
+          {
+            "display": "block",
+            "role": "main",
+            "name": "main",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "main",
+            "landmark_kind": "main",
+            "control_type": null,
+            "children": [
+              {
+                "display": "block",
+                "role": "article",
+                "name": "article",
+                "id": "post",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "section_kind": "article",
+                "control_type": null,
+                "children": [
+                  { "display": "block", "role": "heading", "name": "h2", "heading_level": 2, "text": "Post", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Post", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
+                  {
+                    "display": "block",
+                    "role": "section",
+                    "name": "section",
+                    "text": null,
+                    "href": null,
+                    "src": null,
+                    "alt": null,
+                    "section_kind": "section",
+                    "control_type": null,
+                    "children": [
+                      { "display": "block", "role": "heading", "name": "h3", "heading_level": 3, "text": "Chapter", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Chapter", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                    ]
+                  }
+                ]
+              },
+              {
+                "display": "block",
+                "role": "aside",
+                "name": "aside",
+                "text": null,
+                "href": null,
+                "src": null,
+                "alt": null,
+                "section_kind": "aside",
+                "landmark_kind": "complementary",
+                "control_type": null,
+                "children": [
+                  { "display": "block", "role": "heading", "name": "h2", "heading_level": 2, "text": "Related", "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Related", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
+                ]
+              }
+            ]
+          },
+          {
+            "display": "block",
+            "role": "footer",
+            "name": "footer",
+            "text": null,
+            "href": null,
+            "src": null,
+            "alt": null,
+            "section_kind": "footer",
+            "landmark_kind": "footer",
+            "control_type": null,
+            "children": [
+              { "display": "inline-text", "role": "text", "name": null, "text": "Fine print", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- add browser-facing heading level, section kind, and landmark kind metadata to content/render projection nodes
- give structural elements like main, nav, article, section, aside, header, footer, and hgroup stable browser roles/default block display
- extend browser readiness/content/render fixtures plus schema governance for document-outline projection coverage

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser

Post-rebase smoke rerun:
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
