### PR TITLE
feat(cas-summation): Phase 57 — bounded × Log × Sqrt combination (1.5.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.5.0 — 2026-05-23
+
+**Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator
+(Python).**
+
+Closes the mixed sub-polynomial gap deferred in Phase 55 and Phase 56.
+Numerator combines Log (sub-polynomial), Sqrt (half-polynomial), and
+optional bounded factors.  Effective growth ``log(k)·k^{deg(P)/2}``
+strictly dominated by ``k^{deg(P)/2+ε}`` for any ``ε > 0``.
+
+### Added
+
+- **``_bounded_log_sqrt_inner_deg``** — requires exactly one Log AND
+  exactly one Sqrt; one-only patterns fall through to Phase 55 / 56.
+  Two-of-either refused.
+
+### Tests
+
+7 new ``TestEvaluateSumPhase57BoundedLogSqrtNumerator`` cases.
+Full suite: **133 passed** (was 126; +7).
+
 ## 1.4.0 — 2026-05-23
 
 **Phase 56 — Bounded × Sqrt(diverging) numerator pattern (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.4.0"
+version = "1.5.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -780,6 +780,21 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
             # for any ``m`` since ``Exp / Pow(b>1, …)`` grows faster
             # than any polynomial, hence faster than any half-degree.
             return True
+    # Phase 57: ``Mul(bounded..., Log(diverging), Sqrt(positive-poly))``
+    # numerator pattern.  Combines sub-polynomial Log growth with half-
+    # polynomial Sqrt growth.  Effective ``log(k) · k^{deg(P)/2}`` is
+    # strictly dominated by ``k^{deg(P)/2 + ε}`` for any ``ε > 0``.
+    # Vanishes when ``2·den_deg > deg(P)`` (polynomial) or non-polynomial
+    # diverging denominator.  Requires both Log and Sqrt — one-only
+    # patterns fall through to Phase 55 / Phase 56.
+    bls_sqrt_deg = _bounded_log_sqrt_inner_deg(num, k)
+    if bls_sqrt_deg is not None:
+        den_deg_bls = _polynomial_degree_in_k(den, k)
+        if den_deg_bls is not None:
+            if 2 * den_deg_bls > bls_sqrt_deg:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1140,6 +1155,50 @@ def _bounded_times_sqrt_inner_deg(node: IRNode, k: IRSymbol) -> int | None:
         if _is_bounded_in_k(arg, k):
             continue
         # Neither Sqrt(positive-poly) nor bounded → unrecognised.
+        return None
+    return sqrt_inner_deg
+
+
+def _bounded_log_sqrt_inner_deg(node: IRNode, k: IRSymbol) -> int | None:
+    """Return the ``Sqrt`` inner polynomial degree (×2) when ``node`` is a
+    ``Mul`` with exactly one ``Log(diverging)`` factor, exactly one
+    ``Sqrt(positive-leading polynomial)`` factor, and any number of
+    bounded factors; ``None`` otherwise.
+
+    Phase 57 — Combines the sub-polynomial growth of ``Log`` with the
+    half-polynomial growth of ``Sqrt(P)``.  Effective growth
+    ``log(k)·k^{deg(P)/2}`` is strictly dominated by ``k^{deg(P)/2+ε}``
+    for any ``ε > 0`` since ``log(k) = o(k^ε)``.  Caller compares
+    ``2·den_deg > deg(P)``.
+
+    Requires **both** Log and Sqrt — patterns with only one fall
+    through to Phase 55 (bounded × Log) or Phase 56 (bounded × Sqrt).
+    Two-of-either is refused (conservative, would need combined
+    growth-rate logic).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count = 0
+    sqrt_inner_deg: int | None = None
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 1:
+                # Two or more Log factors — refuse.
+                return None
+            continue
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_inner_deg is not None:
+                # Two Sqrt factors — refuse.
+                return None
+            sqrt_inner_deg = deg_x2
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor.
+        return None
+    if log_count != 1 or sqrt_inner_deg is None:
         return None
     return sqrt_inner_deg
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -6,6 +6,7 @@ from symbolic_ir import (
     ADD,
     DIV,
     GAMMA_FUNC,
+    LOG,
     MUL,
     POW,
     PRODUCT,
@@ -1886,3 +1887,135 @@ class TestEvaluateSumPhase56BoundedTimesSqrtNumerator:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         # Phase 56 conservative: refuses two-sqrt patterns.
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+# ---------------------------------------------------------------------------
+# Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase57BoundedLogSqrtNumerator:
+    def test_sin_log_sqrt_over_k_squared_closes(self):
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_sqrt_only_over_k_squared_closes(self):
+        from symbolic_ir import POW, SQRT, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (log_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_cos_log_sqrt_k_cubed_over_k_squared_closes(self):
+        from symbolic_ir import COS, POW, SQRT, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (cos_k, log_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (cos_kp1, log_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_bounded_log_sqrt_over_exponential_closes(self):
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_sqrt_k_cubed_over_k_refused(self):
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_two_log_factors_refused(self):
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        log_kp1_inner = IRApply(LOG, (IRApply(ADD, (_k, IRInteger(1))),))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, log_kp1_inner, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp2 = IRApply(LOG, (IRApply(ADD, (kp1, IRInteger(1))),))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, log_kp2, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_no_sqrt_falls_through_to_phase55(self):
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Phase 55 catches this (bounded × Log).
+        assert not (isinstance(result, IRApply) and result.head == SUM)


### PR DESCRIPTION
## Summary

Closes the long-deferred mixed sub-polynomial gap noted in Phase 55
and Phase 56.  Recognises ``Div(Mul(bounded..., Log(h), Sqrt(P)), den)``
shapes where the numerator combines:

- ``Log(h(k))`` — sub-polynomial growth (``o(k^ε)`` for any ``ε > 0``)
- ``Sqrt(P(k))`` — half-polynomial growth (``k^{deg(P)/2}``)
- bounded factors — uniformly ``≤ C``

Effective growth is ``log(k) · k^{deg(P)/2}``, strictly dominated by
``k^{deg(P)/2 + ε}`` for any positive ``ε``.  Quotient vanishes when:
- polynomial denominator with ``2·den_deg > deg(P)``, OR
- non-polynomial diverging denominator (Exp / Pow / Log×poly).

Bumps ``cas-summation`` 1.3.0 → 1.5.0 (skipping 1.4.0 reserved for the
in-flight PR #4167 / #4171 — Phase 56 ports).

### Added

| Function | Returns |
|---|---|
| ``_bounded_log_sqrt_inner_deg`` | ``deg(P)`` for ``Mul`` with **exactly one** Log AND **exactly one** Sqrt; ``None`` otherwise |

### Test plan

- [x] ``pytest tests/ -k phase57`` → 7 passed
- [x] ``pytest tests/`` → 133 passed (was 126; +7)
- [x] No regressions; Phase 55 path verified unchanged when no Sqrt
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

### Stacks on

- PR #4167 (Phase 56 Python) — independent codewise (Phase 57 requires
  **both** Log and Sqrt; Phase 56 handles Sqrt-only)
- PR #4171 (Phase 56 TS+Rust port) — independent

### Still deferred

- Two-Log or two-Sqrt patterns (combined growth-rate logic).
- Cross-language port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)