### PR TITLE
spice: add MOSFET channel noise

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -15,6 +15,9 @@
 - **MOS Level-1 capacitance models** — `CGSO`, `CGDO`, `CGBO`, `CBS`, and
   `CBD` now contribute MOSFET small-signal AC susceptance.
 
+- **MOSFET channel thermal noise** — `.NOISE` now includes long-channel
+  `4kTγgm` channel noise for biased MOSFETs in the per-element breakdown.
+
 - **Diode emission coefficient models** — `Diode.N` now scales the effective
   thermal voltage in DC and small-signal diode conductance calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -6254,7 +6254,8 @@ def mc_dc(
 #   Diode       : S_i = 2q|I_D|, current noise anode → cathode
 #   BJT         : S_i = 2q|I_C|, current noise base → emitter (collector
 #                 junction — approximated as proportional to I_C)
-#   All others (Capacitor, Inductor, VoltageSource, CurrentSource, Mosfet):
+#   Mosfet      : S_i = 4kTγgm, channel thermal noise drain → source
+#   All others (Capacitor, Inductor, VoltageSource, CurrentSource):
 #                 treated as noiseless in this model
 #
 # The adjoint method — computing all contributions in one solve
@@ -6313,6 +6314,7 @@ def mc_dc(
 # Physical constants used in noise calculations.
 _BOLTZMANN: float = 1.380649e-23  # Boltzmann constant [J/K]
 _ELECTRON_CHARGE: float = 1.602176634e-19  # Electron charge [C]
+_MOSFET_CHANNEL_NOISE_GAMMA: float = 2.0 / 3.0
 
 
 @dataclass(frozen=True)
@@ -6324,11 +6326,13 @@ class NoiseEntry:
     element_name : str
         Name of the circuit element generating this noise.
     noise_type : str
-        ``"thermal"`` (Johnson-Nyquist noise, for resistors) or
+        ``"thermal"`` (Johnson-Nyquist noise, for resistors and MOSFET
+        channel noise) or
         ``"shot"`` (Poisson/shot noise, for diodes and BJTs).
     source_psd : float
         Noise current power spectral density at the source itself, in A²/Hz.
-        For resistors: ``4kT/R``.  For diodes/BJTs: ``2q|I_DC|``.
+        For resistors: ``4kT/R``.  For MOSFETs: ``4kTγgm``.  For
+        diodes/BJTs: ``2q|I_DC|``.
     output_psd : float
         Contribution to the output voltage noise spectral density, in V²/Hz.
         Computed as ``|H_k(jω)|² × source_psd`` where ``H_k`` is the transfer
@@ -6474,8 +6478,22 @@ def _collect_noise_sources(
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]
             sources.append((el.name, "shot", n_b, n_e, psd))
 
-        # Capacitors, Inductors, VoltageSources, CurrentSources, MOSFETs:
-        # noiseless in this first-order model.
+        elif isinstance(el, Mosfet):
+            # Long-channel MOSFET channel thermal noise: S_i = 4kTγgm.
+            Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+            Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
+            Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+            Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
+            r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
+            gm = max(0.0, float(r.gm))
+            if gm > 0.0:
+                psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
+                n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+                n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+                sources.append((el.name, "thermal", n_d, n_s, psd))
+
+        # Capacitors, Inductors, VoltageSources, CurrentSources: noiseless in
+        # this first-order model.
 
     return sources
 
@@ -6493,10 +6511,10 @@ def noise_ac(
     """Small-signal noise analysis (the SPICE .NOISE analysis).
 
     Computes the voltage noise power spectral density (PSD) at ``output_node``
-    due to thermal noise (Johnson-Nyquist) in resistors and shot noise in
-    diodes and BJTs, at each frequency in ``freqs``.  Also reports the noise
-    referred back to ``input_source`` so you can compare it directly to your
-    signal level.
+    due to thermal noise (Johnson-Nyquist) in resistors, MOSFET channel
+    thermal noise, and shot noise in diodes and BJTs, at each frequency in
+    ``freqs``.  Also reports the noise referred back to ``input_source`` so
+    you can compare it directly to your signal level.
 
     Algorithm
     ---------
@@ -6550,8 +6568,9 @@ def noise_ac(
 
     Notes
     -----
-    - Noiseless elements: Capacitor, Inductor, VoltageSource, CurrentSource,
-      Mosfet.  Extending to MOSFET channel noise (``4kT γ gm``) is future work.
+    - MOSFET channel noise uses the long-channel thermal approximation
+      ``4kT γ gm`` with ``γ = 2/3``.
+    - Noiseless elements: Capacitor, Inductor, VoltageSource, CurrentSource.
     - If the AC matrix is singular at a frequency, that point's PSDs are 0.0.
     - Output PSD in V²/Hz; take ``math.sqrt(pt.output_psd)`` for V/√Hz density.
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -4478,6 +4478,48 @@ def test_noise_bjt_shot_noise_type_string() -> None:
     assert bjt_entry.noise_type == "shot"
 
 
+def test_noise_mosfet_channel_thermal_noise() -> None:
+    """A biased MOSFET contributes long-channel channel thermal noise."""
+    c = Circuit()
+    c.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    c.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    c.add(Resistor("Rload", "vdd", "out", 1000.0))
+    c.add(Mosfet(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(
+                VT0=1.0,
+                KP=1.0e-3,
+                LAMBDA=0.0,
+                GAMMA=0.0,
+                W=1.0,
+                L=1.0,
+            )),
+        ),
+    ))
+
+    result = noise_ac(c, "out", "Vgate", freqs=[1000.0], temperature=300.0)
+    entry = next(
+        (e for e in result.points[0].entries if e.element_name == "M1"), None
+    )
+    gm = 1.0e-3 * (3.0 - 1.0)
+    expected_source_psd = 4.0 * _kB * 300.0 * (2.0 / 3.0) * gm
+
+    assert entry is not None, "No MOSFET channel noise entry"
+    assert entry.noise_type == "thermal"
+    assert isclose(entry.source_psd, expected_source_psd, rel_tol=1e-6)
+    assert isclose(
+        entry.output_psd,
+        expected_source_psd * 1000.0 ** 2,
+        rel_tol=1e-6,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Section 51 — Noise analysis: frequency sweep and defaults
 # ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -9,6 +9,8 @@
   `V(node)` and `I(source)` probes.
 - Add MOS Level-1 capacitance support through `CGSO`, `CGDO`, `CGBO`, `CBS`,
   and `CBD`, contributing small-signal AC susceptance.
+- Add MOSFET channel thermal noise to `.NOISE` via the long-channel `4kTγgm`
+  model and per-element `M` device contributions.
 - Add diode emission coefficient support through `emission_coefficient`,
   scaling the effective thermal voltage in DC and small-signal diode
   conductance.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -5,6 +5,7 @@ const PIVOT_EPSILON: f64 = 1.0e-12;
 const SPARSE_SOLVER_THRESHOLD: usize = 30;
 const TWO_PI: f64 = std::f64::consts::PI * 2.0;
 const BOLTZMANN: f64 = 1.380_649e-23;
+const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Circuit {
@@ -3515,14 +3516,14 @@ pub fn noise_ac(
     let voltage_sources = collect_ac_voltage_sources(circuit)?;
     let node_count = node_indices.len();
     let matrix_size = node_count + voltage_sources.len();
-    let uses_explicit_ac_sources = circuit_has_explicit_ac_sources(circuit);
-    let operating_point = if uses_explicit_ac_sources && matrix_size > 0 {
+    let operating_point = if matrix_size > 0 {
         solve_linear_circuit(circuit, &[], &[], None)?.vector
     } else {
         vec![0.0; matrix_size]
     };
     let output_index = node_index(&node_indices, output_node);
-    let noise_sources = collect_noise_sources(circuit, &node_indices, temperature_kelvin)?;
+    let noise_sources =
+        collect_noise_sources(circuit, &node_indices, &operating_point, temperature_kelvin)?;
     let frequencies = if frequencies_hz.is_empty() {
         default_noise_frequencies()
     } else {
@@ -5646,24 +5647,59 @@ fn input_source_type_error(input_source: &str, kind: &str) -> SpiceError {
 fn collect_noise_sources(
     circuit: &Circuit,
     node_indices: &HashMap<String, usize>,
+    operating_point: &[f64],
     temperature_kelvin: f64,
 ) -> Result<Vec<NoiseSource>, SpiceError> {
     let mut sources = Vec::new();
     for element in circuit.elements() {
-        if let Element::Resistor(resistor) = element {
-            if !resistor.resistance_ohms.is_finite() || resistor.resistance_ohms <= 0.0 {
-                return Err(SpiceError::InvalidElement {
-                    name: resistor.name.clone(),
-                    reason: "resistance must be finite and positive".to_string(),
+        match element {
+            Element::Resistor(resistor) => {
+                if !resistor.resistance_ohms.is_finite() || resistor.resistance_ohms <= 0.0 {
+                    return Err(SpiceError::InvalidElement {
+                        name: resistor.name.clone(),
+                        reason: "resistance must be finite and positive".to_string(),
+                    });
+                }
+                sources.push(NoiseSource {
+                    element_name: resistor.name.clone(),
+                    noise_type: NoiseType::Thermal,
+                    positive: node_index(node_indices, &resistor.n1),
+                    negative: node_index(node_indices, &resistor.n2),
+                    source_psd: 4.0 * BOLTZMANN * temperature_kelvin / resistor.resistance_ohms,
                 });
             }
-            sources.push(NoiseSource {
-                element_name: resistor.name.clone(),
-                noise_type: NoiseType::Thermal,
-                positive: node_index(node_indices, &resistor.n1),
-                negative: node_index(node_indices, &resistor.n2),
-                source_psd: 4.0 * BOLTZMANN * temperature_kelvin / resistor.resistance_ohms,
-            });
+            Element::Mosfet(mosfet) => {
+                validate_mosfet(mosfet)?;
+                let drain = node_index(node_indices, &mosfet.drain);
+                let gate = node_index(node_indices, &mosfet.gate);
+                let source = node_index(node_indices, &mosfet.source);
+                let body = node_index(node_indices, &mosfet.body);
+                let drain_voltage = vector_voltage(operating_point, drain);
+                let gate_voltage = vector_voltage(operating_point, gate);
+                let source_voltage = vector_voltage(operating_point, source);
+                let body_voltage = vector_voltage(operating_point, body);
+                let result = evaluate_mosfet_level1(
+                    mosfet,
+                    gate_voltage - source_voltage,
+                    drain_voltage - source_voltage,
+                    body_voltage - source_voltage,
+                );
+                let gm = result.gm.max(0.0);
+                if gm > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: mosfet.name.clone(),
+                        noise_type: NoiseType::Thermal,
+                        positive: drain,
+                        negative: source,
+                        source_psd: 4.0
+                            * BOLTZMANN
+                            * temperature_kelvin
+                            * MOSFET_CHANNEL_NOISE_GAMMA
+                            * gm,
+                    });
+                }
+            }
+            _ => {}
         }
     }
     Ok(sources)

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -1,9 +1,10 @@
 use spice_engine::{
-    noise_ac, noise_ac_default, Capacitor, Circuit, CurrentSource, Element, NoiseType, Resistor,
-    SpiceError, VoltageSource,
+    noise_ac, noise_ac_default, Capacitor, Circuit, CurrentSource, Element, Mosfet,
+    MosfetLevel1Params, MosfetType, NoiseType, Resistor, SpiceError, VoltageSource,
 };
 
 const BOLTZMANN: f64 = 1.380_649e-23;
+const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 
 fn assert_close(actual: f64, expected: f64, tolerance: f64) {
     assert!(
@@ -96,6 +97,56 @@ fn noise_ac_rc_low_pass_rolls_off_with_frequency() {
     assert!(at_corner > high, "corner={at_corner}, high={high}");
     assert!((at_corner - low / 2.0).abs() < low * 0.05);
     assert!(high < low * 1.0e-4, "high={high}, low={low}");
+}
+
+#[test]
+fn noise_ac_includes_mosfet_channel_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            vt0: 1.0,
+            kp: 1.0e-3,
+            lambda: 0.0,
+            gamma: 0.0,
+            w: 1.0,
+            l: 1.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let point = &noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0)
+        .unwrap()
+        .points[0];
+    let entry = point
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "M1")
+        .expect("missing MOSFET channel noise entry");
+    let gm = 1.0e-3 * (3.0 - 1.0);
+    let expected_source_psd = 4.0 * BOLTZMANN * 300.0 * MOSFET_CHANNEL_NOISE_GAMMA * gm;
+
+    assert_eq!(entry.noise_type, NoiseType::Thermal);
+    assert_close(entry.source_psd, expected_source_psd, 1.0e-32);
+    assert_close(
+        entry.output_psd,
+        expected_source_psd * 1_000.0_f64.powi(2),
+        1.0e-27,
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -9,6 +9,8 @@
   `V(node)` and `I(source)` probes.
 - Add MOS Level-1 capacitance support through `CGSO`, `CGDO`, `CGBO`, `CBS`,
   and `CBD`, contributing small-signal AC susceptance.
+- Add MOSFET channel thermal noise to `.NOISE` via the long-channel `4kTγgm`
+  model and per-element `M` device contributions.
 - Add diode emission coefficient support through `emissionCoefficient`, scaling
   the effective thermal voltage in DC and small-signal diode conductance.
 - Add diode breakdown support through `breakdownVoltage` / `breakdownCurrent`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2,6 +2,7 @@ const PIVOT_EPSILON = 1.0e-12;
 const SPARSE_SOLVER_THRESHOLD = 30;
 const TWO_PI = Math.PI * 2.0;
 const BOLTZMANN = 1.380_649e-23;
+const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 
 export type Element =
   | Resistor
@@ -2115,15 +2116,16 @@ export function noiseAc(
   const nodeCount = nodeIndices.size;
   const matrixSize = nodeCount + voltageSources.size;
   const outputIndex = nodeIndex(nodeIndices, outputNode);
-  const noiseSources = collectNoiseSources(
-    circuit,
-    nodeIndices,
-    temperatureKelvin,
-  );
   const operatingPoint = solveDcOperatingPointForSmallSignal(
     circuit,
     nodeIndices,
     voltageSources,
+  );
+  const noiseSources = collectNoiseSources(
+    circuit,
+    nodeIndices,
+    operatingPoint,
+    temperatureKelvin,
   );
 
   const points = frequenciesHz.map((frequencyHz) => {
@@ -4749,23 +4751,49 @@ function findInputSource(circuit: Circuit, inputSource: string): InputSource {
 function collectNoiseSources(
   circuit: Circuit,
   nodeIndices: ReadonlyMap<string, number>,
+  operatingPoint: readonly number[],
   temperatureKelvin: number,
 ): NoiseSource[] {
   const sources: NoiseSource[] = [];
   for (const element of circuit.elements()) {
-    if (element.kind !== "resistor") {
-      continue;
+    if (element.kind === "resistor") {
+      if (!Number.isFinite(element.resistanceOhms) || element.resistanceOhms <= 0) {
+        throw invalidElement(element.name, "resistance must be finite and positive");
+      }
+      sources.push({
+        elementName: element.name,
+        noiseType: "thermal",
+        positive: nodeIndex(nodeIndices, element.n1),
+        negative: nodeIndex(nodeIndices, element.n2),
+        sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.resistanceOhms,
+      });
+    } else if (element.kind === "mosfet") {
+      validateMosfet(element);
+      const drain = nodeIndex(nodeIndices, element.drain);
+      const gate = nodeIndex(nodeIndices, element.gate);
+      const source = nodeIndex(nodeIndices, element.source);
+      const body = nodeIndex(nodeIndices, element.body);
+      const drainVoltage = vectorVoltage(operatingPoint, drain);
+      const gateVoltage = vectorVoltage(operatingPoint, gate);
+      const sourceVoltage = vectorVoltage(operatingPoint, source);
+      const bodyVoltage = vectorVoltage(operatingPoint, body);
+      const result = evaluateMosfetLevel1(
+        element,
+        gateVoltage - sourceVoltage,
+        drainVoltage - sourceVoltage,
+        bodyVoltage - sourceVoltage,
+      );
+      const gm = Math.max(0.0, result.gm);
+      if (gm > 0.0) {
+        sources.push({
+          elementName: element.name,
+          noiseType: "thermal",
+          positive: drain,
+          negative: source,
+          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin * MOSFET_CHANNEL_NOISE_GAMMA * gm,
+        });
+      }
     }
-    if (!Number.isFinite(element.resistanceOhms) || element.resistanceOhms <= 0) {
-      throw invalidElement(element.name, "resistance must be finite and positive");
-    }
-    sources.push({
-      elementName: element.name,
-      noiseType: "thermal",
-      positive: nodeIndex(nodeIndices, element.n1),
-      negative: nodeIndex(nodeIndices, element.n2),
-      sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.resistanceOhms,
-    });
   }
   return sources;
 }

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -4,12 +4,14 @@ import {
   SpiceError,
   capacitor,
   currentSource,
+  mosfet,
   noiseAc,
   resistor,
   voltageSource,
 } from "../src/index.js";
 
 const BOLTZMANN = 1.380_649e-23;
+const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 
 describe("noiseAc", () => {
   it("computes Johnson noise for a single grounded resistor", () => {
@@ -80,6 +82,32 @@ describe("noiseAc", () => {
     expect(corner.outputPsd).toBeGreaterThan(high.outputPsd);
     expect(corner.outputPsd).toBeCloseTo(low.outputPsd / 2.0, 1);
     expect(high.outputPsd).toBeLessThan(low.outputPsd * 1.0e-4);
+  });
+
+  it("includes MOSFET channel thermal noise", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", {
+      VT0: 1.0,
+      KP: 1.0e-3,
+      LAMBDA: 0.0,
+      GAMMA: 0.0,
+      W: 1.0,
+      L: 1.0,
+    }));
+
+    const point = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0];
+    const entry = point.entries.find((candidate) => candidate.elementName === "M1");
+    const gm = 1.0e-3 * (3.0 - 1.0);
+    const expectedSourcePsd =
+      4.0 * BOLTZMANN * 300.0 * MOSFET_CHANNEL_NOISE_GAMMA * gm;
+
+    expect(entry).toBeDefined();
+    expect(entry?.noiseType).toBe("thermal");
+    expect(entry?.sourcePsd).toBeCloseTo(expectedSourcePsd, 30);
+    expect(entry?.outputPsd).toBeCloseTo(expectedSourcePsd * 1_000.0 ** 2, 30);
   });
 
   it("uses default logarithmic frequencies", () => {

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -30,8 +30,9 @@ Historical references:
 The repo already has the essential solver spine:
 
 - MNA-based DC operating point with Newton-Raphson.
-- DC source sweep, transfer function, sensitivity, Monte Carlo, noise, AC
-  sweep, transient analysis, and recent PSS footholds.
+- DC source sweep, transfer function, sensitivity, Monte Carlo, noise
+  including MOSFET channel thermal noise, AC sweep, transient analysis, and
+  recent PSS footholds.
 - R, C, L, independent V/I sources, all four dependent sources, diode, BJT,
   MOSFET, behavioral sources, subcircuits, and sparse real solve support.
 - Python, TypeScript, and Rust `spice-engine` packages.

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -186,7 +186,7 @@ files.
 | v0.6.0 | #2353 | DC parameter sweep (`.DC`) |
 | v0.7.0 | #2357 | DC sensitivity analysis (`.SENS`) — ∂V/∂P per element |
 | v0.8.0 | #2359 | Monte Carlo (`.MC`) — Gaussian + uniform tolerance distributions |
-| v0.9.0 | #2370 | Noise analysis (`.NOISE`) — Johnson-Nyquist + shot noise, adjoint method |
+| v0.9.0 | #2370 | Noise analysis (`.NOISE`) — Johnson-Nyquist, MOSFET channel thermal, and shot noise; adjoint method |
 
 **Elements on main:** `Resistor`, `Capacitor`, `Inductor`, `VoltageSource`,
 `CurrentSource`, `BSource`, `Diode`, `Mosfet`, `BJT`


### PR DESCRIPTION
## Summary

- add long-channel MOSFET channel thermal noise to Python, TypeScript, and Rust `noise_ac`
- compute per-device source PSD as `4kT * 2/3 * gm` from the DC operating point
- add cross-language common-source `.NOISE` tests and update SPICE/changelog notes

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-mosfet-channel-noise sh BUILD` in `code/packages/python/spice-engine`
- `npm run build && npm test -- --run tests/noise.test.ts` in `code/packages/typescript/spice-engine`
- `npm test` in `code/packages/typescript/spice-engine`
- `cargo fmt -p spice-engine --check && cargo test -p spice-engine --test noise_tests` in `code/packages/rust`
- `cargo test -p spice-engine` in `code/packages/rust`
- `git diff --check`
