### PR TITLE
feat(mini-sqlite): recognise PRAGMA read_uncommitted + query_only

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [2.13.0] - 2026-05-24
+
+### Added
+
+- ``PRAGMA read_uncommitted`` and ``PRAGMA query_only`` are now
+  recognised as accept-and-store boolean PRAGMAs (default ``0``).
+  Reads return the current integer; writes accept
+  ``1``/``0``/``ON``/``OFF``/``TRUE``/``FALSE``/``YES``/``NO`` and
+  the value persists for the lifetime of the connection.  Both are
+  also advertised in ``PRAGMA pragma_list``.
+
+  Previously both returned ``[]`` (vs sqlite3's documented
+  ``[(0,)]`` default) and silently dropped writes — defensive callers
+  in ORMs and migration tools that probe these PRAGMAs to decide
+  whether to issue an explicit reset would trip on the missing
+  default.
+
+### Scope limits
+
+- ``read_uncommitted`` controls SQLite's shared-cache isolation
+  level.  Mini-sqlite has no shared cache, so the PRAGMA's value
+  has no semantic effect — it just round-trips per connection.
+- ``query_only = 1`` should reject writes in SQLite ("attempt to
+  write a readonly database").  Mini-sqlite does NOT yet enforce
+  the read-only gate — INSERT/UPDATE/DELETE still execute even
+  when ``query_only = 1``.  Enforcement is a deferred increment,
+  pinned by an explicit regression test that documents the current
+  divergence.
+
 ## [2.12.0] - 2026-05-24
 
 ### Fixed

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.12.0"
+version = "2.13.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
+++ b/code/packages/python/mini-sqlite/src/mini_sqlite/engine.py
@@ -827,6 +827,18 @@ _PRAGMA_DEFAULTS: dict[str, tuple[object, str]] = {
     # migration tools that toggle it during repair flows don't trip on
     # unrecognised PRAGMA.
     "writable_schema":  (0,                "integer"),  # bool; off by default
+    # read_uncommitted — selects whether SQLite uses the "READ UNCOMMITTED"
+    # isolation level (shared-cache mode only).  Mini-sqlite has no
+    # shared cache so the flag has no semantic effect, but ORMs probe
+    # it defensively before deciding whether to issue an explicit
+    # ``PRAGMA read_uncommitted = 0`` for a clean baseline.
+    "read_uncommitted": (0,                "integer"),  # bool; off by default
+    # query_only — when ON, SQLite rejects writes ("attempt to write a
+    # readonly database").  Mini-sqlite doesn't enforce the read-only
+    # semantics yet — the PRAGMA value just round-trips per connection,
+    # so callers that read it back to confirm settings see the value
+    # they wrote.  Enforcement is a future increment.
+    "query_only":       (0,                "integer"),  # bool; off by default
 }
 
 # Per-connection PRAGMA state.  Keyed by the backend object's id() so each
@@ -1266,6 +1278,15 @@ def _run_pragma(backend: Backend, sql: str, *, fk_child: dict | None = None) -> 
         # PRAGMA defensively (e.g. to skip a repair flow) still see the
         # expected value.
         "writable_schema",
+        # ``read_uncommitted`` controls SQLite's shared-cache isolation
+        # level.  Mini-sqlite has no shared cache, so this is purely a
+        # round-tripped value with no semantic effect.
+        "read_uncommitted",
+        # ``query_only`` is meant to reject writes when ON.  Mini-sqlite
+        # round-trips the value but does NOT yet enforce the read-only
+        # gate — INSERT/UPDATE/DELETE will still execute even when
+        # ``query_only = 1``.  Enforcement is a future increment.
+        "query_only",
     }
     _INT_PRAGMAS = {
         "temp_store",

--- a/code/packages/python/mini-sqlite/tests/test_tier3_pragma_read_uncommitted_and_query_only.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_pragma_read_uncommitted_and_query_only.py
@@ -1,0 +1,148 @@
+"""Tests for ``PRAGMA read_uncommitted`` and ``PRAGMA query_only``.
+
+Both PRAGMAs are recognised as accept-and-store boolean settings
+that round-trip per connection (default ``0``).  Mini-sqlite does
+not honour the underlying semantics — ``read_uncommitted`` selects
+SQLite's shared-cache isolation level (mini-sqlite has no shared
+cache) and ``query_only`` should reject writes when ON (enforcement
+is a future increment).  Callers that read the PRAGMA back to
+confirm settings — common in ORMs and migration tools — see the
+SQLite-compatible values.
+
+Previously mini-sqlite returned ``[]`` for both reads (vs sqlite3's
+``[(0,)]`` default) and silently dropped writes.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match_pragma(*pragmas: str, final_read: str) -> None:
+    """Run a sequence of PRAGMAs then a final read, comparing oracles."""
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    for c in (mini, ref):
+        for p in pragmas:
+            c.execute(p)
+    assert mini.execute(final_read).fetchall() == ref.execute(final_read).fetchall()
+
+
+class TestReadUncommittedDefault:
+    def test_default_is_zero(self) -> None:
+        _both_match_pragma(final_read="PRAGMA read_uncommitted")
+
+
+class TestReadUncommittedSet:
+    def test_set_one(self) -> None:
+        _both_match_pragma(
+            "PRAGMA read_uncommitted = 1",
+            final_read="PRAGMA read_uncommitted",
+        )
+
+    def test_set_zero(self) -> None:
+        _both_match_pragma(
+            "PRAGMA read_uncommitted = 1",
+            "PRAGMA read_uncommitted = 0",
+            final_read="PRAGMA read_uncommitted",
+        )
+
+    def test_set_on(self) -> None:
+        _both_match_pragma(
+            "PRAGMA read_uncommitted = ON",
+            final_read="PRAGMA read_uncommitted",
+        )
+
+    def test_set_off(self) -> None:
+        _both_match_pragma(
+            "PRAGMA read_uncommitted = ON",
+            "PRAGMA read_uncommitted = OFF",
+            final_read="PRAGMA read_uncommitted",
+        )
+
+
+class TestQueryOnlyDefault:
+    def test_default_is_zero(self) -> None:
+        _both_match_pragma(final_read="PRAGMA query_only")
+
+
+class TestQueryOnlySet:
+    def test_set_one(self) -> None:
+        _both_match_pragma(
+            "PRAGMA query_only = 1",
+            final_read="PRAGMA query_only",
+        )
+
+    def test_set_zero(self) -> None:
+        _both_match_pragma(
+            "PRAGMA query_only = 1",
+            "PRAGMA query_only = 0",
+            final_read="PRAGMA query_only",
+        )
+
+    def test_set_true(self) -> None:
+        _both_match_pragma(
+            "PRAGMA query_only = TRUE",
+            final_read="PRAGMA query_only",
+        )
+
+    def test_set_false(self) -> None:
+        _both_match_pragma(
+            "PRAGMA query_only = TRUE",
+            "PRAGMA query_only = FALSE",
+            final_read="PRAGMA query_only",
+        )
+
+
+class TestPragmaListContains:
+    """Both must be advertised in PRAGMA pragma_list."""
+
+    def test_read_uncommitted_in_pragma_list(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        names = {r[0] for r in m.execute("PRAGMA pragma_list").fetchall()}
+        assert "read_uncommitted" in names
+
+    def test_query_only_in_pragma_list(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        names = {r[0] for r in m.execute("PRAGMA pragma_list").fetchall()}
+        assert "query_only" in names
+
+
+class TestConnectionIsolation:
+    """Each connection carries its own state."""
+
+    def test_read_uncommitted_isolation(self) -> None:
+        a = mini_sqlite.connect(":memory:")
+        b = mini_sqlite.connect(":memory:")
+        a.execute("PRAGMA read_uncommitted = 1")
+        assert b.execute("PRAGMA read_uncommitted").fetchall() == [(0,)]
+        assert a.execute("PRAGMA read_uncommitted").fetchall() == [(1,)]
+
+    def test_query_only_isolation(self) -> None:
+        a = mini_sqlite.connect(":memory:")
+        b = mini_sqlite.connect(":memory:")
+        a.execute("PRAGMA query_only = 1")
+        assert b.execute("PRAGMA query_only").fetchall() == [(0,)]
+        assert a.execute("PRAGMA query_only").fetchall() == [(1,)]
+
+
+class TestQueryOnlyEnforcementNotIncluded:
+    """Document the scope limit: ``query_only`` does NOT yet block writes.
+
+    SQLite raises ``OperationalError: attempt to write a readonly
+    database`` when ``query_only = 1`` and a write is attempted.
+    Mini-sqlite currently allows the write through — enforcement is
+    deferred to a future increment.  Pin the current behaviour so a
+    future fix that wires the gate is detected (the test will need
+    updating then, with a matching CHANGELOG note).
+    """
+
+    def test_query_only_does_not_block_writes_yet(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        m.execute("CREATE TABLE t (a INT)")
+        m.execute("PRAGMA query_only = 1")
+        # Currently no error — mini-sqlite does not enforce read-only mode.
+        m.execute("INSERT INTO t VALUES (1)")
+        assert m.execute("SELECT * FROM t").fetchall() == [(1,)]


### PR DESCRIPTION
## Summary

- Adds `PRAGMA read_uncommitted` and `PRAGMA query_only` as recognised boolean PRAGMAs (default `0`, settable, round-trip per connection).
- Previously both returned `[]` (vs sqlite3's `[(0,)]` default) and silently dropped writes.
- Two entries in `_PRAGMA_DEFAULTS` + two in `_BOOL_PRAGMAS` — existing scalar handler covers everything else, and `pragma_list` auto-picks them up.

## Scope limits (documented in CHANGELOG + tests)

- `read_uncommitted` controls SQLite's shared-cache isolation; mini-sqlite has no shared cache so the value has no semantic effect.
- `query_only = 1` should reject writes in SQLite. Mini-sqlite does NOT yet enforce the read-only gate — pinned by an explicit regression test that documents the current divergence so a future enforcement PR can update it.

## Version bump

- `mini-sqlite`: 2.12 → 2.13

## Test plan

- [x] 15 new oracle tests pass (defaults, integer set/get, keyword set/get, pragma_list inclusion, per-connection isolation, scope-limit pin for query_only non-enforcement)
- [x] mini-sqlite suite (2295 tests) clean
- [x] Ruff clean
- [x] Security review passed — pure value-round-trip change, no new write authorization gate introduced (writes were always unrestricted in mini-sqlite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)