### PR TITLE
fix(sql-vm): CAST(numeric AS BLOB) encodes via text (matches SQLite)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [2.14.0] - 2026-05-24
+
+### Fixed
+
+- ``CAST(<numeric> AS BLOB)`` now matches SQLite — the BLOB is the
+  UTF-8 encoding of the numeric's text form (``CAST(1 AS BLOB)``
+  → ``b'1'``, not ``b'\x00\x00\x00\x00\x00\x00\x00\x01'``).
+  Previously the integer and float paths used ``struct.pack`` to
+  produce 8-byte big-endian binary blobs that didn't survive
+  round-tripping through SQLite's text-first conversion rules.
+  See sql-vm 1.58.0 for the scalar-function-level fix.
+
+### Known limitation
+
+- ``CAST(<blob> AS TEXT)`` still hex-encodes the BLOB bytes rather
+  than UTF-8-decoding them.  So ``CAST(CAST(42 AS BLOB) AS TEXT)``
+  returns ``'3432'`` (hex of ``b'42'``) instead of SQLite's
+  ``'42'``.  Pinned by a regression test
+  (``TestKnownLimitationBlobToText``) so a future BLOB→TEXT fix is
+  reminded to update both directions and lift the test together.
+
 ## [2.13.0] - 2026-05-24
 
 ### Added

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.13.0"
+version = "2.14.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_cast_numeric_to_blob.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_cast_numeric_to_blob.py
@@ -1,0 +1,97 @@
+"""Tests for ``CAST(<numeric> AS BLOB)`` matching SQLite's text-first rule.
+
+SQLite's numeric→BLOB cast goes through the TEXT representation
+first: ``CAST(1 AS BLOB)`` yields the UTF-8 encoding of the
+integer's decimal string (``b'1'``, one byte), not an 8-byte
+big-endian packed integer.  The same rule applies to floats
+(``CAST(1.5 AS BLOB)`` → ``b'1.5'``) and to booleans (``CAST(TRUE
+AS BLOB)`` → ``b'1'`` because TRUE = 1).
+
+Mini-sqlite's CAST handler previously called ``struct.pack(">q", x)``
+for integers and ``struct.pack(">d", x)`` for floats — packing into
+8-byte binary blobs that don't match SQLite's wire format and
+silently corrupt round-trip ``CAST(n AS BLOB) AS TEXT`` patterns
+that callers rely on for type-erased serialization.
+
+See sql-vm 1.58.0 for the scalar-function fix.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestIntToBlob:
+    def test_zero(self) -> None:
+        _both_match("SELECT CAST(0 AS BLOB)")
+
+    def test_one(self) -> None:
+        _both_match("SELECT CAST(1 AS BLOB)")
+
+    def test_multi_digit(self) -> None:
+        _both_match("SELECT CAST(42 AS BLOB)")
+
+    def test_negative(self) -> None:
+        _both_match("SELECT CAST(-7 AS BLOB)")
+
+    def test_large(self) -> None:
+        _both_match("SELECT CAST(9223372036854775807 AS BLOB)")
+
+
+class TestBoolToBlob:
+    """TRUE / FALSE are SQLite-level aliases for 1 / 0; the BLOB cast
+    must follow the integer path, not Python's ``str(bool)``."""
+
+    def test_true(self) -> None:
+        _both_match("SELECT CAST(TRUE AS BLOB)")
+
+    def test_false(self) -> None:
+        _both_match("SELECT CAST(FALSE AS BLOB)")
+
+
+class TestFloatToBlob:
+    def test_one_point_five(self) -> None:
+        _both_match("SELECT CAST(1.5 AS BLOB)")
+
+    def test_negative_float(self) -> None:
+        _both_match("SELECT CAST(-3.14 AS BLOB)")
+
+    def test_zero_point(self) -> None:
+        _both_match("SELECT CAST(0.0 AS BLOB)")
+
+
+class TestPassthrough:
+    """Regression: existing string and NULL paths must keep matching."""
+
+    def test_string_passthrough(self) -> None:
+        _both_match("SELECT CAST('hello' AS BLOB)")
+
+    def test_empty_string(self) -> None:
+        _both_match("SELECT CAST('' AS BLOB)")
+
+    def test_null_blob(self) -> None:
+        _both_match("SELECT CAST(NULL AS BLOB)")
+
+
+class TestKnownLimitationBlobToText:
+    """``CAST(<blob> AS TEXT)`` currently hex-encodes the BLOB bytes
+    instead of UTF-8-decoding them — so ``CAST(CAST(42 AS BLOB) AS
+    TEXT)`` returns ``'3432'`` (hex of ``b'42'``) rather than the
+    SQLite-compatible ``'42'``.  Out of scope for this PR; pinned
+    so a future BLOB→TEXT fix is reminded to update this test
+    alongside the CHANGELOG entry."""
+
+    def test_int_blob_to_text_diverges(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        # Hex of '42' is '3432'.
+        assert m.execute(
+            "SELECT CAST(CAST(42 AS BLOB) AS TEXT)"
+        ).fetchall() == [("3432",)]

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.58.0 — 2026-05-24
+
+### Fixed
+
+- ``CAST(<numeric> AS BLOB)`` now yields the UTF-8 encoding of the
+  numeric's textual representation, matching SQLite::
+
+      CAST(1 AS BLOB)     ⟶  b'1'
+      CAST(42 AS BLOB)    ⟶  b'42'
+      CAST(-7 AS BLOB)    ⟶  b'-7'
+      CAST(1.5 AS BLOB)   ⟶  b'1.5'
+      CAST(TRUE AS BLOB)  ⟶  b'1'
+
+  Previously these used ``struct.pack(">q", x)`` for integers (and
+  ``">d"`` for floats), producing 8-byte big-endian binary blobs
+  that don't match SQLite's wire format and broke round-trip
+  ``CAST(n AS BLOB)`` patterns that callers use for type-erased
+  serialization.
+
+  Fix in ``_cast_fn``'s BLOB-affinity branch: special-case ``bool``,
+  ``int``, and ``float`` to encode via ``str(value).encode("utf-8")``.
+  ``bool`` is checked before ``int`` because Python's ``bool`` is a
+  subclass of ``int`` — without the explicit check, ``True`` would
+  be encoded as ``b'True'`` (wrong) instead of ``b'1'`` (right).
+  ``struct`` import removed (no longer used).
+
 ## 1.57.0 — 2026-05-24
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.57.0"
+version = "1.58.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -58,7 +58,6 @@ import json as _json
 import math
 import os
 import re
-import struct
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
@@ -365,10 +364,20 @@ def _cast_fn(x: SqlValue, target_type: SqlValue) -> SqlValue:
                 return x
             if isinstance(x, str):
                 return x.encode("utf-8")
+            # SQLite's numeric→BLOB cast goes through the TEXT
+            # representation first: ``CAST(1 AS BLOB)`` yields
+            # ``b'1'`` (one byte) — the UTF-8 encoding of the
+            # integer's decimal string — not an 8-byte big-endian
+            # packed int.  The same applies to floats (``b'1.5'``)
+            # and booleans (``CAST(TRUE AS BLOB)`` → ``b'1'``).
+            # Check ``bool`` before ``int`` because Python's
+            # ``bool`` is a subclass of ``int``.
+            if isinstance(x, bool):
+                return str(int(x)).encode("utf-8")
             if isinstance(x, int):
-                return struct.pack(">q", x)
+                return str(x).encode("utf-8")
             if isinstance(x, float):
-                return struct.pack(">d", x)
+                return str(x).encode("utf-8")
             return bytes(x)  # type: ignore[call-overload]
         if t in ("boolean", "bool"):
             return bool(x)


### PR DESCRIPTION
## Summary

- `CAST(<numeric> AS BLOB)` now returns the UTF-8 encoding of the numeric's text form (e.g. `CAST(1 AS BLOB)` → `b'1'`, `CAST(1.5 AS BLOB)` → `b'1.5'`), matching SQLite. Previously returned 8-byte big-endian binary blobs from `struct.pack`.
- Special-cases `bool` before `int` in the BLOB-affinity branch so `CAST(TRUE AS BLOB)` → `b'1'` (not `b'True'`).
- Removed now-unused `struct` import.

## Version bumps

- `sql-vm`: 1.57 → 1.58
- `mini-sqlite`: 2.13 → 2.14

## Test plan

- [x] 14 new oracle tests pass (int/bool/float → BLOB, string + NULL regression, known-limitation pin for BLOB→TEXT divergence)
- [x] sql-vm suite (921 tests) clean
- [x] mini-sqlite suite (2310 tests) clean
- [x] Ruff clean
- [x] Security review passed

## Known limitation (pinned)

`CAST(<blob> AS TEXT)` still hex-encodes the BLOB bytes instead of UTF-8-decoding them. Pinned by `TestKnownLimitationBlobToText` so a future fix updates both directions together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)