### PR TITLE
feat(ruby-parser): Phase 6n — range expressions `..` and `...`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -120,7 +120,30 @@ expression_stmt = expression ;
 #
 # Left-associativity: `a || b || c` folds as `(a || b) || c`,
 # matching `+`/`-` and Ruby's actual semantics.
-expression   = logical_or ;
+# Phase 6n — range expressions `a..b` (inclusive) and `a...b` (exclusive).
+#
+# Precedence: range is OUTER over `logical_or` because Ruby's `..`/`...`
+# bind *looser* than `||`.  So `a || b .. c || d` parses as
+# `(a || b) .. (c || d)` — exactly what you'd expect.
+#
+# Shape: `range = logical_or [ ( "..." | ".." ) logical_or ]`.  The
+# zero-or-one repetition means a bare `logical_or` passes through
+# transparently (no range), while a single range op binds exactly two
+# operands.  Range is NOT chainable in Ruby — `1..5..10` is a parse
+# error — so the optional rather than zero-or-more form is correct.
+#
+# Note on token typing: the lexer's `fuse_range_ops` fuses two `.`
+# tokens into a single `Name`-typed token with value `..` (and three
+# into `...`).  Era ≥ 2.6 sets an `endless` flag on `..`/`...` tokens
+# followed by a closer — but for v0 we treat both ends as required.
+# Endless ranges (`(1..)`, `arr[2..]`) and beginless ranges (`(..5)`)
+# are deferred to a follow-up phase.
+#
+# Operator alternation lists `"..."` before `".."` defensively, but
+# the lexer already pre-fuses the two forms into distinct tokens so
+# the order is not actually significant.
+expression   = range ;
+range        = logical_or [ ( "..." | ".." ) logical_or ] ;
 logical_or   = logical_and { ( "||" | "or" ) logical_and } ;
 logical_and  = logical_not { ( "&&" | "and" ) logical_not } ;
 # `logical_not` uses `{ }` (zero-or-more) instead of right-recursive

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.15.0] - 2026-05-24
+
+### Added (Phase 6n — range expressions `..` and `...`)
+
+New grammar layer inserted between `expression` and `logical_or`:
+
+```
+expression = range ;
+range      = logical_or [ ( "..." | ".." ) logical_or ] ;
+```
+
+`expression` is now a transparent wrapper over `range`.  When no `..`/`...` token follows the first `logical_or`, the `range` rule passes through the single operand unchanged — so existing parses for non-range expressions continue to produce the same shape (modulo an extra `range` node in the AST).
+
+**Precedence**: range sits OUTER over `logical_or` because Ruby's `..`/`...` bind *looser* than `||`.  So `a || b .. c || d` parses as `(a || b) .. (c || d)`.  (Test that exercises this with explicit parens — see Test notes below.)
+
+**Non-chainable**: the optional (zero-or-one) repetition is intentional; `1..5..10` is a parse error in Ruby and our grammar matches that by not allowing chaining.
+
+**Token typing**: the lexer's `fuse_range_ops` (Phase 4e) pre-fuses two consecutive `.` tokens into a single `Name`-typed token with value `..` (three → `...`).  The grammar matches these by literal *value* (`"..."`, `".."`), the same trick used for `"=>"`, `"<="`, `"&&"`, etc.
+
+**Endless / beginless ranges**: out of scope for this phase.  The lexer already flags `..`/`...` followed by a closer (era ≥ 2.6), but the parser-side support — `(1..)`, `arr[2..]`, `(..5)` — gets its own phase.
+
+### Tests (+6 new, total 71)
+- `test_parse_inclusive_range` — `1..5` produces a `range` node carrying a `..` token and two `logical_or` operands.
+- `test_parse_exclusive_range` — `1...5` carries `...`.
+- `test_parse_range_in_assignment_rhs` — `x = 1..10` nests the range in an assignment.
+- `test_parse_range_with_arithmetic_endpoints` — `1 + 2 .. 10 - 3` proves range binds looser than `+`/`-`.
+- `test_parse_range_inside_array_literal` — `[1..5]` works as an array element.
+- `test_parse_range_with_paren_logical_operands` — `(a || b)..(c || d)` proves operands can be full logical chains.
+
+Note: a precedence test for the unparenthesised form (`a || b .. c || d`) was attempted but hit the v0 `method_call_no_paren` framework ambiguity (lessons.md).  The arithmetic-endpoints and paren-operand tests cover the precedence ladder around range without tripping that issue.
+
 ## [0.14.0] - 2026-05-24
 
 ### Added (Phase 6m — logical operators `&&`, `||`, `and`, `or`, `not`, `!`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -337,8 +337,22 @@ pub fn parser_grammar() -> ParserGrammar {
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
-            body: GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
-            line_number: 123,
+            body: GrammarElement::RuleReference { name: r#"range"#.to_string() },
+            line_number: 145,
+        },
+        GrammarRule {
+            name: r#"range"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::Literal { value: r#"..."#.to_string() },
+                                GrammarElement::Literal { value: r#".."#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 146,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -352,7 +366,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 124,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -366,7 +380,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 125,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -377,7 +391,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 132,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -395,7 +409,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 133,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -409,7 +423,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 134,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -423,7 +437,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 135,
+            line_number: 158,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -446,7 +460,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 145,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -454,7 +468,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 146,
+            line_number: 169,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -466,7 +480,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 147,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -481,7 +495,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 148,
+            line_number: 171,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -496,7 +510,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 149,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -512,7 +526,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 150,
+            line_number: 173,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1026,5 +1026,122 @@ mod tests {
         assert!(find_descendant(&ast, "logical_or").is_some(),
             "expected logical_or inside def body");
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6n — range expressions `..` and `...`
+    // -----------------------------------------------------------------------
+    //
+    // The lexer pre-fuses two/three consecutive `.` tokens into a single
+    // `Name`-typed token whose value is `..` or `...`.  The grammar matches
+    // those tokens by literal *value* (same as `"=>"`, `"<="`, `"&&"`).
+    //
+    // A bare expression (no range op) still produces a `range` rule node
+    // in the AST — the rule is the new expression entry point — but with
+    // exactly one inner `logical_or` child and no `..`/`...` token.
+
+    #[test]
+    fn test_parse_inclusive_range() {
+        // `1..5` — a `range` node with two `logical_or` operand children
+        // and a `..` token between them.
+        let ast = parse_ruby("1..5");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, ".."),
+            "expected `..` token inside the range node"
+        );
+        // Two logical_or operands flank the `..`.
+        let operand_count = r
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "logical_or"))
+            .count();
+        assert_eq!(operand_count, 2, "expected 2 logical_or operands");
+    }
+
+    #[test]
+    fn test_parse_exclusive_range() {
+        // `1...5` — same shape as inclusive but `...` token.
+        let ast = parse_ruby("1...5");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(
+            tree_has_token_value(r, "..."),
+            "expected `...` token inside the range node"
+        );
+    }
+
+    #[test]
+    fn test_parse_range_in_assignment_rhs() {
+        // `x = 1..10` — range expression nests inside an assignment.
+        let ast = parse_ruby("x = 1..10");
+        // The assignment rule still fires.
+        assert!(find_descendant(&ast, "assignment").is_some());
+        // And there's a range node somewhere below.
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        assert!(tree_has_token_value(r, ".."));
+    }
+
+    #[test]
+    fn test_parse_range_with_arithmetic_endpoints() {
+        // `1 + 2 .. 10 - 3` — both endpoints are arithmetic.  Range binds
+        // looser than `+`/`-`, so this parses as `(1 + 2) .. (10 - 3)`.
+        // Each operand subtree under the range node has its own `sum` node
+        // with `+`/`-` tokens inside.
+        let ast = parse_ruby("1 + 2 .. 10 - 3");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        // The range carries exactly one `..` token and the two arithmetic
+        // operator tokens (`+`, `-`) live inside its operand subtrees.
+        fn count_value(node: &GrammarASTNode, val: &str) -> usize {
+            let mut n = 0;
+            for c in &node.children {
+                match c {
+                    ASTNodeOrToken::Token(t) if t.value == val => n += 1,
+                    ASTNodeOrToken::Node(sub) => n += count_value(sub, val),
+                    _ => {}
+                }
+            }
+            n
+        }
+        assert_eq!(count_value(r, ".."), 1, "expected exactly one `..` token");
+        assert_eq!(count_value(r, "+"), 1, "expected `+` inside the range");
+        assert_eq!(count_value(r, "-"), 1, "expected `-` inside the range");
+    }
+
+    #[test]
+    fn test_parse_range_inside_array_literal() {
+        // `[1..5]` — range expression as an array element.
+        let ast = parse_ruby("[1..5]");
+        let arr = find_descendant(&ast, "array_literal").expect("expected array_literal");
+        // Range nested inside the array.
+        assert!(
+            find_descendant(arr, "range").is_some(),
+            "expected range inside array_literal"
+        );
+        assert!(tree_has_token_value(arr, ".."));
+    }
+
+    #[test]
+    fn test_parse_range_with_paren_logical_operands() {
+        // `(a || b)..(c || d)` — explicit parens make precedence
+        // unambiguous and dodge the `method_call_no_paren` framework
+        // ambiguity (see lessons.md, "logical operators inside def body").
+        //
+        // The range carries `..` and each operand subtree contains its
+        // own `||`.
+        let ast = parse_ruby("(a || b)..(c || d)");
+        let r = find_descendant(&ast, "range").expect("expected range node");
+        fn count_value(node: &GrammarASTNode, val: &str) -> usize {
+            let mut n = 0;
+            for c in &node.children {
+                match c {
+                    ASTNodeOrToken::Token(t) if t.value == val => n += 1,
+                    ASTNodeOrToken::Node(sub) => n += count_value(sub, val),
+                    _ => {}
+                }
+            }
+            n
+        }
+        assert_eq!(count_value(r, ".."), 1);
+        assert_eq!(count_value(r, "||"), 2, "expected `||` in both operand subtrees");
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.15.0] - 2026-05-24
+
+### Added (Phase 6n — range expressions lowering)
+
+SIR encoding:
+- `a..b`  →  `BuiltinCall("range", [a, b, BoolLit(false)])` ; inclusive end
+- `a...b` →  `BuiltinCall("range", [a, b, BoolLit(true)])`  ; exclusive end
+
+A single builtin name (`range`) handles both forms; the third argument carries the inclusive/exclusive flag so downstream emitters can pattern-match once and read the flag.  Effects default to `PURE` — constructing a range observes nothing.
+
+### Lowerer changes
+- `lower_expression` gained a `"range"` dispatch arm.
+- New helper `lower_range(node)` filters operand `logical_or` sub-nodes from the `..`/`...` operator token, then either passes through (1 operand, no op) or emits the three-arg `BuiltinCall`.
+
+### Tests (+4 new, total 74)
+- `inclusive_range_lowers_to_range_builtin_with_false_flag` — `1..5` → flag = false.
+- `exclusive_range_lowers_to_range_builtin_with_true_flag` — `1...5` → flag = true.
+- `range_with_variable_operands_uses_var_refs` — `(a..b)` over function params (parens dodge the lessons.md ambiguity).
+- `range_module_passes_sir_validator` — end-to-end smoke test through the validator.
+
+### Out of scope (deferred to follow-up phase)
+- Endless ranges `(1..)`, `arr[2..]` (lexer 4e already flags these; parser support TBD).
+- Beginless ranges `(..5)`.
+
 ## [0.14.0] - 2026-05-24
 
 ### Added (Phase 6m — logical operators lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1295,4 +1295,91 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6n — range expressions lowering
