### PR TITLE
Add browser media playback metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -239,6 +239,7 @@ def check_browser_readiness_case(
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "media", errors)
     require_object_list(f"{case_path}.expected", expected, "forms", errors)
     require_object_list(f"{case_path}.expected", expected, "tables", errors)
     check_browser_expected_lists(case_path, expected, errors)
@@ -286,6 +287,22 @@ def check_browser_expected_lists(
         image_path = f"{case_path}.expected.images[{index}]"
         for field in ("src", "resolved_src", "alt", "width", "height"):
             require_optional_nullable_string(image_path, image, field, errors)
+
+    for index, media in enumerate(object_list_items(expected, "media")):
+        media_path = f"{case_path}.expected.media[{index}]"
+        require_string(media_path, media, "kind", errors)
+        for field in (
+            "src",
+            "resolved_src",
+            "poster",
+            "resolved_poster",
+            "width",
+            "height",
+            "preload",
+        ):
+            require_optional_nullable_string(media_path, media, field, errors)
+        for field in ("controls", "autoplay", "loop_media", "muted", "playsinline"):
+            require_optional_boolean(media_path, media, field, errors)
 
     for index, form in enumerate(object_list_items(expected, "forms")):
         form_path = f"{case_path}.expected.forms[{index}]"
@@ -380,6 +397,9 @@ def check_browser_content_node(
         "height",
         "type_hint",
         "media",
+        "poster",
+        "resolved_poster",
+        "preload",
         "control_type",
         "form_owner",
         "label_for",
@@ -416,6 +436,11 @@ def check_browser_content_node(
         "checked",
         "selected",
         "multiple",
+        "controls",
+        "autoplay",
+        "loop_media",
+        "muted",
+        "playsinline",
         "list_reversed",
     ):
         require_optional_boolean(node_path, node, field, errors)
@@ -480,6 +505,9 @@ def check_browser_render_node(
         "height",
         "type_hint",
         "media",
+        "poster",
+        "resolved_poster",
+        "preload",
         "control_type",
         "form_owner",
         "label_for",
@@ -516,6 +544,11 @@ def check_browser_render_node(
         "checked",
         "selected",
         "multiple",
+        "controls",
+        "autoplay",
+        "loop_media",
+        "muted",
+        "playsinline",
         "list_reversed",
     ):
         require_optional_boolean(node_path, node, field, errors)
@@ -673,6 +706,16 @@ def require_object_list(
     value = data.get(field)
     if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
         errors.append(f"{path}.{field} must be a list of objects")
+
+
+def require_optional_object_list(
+    path: str,
+    data: dict[str, Any],
+    field: str,
+    errors: list[str],
+) -> None:
+    if field in data:
+        require_object_list(path, data, field, errors)
 
 
 def object_list_items(data: dict[str, Any], field: str) -> list[dict[str, Any]]:

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -208,6 +208,9 @@ documented in this file.
   embedded resource metadata for frames, objects, embeds, media, and images,
   including resolved source URLs, resource kind, type hints, media attributes,
   and authored dimensions for fetch and layout planning.
+- Browser-facing document, content-tree, and render-tree projections now carry
+  media playback metadata for `audio` and `video`, including playback flags,
+  and preload/poster fields.
 - Browser-facing table summaries and tree projections now carry table layout and
   accessibility metadata, including effective column counts, column hints,
   row-group identity, column and cell spans, header associations, scopes, and

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -81,6 +81,8 @@ The current parser surface includes:
 - browser-facing embedded resource metadata for replaced content such as
   `iframe`, `object`, `embed`, `audio`, and `video`, including resolved source
   URLs, resource kind, type hints, media attributes, and authored dimensions
+- browser-facing media playback metadata for `audio` and `video`, including
+  playback flags and preload/poster fields
 - browser-facing table layout and accessibility metadata, including effective
   column counts, column hints, row-group identity, column spans, cell spans,
   header associations, scopes, and abbreviated header labels

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -831,6 +831,7 @@ pub struct BrowserDocument {
     pub headings: Vec<BrowserHeading>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
+    pub media: Vec<BrowserMedia>,
     pub forms: Vec<BrowserForm>,
     pub tables: Vec<BrowserTable>,
 }
@@ -891,6 +892,14 @@ pub struct BrowserContentNode {
     pub height: Option<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
+    pub poster: Option<String>,
+    pub resolved_poster: Option<String>,
+    pub preload: Option<String>,
+    pub controls: bool,
+    pub autoplay: bool,
+    pub loop_media: bool,
+    pub muted: bool,
+    pub playsinline: bool,
     pub control_type: Option<String>,
     pub form_owner: Option<String>,
     pub label_for: Option<String>,
@@ -954,6 +963,14 @@ pub struct BrowserRenderNode {
     pub height: Option<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
+    pub poster: Option<String>,
+    pub resolved_poster: Option<String>,
+    pub preload: Option<String>,
+    pub controls: bool,
+    pub autoplay: bool,
+    pub loop_media: bool,
+    pub muted: bool,
+    pub playsinline: bool,
     pub control_type: Option<String>,
     pub form_owner: Option<String>,
     pub label_for: Option<String>,
@@ -1015,6 +1032,23 @@ pub struct BrowserImage {
     pub alt: Option<String>,
     pub width: Option<String>,
     pub height: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMedia {
+    pub kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub poster: Option<String>,
+    pub resolved_poster: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub controls: bool,
+    pub autoplay: bool,
+    pub loop_media: bool,
+    pub muted: bool,
+    pub playsinline: bool,
+    pub preload: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1173,6 +1207,14 @@ impl BrowserRenderNode {
             height: content_node.height.clone(),
             type_hint: content_node.type_hint.clone(),
             media: content_node.media.clone(),
+            poster: content_node.poster.clone(),
+            resolved_poster: content_node.resolved_poster.clone(),
+            preload: content_node.preload.clone(),
+            controls: content_node.controls,
+            autoplay: content_node.autoplay,
+            loop_media: content_node.loop_media,
+            muted: content_node.muted,
+            playsinline: content_node.playsinline,
             control_type: content_node.control_type.clone(),
             form_owner: content_node.form_owner.clone(),
             label_for: content_node.label_for.clone(),
@@ -8154,6 +8196,9 @@ fn collect_browser_facts(
                 width: element.attribute("width").map(ToOwned::to_owned),
                 height: element.attribute("height").map(ToOwned::to_owned),
             }),
+            "audio" | "video" => summary
+                .media
+                .push(browser_media_element(element, summary.base_href.as_deref())),
             "form" => summary.forms.push(BrowserForm {
                 action: element.attribute("action").map(ToOwned::to_owned),
                 resolved_action: element
@@ -8507,6 +8552,14 @@ fn collect_browser_content_nodes_with_mode(
                         height: None,
                         type_hint: None,
                         media: None,
+                        poster: None,
+                        resolved_poster: None,
+                        preload: None,
+                        controls: false,
+                        autoplay: false,
+                        loop_media: false,
+                        muted: false,
+                        playsinline: false,
                         control_type: None,
                         form_owner: None,
                         label_for: None,
@@ -8600,6 +8653,7 @@ fn browser_content_node_for_element(
 
     let href = element.attribute("href").map(ToOwned::to_owned);
     let src = browser_content_src(element);
+    let poster = browser_media_poster(element);
     let quote_cite = browser_quote_cite(element);
     let control_labels = browser_control_labels(element, labels, current_label_text);
     let accessible_name = browser_accessible_name(element, role, &control_labels);
@@ -8630,6 +8684,16 @@ fn browser_content_node_for_element(
         height: element.attribute("height").map(ToOwned::to_owned),
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
+        resolved_poster: poster
+            .as_deref()
+            .and_then(|poster| resolve_browser_url(poster, base_href)),
+        poster,
+        preload: browser_media_preload(element),
+        controls: browser_media_controls(element),
+        autoplay: browser_media_autoplay(element),
+        loop_media: browser_media_loop(element),
+        muted: browser_media_muted(element),
+        playsinline: browser_media_playsinline(element),
         control_type: browser_content_control_type(element),
         form_owner: browser_form_owner(element),
         label_for: browser_label_for(element),
@@ -8775,6 +8839,68 @@ fn browser_content_resource_kind(element: &Element) -> Option<String> {
         "canvas" => Some("canvas".to_string()),
         _ => None,
     }
+}
+
+fn browser_media_element(element: &Element, base_href: Option<&str>) -> BrowserMedia {
+    let src = element.attribute("src").map(ToOwned::to_owned);
+    let poster = browser_media_poster(element);
+    BrowserMedia {
+        kind: element.name.clone(),
+        resolved_src: src
+            .as_deref()
+            .and_then(|src| resolve_browser_url(src, base_href)),
+        src,
+        resolved_poster: poster
+            .as_deref()
+            .and_then(|poster| resolve_browser_url(poster, base_href)),
+        poster,
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
+        controls: browser_media_controls(element),
+        autoplay: browser_media_autoplay(element),
+        loop_media: browser_media_loop(element),
+        muted: browser_media_muted(element),
+        playsinline: browser_media_playsinline(element),
+        preload: browser_media_preload(element),
+    }
+}
+
+fn browser_media_poster(element: &Element) -> Option<String> {
+    if element.name == "video" {
+        element.attribute("poster").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_media_preload(element: &Element) -> Option<String> {
+    if matches!(element.name.as_str(), "audio" | "video") {
+        element.attribute("preload").map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn browser_media_controls(element: &Element) -> bool {
+    matches!(element.name.as_str(), "audio" | "video") && element.attribute("controls").is_some()
+}
+
+fn browser_media_autoplay(element: &Element) -> bool {
+    matches!(element.name.as_str(), "audio" | "video") && element.attribute("autoplay").is_some()
+}
+
+fn browser_media_loop(element: &Element) -> bool {
+    matches!(element.name.as_str(), "audio" | "video") && element.attribute("loop").is_some()
+}
+
+fn browser_media_muted(element: &Element) -> bool {
+    matches!(element.name.as_str(), "audio" | "video") && element.attribute("muted").is_some()
+}
+
+fn browser_media_playsinline(element: &Element) -> bool {
+    matches!(element.name.as_str(), "audio" | "video")
+        && (element.attribute("playsinline").is_some()
+            || element.attribute("webkit-playsinline").is_some())
 }
 
 fn browser_table_section_kind(element: &Element) -> Option<String> {
@@ -9814,6 +9940,51 @@ mod tests {
                 .as_deref(),
             Some("Query")
         );
+    }
+
+    #[test]
+    fn browser_media_metadata_tracks_playback_and_poster_state() {
+        let document = parse_html(
+            "<base href=\"https://example.test/watch/index.html\">\
+             <video id=hero src=movie.mp4 poster=poster.jpg controls autoplay loop muted playsinline preload=metadata width=640 height=360></video>\
+             <audio src=theme.ogg controls preload=none></audio>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        let video = &summary.media[0];
+        assert_eq!(video.kind, "video");
+        assert_eq!(
+            video.resolved_src.as_deref(),
+            Some("https://example.test/watch/movie.mp4")
+        );
+        assert_eq!(
+            video.resolved_poster.as_deref(),
+            Some("https://example.test/watch/poster.jpg")
+        );
+        assert_eq!(video.width.as_deref(), Some("640"));
+        assert!(video.controls);
+        assert!(video.autoplay);
+        assert!(video.loop_media);
+        assert!(video.muted);
+        assert!(video.playsinline);
+        assert_eq!(video.preload.as_deref(), Some("metadata"));
+        assert_eq!(summary.media[1].kind, "audio");
+        assert_eq!(summary.media[1].preload.as_deref(), Some("none"));
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        let media = &content_tree.children[0];
+        assert_eq!(media.role, "media");
+        assert_eq!(media.poster.as_deref(), Some("poster.jpg"));
+        assert_eq!(
+            media.resolved_poster.as_deref(),
+            Some("https://example.test/watch/poster.jpg")
+        );
+        assert!(media.controls);
+
+        let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
+        assert_eq!(render_tree.children[0].display, "inline-replaced");
+        assert!(render_tree.children[0].controls);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -56,6 +56,22 @@ struct ExpectedContentNode {
     type_hint: Option<String>,
     #[serde(default)]
     media: Option<String>,
+    #[serde(default)]
+    poster: Option<String>,
+    #[serde(default)]
+    resolved_poster: Option<String>,
+    #[serde(default)]
+    preload: Option<String>,
+    #[serde(default)]
+    controls: bool,
+    #[serde(default)]
+    autoplay: bool,
+    #[serde(default)]
+    loop_media: bool,
+    #[serde(default)]
+    muted: bool,
+    #[serde(default)]
+    playsinline: bool,
     control_type: Option<String>,
     #[serde(default)]
     form_owner: Option<String>,
@@ -181,6 +197,14 @@ impl ExpectedContentNode {
             height: self.height,
             type_hint: self.type_hint,
             media: self.media,
+            poster: self.poster,
+            resolved_poster: self.resolved_poster,
+            preload: self.preload,
+            controls: self.controls,
+            autoplay: self.autoplay,
+            loop_media: self.loop_media,
+            muted: self.muted,
+            playsinline: self.playsinline,
             control_type: self.control_type,
             form_owner: self.form_owner,
             label_for: self.label_for,

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,6 +1,7 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserForm, BrowserFormControl,
-    BrowserHeading, BrowserImage, BrowserLink, BrowserMeta, BrowserResource, BrowserTable,
+    BrowserHeading, BrowserImage, BrowserLink, BrowserMedia, BrowserMeta, BrowserResource,
+    BrowserTable,
 };
 use serde::Deserialize;
 
@@ -44,6 +45,8 @@ struct ExpectedBrowserDocument {
     headings: Vec<ExpectedHeading>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
+    #[serde(default)]
+    media: Vec<ExpectedMedia>,
     forms: Vec<ExpectedForm>,
     tables: Vec<ExpectedTable>,
 }
@@ -105,6 +108,34 @@ struct ExpectedImage {
     alt: Option<String>,
     width: Option<String>,
     height: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMedia {
+    kind: String,
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    poster: Option<String>,
+    #[serde(default)]
+    resolved_poster: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    controls: bool,
+    #[serde(default)]
+    autoplay: bool,
+    #[serde(default)]
+    loop_media: bool,
+    #[serde(default)]
+    muted: bool,
+    #[serde(default)]
+    playsinline: bool,
+    #[serde(default)]
+    preload: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -223,6 +254,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedImage::into_browser_image)
                 .collect(),
+            media: self
+                .media
+                .into_iter()
+                .map(ExpectedMedia::into_browser_media)
+                .collect(),
             forms: self
                 .forms
                 .into_iter()
@@ -308,6 +344,26 @@ impl ExpectedImage {
             alt: self.alt,
             width: self.width,
             height: self.height,
+        }
+    }
+}
+
+impl ExpectedMedia {
+    fn into_browser_media(self) -> BrowserMedia {
+        BrowserMedia {
+            kind: self.kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            poster: self.poster,
+            resolved_poster: self.resolved_poster,
+            width: self.width,
+            height: self.height,
+            controls: self.controls,
+            autoplay: self.autoplay,
+            loop_media: self.loop_media,
+            muted: self.muted,
+            playsinline: self.playsinline,
+            preload: self.preload,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -57,6 +57,22 @@ struct ExpectedRenderNode {
     type_hint: Option<String>,
     #[serde(default)]
     media: Option<String>,
+    #[serde(default)]
+    poster: Option<String>,
+    #[serde(default)]
+    resolved_poster: Option<String>,
+    #[serde(default)]
+    preload: Option<String>,
+    #[serde(default)]
+    controls: bool,
+    #[serde(default)]
+    autoplay: bool,
+    #[serde(default)]
+    loop_media: bool,
+    #[serde(default)]
+    muted: bool,
+    #[serde(default)]
+    playsinline: bool,
     control_type: Option<String>,
     #[serde(default)]
     form_owner: Option<String>,
@@ -183,6 +199,14 @@ impl ExpectedRenderNode {
             height: self.height,
             type_hint: self.type_hint,
             media: self.media,
+            poster: self.poster,
+            resolved_poster: self.resolved_poster,
+            preload: self.preload,
+            controls: self.controls,
+            autoplay: self.autoplay,
+            loop_media: self.loop_media,
+            muted: self.muted,
+            playsinline: self.playsinline,
             control_type: self.control_type,
             form_owner: self.form_owner,
             label_for: self.label_for,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -18,7 +18,8 @@ from `base` hrefs while preserving raw authored link and resource attributes,
 and document/body identity and language metadata such as `lang`, `dir`, body
 `id`, and tokenized body classes. Form cases also pin labels, derived
 accessible names, owner references, placeholder/autocomplete hints, and
-required/readonly/multiple control state.
+required/readonly/multiple control state. Media cases pin audio/video playback
+flags and preload/poster metadata.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body
@@ -39,7 +40,8 @@ line/word/thematic break kinds. Document-outline cases pin heading levels,
 sectioning roles, and landmark-like regions such as `main`, `nav`, `aside`,
 `header`, and `footer`. Form cases also preserve label associations, accessible
 names, owner references, and control-state hints for downstream accessibility
-and layout code.
+and layout code. Media nodes also preserve playback flags, preload/poster
+metadata for fetch and layout planning.
 
 `html-browser-render-tree.json` is a checked parser acceptance corpus for the
 browser-facing render-tree input projection. It verifies that the content tree
@@ -57,7 +59,8 @@ citations, preformatted whitespace policy, and break kinds while mapping to
 stable display categories. Document-outline render inputs keep heading levels
 and section/landmark metadata while mapping those structural regions to block
 display categories. Form accessibility metadata is preserved while controls map
-to inline-replaced render inputs.
+to inline-replaced render inputs. Media playback metadata is preserved while
+audio/video nodes map to inline-replaced render inputs.
 
 Validate the checked-in smoke fixture's case boundaries and metadata with:
 

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -598,8 +598,54 @@
         "children": [
           { "role": "frame", "name": "iframe", "title": "Frame", "text": null, "href": null, "src": "frame.html", "resolved_src": "https://example.test/media/frame.html", "alt": null, "resource_kind": "frame", "width": "320", "height": "200", "control_type": null, "children": [] },
           { "role": "object", "name": "object", "text": null, "href": null, "src": "movie.swf", "resolved_src": "https://example.test/media/movie.swf", "alt": null, "resource_kind": "object", "width": "400", "height": "300", "type_hint": "application/x-shockwave-flash", "control_type": null, "children": [] },
-          { "role": "media", "name": "video", "text": null, "href": null, "src": "movie.mp4", "resolved_src": "https://example.test/media/movie.mp4", "alt": null, "resource_kind": "video", "width": "640", "height": "360", "control_type": null, "children": [] },
+          { "role": "media", "name": "video", "text": null, "href": null, "src": "movie.mp4", "resolved_src": "https://example.test/media/movie.mp4", "alt": null, "resource_kind": "video", "width": "640", "height": "360", "controls": true, "control_type": null, "children": [] },
           { "role": "embed", "name": "embed", "text": null, "href": null, "src": "legacy.mov", "resolved_src": "https://example.test/media/legacy.mov", "alt": null, "resource_kind": "embed", "width": "160", "height": "120", "type_hint": "video/quicktime", "control_type": null, "children": [] }
+        ]
+      }
+    },
+    {
+      "id": "media-playback-nodes",
+      "description": "Media content nodes keep playback attributes and resolved poster URLs.",
+      "input": "<base href=\"https://example.test/watch/index.html\"><body><video id=hero src=movie.mp4 poster=poster.jpg controls autoplay loop muted playsinline preload=metadata width=640 height=360></video><audio src=theme.ogg controls preload=none></audio>",
+      "expected": {
+        "children": [
+          {
+            "role": "media",
+            "name": "video",
+            "id": "hero",
+            "text": null,
+            "href": null,
+            "src": "movie.mp4",
+            "resolved_src": "https://example.test/watch/movie.mp4",
+            "alt": null,
+            "resource_kind": "video",
+            "width": "640",
+            "height": "360",
+            "poster": "poster.jpg",
+            "resolved_poster": "https://example.test/watch/poster.jpg",
+            "preload": "metadata",
+            "controls": true,
+            "autoplay": true,
+            "loop_media": true,
+            "muted": true,
+            "playsinline": true,
+            "control_type": null,
+            "children": []
+          },
+          {
+            "role": "media",
+            "name": "audio",
+            "text": null,
+            "href": null,
+            "src": "theme.ogg",
+            "resolved_src": "https://example.test/watch/theme.ogg",
+            "alt": null,
+            "resource_kind": "audio",
+            "preload": "none",
+            "controls": true,
+            "control_type": null,
+            "children": []
+          }
         ]
       }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -173,6 +173,64 @@
         "headings": [],
         "links": [],
         "images": [],
+        "media": [
+          {
+            "kind": "video",
+            "src": "movie.mp4",
+            "resolved_src": "https://example.test/media/movie.mp4",
+            "width": "640",
+            "height": "360",
+            "controls": true
+          }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "media-playback-poster-page",
+      "description": "Media summaries expose playback state and poster resolution metadata.",
+      "input": "<base href=\"https://example.test/watch/index.html\"><body><video id=hero src=movie.mp4 poster=poster.jpg controls autoplay loop muted playsinline preload=metadata width=640 height=360></video><audio src=theme.ogg controls preload=none></audio>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/watch/index.html",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "video", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "async_script": false, "defer_script": false },
+          { "kind": "audio", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "rel": null, "type_hint": null, "media": null, "title": null, "width": null, "height": null, "async_script": false, "defer_script": false }
+        ],
+        "anchors": [
+          { "id": "hero", "name": null, "text": "" }
+        ],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "media": [
+          {
+            "kind": "video",
+            "src": "movie.mp4",
+            "resolved_src": "https://example.test/watch/movie.mp4",
+            "poster": "poster.jpg",
+            "resolved_poster": "https://example.test/watch/poster.jpg",
+            "width": "640",
+            "height": "360",
+            "controls": true,
+            "autoplay": true,
+            "loop_media": true,
+            "muted": true,
+            "playsinline": true,
+            "preload": "metadata"
+          },
+          {
+            "kind": "audio",
+            "src": "theme.ogg",
+            "resolved_src": "https://example.test/watch/theme.ogg",
+            "controls": true,
+            "preload": "none"
+          }
+        ],
         "forms": [],
         "tables": []
       }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -557,8 +557,56 @@
         "children": [
           { "display": "inline-replaced", "role": "frame", "name": "iframe", "title": "Frame", "text": null, "href": null, "src": "frame.html", "resolved_src": "https://example.test/media/frame.html", "alt": null, "resource_kind": "frame", "width": "320", "height": "200", "control_type": null, "children": [] },
           { "display": "inline-replaced", "role": "object", "name": "object", "text": null, "href": null, "src": "movie.swf", "resolved_src": "https://example.test/media/movie.swf", "alt": null, "resource_kind": "object", "width": "400", "height": "300", "type_hint": "application/x-shockwave-flash", "control_type": null, "children": [] },
-          { "display": "inline-replaced", "role": "media", "name": "video", "text": null, "href": null, "src": "movie.mp4", "resolved_src": "https://example.test/media/movie.mp4", "alt": null, "resource_kind": "video", "width": "640", "height": "360", "control_type": null, "children": [] },
+          { "display": "inline-replaced", "role": "media", "name": "video", "text": null, "href": null, "src": "movie.mp4", "resolved_src": "https://example.test/media/movie.mp4", "alt": null, "resource_kind": "video", "width": "640", "height": "360", "controls": true, "control_type": null, "children": [] },
           { "display": "inline-replaced", "role": "embed", "name": "embed", "text": null, "href": null, "src": "legacy.mov", "resolved_src": "https://example.test/media/legacy.mov", "alt": null, "resource_kind": "embed", "width": "160", "height": "120", "type_hint": "video/quicktime", "control_type": null, "children": [] }
+        ]
+      }
+    },
+    {
+      "id": "media-playback-display-metadata",
+      "description": "Media render nodes preserve playback attributes on inline replaced render inputs.",
+      "input": "<base href=\"https://example.test/watch/index.html\"><body><video id=hero src=movie.mp4 poster=poster.jpg controls autoplay loop muted playsinline preload=metadata width=640 height=360></video><audio src=theme.ogg controls preload=none></audio>",
+      "expected": {
+        "children": [
+          {
+            "display": "inline-replaced",
+            "role": "media",
+            "name": "video",
+            "id": "hero",
+            "text": null,
+            "href": null,
+            "src": "movie.mp4",
+            "resolved_src": "https://example.test/watch/movie.mp4",
+            "alt": null,
+            "resource_kind": "video",
+            "width": "640",
+            "height": "360",
+            "poster": "poster.jpg",
+            "resolved_poster": "https://example.test/watch/poster.jpg",
+            "preload": "metadata",
+            "controls": true,
+            "autoplay": true,
+            "loop_media": true,
+            "muted": true,
+            "playsinline": true,
+            "control_type": null,
+            "children": []
+          },
+          {
+            "display": "inline-replaced",
+            "role": "media",
+            "name": "audio",
+            "text": null,
+            "href": null,
+            "src": "theme.ogg",
+            "resolved_src": "https://example.test/watch/theme.ogg",
+            "alt": null,
+            "resource_kind": "audio",
+            "preload": "none",
+            "controls": true,
+            "control_type": null,
+            "children": []
+          }
         ]
       }
     }


### PR DESCRIPTION
## Summary
- add browser media playback metadata for audio/video document summaries
- carry poster/preload/playback flags through content and render projections
- extend browser fixture schemas, fixtures, docs, and tests for media readiness

## Testing
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_media_metadata_tracks_playback_and_poster_state
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
