### PR TITLE
fix(sql-vm,mini-sqlite): UTF-8-decode BLOB→TEXT cast (SQLite parity)

### DIFF
--- a/code/packages/python/mini-sqlite/CHANGELOG.md
+++ b/code/packages/python/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2.15.0] - 2026-05-24
+
+### Fixed
+
+- ``CAST(<blob> AS TEXT)`` now UTF-8-decodes the BLOB bytes rather
+  than hex-encoding them — matches SQLite.  So ``CAST(x'48656c6c6f'
+  AS TEXT)`` returns ``'Hello'`` (was ``'48656c6c6f'``) and
+  ``CAST(CAST(42 AS BLOB) AS TEXT)`` round-trips to ``'42'`` (was
+  ``'3432'``).  Together with the 2.14.0 fix to ``CAST(<numeric> AS
+  BLOB)``, this restores SQLite's documented round-trip identity::
+
+      CAST(CAST(n AS BLOB) AS TEXT) == CAST(n AS TEXT)
+
+  Lifts the "Known limitation" noted in 2.14.0.  Invalid UTF-8
+  bytes are mapped to U+FFFD via ``errors="replace"`` so the cast
+  is total (mini's SQL-engine layer stays lenient; sqlite3's Python
+  binding raises at fetch time via ``text_factory`` instead — a
+  binding-layer divergence, not an engine-layer one).  See sql-vm
+  1.59.0 for the scalar-function-level fix.
+
 ## [2.14.0] - 2026-05-24
 
 ### Fixed
@@ -11,15 +31,6 @@
   produce 8-byte big-endian binary blobs that didn't survive
   round-tripping through SQLite's text-first conversion rules.
   See sql-vm 1.58.0 for the scalar-function-level fix.
-
-### Known limitation
-
-- ``CAST(<blob> AS TEXT)`` still hex-encodes the BLOB bytes rather
-  than UTF-8-decoding them.  So ``CAST(CAST(42 AS BLOB) AS TEXT)``
-  returns ``'3432'`` (hex of ``b'42'``) instead of SQLite's
-  ``'42'``.  Pinned by a regression test
-  (``TestKnownLimitationBlobToText``) so a future BLOB→TEXT fix is
-  reminded to update both directions and lift the test together.
 
 ## [2.13.0] - 2026-05-24
 

--- a/code/packages/python/mini-sqlite/pyproject.toml
+++ b/code/packages/python/mini-sqlite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-mini-sqlite"
-version = "2.14.0"
+version = "2.15.0"
 description = "PEP 249 DB-API 2.0 facade over the sql-lexer / parser / planner / optimizer / codegen / vm / backend stack."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_cast_blob_to_text.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_cast_blob_to_text.py