+    // -----------------------------------------------------------------
+    //
+    // SIR encoding:
+    //   `a..b`  → BuiltinCall("range", [a, b, BoolLit(false)])  ; inclusive
+    //   `a...b` → BuiltinCall("range", [a, b, BoolLit(true)])   ; exclusive
+    //
+    // The third arg is the exclusive-end flag — keeping the builtin's
+    // name uniform across both forms means downstream emitters can
+    // pattern-match on `range` once and read the flag.
+
+    #[test]
+    fn inclusive_range_lowers_to_range_builtin_with_false_flag() {
+        // `def r() 1..5 end` — RHS of the def body is a range literal.
+        let m = lower("def r\n  1..5\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "range");
+                assert_eq!(args.len(), 3, "expected [start, end, exclusive_flag]");
+                assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&args[1], Expr::IntLit { value: 5, .. }));
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: false, .. }),
+                    "inclusive `..` should set the exclusive flag to false; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn exclusive_range_lowers_to_range_builtin_with_true_flag() {
+        // `def r() 1...5 end` — exclusive form sets flag to true.
+        let m = lower("def r\n  1...5\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "range");
+                assert_eq!(args.len(), 3);
+                assert!(
+                    matches!(&args[2], Expr::BoolLit { value: true, .. }),
+                    "exclusive `...` should set the flag to true; got {:?}",
+                    &args[2]
+                );
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn range_with_variable_operands_uses_var_refs() {
+        // `def r(a, b) (a..b) end` — range over function params.  Params
+        // are in scope so the VarRef survives validation.  Parens wrap
+        // the range so the bare-NAME-led body doesn't trigger the
+        // `method_call_no_paren` framework ambiguity (lessons.md).
+        let m = lower("def r(a, b)\n  (a..b)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "r").unwrap();
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } if name == "range" => {
+                assert_eq!(args.len(), 3);
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&args[1], Expr::VarRef { name, .. } if name == "b"));
+            }
+            other => panic!("expected BuiltinCall(range, …), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn range_module_passes_sir_validator() {
+        // End-to-end smoke check: a range expression survives validation.
+        // Parens for the same reason as above.
+        let m = lower(concat!(
+            "def r(a, b)\n",
+            "  (a..b)\n",
+            "end\n",
+        ));
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected range output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1198,6 +1198,10 @@ impl Lowerer {
             // `BuiltinCall("or", [lhs, rhs])`.  Operator forms `||`
             // (symbol) and `or` (keyword) lower identically — see the
             // grammar comment for the v0 simplification.
+            // Phase 6n — range expressions `a..b` (inclusive) and
+            // `a...b` (exclusive).  Either a bare `logical_or` pass-through
+            // or a `BuiltinCall("range", [start, end, BoolLit(exclusive)])`.
+            "range" => self.lower_range(node),
             "logical_or" => self.lower_logical_chain(node, &["||", "or"], "or"),
             // Phase 6m — logical-AND chain: same pattern as logical_or.
             "logical_and" => self.lower_logical_chain(node, &["&&", "and"], "and"),
@@ -1461,6 +1465,82 @@ impl Lowerer {
             };
         }
         Ok(expr)
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6n — range expressions `..` / `...`
+    // -------------------------------------------------------------------
+
+    /// Lower a `range` node.  Grammar shape:
+    ///
+    ///   range = logical_or [ ( "..." | ".." ) logical_or ]
+    ///
+    /// Two cases:
+    ///   - One operand child, no `..`/`...` token → pass through (the
+    ///     range rule is just a transparent wrapper in this case).
+    ///   - Two operand children with a `..` or `...` token between them
+    ///     → emit `BuiltinCall("range", [start, end, BoolLit(exclusive)])`.
+    ///     The third argument carries the inclusive/exclusive flag so a
+    ///     single builtin handles both forms without name multiplication.
+    ///     `..` → exclusive=false; `...` → exclusive=true.
+    ///
+    /// Range is pure: building a range doesn't observe or mutate any
+    /// state.  (Iterating over one *would* run code, but that's a
+    /// separate call.)
+    fn lower_range(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        // Collect operand sub-nodes (each a `logical_or`).
+        let operands: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        // Find the `..` or `...` operator token (if present).
+        let op_tok = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.value == ".." || t.value == "..." => Some(t),
+            _ => None,
+        });
+
+        match (operands.len(), op_tok) {
+            // Bare logical_or pass-through — no range operator.
+            (1, None) => self.lower_expression(operands[0]),
+            // Two operands separated by `..` or `...`.
+            (2, Some(tok)) => {
+                let start = self.lower_expression(operands[0])?;
+                let end = self.lower_expression(operands[1])?;
+                let exclusive = tok.value == "...";
+                let op_span = self.span_of_token(tok);
+                Ok(Expr::BuiltinCall {
+                    name: "range".to_string(),
+                    args: vec![
+                        start,
+                        end,
+                        // The third arg is a flag — `true` means
+                        // exclusive (`...`), `false` means inclusive
+                        // (`..`).  Carrying it as data keeps the
+                        // builtin's signature uniform.
+                        Expr::BoolLit { value: exclusive, span: op_span.clone() },
+                    ],
+                    effects: EffectSet::PURE,
+                    span: op_span,
+                })
+            }
+            // Shouldn't happen given the grammar shape — but be
+            // defensive: a missing operator with two operands or a
+            // present operator with the wrong operand count points
+            // at a grammar regeneration gone awry.
+            (n, _) => Err(RubyLowerError {
+                message: format!(
+                    "range node had {n} operand(s) and op={:?} — expected (1, None) or (2, Some(..|...))",
+                    op_tok.map(|t| t.value.clone()),
+                ),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }),
+        }
     }
 
     /// Lower a `factor` node — the leaves of the expression tree.


