### PR TITLE
[codex] Add Board VM input callback transport readiness

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -242,6 +242,10 @@ policy.
 transport health records with Rust-owned health names, labels, queue-depth
 metadata, terminal/retry flags, and messages, so frontends can present callback
 transport health without rebuilding diagnostic policy.
+`input_callback_transport_readiness_summary` records that health as stable
+transport readiness records with Rust-owned readiness names, labels,
+queue-depth metadata, terminal/retry flags, and messages, so frontends can gate
+callback transport readiness without rebuilding health policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -2334,6 +2334,100 @@ pub struct LanguageInputCallbackTransportHealthSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportReadinessKind {
+    CallbackRunnerHandoffReadiness,
+    AdapterEventPublicationReadiness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportReadinessSummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub readiness_label: String,
+    pub readiness_kind: LanguageInputCallbackTransportReadinessKind,
+    pub readiness_name: String,
+    pub health_kind: LanguageInputCallbackTransportHealthKind,
+    pub health_name: String,
+    pub diagnostic_kind: LanguageInputCallbackTransportDiagnosticKind,
+    pub diagnostic_name: String,
+    pub completion_kind: LanguageInputCallbackTransportCompletionKind,
+    pub completion_name: String,
+    pub finalization_kind: LanguageInputCallbackTransportFinalizationKind,
+    pub finalization_name: String,
+    pub resolution_kind: LanguageInputCallbackTransportResolutionKind,
+    pub resolution_name: String,
+    pub decision_kind: LanguageInputCallbackTransportDecisionKind,
+    pub decision_name: String,
+    pub logic_kind: LanguageInputCallbackTransportLogicKind,
+    pub logic_name: String,
+    pub reference_kind: LanguageInputCallbackTransportReferenceKind,
+    pub reference_name: String,
+    pub bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+    pub bookmark_name: String,
+    pub cursor_kind: LanguageInputCallbackTransportCursorKind,
+    pub cursor_name: String,
+    pub marker_kind: LanguageInputCallbackTransportMarkerKind,
+    pub marker_name: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub marker_recorded: bool,
+    pub cursor_recorded: bool,
+    pub bookmark_recorded: bool,
+    pub reference_recorded: bool,
+    pub logic_recorded: bool,
+    pub decision_recorded: bool,
+    pub resolution_recorded: bool,
+    pub finalization_recorded: bool,
+    pub completion_recorded: bool,
+    pub diagnostic_recorded: bool,
+    pub health_recorded: bool,
+    pub readiness_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_readiness: u8,
+    pub message: String,
+    pub health_summary: LanguageInputCallbackTransportHealthSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -3107,6 +3201,19 @@ pub const fn input_callback_transport_health_kind_name(
         }
         LanguageInputCallbackTransportHealthKind::AdapterEventPublicationHealth => {
             "adapter_event_publication_health"
+        }
+    }
+}
+
+pub const fn input_callback_transport_readiness_kind_name(
+    kind: LanguageInputCallbackTransportReadinessKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportReadinessKind::CallbackRunnerHandoffReadiness => {
+            "callback_runner_handoff_readiness"
+        }
+        LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness => {
+            "adapter_event_publication_readiness"
         }
     }
 }
@@ -5691,6 +5798,99 @@ pub fn input_callback_transport_health_summary(
     }
 }
 