@@ -1,0 +1,88 @@
+"""Tests for ``CAST(<blob> AS TEXT)`` UTF-8 decoding (matches SQLite).
+
+SQLite's BLOB→TEXT cast treats the BLOB bytes as the encoded text
+representation and UTF-8-decodes them.  So::
+
+    CAST(x'48656c6c6f' AS TEXT)  ⟶  'Hello'   (not '48656c6c6f')
+    CAST(x'31' AS TEXT)          ⟶  '1'       (not '31')
+    CAST(x'3432' AS TEXT)        ⟶  '42'      (not '3432')
+
+Mini-sqlite previously hex-encoded the bytes, breaking the
+documented identity::
+
+    CAST(CAST(n AS BLOB) AS TEXT) == CAST(n AS TEXT)
+
+The fix (sql-vm 1.59.0) changes the BLOB → TEXT path in
+``_cast_fn`` from ``x.hex()`` to ``x.decode("utf-8",
+errors="replace")``.  Invalid UTF-8 bytes are mapped to U+FFFD
+rather than raising — matches SQLite's "decode lazily, never error
+mid-query" stance and keeps the cast total.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import mini_sqlite
+
+
+def _both_match(query: str) -> None:
+    mini = mini_sqlite.connect(":memory:")
+    ref = sqlite3.connect(":memory:")
+    assert mini.execute(query).fetchall() == ref.execute(query).fetchall()
+
+
+class TestAsciiBlob:
+    def test_hello(self) -> None:
+        _both_match("SELECT CAST(x'48656c6c6f' AS TEXT)")
+
+    def test_single_digit(self) -> None:
+        _both_match("SELECT CAST(x'31' AS TEXT)")
+
+    def test_multi_digit(self) -> None:
+        _both_match("SELECT CAST(x'3432' AS TEXT)")
+
+    def test_empty_blob(self) -> None:
+        _both_match("SELECT CAST(x'' AS TEXT)")
+
+
+class TestNumericRoundTrip:
+    """``CAST(CAST(n AS BLOB) AS TEXT)`` recovers the textual form
+    of ``n`` — pinning the documented SQLite identity."""
+
+    def test_int_one(self) -> None:
+        _both_match("SELECT CAST(CAST(1 AS BLOB) AS TEXT)")
+
+    def test_int_forty_two(self) -> None:
+        _both_match("SELECT CAST(CAST(42 AS BLOB) AS TEXT)")
+
+    def test_int_negative(self) -> None:
+        _both_match("SELECT CAST(CAST(-7 AS BLOB) AS TEXT)")
+
+    def test_float_one_point_five(self) -> None:
+        _both_match("SELECT CAST(CAST(1.5 AS BLOB) AS TEXT)")
+
+    def test_bool_true(self) -> None:
+        _both_match("SELECT CAST(CAST(TRUE AS BLOB) AS TEXT)")
+
+    def test_bool_false(self) -> None:
+        _both_match("SELECT CAST(CAST(FALSE AS BLOB) AS TEXT)")
+
+
+class TestUtf8MultiByte:
+    """Multi-byte UTF-8 sequences round-trip cleanly."""
+
+    def test_e_acute(self) -> None:
+        _both_match("SELECT CAST(x'c3a9' AS TEXT)")
+
+
+class TestInvalidUtf8:
+    """Invalid UTF-8 → U+FFFD replacement (slight divergence from
+    sqlite3's text_factory which raises, but matches the SQLite
+    engine's lenient decoding stance).  Pin mini's lenient
+    behaviour so a future strict-mode addition is detected."""
+
+    def test_invalid_byte_becomes_replacement_char(self) -> None:
+        m = mini_sqlite.connect(":memory:")
+        (val,) = m.execute("SELECT CAST(x'ff' AS TEXT)").fetchall()[0]
+        assert val == "�"

--- a/code/packages/python/mini-sqlite/tests/test_tier3_cast_numeric_to_blob.py
+++ b/code/packages/python/mini-sqlite/tests/test_tier3_cast_numeric_to_blob.py
@@ -81,17 +81,21 @@ class TestPassthrough:
         _both_match("SELECT CAST(NULL AS BLOB)")
 
 
-class TestKnownLimitationBlobToText:
-    """``CAST(<blob> AS TEXT)`` currently hex-encodes the BLOB bytes
-    instead of UTF-8-decoding them — so ``CAST(CAST(42 AS BLOB) AS
-    TEXT)`` returns ``'3432'`` (hex of ``b'42'``) rather than the
-    SQLite-compatible ``'42'``.  Out of scope for this PR; pinned
-    so a future BLOB→TEXT fix is reminded to update this test
-    alongside the CHANGELOG entry."""
+class TestRoundTripIdentity:
+    """``CAST(CAST(x AS BLOB) AS TEXT)`` recovers the original textual
+    form for numeric ``x`` — now that the BLOB→TEXT direction
+    UTF-8-decodes (mini-sqlite 2.15+ / sql-vm 1.59+).  Replaces the
+    earlier ``TestKnownLimitationBlobToText`` pin which documented the
+    hex-encoding divergence."""
 
-    def test_int_blob_to_text_diverges(self) -> None:
-        m = mini_sqlite.connect(":memory:")
-        # Hex of '42' is '3432'.
-        assert m.execute(
-            "SELECT CAST(CAST(42 AS BLOB) AS TEXT)"
-        ).fetchall() == [("3432",)]
+    def test_int_roundtrip(self) -> None:
+        _both_match("SELECT CAST(CAST(42 AS BLOB) AS TEXT)")
+
+    def test_bool_roundtrip(self) -> None:
+        _both_match("SELECT CAST(CAST(TRUE AS BLOB) AS TEXT)")
+
+    def test_float_roundtrip(self) -> None:
+        _both_match("SELECT CAST(CAST(1.5 AS BLOB) AS TEXT)")
+
+    def test_negative_int_roundtrip(self) -> None:
+        _both_match("SELECT CAST(CAST(-7 AS BLOB) AS TEXT)")

--- a/code/packages/python/sql-vm/CHANGELOG.md
+++ b/code/packages/python/sql-vm/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.59.0 — 2026-05-24
+
+### Fixed
+
+- ``CAST(<blob> AS TEXT)`` now UTF-8-decodes the BLOB bytes instead
+  of hex-encoding them, matching SQLite::
+
+      CAST(x'48656c6c6f' AS TEXT)  ⟶  'Hello'   (was '48656c6c6f')
+      CAST(x'31' AS TEXT)          ⟶  '1'       (was '31')
+      CAST(x'3432' AS TEXT)        ⟶  '42'      (was '3432')
+
+  Together with the 1.58.0 fix to ``CAST(<numeric> AS BLOB)``, this
+  restores SQLite's documented round-trip identity::
+
+      CAST(CAST(n AS BLOB) AS TEXT) == CAST(n AS TEXT)
+
+  Fix in ``_cast_fn``'s TEXT-affinity branch: the ``bytes`` arm now
+  calls ``x.decode("utf-8", errors="replace")`` instead of
+  ``x.hex()``.  Invalid UTF-8 bytes are mapped to U+FFFD rather
+  than raising — matches SQLite's "decode lazily, never error
+  mid-query" stance and keeps the cast total.
+
 ## 1.58.0 — 2026-05-24
 
 ### Fixed

--- a/code/packages/python/sql-vm/pyproject.toml
+++ b/code/packages/python/sql-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sql-vm"
-version = "1.58.0"
+version = "1.59.0"
 description = "Dispatch-loop virtual machine that executes sql-codegen Programs against a pluggable Backend."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
+++ b/code/packages/python/sql-vm/src/sql_vm/scalar_functions.py
@@ -349,7 +349,15 @@ def _cast_fn(x: SqlValue, target_type: SqlValue) -> SqlValue:
                  "varying character", "nchar", "native character",
                  "clob"):
             if isinstance(x, bytes):
-                return x.hex()
+                # SQLite's BLOB→TEXT cast UTF-8-decodes the bytes
+                # (treating them as the encoded text representation),
+                # NOT hex-encodes them.  So ``CAST(x'48656c6c6f' AS
+                # TEXT)`` is ``'Hello'`` and ``CAST(CAST(42 AS BLOB)
+                # AS TEXT)`` round-trips to ``'42'``.  Invalid UTF-8
+                # bytes are replaced with U+FFFD via ``errors="replace"``
+                # so a malformed blob can never raise UnicodeDecodeError
+                # mid-query (matches SQLite's lenient decoding).
+                return x.decode("utf-8", errors="replace")
             # SQLite has no native boolean type — TRUE / FALSE round-trip
             # as integers 1 / 0.  ``CAST(TRUE AS TEXT)`` must therefore
             # yield ``'1'``, not Python's ``'True'``.  Check ``bool``

--- a/code/packages/python/sql-vm/tests/test_scalar_functions.py
+++ b/code/packages/python/sql-vm/tests/test_scalar_functions.py
@@ -226,11 +226,17 @@ class TestCast:
     def test_cast_float_to_text(self) -> None:
         assert fn("cast", 3.14, "text") == "3.14"
 
-    def test_cast_blob_to_text_is_hex(self) -> None:
-        # bytes → hex string per our CAST implementation.
-        result = fn("cast", b"\xde\xad", "text")
-        assert isinstance(result, str)
-        assert result.lower() == "dead"
+    def test_cast_blob_to_text_utf8_decodes(self) -> None:
+        # bytes → UTF-8-decoded text (matches SQLite, replaces the
+        # earlier hex-encoding behaviour as of sql-vm 1.59.0).
+        assert fn("cast", b"Hello", "text") == "Hello"
+        assert fn("cast", b"42", "text") == "42"
+        # Empty BLOB round-trips to empty string.
+        assert fn("cast", b"", "text") == ""
+        # Invalid UTF-8 bytes are replaced with U+FFFD rather than
+        # raising — keeps the cast total and matches SQLite's
+        # "decode lazily, never error mid-query" stance.
+        assert fn("cast", b"\xff", "text") == "�"
 
     def test_cast_string_to_blob(self) -> None:
         result = fn("cast", "hi", "blob")


### PR DESCRIPTION
## Summary

- `CAST(<blob> AS TEXT)` now UTF-8-decodes the BLOB bytes instead of hex-encoding them, matching SQLite.
- Together with PR #4221 (CAST numeric→BLOB), this restores SQLite's documented round-trip identity: `CAST(CAST(n AS BLOB) AS TEXT) == CAST(n AS TEXT)`.
- Lifts the "Known limitation" note from mini-sqlite 2.14.0.

## Why

The previous BLOB→TEXT branch in `_cast_fn` called `x.hex()`, so `CAST(x'48656c6c6f' AS TEXT)` returned `'48656c6c6f'` instead of `'Hello'`, and `CAST(CAST(42 AS BLOB) AS TEXT)` returned `'3432'` instead of `'42'`. SQLite's BLOB→TEXT cast treats the bytes as the encoded text representation and UTF-8-decodes them.

## What changed

`code/packages/python/sql-vm/src/sql_vm/scalar_functions.py` — `_cast_fn`'s TEXT-affinity branch swaps `x.hex()` for `x.decode("utf-8", errors="replace")`. Invalid UTF-8 maps to U+FFFD rather than raising — keeps the cast total and matches SQLite's "decode lazily, never error mid-query" stance.

## Tests

- **New** `mini-sqlite/tests/test_tier3_cast_blob_to_text.py` (12 oracle tests): ASCII blob, numeric round-trip, multi-byte UTF-8, invalid-UTF-8 replacement.
- **Updated** `mini-sqlite/tests/test_tier3_cast_numeric_to_blob.py`: replaced `TestKnownLimitationBlobToText` pin with `TestRoundTripIdentity` oracle-comparing the now-fixed round trip.
- **Updated** `sql-vm/tests/test_scalar_functions.py`: `test_cast_blob_to_text_is_hex` → `test_cast_blob_to_text_utf8_decodes`.

## Versions

- sql-vm 1.58.0 → 1.59.0
- mini-sqlite 2.14.0 → 2.15.0

## Test plan

- [x] Local: all sql-vm tests pass (369)
- [x] Local: all new mini-sqlite cast tests pass (29 across both files)
- [x] Ruff clean on touched files
- [x] Security review passed (no findings)
- [ ] CI: build (macOS / Ubuntu×2 / Windows) + CodeQL Python Analyze green
- [ ] CI: full mini-sqlite oracle suite green (no regression in non-cast tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)