### PR DESCRIPTION
## Summary

- Adds Ruby range expressions `a..b` (inclusive) and `a...b` (exclusive) to the grammar.
- Inserts a new `range` rule between `expression` and `logical_or`, with proper precedence (range binds *looser* than `||`/`&&`).
- Lowers ranges to `BuiltinCall("range", [start, end, BoolLit(exclusive)])` in the SIR, with all effects PURE.

## Grammar change

```
expression = range ;
range      = logical_or [ ( "..." | ".." ) logical_or ] ;
```

- Optional (zero-or-one) repetition correctly forbids chaining — `1..5..10` is a parse error in real Ruby and our grammar matches that.
- The lexer's pre-existing Phase 4e `fuse_range_ops` already gives us single `..`/`...` tokens; grammar matches by literal value, same trick as `"=>"`, `"<="`, `"&&"`.

## SIR lowering

| Source | SIR |
|---|---|
| `a..b` | `BuiltinCall("range", [a, b, BoolLit(false)])` |
| `a...b` | `BuiltinCall("range", [a, b, BoolLit(true)])` |

Third argument flag keeps the builtin name uniform so downstream emitters can pattern-match once.

## Deferred to follow-up

- Endless ranges (`(1..)`, `arr[2..]`) — lexer 4e already flags these; parser-side support gets its own phase.
- Beginless ranges (`(..5)`).

## Tests

- `coding-adventures-ruby-parser`: 65 → **71** (+6 grammar tests).
- `ruby-to-semantic-ir`: 70 → **74** (+4 lowering tests).
- `coding-adventures-ruby-lexer`: 142 (unchanged).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-parser` (71/71 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (74/74 pass)
- [x] `cargo test -p coding-adventures-ruby-lexer` (142/142 pass)
- [x] Security review (via `/security-review` sub-agent) — passed
- [ ] CI green

Follows PR #4204 (Phase 6m — logical operators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)