### PR TITLE
feat(cas-summation): Phase 57 — bounded × Log × Sqrt combination (TS+Rust port, 1.5.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog
 
+## 1.5.0 — 2026-05-23
+
+**Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator
+(Python).**
+
+Closes the long-deferred mixed sub-polynomial gap noted in Phase 55
+and Phase 56 CHANGELOGs.  Recognises ``Div(Mul(bounded..., Log(h),
+Sqrt(P)), den)`` shapes where the numerator combines:
+
+- ``Log(h(k))`` — sub-polynomial growth (``o(k^ε)`` for any ``ε > 0``)
+- ``Sqrt(P(k))`` — half-polynomial growth (``k^{deg(P)/2}``)
+- bounded factors — uniformly ``≤ C``
+
+The effective growth rate is therefore ``log(k) · k^{deg(P)/2}``,
+strictly dominated by ``k^{deg(P)/2 + ε}`` for any positive ``ε`` —
+which means a denominator with ``den_deg > deg(P)/2`` (i.e.
+``2·den_deg > deg(P)``) wins, and the quotient vanishes.  Non-
+polynomial diverging denominators (Exp / Pow / Log×poly) dominate
+automatically.
+
+This complements:
+- Phase 55 (bounded × Log) — when no Sqrt factor present
+- Phase 56 (bounded × Sqrt — when ports land) — when no Log factor
+
+> Note: stacks on PR #4167 (Phase 56 Python) and PR #4171
+> (Phase 56 TS+Rust port).  Phase 57 builds on the existing
+> Phase 55 helpers in main; the implementation is independent of
+> Phase 56's helper since Phase 57 requires **both** Log and Sqrt
+> (Phase 56's "Sqrt without Log" case is distinct).
+
+Bumps cas-summation 1.3.0 → 1.5.0 (skipping 1.4.0 reserved for PR
+#4167, in flight).
+
+### Added
+
+- **``_bounded_log_sqrt_inner_deg(node, k) -> int | None``** —
+  Phase 57 helper.  Returns ``deg(P)`` (×2 half-degree, matching the
+  Phase 51 / 53 / 56 idiom) when ``node`` is a ``Mul`` with:
+
+    1. exactly one ``Log(diverging)`` factor (refuse if two+)
+    2. exactly one ``Sqrt(positive-leading polynomial)`` factor
+       (refuse if two+ or negative-leading inner)
+    3. any number of bounded factors (zero is OK)
+    4. no other factors (any unrecognised factor → ``None``)
+
+  Returns ``None`` when the Log XOR Sqrt requirement isn't met, so
+  Phase 55 (bounded × Log only) and the future Phase 56 (bounded ×
+  Sqrt only) handle those cases.
+
+### Changed
+
+- ``_g_vanishes_at_infinity`` adds a Phase 57 branch between
+  Phase 55 (bounded × Log) and the Phase 42 polynomial widening.
+  Same dispatch shape as Phase 51 / 53 / 56: compare ``2 × den_deg``
+  to ``sqrt_inner_deg`` for polynomial denominators, or short-circuit
+  on non-polynomial divergence.
+
+### Added — tests
+
+`tests/test_summation.py::TestEvaluateSumPhase57BoundedLogSqrtNumerator`
+— 7 new cases:
+
+- ``test_sin_log_sqrt_over_k_squared_closes`` — 1/2 < 2.
+- ``test_log_sqrt_only_over_k_squared_closes`` — bounded factors
+  not required.
+- ``test_cos_log_sqrt_k_cubed_over_k_squared_closes`` — 3/2 < 2
+  (tight margin).
+- ``test_bounded_log_sqrt_over_exponential_closes`` — exponential
+  denominator dominates sub-polynomial growth.
+- ``test_sin_log_sqrt_k_cubed_over_k_refused`` — 3/2 > 1: no vanish.
+- ``test_two_log_factors_refused`` — conservative.
+- ``test_no_sqrt_falls_through`` — Phase 55 picks up the slack
+  (``sin·log/k²`` still closes via the existing bounded × Log branch).
+
+Total: **133 tests** (was 126; +7 net new), no regressions.
+
+### Still deferred
+
+- Two-Log or two-Sqrt patterns (would need combined growth-rate
+  logic across multiple factors of the same family).
+- Cross-language port to TypeScript / Rust.
+
 ## 1.3.0 — 2026-05-23
 
 **Phase 55 — Bounded×Log(diverging) numerator pattern (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.3.0"
+version = "1.5.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -759,6 +759,22 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     # Any strictly diverging denominator therefore dominates.
     if _is_bounded_times_log_in_k(num, k) and _h_diverges_at_infinity(den, k):
         return True
+    # Phase 57: ``Mul(bounded..., Log(diverging), Sqrt(positive-poly))``
+    # numerator pattern.  Combines the sub-polynomial growth of ``Log``
+    # with the half-polynomial growth of ``Sqrt(P)``.  Effective growth
+    # is dominated by ``k^{deg(P)/2}`` because ``log(k) = o(k^ε)`` for
+    # any ``ε > 0``.  The quotient vanishes when the denominator grows
+    # strictly faster than ``k^{deg(P)/2}`` — either polynomially
+    # (``2·den_deg > deg(P)``) or transcendentally (any non-polynomial
+    # diverging shape).
+    bls_sqrt_deg = _bounded_log_sqrt_inner_deg(num, k)
+    if bls_sqrt_deg is not None:
+        den_deg_bls = _polynomial_degree_in_k(den, k)
+        if den_deg_bls is not None:
+            if 2 * den_deg_bls > bls_sqrt_deg:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1066,6 +1082,81 @@ def _is_bounded_times_log_in_k(node: IRNode, k: IRSymbol) -> bool:
         # Factor is neither Log(diverging) nor bounded — unrecognised.
         return False
     return log_count == 1
+
+
+def _bounded_log_sqrt_inner_deg(node: IRNode, k: IRSymbol) -> int | None:
+    """Return the ``Sqrt`` inner polynomial degree (×2) when ``node`` is a
+    ``Mul`` with exactly one ``Log(diverging)`` factor, exactly one
+    ``Sqrt(positive-leading polynomial)`` factor, and any number of
+    bounded factors; ``None`` otherwise.
+
+    Phase 57 — Combines the sub-polynomial growth of ``Log`` with the
+    half-polynomial growth of ``Sqrt(P)``.  Effective growth is
+    ``log(k)·k^{deg(P)/2}``, which is dominated by ``k^{deg(P)/2 + ε}``
+    for any ``ε > 0`` since ``log(k) = o(k^ε)``.  For the strict
+    inequality, the denominator must satisfy ``2·den_deg > deg(P)`` (i.e.
+    ``den_deg > deg(P)/2``).
+
+    Returns ``deg(P)`` (×2 to stay in integer arithmetic, matching the
+    Phase 51 / 53 / 56 idiom) so callers compare against ``2·den_deg``.
+
+    Requires **both** a Log factor and a Sqrt factor — patterns with only
+    one of them are handled by:
+      - Phase 50 (bare Log)
+      - Phase 51 (bare Sqrt)
+      - Phase 55 (bounded × Log)
+      - Phase 56 (bounded × Sqrt — when that ports lands; see PR #4167)
+
+    +---------------------------------------------------+----------+
+    | Input                                             | Return   |
+    +===================================================+==========+
+    | ``Mul(Sin(k), Log(k), Sqrt(k))``                  | ``1``    |
+    | ``Mul(Cos(k), Log(k+1), Sqrt(k³))``               | ``3``    |
+    | ``Mul(Sin(k), Cos(k), Log(k), Sqrt(k²))``         | ``2``    |
+    | ``Mul(Log(k), Sqrt(k))``                          | ``1``    |
+    | ``Mul(Sin(k), Log(k))``  (no Sqrt)                | ``None`` |
+    | ``Mul(Sin(k), Sqrt(k))`` (no Log)                 | ``None`` |
+    | ``Mul(Log(k), Log(k), Sqrt(k))`` (two Log)        | ``None`` |
+    | ``Mul(Log(k), Sqrt(k), Sqrt(k))`` (two Sqrt)      | ``None`` |
+    | ``Mul(k, Log(k), Sqrt(k))`` (k not bounded)       | ``None`` |
+    | ``Mul(Sin(k), Log(k), Sqrt(-k))`` (negative poly) | ``None`` |
+    +---------------------------------------------------+----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → record (refuse a second).
+         - ``Sqrt(positive-poly)`` → record ×2 degree (refuse a second).
+         - ``bounded_in_k`` → accept.
+         - otherwise → return ``None``.
+      3. Require **exactly one** Log AND **exactly one** Sqrt; otherwise ``None``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count = 0
+    sqrt_inner_deg: int | None = None
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 1:
+                # Two or more Log factors — refuse (would need a
+                # combined growth-rate calculation we haven't justified).
+                return None
+            continue
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_inner_deg is not None:
+                # Two Sqrt factors — refuse.
+                return None
+            sqrt_inner_deg = deg_x2
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor.
+        return None
+    if log_count != 1 or sqrt_inner_deg is None:
+        return None
+    return sqrt_inner_deg
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -6,6 +6,7 @@ from symbolic_ir import (
     ADD,
     DIV,
     GAMMA_FUNC,
+    LOG,
     MUL,
     POW,
     PRODUCT,
@@ -1758,3 +1759,154 @@ class TestEvaluateSumPhase55BoundedTimesLogNumerator:
         assert isinstance(result, IRApply) and result.head == SUM, (
             f"Phase 55: constant denominator should stay unevaluated; got {result!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator.
+#
+# Closes the deferred mixed sub-polynomial gap from Phase 55/56: shapes
+# like sin(k)·log(k)·sqrt(k)/k² where Log and Sqrt are both present.
+# Effective growth = sqrt half-degree (Log contributes sub-polynomially).
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase57BoundedLogSqrtNumerator:
+    def test_sin_log_sqrt_over_k_squared_closes(self):
+        """``sin(k)·log(k)·sqrt(k)/k²``: half-deg 1/2 < 2 → vanishes."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM), (
+            f"Phase 57 should close; got {result!r}"
+        )
+
+    def test_log_sqrt_only_over_k_squared_closes(self):
+        """``log(k)·sqrt(k)/k²``: no bounded factor, but Log and Sqrt
+        both present → Phase 57 still fires."""
+        from symbolic_ir import POW, SQRT, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (log_k, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_cos_log_sqrt_k_cubed_over_k_squared_closes(self):
+        """``cos(k)·log(k)·sqrt(k³)/k²``: half-deg 3/2 < 2 (tight margin)."""
+        from symbolic_ir import COS, POW, SQRT, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (cos_k, log_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (cos_kp1, log_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_bounded_log_sqrt_over_exponential_closes(self):
+        """``sin(k)·log(k)·sqrt(k³)/2^k``: exponential dominates."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_sqrt_k_cubed_over_k_refused(self):
+        """``sin(k)·log(k)·sqrt(k³)/k``: half-deg 3/2 > deg 1 → does NOT
+        vanish.  Phase 57 must refuse.
+        """
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k3 = IRApply(SQRT, (IRApply(POW, (_k, IRInteger(3))),))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (IRApply(POW, (kp1, IRInteger(3))),))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_two_log_factors_refused(self):
+        """``sin(k)·log(k)·log(k+1)·sqrt(k)/k²``: two Log factors → refused."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        log_kp1_inner = IRApply(LOG, (IRApply(ADD, (_k, IRInteger(1))),))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, log_kp1_inner, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp2 = IRApply(LOG, (IRApply(ADD, (kp1, IRInteger(1))),))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, log_kp2, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Phase 57 conservative: refuses two-Log patterns.
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_no_sqrt_falls_through(self):
+        """``sin(k)·log(k)/k²``: no Sqrt factor → Phase 57 declines, but
+        Phase 55 catches it (bounded × Log).  End-to-end still closes.
+        """
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(2)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        # Phase 55 handles this case — pin the chain still closes.
+        assert not (isinstance(result, IRApply) and result.head == SUM)

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.5.0 — 2026-05-23
+
+**Phase 57 — Bounded × Log × Sqrt combination (Rust port).**
+
+Ports Python ``cas-summation`` 1.5.0 (PR #4215).  Combines Log
+(sub-polynomial) and Sqrt (half-polynomial) growth.
+
+### Added
+
+- **`bounded_log_sqrt_inner_deg(node, k) -> Option<i64>`** — returns
+  ``deg(P)`` (×2 half-degree) for ``Mul`` with exactly one Log AND
+  exactly one Sqrt(positive-poly), plus any bounded factors.
+  Returns ``None`` for one-only patterns or two-of-either.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds Phase 57 branch after Phase 56,
+  comparing ``2 * den_deg > deg(P)`` for polynomial denominators or
+  short-circuiting on non-polynomial divergence.
+
+### Tests
+
+4 new ``phase57_*`` cases.  Full suite: **73 passed** (was 69; +4).
+
 ## 1.4.0 — 2026-05-23
 
 **Phase 56 — Bounded × Sqrt(diverging) numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.4.0 — 2026-05-23
+
+**Phase 56 — Bounded × Sqrt(diverging) numerator pattern (Rust port).**
+
+Ports Python ``cas-summation`` 1.4.0 (PR #4167).  Bounded × sqrt
+analogue of Phase 55's bounded × log.
+
+### Added
+
+- **`bounded_times_sqrt_inner_deg(node, k) -> Option<i64>`** —
+  returns ``deg(P)`` (×2 half-degree to stay in i64 arithmetic) for
+  ``Mul`` of exactly one ``Sqrt(positive-poly)`` factor and rest
+  bounded.  Returns ``None`` for the no-Sqrt case, two-Sqrt case
+  (conservative), or unrecognised factors.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds Phase 56 branch after Phase 55,
+  comparing ``2 * den_deg > deg(P)`` for polynomial denominators or
+  short-circuiting on non-polynomial divergence.
+
+### Tests
+
+3 new ``phase56_*`` cases.  Full suite: **69 passed** (was 66; +3).
+
 ## 1.3.0 — 2026-05-23
 
 **Phase 55 — Bounded×Log(diverging) numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1171,6 +1171,41 @@ fn is_bounded_times_log_in_k(node: &IRNode, k: &IRNode) -> bool {
     log_count == 1
 }
 
+/// Phase 56 (Rust port): Return the ``Sqrt`` inner polynomial degree
+/// (×2 to stay exact) when ``node`` is a ``Mul`` with exactly one
+/// ``Sqrt(positive-leading polynomial)`` factor and all remaining
+/// factors bounded in ``k``; ``None`` otherwise.
+///
+/// Mirror of ``is_bounded_times_log_in_k`` for sqrt instead of log.
+/// Returns ``deg(P)`` (= 2 × half-degree) so callers can compare with
+/// ``2 * den_deg`` in integer arithmetic.
+fn bounded_times_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut sqrt_inner_deg: Option<i64> = None;
+    for arg in &apply_node.args {
+        if let Some(deg) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_inner_deg.is_some() {
+                // Two Sqrt factors — refuse (conservative).
+                return None;
+            }
+            sqrt_inner_deg = Some(deg);
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Neither Sqrt(positive-poly) nor bounded → unrecognised.
+        return None;
+    }
+    sqrt_inner_deg
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1247,6 +1282,19 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     // the numerator's effective polynomial degree is 0 (no polynomial factor).
     if is_bounded_times_log_in_k(num, k) && h_diverges_at_infinity(den, k) {
         return true;
+    }
+    // Phase 56: Mul(bounded, Sqrt(positive-poly)) numerator pattern.
+    // Effective growth ``deg(P)/2``; closes when:
+    //   - polynomial denominator with ``2 * den_deg > deg(P)``, OR
+    //   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+    if let Some(sqrt_inner_deg) = bounded_times_sqrt_inner_deg(num, k) {
+        if let Some(den_deg_bs) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_bs > sqrt_inner_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
     }
     // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
     let num_deg = match polynomial_degree_in_k(num, k) {

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1206,6 +1206,58 @@ fn bounded_times_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
     sqrt_inner_deg
 }
 
+/// Phase 57 (Rust port): Return the ``Sqrt`` inner polynomial degree
+/// (×2) when ``node`` is a ``Mul`` with exactly one
+/// ``Log(diverging)`` factor, exactly one
+/// ``Sqrt(positive-leading polynomial)`` factor, and any number of
+/// bounded factors; ``None`` otherwise.
+///
+/// Combines sub-polynomial Log growth with half-polynomial Sqrt
+/// growth.  Effective growth ``log(k) · k^{deg(P)/2}`` is strictly
+/// dominated by ``k^{deg(P)/2 + ε}`` for any ``ε > 0``.  Caller
+/// compares ``2 * den_deg > deg(P)`` (i.e. ``den_deg > deg(P)/2``).
+///
+/// Requires **both** Log and Sqrt; one-only patterns are handled by
+/// Phase 55 (bounded × Log) or Phase 56 (bounded × Sqrt).
+fn bounded_log_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut log_count = 0usize;
+    let mut sqrt_inner_deg: Option<i64> = None;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 1 {
+                // Two or more Log factors — refuse.
+                return None;
+            }
+            continue;
+        }
+        if let Some(deg) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_inner_deg.is_some() {
+                // Two Sqrt factors — refuse.
+                return None;
+            }
+            sqrt_inner_deg = Some(deg);
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Unrecognised factor.
+        return None;
+    }
+    if log_count != 1 {
+        return None;
+    }
+    sqrt_inner_deg
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1290,6 +1342,21 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(sqrt_inner_deg) = bounded_times_sqrt_inner_deg(num, k) {
         if let Some(den_deg_bs) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_bs > sqrt_inner_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 57: Mul(bounded..., Log(diverging), Sqrt(positive-poly))
+    // numerator — combines sub-polynomial Log with half-polynomial
+    // Sqrt.  Effective growth ``log(k)·k^{deg(P)/2}`` strictly
+    // dominated by ``k^{deg(P)/2 + ε}``.  Closes when
+    // ``2 * den_deg > deg(P)`` (polynomial) or denominator is
+    // non-polynomial diverging.  Requires both Log and Sqrt.
+    if let Some(sqrt_inner_deg) = bounded_log_sqrt_inner_deg(num, k) {
+        if let Some(den_deg_bls) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_bls > sqrt_inner_deg {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1346,3 +1346,63 @@ fn phase55_bounded_times_log_constant_denominator_stays() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 56 (Rust port): bounded × Sqrt(diverging) numerator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase56_sin_times_sqrt_k_over_k_squared_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase56_sin_times_sqrt_k_cubed_over_exponential_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1_3]);
+    // Denominator is 2^k — exponential, dominates polynomial of any degree.
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase56_sin_times_sqrt_k_cubed_over_k_refused() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k.clone()]),
+        apply(sym(DIV), vec![num_kp1, kp1]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    // 3/2 > 1 → does not vanish.
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1406,3 +1406,86 @@ fn phase56_sin_times_sqrt_k_cubed_over_k_refused() {
     // 3/2 > 1 → does not vanish.
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 57 (Rust port): bounded × Log(diverging) × Sqrt(positive-poly).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase57_sin_log_sqrt_over_k_squared_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase57_log_sqrt_only_over_k_squared_closes() {
+    let k = sym("k");
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k, sqrt_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1, sqrt_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase57_sin_log_sqrt_k_cubed_over_exponential_closes() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase57_sin_log_sqrt_k_cubed_over_k_refused() {
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k.clone()]),
+        apply(sym(DIV), vec![num_kp1, kp1]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    // 3/2 > 1 → does not vanish.
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.4.0 — 2026-05-23
+
+**Phase 56 — Bounded × Sqrt(diverging) numerator pattern (TypeScript port).**
+
+Ports Python ``cas-summation`` 1.4.0 (PR #4167).  Bounded × sqrt
+analogue of Phase 55's bounded × log.  Effective growth degree is
+``deg(P)/2``; quotient vanishes when ``denDeg > deg(P)/2``
+(polynomial) or denominator is non-polynomial diverging.
+
+### Added
+
+- **`boundedTimesSqrtHalfDegree(node, k)`** — returns ``deg(P)/2``
+  (half-degree) for ``Mul`` of exactly one ``Sqrt(positive-poly)``
+  factor and rest bounded.  Returns ``undefined`` for the no-Sqrt
+  case, two-Sqrt case (conservative), or unrecognised factors.
+
+### Changed
+
+- ``gVanishesAtInfinity`` adds Phase 56 branch after Phase 55, with
+  two denominator sub-cases (polynomial ``denDeg > halfDeg`` OR
+  non-polynomial diverging dominates).
+
+### Tests
+
+3 new ``summation: Phase 56 bounded × sqrt numerator`` cases.
+Full suite: **69 passed** (was 66; +3).
+
 ## 1.3.0 — 2026-05-23
 
 **Phase 55 — Bounded×Log(diverging) numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.5.0 — 2026-05-23
+
+**Phase 57 — Bounded × Log × Sqrt combination (TypeScript port).**
+
+Ports Python ``cas-summation`` 1.5.0 (PR #4215).  Combines Log
+(sub-polynomial) and Sqrt (half-polynomial) growth.  Effective
+growth ``log(k)·k^{deg(P)/2}`` is strictly dominated by
+``k^{deg(P)/2 + ε}`` for any ``ε > 0``.
+
+### Added
+
+- **`boundedLogSqrtHalfDegree(node, k)`** — returns ``deg(P)/2`` for
+  ``Mul`` with exactly one ``Log(diverging)`` factor, exactly one
+  ``Sqrt(positive-poly)`` factor, and any number of bounded factors.
+  Returns ``undefined`` for one-only patterns (Phase 55 / Phase 56
+  handle those) or two-of-either (conservative).
+
+### Changed
+
+- ``gVanishesAtInfinity`` adds Phase 57 branch after Phase 56.
+
+### Tests
+
+4 new ``summation: Phase 57 bounded × Log × Sqrt numerator`` cases.
+Full suite: **73 passed** (was 69; +4).
+
 ## 1.4.0 — 2026-05-23
 
 **Phase 56 — Bounded × Sqrt(diverging) numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -912,6 +912,62 @@ function boundedTimesSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined
   return sqrtHalfDeg;
 }
 
+/**
+ * Phase 57 (TypeScript port): Return the ``Sqrt`` inner half-degree
+ * when ``node`` is a ``Mul`` with exactly one ``Log(diverging)`` factor,
+ * exactly one ``Sqrt(positive-leading polynomial)`` factor, and any
+ * number of bounded factors; ``undefined`` otherwise.
+ *
+ * Combines the sub-polynomial growth of ``Log`` with the half-
+ * polynomial growth of ``Sqrt``.  Effective growth is
+ * ``log(k) · k^{deg(P)/2}``, strictly dominated by
+ * ``k^{deg(P)/2 + ε}`` for any ``ε > 0``.  Caller compares
+ * ``denDeg > halfDeg``.
+ *
+ * Requires **both** Log and Sqrt — patterns with only one fall
+ * through to Phase 55 (bounded × Log) or Phase 56 (bounded × Sqrt).
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Log(diverging)`` → record (refuse a second).
+ *      - ``Sqrt(positive-poly)`` → record half-deg (refuse a second).
+ *      - ``bounded`` → accept.
+ *      - otherwise → return undefined.
+ *   3. Require exactly one Log AND exactly one Sqrt.
+ */
+function boundedLogSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let sqrtHalfDeg: number | undefined;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 1) {
+        // Two or more Log factors — refuse.
+        return undefined;
+      }
+      continue;
+    }
+    const sqrtDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (sqrtDeg !== undefined) {
+      if (sqrtHalfDeg !== undefined) {
+        // Two Sqrt factors — refuse.
+        return undefined;
+      }
+      sqrtHalfDeg = sqrtDeg;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Unrecognised factor.
+    return undefined;
+  }
+  if (logCount !== 1 || sqrtHalfDeg === undefined) return undefined;
+  return sqrtHalfDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -991,6 +1047,24 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBs = polynomialDegreeInK(den, k);
     if (denDegBs !== undefined) {
       if (denDegBs > sqrtBoundedHalfDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 57: Mul(bounded..., Log(diverging), Sqrt(positive-poly))
+  // numerator pattern — combines sub-polynomial Log growth with
+  // half-polynomial Sqrt growth.  Effective growth log(k)·k^{deg(P)/2}
+  // is strictly dominated by k^{deg(P)/2 + ε} for any ε > 0.  Vanishes
+  // when denDeg > halfDeg (polynomial) or denominator is non-polynomial
+  // diverging.  Requires both Log and Sqrt (Phase 55 / Phase 56 handle
+  // the one-only cases).
+  const bls_halfDeg = boundedLogSqrtHalfDegree(num, k);
+  if (bls_halfDeg !== undefined) {
+    const denDegBls = polynomialDegreeInK(den, k);
+    if (denDegBls !== undefined) {
+      if (denDegBls > bls_halfDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -869,6 +869,49 @@ function isBoundedTimesLogInK(node: IRNode, k: IRNode): boolean {
   return logCount === 1;
 }
 
+/**
+ * Phase 56 (TypeScript port): Return the ``Sqrt`` inner half-degree
+ * when ``node`` is a ``Mul`` with exactly one
+ * ``Sqrt(positive-leading polynomial)`` factor and all remaining
+ * factors bounded in ``k``; ``undefined`` otherwise.
+ *
+ * Mirror of :func:`isBoundedTimesLogInK` but for sqrt instead of log.
+ * Returns the half-degree directly (Phase 51's
+ * ``sqrtEffectiveHalfDegree`` already returns the half value in TS),
+ * so the caller compares ``denDeg > sqrtHalfDeg`` directly.
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Sqrt(positive-leading polynomial)`` → record its half-deg;
+ *        refuse if a second sqrt appears.
+ *      - ``bounded`` → accept.
+ *      - otherwise → return undefined.
+ *   3. Require exactly one sqrt factor.
+ */
+function boundedTimesSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  for (const arg of node.args) {
+    const deg = sqrtEffectiveHalfDegree(arg, k);
+    if (deg !== undefined) {
+      if (sqrtHalfDeg !== undefined) {
+        // Two Sqrt factors — refuse (conservative, would need
+        // combined growth-rate logic).
+        return undefined;
+      }
+      sqrtHalfDeg = deg;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Neither Sqrt(positive-poly) nor bounded → unrecognised.
+    return undefined;
+  }
+  return sqrtHalfDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -937,6 +980,22 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   // but log itself is dominated by any polynomial or faster-growing denominator).
   if (isBoundedTimesLogInK(num, k) && hDivergesAtInfinity(den, k)) {
     return true;
+  }
+  // Phase 56: Mul(bounded, Sqrt(positive-poly)) numerator pattern.
+  // Effective growth degree is deg(P)/2.  Vanishes when:
+  //   - denominator is polynomial with deg(den) > deg(P)/2, OR
+  //   - denominator is non-polynomial diverging (Exp / Pow / Log×poly)
+  //     which dominates any sub-polynomial sqrt growth automatically.
+  const sqrtBoundedHalfDeg = boundedTimesSqrtHalfDegree(num, k);
+  if (sqrtBoundedHalfDeg !== undefined) {
+    const denDegBs = polynomialDegreeInK(den, k);
+    if (denDegBs !== undefined) {
+      if (denDegBs > sqrtBoundedHalfDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
   }
   // Phase 42 widening: deg(num) < deg(den) on pure polynomials.
   const numDeg = polynomialDegreeInK(num, k);

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1125,3 +1125,83 @@ describe("summation: Phase 56 bounded × sqrt numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 57 (TS port): bounded × Log(diverging) × Sqrt(positive-poly) numerator.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 57 bounded × Log × Sqrt numerator", () => {
+  it("∑ [sin(k)·log(k)·sqrt(k)/k² − ...] closes (1/2 < 2)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, logK, sqrtK]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [log(k)·sqrt(k)/k² − ...] closes (no bounded factor)", () => {
+    const k = sym("k");
+    const logK = app(LOG, [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [logK, sqrtK]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [logKp1, sqrtKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin·log·sqrt(k³)/2^k − ...] closes (exp dominates)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, logK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin·log·sqrt(k³)/k stays unevaluated (3/2 > 1)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, logK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, k]),
+      app(DIV, [numKp1, kp1]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1067,3 +1067,61 @@ describe("summation: Phase 55 Bounded×Log(diverging) numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 56 (TS port): bounded × Sqrt(diverging) numerator.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 56 bounded × sqrt numerator", () => {
+  it("∑ [sin(k)·sqrt(k)/k² − ...] closes (1/2 < 2)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, sqrtK]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·sqrt(k³)/2^k − ...] closes (sqrt < exp)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin(k)·sqrt(k³)/k stays unevaluated (3/2 > 1)", () => {
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, k]),
+      app(DIV, [numKp1, kp1]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // 3/2 > 1 → does not vanish.
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Phase 57 fix (PR #4215) to TypeScript and Rust.
Combines ``Log`` (sub-polynomial) and ``Sqrt`` (half-polynomial)
growth.  Effective growth ``log(k) · k^{deg(P)/2}`` is strictly
dominated by ``k^{deg(P)/2 + ε}`` for any ``ε > 0``.

Bumps:
- ``@coding-adventures/cas-summation`` 1.4.0 → 1.5.0
- ``cas-summation`` (Rust)             1.4.0 → 1.5.0

### Added (both languages)

| Language | Function | Returns |
|---|---|---|
| TS | ``boundedLogSqrtHalfDegree`` | ``deg(P)/2`` as ``number`` |
| Rust | ``bounded_log_sqrt_inner_deg`` | ``deg(P)`` (×2 half-deg) as ``Option<i64>`` |

Both require exactly one Log AND exactly one Sqrt; one-only patterns
fall through to Phase 55 / Phase 56.

### Test plan

- [x] TS: ``npm test`` → 73 passed (was 69; +4)
- [x] Rust: ``cargo test`` → 73 passed (was 69; +4)
- [x] Security review (Agent) → SECURITY REVIEW PASSED
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)