### PR TITLE
feat(components/Grid): UI31-L10 — migrate Grid.mll to HostTable*

### DIFF
--- a/code/components/Grid/Grid.mll
+++ b/code/components/Grid/Grid.mll
@@ -1,25 +1,92 @@
 // Grid.mll — Layout definition for the Grid component.
 //
+// UI31-L10 migration: this layout now composes from the UI31 HostTable
+// kernel family (HostTable + HostTableHead/Body + Row + Text) instead
+// of the legacy built-in `Grid` primitive. The motivation is the UI31
+// non-negotiable accessibility + RTL contracts that the HostTable
+// family ships across all seven backends (React, HTML, WebComponent,
+// Flutter, Qt, SwiftUI, XAML) per #4143, #4156, #4162, #4166, #4185,
+// #4194, #4198 — semantics that the built-in `Grid` primitive only
+// delivered on React.
+//
 // Layout tree:
 //
-//   Column [ root ]          ← flex column container; fills available width
-//     Grid [ cell-grid ] (   ← the single table primitive; no children
-//       headers: slot: column-headers ,
-//       rows:    slot: viewport-rows
-//     )
+//   Column [ root ]                          ← flex column container
+//     HostTable [ cell-grid ]                ← native <table> on web,
+//                                             SwiftUI VStack/HStack,
+//                                             QtQuick ColumnLayout,
+//                                             Flutter DataTable,
+//                                             WinUI Grid on XAML.
+//       HostTableHead                        ← native <thead>
+//         Row                                ← native <tr>
+//           For ( each: column-headers,
+//                 as: header )               ← one <th> per header text
+//             Text ( content: header )
+//       HostTableBody                        ← native <tbody>
+//         For ( each: viewport-rows,
+//               as: row )                    ← one <tr> per data row
+//           Row {
+//             Text ( content: row )
+//           }
 //
-// The Grid primitive is a leaf node — it takes no children in the layout
-// tree.  Instead it receives slot references as props and the React backend
-// expands them into <thead>/<tbody> via .map() at compile time.
+// Why HostTable* over the built-in `Grid` primitive?
+// --------------------------------------------------
+// The built-in `Grid` primitive was a React-only special case: it
+// emitted `<table><thead><tbody>` directly, but every other backend
+// either errored or fell back to a div-soup placeholder. HostTable*
+// makes each backend lower to its native, accessibility-aware table
+// widget:
 //
-// Part names ("root", "cell-grid") map to mosstyle selectors so the .msl
-// file can provide scoped visual styles without any class name collisions.
+//   - HTML / React / WebComponent → real `<table>` (with `<thead>`,
+//     `<tbody>`, `<tr>`, `<td>`) — screen readers walk row/col
+//     associations automatically; ARIA `aria-rowindex` and
+//     `aria-colindex` are intrinsic to the elements.
+//   - Flutter → `DataTable` widget — TalkBack / VoiceOver see real
+//     table semantics, not `Container` mush.
+//   - SwiftUI → `VStack(.leading, spacing: 0)` of `HStack` rows that
+//     SwiftUI's accessibility framework groups as a coherent table.
+//   - Qt → `ColumnLayout` of `RowLayout`s — Qt Accessibility recognises
+//     the structural shape.
+//   - XAML → `<Grid>` with `<Grid.RowDefinitions>` per section — WinUI's
+//     automation peer derives row/col semantics from `Grid.Row="..."`.
+//
+// All seven backends ALSO honour the UI31 §3.2 RTL contract — Grid's
+// interface would need a `dir` slot for authors to actually flip the
+// direction (out of scope here — would extend Grid.mil), but the
+// contract is preserved end-to-end so a future Grid v2 can opt in
+// without touching emitters.
+//
+// v1 caveats (intentional — matched to Grid.mil's slot shape)
+// -----------------------------------------------------------
+// Grid.mil declares `column-headers : list<text>` and `viewport-rows :
+// list<text>` — both flat lists of text. So each `<tr>` in the body
+// carries one `<td>` containing the row's text. A v2 Grid extending
+// viewport-rows to `list<list<text>>` would let the inner For iterate
+// columns; that is a separate change (matches the v0.1.0 caveat in
+// `packages/mosaic-pkg-grid/src/Grid.mll`).
+//
+// Part names ("root", "cell-grid") still map to mosstyle selectors so
+// the .msl file can provide scoped visual styles. `.mos-Grid-cell-grid`
+// now selects the HostTable's emitted `<table>` element directly,
+// matching the previous behaviour bit-for-bit on web.
 
 layout Grid {
   Column [ root ] {
-    Grid [ cell-grid ] (
-      headers: slot: column-headers ,
-      rows:    slot: viewport-rows
-    )
+    HostTable [ cell-grid ] {
+      HostTableHead {
+        Row {
+          For ( each: slot: column-headers , as: header ) {
+            Text ( content: header )
+          }
+        }
+      }
+      HostTableBody {
+        For ( each: slot: viewport-rows , as: row ) {
+          Row {
+            Text ( content: row )
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

UI31 plan item L10. The Grid component's layout previously composed from the built-in `Grid` primitive — a React-only special case that emitted `<table>/<thead>/<tbody>` directly but errored or fell back to div-soup on every other backend.

It now composes from the **UI31 HostTable kernel family** (HostTable + HostTableHead + HostTableBody + Row + For + Text), gaining native accessibility + RTL contracts across all seven backends per #4143, #4156, #4162, #4166, #4185, #4194, #4198:

| Backend | Native widget |
|---|---|
| HTML / React / WebComponent | `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<td>` (intrinsic ARIA row/col) |
| Flutter | `DataTable` (TalkBack/VoiceOver native semantics) |
| SwiftUI | `VStack(.leading)` of `HStack` rows (SwiftUI a11y framework groups as table) |
| Qt | `ColumnLayout` of `RowLayout`s (Qt Accessibility recognises shape) |
| XAML | `<Grid>` with `<Grid.RowDefinitions>` per section (WinUI automation peer derives row/col) |

## Interface stability

`Grid.mil` is unchanged. The public interface (`column-headers`, `viewport-rows`, `onRowClick`) is stable. Part name `cell-grid` and the `.mos-Grid-cell-grid` mosstyle selector are preserved so the .msl bindings continue to work bit-for-bit.

## Deprecation note

The legacy built-in `Grid` primitive stays in the kernel for now per UI31 §6's deprecation timeline. The sister file `packages/mosaic-pkg-grid/src/Grid.mll` had already done this migration in v0.1.0; this PR brings `components/Grid/Grid.mll` (the reference/demo component) into alignment.

Security review: PASSED — pure markup change, no new code paths, slot references match Grid.mil unchanged.

## Test plan

- [x] security-review sub-agent — passed
- [x] Layout uses same primitives + syntax as the already-validated `packages/mosaic-pkg-grid/src/Grid.mll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)