+pub fn input_callback_transport_readiness_summary(
+    health_summary: &LanguageInputCallbackTransportHealthSummary,
+) -> LanguageInputCallbackTransportReadinessSummary {
+    let readiness_kind = input_callback_transport_readiness_kind(health_summary.health_kind);
+
+    LanguageInputCallbackTransportReadinessSummary {
+        endpoint: health_summary.endpoint.clone(),
+        connection_label: health_summary.connection_label.clone(),
+        readiness_label: input_callback_transport_readiness_label(health_summary, readiness_kind),
+        readiness_kind,
+        readiness_name: input_callback_transport_readiness_kind_name(readiness_kind).to_owned(),
+        health_kind: health_summary.health_kind,
+        health_name: health_summary.health_name.clone(),
+        diagnostic_kind: health_summary.diagnostic_kind,
+        diagnostic_name: health_summary.diagnostic_name.clone(),
+        completion_kind: health_summary.completion_kind,
+        completion_name: health_summary.completion_name.clone(),
+        finalization_kind: health_summary.finalization_kind,
+        finalization_name: health_summary.finalization_name.clone(),
+        resolution_kind: health_summary.resolution_kind,
+        resolution_name: health_summary.resolution_name.clone(),
+        decision_kind: health_summary.decision_kind,
+        decision_name: health_summary.decision_name.clone(),
+        logic_kind: health_summary.logic_kind,
+        logic_name: health_summary.logic_name.clone(),
+        reference_kind: health_summary.reference_kind,
+        reference_name: health_summary.reference_name.clone(),
+        bookmark_kind: health_summary.bookmark_kind,
+        bookmark_name: health_summary.bookmark_name.clone(),
+        cursor_kind: health_summary.cursor_kind,
+        cursor_name: health_summary.cursor_name.clone(),
+        marker_kind: health_summary.marker_kind,
+        marker_name: health_summary.marker_name.clone(),
+        checkpoint_kind: health_summary.checkpoint_kind,
+        checkpoint_name: health_summary.checkpoint_name.clone(),
+        snapshot_kind: health_summary.snapshot_kind,
+        snapshot_name: health_summary.snapshot_name.clone(),
+        archive_kind: health_summary.archive_kind,
+        archive_name: health_summary.archive_name.clone(),
+        journal_kind: health_summary.journal_kind,
+        journal_name: health_summary.journal_name.clone(),
+        log_kind: health_summary.log_kind,
+        log_name: health_summary.log_name.clone(),
+        audit_kind: health_summary.audit_kind,
+        audit_name: health_summary.audit_name.clone(),
+        trace_kind: health_summary.trace_kind,
+        trace_name: health_summary.trace_name.clone(),
+        outcome_kind: health_summary.outcome_kind,
+        outcome_name: health_summary.outcome_name.clone(),
+        receipt_kind: health_summary.receipt_kind,
+        receipt_name: health_summary.receipt_name.clone(),
+        acknowledgement_kind: health_summary.acknowledgement_kind,
+        acknowledgement_name: health_summary.acknowledgement_name.clone(),
+        delivery_route: health_summary.delivery_route,
+        delivery_route_name: health_summary.delivery_route_name.clone(),
+        event_kind: health_summary.event_kind,
+        event_name: health_summary.event_name.clone(),
+        report_kind: health_summary.report_kind,
+        report_name: health_summary.report_name.clone(),
+        action: health_summary.action,
+        action_name: health_summary.action_name.clone(),
+        callback_runner_handoff: health_summary.callback_runner_handoff,
+        adapter_event_published: health_summary.adapter_event_published,
+        delivery_acknowledged: health_summary.delivery_acknowledged,
+        receipt_recorded: health_summary.receipt_recorded,
+        outcome_recorded: health_summary.outcome_recorded,
+        trace_recorded: health_summary.trace_recorded,
+        audit_recorded: health_summary.audit_recorded,
+        log_recorded: health_summary.log_recorded,
+        journal_recorded: health_summary.journal_recorded,
+        archive_recorded: health_summary.archive_recorded,
+        snapshot_recorded: health_summary.snapshot_recorded,
+        checkpoint_recorded: health_summary.checkpoint_recorded,
+        marker_recorded: health_summary.marker_recorded,
+        cursor_recorded: health_summary.cursor_recorded,
+        bookmark_recorded: health_summary.bookmark_recorded,
+        reference_recorded: health_summary.reference_recorded,
+        logic_recorded: health_summary.logic_recorded,
+        decision_recorded: health_summary.decision_recorded,
+        resolution_recorded: health_summary.resolution_recorded,
+        finalization_recorded: health_summary.finalization_recorded,
+        completion_recorded: health_summary.completion_recorded,
+        diagnostic_recorded: health_summary.diagnostic_recorded,
+        health_recorded: health_summary.health_recorded,
+        readiness_recorded: true,
+        terminal: health_summary.terminal,
+        retryable: health_summary.retryable,
+        queue_depth_after_readiness: health_summary.queue_depth_after_health,
+        message: input_callback_transport_readiness_message(readiness_kind).to_owned(),
+        health_summary: health_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -7811,6 +8011,44 @@ fn input_callback_transport_health_message(
         }
         LanguageInputCallbackTransportHealthKind::AdapterEventPublicationHealth => {
             "Transport health should track the adapter event publication diagnostic state."
+        }
+    }
+}
+
+fn input_callback_transport_readiness_kind(
+    health_kind: LanguageInputCallbackTransportHealthKind,
+) -> LanguageInputCallbackTransportReadinessKind {
+    match health_kind {
+        LanguageInputCallbackTransportHealthKind::CallbackRunnerHandoffHealth => {
+            LanguageInputCallbackTransportReadinessKind::CallbackRunnerHandoffReadiness
+        }
+        LanguageInputCallbackTransportHealthKind::AdapterEventPublicationHealth => {
+            LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness
+        }
+    }
+}
+
+fn input_callback_transport_readiness_label(
+    health_summary: &LanguageInputCallbackTransportHealthSummary,
+    readiness_kind: LanguageInputCallbackTransportReadinessKind,
+) -> String {
+    format!(
+        "{} transport_readiness={} readiness_recorded=true queue_depth_after_readiness={}",
+        health_summary.health_label,
+        input_callback_transport_readiness_kind_name(readiness_kind),
+        health_summary.queue_depth_after_health
+    )
+}
+
+fn input_callback_transport_readiness_message(
+    readiness_kind: LanguageInputCallbackTransportReadinessKind,
+) -> &'static str {
+    match readiness_kind {
+        LanguageInputCallbackTransportReadinessKind::CallbackRunnerHandoffReadiness => {
+            "Transport readiness should track the callback-runner handoff health state."
+        }
+        LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness => {
+            "Transport readiness should track the adapter event publication health state."
         }
     }
 }
