### PR TITLE
feat(ruby-lexer): Phase 4m — backtick command literals `cmd args`

### DIFF
--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.18.0] - 2026-05-24
+
+### Added (Phase 4m — backtick command literals `` `cmd args` ``)
+
+Ruby has had `` `cmd args` `` command-execution literals since 1.0 — they spawn a shell, execute the body, and yield the standard-output as a string.  The lexer was the missing piece: until this chunk the leading backtick was an unrecognised character.
+
+Implementation lives entirely in the state machine — no post-pass needed.
+
+#### Token shape
+
+- **`` `cmd args` ``** → `TokenType::String` with value `` `cmd args` `` (literally, with the backticks re-wrapped).
+- Parser-side distinguishes backtick literals from plain strings by inspecting the lexeme's leading character — same sentinel-by-prefix trick used by percent literals (`%w[…]`) and heredocs (`<<TAG\n…TAG`).
+
+#### State-machine additions
+
+- Alphabet: `` ` `` (backtick).
+- New token kind: `Backtick` (mapped to `TokenType::String` in the emit handler).
+- New states: `backtick_body`, `backtick_escape`.
+- `data` → `backtick_body` on `` ` ``.
+- Inside `backtick_body`:
+  - `` ` `` → `data` (`emit(Backtick)`).
+  - `\\` → `backtick_escape`.
+  - `\n` is allowed (multi-line bodies, matching `string_d_body`).
+  - EOF → `parse_error(unterminated_backtick)`.
+  - Anything else → append.
+- `backtick_escape` handles the same five escapes as `string_d_escape` (`n`, `t`, `r`, `\\`, plus `` ` `` instead of `"` since `` ` `` is the close char) and falls through to `append_text(current)` otherwise.
+
+#### Out of scope (deferred to follow-up)
+
+- `#{}` interpolation inside `` `…` ``.  Real Ruby allows it; v0 treats `#` as a literal character inside the body.  The parser-side phase 7a (backtick parsing) can layer interpolation later.
+- Backtick as a *method name* (`def \`(cmd); …; end`).  Outside scope for v0 — that needs special lex-state feedback.
+
+### Tests (+7 new, total 149)
+- `backtick_simple_command_lexes_as_string_with_backticks`
+- `backtick_empty_body_lexes_to_two_backticks`
+- `backtick_escape_sequences_resolved_in_body`
+- `backtick_multiline_command_keeps_newlines`
+- `backtick_lexing_is_era_invariant` — every era ≥ 1.8 produces the same token shape (backticks are pre-1.0, hence era-invariant).
+- `backtick_does_not_swallow_following_tokens`
+- `backtick_unterminated_reports_diagnostic` — exercises the `parse_error(unterminated_backtick)` action.
+
 ## [0.17.0] - 2026-05-24
 
 ### Added (Phase 4l — radix-prefixed integers `0x1F`, `0b1010`, `0o17`, `0d42`)

--- a/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
+++ b/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
@@ -51,6 +51,10 @@ alphabet = [
   # part of Ruby since 1.0, so they're not era-gated — they were
   # simply missing from the baseline lexer until now.
   "@", "$",
+  # Phase 4m — backtick (`` ` ``) opens a command-execution literal
+  # (`` `ls -la` `` runs the shell command).  Ruby has had this since
+  # 1.0, so no era gating — just a new dispatch from `data`.
+  "`",
   # string-escape letters (n, t, r) — referenced as `literal` matchers
   # inside string_d_escape.  range matchers don't need alphabet entries
   # but literal matchers do.
@@ -106,6 +110,15 @@ fields = ["value"]
 
 [[tokens]]
 name = "PercentBigI"   # %I[a b c]   — interpolating symbol array (2.0+)
+fields = ["value"]
+
+# Phase 4m — `` `cmd` `` command-execution literal.  Lexically it
+# resembles a string: open backtick, body with escapes, close backtick.
+# Semantically it runs the body as a shell command — but that's the
+# runtime's concern.  The lexer just emits a `Backtick` token carrying
+# the raw body (without the surrounding backticks).
+[[tokens]]
+name = "Backtick"      # `` `ls -la` `` — command-execution literal
 fields = ["value"]
 
 [[tokens]]
@@ -292,6 +305,20 @@ id = "after_dollar"      # saw `$`, peeking for an ident-starter first char
 [[states]]
 id = "dollar_body"       # inside `$x` — slurp ident chars then emit Name
 
+# Phase 4m — backtick command literal `` `cmd args` ``.  Two states:
+# the body collects raw bytes (with minimal escape handling), and the
+# escape state processes a single escape sequence then returns.  The
+# shape mirrors `string_d_body` / `string_d_escape` — same idea, but:
+#   - the close terminator is a backtick, not a double quote, and
+#   - we don't peek for `#` interpolation in v0.  Real Ruby allows
+#     `#{}` interpolation inside backticks; the parser-side phase
+#     (7a) can promote `#` handling once the rest of backtick lexing
+#     is in place.  For now, `#` is a literal character.
+[[states]]
+id = "backtick_body"     # inside `` `…` `` — accumulating command body
+[[states]]
+id = "backtick_escape"   # inside `` `…` `` after a `\` — processing one escape char
+
 [[states]]
 id = "done"
 final = true
@@ -367,6 +394,15 @@ actions = ["clear_text"]
 from = "data"
 matcher = { literal = "'" }
 to = "string_s_body"
+actions = ["clear_text"]
+
+# Phase 4m — backtick opens a command-execution literal.  Clear the
+# text buffer (the value field carries the body *without* the
+# surrounding backticks, matching how `String` carries it).
+[[transitions]]
+from = "data"
+matcher = { literal = "`" }
+to = "backtick_body"
 actions = ["clear_text"]
 
 # Punctuation that emits immediately.
@@ -817,6 +853,105 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = ["parse_error(unterminated_string)", "emit(Eof)"]
+
+# ─────────────────────────────────────────────────────────────────
+# Backtick command literal (Phase 4m) — `` `cmd args` ``.
+#
+# Shape mirrors `string_d_body`:
+#   - `\` opens an escape (one of `\\`, `` \` ``, `\n`, `\t`, `\r`,
+#     literal otherwise).
+#   - The matching `` ` `` closes the literal and we emit `Backtick`.
+#   - `\n` is permitted inside the body (multi-line shell commands).
+#   - EOF mid-body is an unterminated-literal error.
+#
+# Differences from `string_d_body`:
+#   - `#` is *not* treated as an interpolation opener in v0.  Real
+#     Ruby allows `#{}` inside backticks; the post-pass / parser
+#     phase 7a can layer interpolation on later when needed.
+# ─────────────────────────────────────────────────────────────────
+
+[[transitions]]
+from = "backtick_body"
+matcher = { literal = "\\" }
+to = "backtick_escape"
+
+# Closing backtick — emit the buffered body as a Backtick token and
+# return to the dispatcher.
+[[transitions]]
+from = "backtick_body"
+matcher = { literal = "`" }
+to = "data"
+actions = ["emit(Backtick)"]
+
+# Multi-line backticks: a literal newline inside the body becomes
+# part of the buffered command — same behaviour as `string_d_body`.
+[[transitions]]
+from = "backtick_body"
+matcher = { literal = "\n" }
+to = "backtick_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "backtick_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_backtick)", "emit(Eof)"]
+
+# Everything else is body content.
+[[transitions]]
+from = "backtick_body"
+matcher = { anything = true }
+to = "backtick_body"
+actions = ["append_text(current)"]
+
+# Escape handling: the same five escapes string_d_escape recognises
+# (`n`, `t`, `r`, `\\`, plus `` ` `` instead of `"` since that's
+# the close char here).  Anything else carries the escape through
+# verbatim — matching how Ruby handles unknown escapes in `` `…` ``.
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { literal = "n" }
+to = "backtick_body"
+actions = ["append_text(\\n)"]
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { literal = "t" }
+to = "backtick_body"
+actions = ["append_text(\\t)"]
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { literal = "r" }
+to = "backtick_body"
+actions = ["append_text(\\r)"]
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { literal = "\\" }
+to = "backtick_body"
+actions = ["append_text(\\\\)"]
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { literal = "`" }
+to = "backtick_body"
+actions = ["append_text(`)"]
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { anything = true }
+to = "backtick_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "backtick_escape"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_backtick)", "emit(Eof)"]
 
 # ─────────────────────────────────────────────────────────────────
 # Regex body  (Phase 2)

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -1236,6 +1236,19 @@ impl RubyLexer {
                 let text = std::mem::take(&mut self.text_buffer);
                 self.push_token(TokenType::String, text);
             }