@@ -18848,6 +19086,296 @@ mod tests {
             )
         );
         assert_eq!(dropped.diagnostic_summary, dropped_diagnostic);
+    }
+
+    #[test]
+    fn input_callback_transport_readiness_is_owned_by_rust_language_core() {
+        fn health_for_lifecycle(
+            lifecycle: &LanguageInputCallbackSessionLifecycleSummary,
+        ) -> LanguageInputCallbackTransportHealthSummary {
+            let action = input_callback_transport_action_summary(lifecycle);
+            let effect = input_callback_transport_effect_summary(&action);
+            let report = input_callback_transport_report_summary(&effect);
+            let event = input_callback_transport_event_summary(&report);
+            let delivery = input_callback_transport_delivery_summary(&event);
+            let acknowledgement = input_callback_transport_acknowledgement_summary(&delivery);
+            let receipt = input_callback_transport_receipt_summary(&acknowledgement);
+            let outcome = input_callback_transport_outcome_summary(&receipt);
+            let trace = input_callback_transport_trace_summary(&outcome);
+            let audit = input_callback_transport_audit_summary(&trace);
+            let log = input_callback_transport_log_summary(&audit);
+            let journal = input_callback_transport_journal_summary(&log);
+            let archive = input_callback_transport_archive_summary(&journal);
+            let snapshot = input_callback_transport_snapshot_summary(&archive);
+            let checkpoint = input_callback_transport_checkpoint_summary(&snapshot);
+            let marker = input_callback_transport_marker_summary(&checkpoint);
+            let cursor = input_callback_transport_cursor_summary(&marker);
+            let bookmark = input_callback_transport_bookmark_summary(&cursor);
+            let reference = input_callback_transport_reference_summary(&bookmark);
+            let logic = input_callback_transport_logic_summary(&reference);
+            let decision = input_callback_transport_decision_summary(&logic);
+            let resolution = input_callback_transport_resolution_summary(&decision);
+            let finalization = input_callback_transport_finalization_summary(&resolution);
+            let completion = input_callback_transport_completion_summary(&finalization);
+            let diagnostic = input_callback_transport_diagnostic_summary(&completion);
+            input_callback_transport_health_summary(&diagnostic)
+        }
+
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_health = health_for_lifecycle(&completed_lifecycle);
+        let completed = input_callback_transport_readiness_summary(&completed_health);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.readiness_kind,
+            LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness
+        );
+        assert_eq!(
+            completed.readiness_name,
+            "adapter_event_publication_readiness"
+        );
+        assert_eq!(
+            completed.health_kind,
+            LanguageInputCallbackTransportHealthKind::AdapterEventPublicationHealth
+        );
+        assert_eq!(
+            completed.diagnostic_kind,
+            LanguageInputCallbackTransportDiagnosticKind::AdapterEventPublicationDiagnostic
+        );
+        assert_eq!(
+            completed.completion_kind,
+            LanguageInputCallbackTransportCompletionKind::AdapterEventPublicationCompletion
+        );
+        assert_eq!(
+            completed.finalization_kind,
+            LanguageInputCallbackTransportFinalizationKind::AdapterEventPublicationFinalization
+        );
+        assert_eq!(
+            completed.resolution_kind,
+            LanguageInputCallbackTransportResolutionKind::AdapterEventPublicationResolution
+        );
+        assert_eq!(
+            completed.decision_kind,
+            LanguageInputCallbackTransportDecisionKind::AdapterEventPublicationDecision
+        );
+        assert_eq!(
+            completed.logic_kind,
+            LanguageInputCallbackTransportLogicKind::AdapterEventPublicationLogic
+        );
+        assert_eq!(
+            completed.reference_kind,
+            LanguageInputCallbackTransportReferenceKind::AdapterEventPublicationReference
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.marker_recorded);
+        assert!(completed.cursor_recorded);
+        assert!(completed.bookmark_recorded);
+        assert!(completed.reference_recorded);
+        assert!(completed.logic_recorded);
+        assert!(completed.decision_recorded);
+        assert!(completed.resolution_recorded);
+        assert!(completed.finalization_recorded);
+        assert!(completed.completion_recorded);
+        assert!(completed.diagnostic_recorded);
+        assert!(completed.health_recorded);
+        assert!(completed.readiness_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_readiness, 2);
+        assert_eq!(
+            completed.readiness_label,
+            format!(
+                "{} transport_readiness=adapter_event_publication_readiness readiness_recorded=true queue_depth_after_readiness=2",
+                completed_health.health_label
+            )
+        );
+        assert_eq!(
+            completed.message,
+            "Transport readiness should track the adapter event publication health state."
+        );
+        assert_eq!(completed.health_summary, completed_health);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_health = health_for_lifecycle(&pending_lifecycle);
+        let pending = input_callback_transport_readiness_summary(&pending_health);
+
+        assert_eq!(
+            pending.readiness_kind,
+            LanguageInputCallbackTransportReadinessKind::CallbackRunnerHandoffReadiness
+        );
+        assert_eq!(pending.readiness_name, "callback_runner_handoff_readiness");
+        assert_eq!(
+            pending.health_kind,
+            LanguageInputCallbackTransportHealthKind::CallbackRunnerHandoffHealth
+        );
+        assert_eq!(
+            pending.diagnostic_kind,
+            LanguageInputCallbackTransportDiagnosticKind::CallbackRunnerHandoffDiagnostic
+        );
+        assert_eq!(
+            pending.completion_kind,
+            LanguageInputCallbackTransportCompletionKind::CallbackRunnerHandoffCompletion
+        );
+        assert_eq!(
+            pending.finalization_kind,
+            LanguageInputCallbackTransportFinalizationKind::CallbackRunnerHandoffFinalization
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.receipt_recorded);
+        assert!(pending.outcome_recorded);
+        assert!(pending.trace_recorded);
+        assert!(pending.audit_recorded);
+        assert!(pending.log_recorded);
+        assert!(pending.journal_recorded);
+        assert!(pending.archive_recorded);
+        assert!(pending.snapshot_recorded);
+        assert!(pending.checkpoint_recorded);
+        assert!(pending.marker_recorded);
+        assert!(pending.cursor_recorded);
+        assert!(pending.bookmark_recorded);
+        assert!(pending.reference_recorded);
+        assert!(pending.logic_recorded);
+        assert!(pending.decision_recorded);
+        assert!(pending.resolution_recorded);
+        assert!(pending.finalization_recorded);
+        assert!(pending.completion_recorded);
+        assert!(pending.diagnostic_recorded);
+        assert!(pending.health_recorded);
+        assert!(pending.readiness_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_readiness, 3);
+        assert_eq!(
+            pending.readiness_label,
+            format!(
+                "{} transport_readiness=callback_runner_handoff_readiness readiness_recorded=true queue_depth_after_readiness=3",
+                pending_health.health_label
+            )
+        );
+        assert_eq!(
+            pending.message,
+            "Transport readiness should track the callback-runner handoff health state."
+        );
+        assert_eq!(pending.health_summary, pending_health);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_health = health_for_lifecycle(&dropped_lifecycle);
+        let dropped = input_callback_transport_readiness_summary(&dropped_health);
+
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.readiness_kind,
+            LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness
+        );
+        assert_eq!(
+            dropped.health_kind,
+            LanguageInputCallbackTransportHealthKind::AdapterEventPublicationHealth
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.marker_recorded);
+        assert!(dropped.cursor_recorded);
+        assert!(dropped.bookmark_recorded);
+        assert!(dropped.reference_recorded);
+        assert!(dropped.logic_recorded);
+        assert!(dropped.decision_recorded);
+        assert!(dropped.resolution_recorded);
+        assert!(dropped.finalization_recorded);
+        assert!(dropped.completion_recorded);
+        assert!(dropped.diagnostic_recorded);
+        assert!(dropped.health_recorded);
+        assert!(dropped.readiness_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_readiness, 1);
+        assert_eq!(
+            dropped.readiness_label,
+            format!(
+                "{} transport_readiness=adapter_event_publication_readiness readiness_recorded=true queue_depth_after_readiness=1",
+                dropped_health.health_label
+            )
+        );
+        assert_eq!(dropped.health_summary, dropped_health);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Rust-owned input callback transport readiness kinds and summaries for callback-runner handoff and adapter event publication health records
- preserve health, diagnostic, completion, finalization, resolution, decision, logic, reference, bookmark, cursor, marker, checkpoint, snapshot, archive, journal, log, audit, trace, outcome, receipt, acknowledgement, delivery, event, report, effect, and action provenance in readiness records
- expose stable readiness labels, queue-depth metadata, terminal/retryability state, and messages so language frontends can gate transport readiness without rebuilding health policy
- document the readiness summary surface in the language-core README

## Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-readiness cargo test -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-readiness cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Generated code/packages/rust/Cargo.lock, code/packages/rust/build-plan.json, and build-plan.json were removed before committing if present. The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.