+            "Backtick" => {
+                // Phase 4m — `` `cmd args` `` command-execution literal.
+                // The text buffer holds the *body* (without the
+                // surrounding backticks).  Encode as `TokenType::String`
+                // with the backticks re-wrapped so the parser can
+                // distinguish backtick literals from plain strings by
+                // inspecting the lexeme's first character.  Same
+                // sentinel-by-prefix trick the percent literals
+                // (`%w[…]`) and heredocs (`<<TAG\n…TAG`) use.
+                let body = std::mem::take(&mut self.text_buffer);
+                let value = format!("`{body}`");
+                self.push_token(TokenType::String, value);
+            }
             "Op" => {
                 let text = std::mem::take(&mut self.text_buffer);
                 let kind = classify_op_token(&text);
@@ -3452,5 +3465,113 @@ mod tests {
         assert!(!is_radix_integer_body("xZZ"));   // Z isn't hex
         assert!(!is_radix_integer_body("foo"));   // wrong prefix letter
         assert!(!is_radix_integer_body("e10"));   // e is exponent, not radix
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 4m — backtick command literals `` `cmd args` ``
+    // -----------------------------------------------------------------
+    //
+    // The lexer emits a single `TokenType::String` token whose value is
+    // the verbatim source including the surrounding backticks
+    // (`` `ls -la` `` → value `` `ls -la` ``).  Parser code can
+    // distinguish backtick literals from plain strings by inspecting
+    // the leading character — same trick used by percent literals and
+    // heredocs.
+
+    /// Helper: tokens whose `value` starts with a backtick.
+    fn backtick_values(toks: &[Token]) -> Vec<String> {
+        toks.iter()
+            .filter(|t| t.type_ == TokenType::String && t.value.starts_with('`'))
+            .map(|t| t.value.clone())
+            .collect()
+    }
+
+    #[test]
+    fn backtick_simple_command_lexes_as_string_with_backticks() {
+        let toks = tokenize_ruby_for_version("`ls -la`", "1.8").unwrap();
+        assert_eq!(backtick_values(&toks), vec!["`ls -la`"]);
+    }
+
+    #[test]
+    fn backtick_empty_body_lexes_to_two_backticks() {
+        // Empty body — opening and closing backtick are adjacent.
+        let toks = tokenize_ruby_for_version("``", "1.8").unwrap();
+        assert_eq!(backtick_values(&toks), vec!["``"]);
+    }
+
+    #[test]
+    fn backtick_escape_sequences_resolved_in_body() {
+        // `\n`, `\t`, `\r`, `\\` get resolved to the escape characters
+        // (same as `string_d_escape`).  Backtick-escape `` \` `` lets
+        // you embed a literal backtick.
+        let toks = tokenize_ruby_for_version(r#"`echo \`hi\`\n`"#, "1.8").unwrap();
+        let v = &backtick_values(&toks)[0];
+        // The escaped backticks become literal backticks; \n becomes a
+        // newline character.  Outer wrapping backticks remain.
+        assert_eq!(v, "`echo `hi`\n`");
+    }
+
+    #[test]
+    fn backtick_multiline_command_keeps_newlines() {
+        // Real ruby allows multi-line `` `…` `` — the body captures
+        // newlines verbatim (same shape as double-quoted strings).
+        let src = "`ls\\\nfoo`"; // backslash-newline continuation in command
+        // Without continuation handling, we just verify a literal
+        // newline inside the body survives.
+        let toks = tokenize_ruby_for_version("`line1\nline2`", "1.8").unwrap();
+        let v = &backtick_values(&toks)[0];
+        assert!(v.contains("line1\nline2"), "expected newline inside body, got {v:?}");
+        // Sanity check the source-based test above did not crash.
+        let _ = tokenize_ruby_for_version(src, "1.8").unwrap();
+    }
+
+    #[test]
+    fn backtick_lexing_is_era_invariant() {
+        // Backticks have been in Ruby since 1.0 — every era produces
+        // the same token shape.
+        let src = "`pwd`";
+        let baseline = backtick_values(&tokenize_ruby_for_version(src, "1.8").unwrap());
+        assert_eq!(baseline, vec!["`pwd`"]);
+        for v in machine::ERA_VERSIONS {
+            let actual = backtick_values(&tokenize_ruby_for_version(src, v).unwrap());
+            assert_eq!(actual, baseline, "backtick lexing diverged in era {v}");
+        }
+    }
+
+    #[test]
+    fn backtick_does_not_swallow_following_tokens() {
+        // After the closing backtick, the dispatcher resumes normal
+        // tokenizing — `puts \`pwd\``  followed by  `+`  `1`  should
+        // yield Name(puts), String(`pwd`), Op(+), Int(1).
+        let toks = tokenize_ruby_for_version("`pwd` + 1", "1.8").unwrap();
+        let kinds: Vec<TokenType> = toks
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.type_)
+            .collect();
+        // Expect: String, Plus, Number  (whitespace skipped).
+        assert_eq!(
+            kinds,
+            vec![TokenType::String, TokenType::Plus, TokenType::Number],
+            "got tokens {toks:?}"
+        );
+    }
+
+    #[test]
+    fn backtick_unterminated_reports_diagnostic() {
+        // A backtick with no closing `` ` `` should leave a diagnostic
+        // behind.  The lexer still finishes (terminates on EOF) — the
+        // `parse_error(unterminated_backtick)` action records the
+        // error rather than aborting.  We use the public RubyLexer API
+        // directly so we can read its diagnostics() after `finish()`.
+        let mut lx = RubyLexer::new("1.8").expect("lexer build");
+        lx.push("`unterminated\n").unwrap();
+        lx.finish().unwrap();
+        let diags = lx.diagnostics();
+        assert!(
+            diags.iter().any(|d| d.code.contains("unterminated_backtick")),
+            "expected unterminated_backtick diagnostic, got {:?}",
+            diags
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds Ruby backtick command literals (`` `ls -la` ``) to the lexer.
- New state-machine states `backtick_body` and `backtick_escape` mirror the existing double-quoted-string sub-machine.
- Tokens emit as `TokenType::String` with the surrounding backticks re-wrapped (`` `body` ``) so parser code can distinguish them from plain strings by inspecting the leading character — same sentinel-by-prefix trick used by percent literals and heredocs.

## State-machine additions

| State | Role |
|---|---|
| `backtick_body` | Inside the literal; accumulates body, recognises escapes, closes on a matching backtick. |
| `backtick_escape` | One-char escape state — same five escapes as `string_d_escape` (`n`, `t`, `r`, `\\`, plus `` ` `` instead of `"`). |

EOF inside the body or escape records an `unterminated_backtick` diagnostic instead of panicking.

## Out of scope

- `#{}` interpolation inside `` `…` `` — real Ruby allows it; v0 treats `#` as a literal character. Parser-side phase 7a can layer interpolation on later.
- Backtick as a method-name receiver — needs special lex-state feedback.

## Tests

- `coding-adventures-ruby-lexer`: 142 → 149 (+7 era-gated tests).
- `coding-adventures-ruby-parser`: 71 (unchanged).
- `ruby-to-semantic-ir`: 74 (unchanged).

Test coverage:
- Simple `` `ls -la` `` round-trip.
- Empty body.
- Escape sequences (`\n`, escaped backtick).
- Multi-line bodies.
- Era invariance across every era ≥ 1.8 (backticks are pre-1.0).
- Trailing tokens (`` `pwd` + 1 ``) still lex correctly.
- Unterminated-literal diagnostic.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (149/149 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (71/71 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (74/74 pass)
- [x] Security review (via `/security-review` sub-agent) — passed
- [ ] CI green

Follows PR #4222 (Phase 6n — range expressions). Parser-side support (Phase 7a) is next once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
