### PR TITLE
spice: route .temp into noise analysis

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve `.temp` cards into Kelvin engine-call temperatures and let explicit
+  `.noise temp=<kelvin>` overrides win over deck-level operating temperatures.
 - Route selected `.options` keys into engine-call helpers:
   `dc_op_kwargs()` for DC Newton options and `transient_kwargs()` for
   transient method/adaptive-step options.

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -33,3 +33,8 @@ cards can carry `method=euler|trap|gear2`; when omitted,
 `netlist.transient_method()` falls back to `.options method=<...>` if present.
 Selected `.options` keys can also be turned into engine-call arguments with
 `netlist.dc_op_kwargs()` and `netlist.transient_kwargs()`.
+Deck-level `.temp` cards can be resolved into Kelvin with
+`netlist.operating_temperature_kelvin()`, and
+`netlist.noise_temperature_kelvin(noise_card)` applies the SPICE precedence
+where an explicit `.noise temp=<kelvin>` overrides the deck operating
+temperature.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -107,6 +107,7 @@ class NoiseAnalysis:
     input_source: str
     freqs: tuple[float, ...] = ()
     temperature: float = 300.0
+    temperature_is_explicit: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -354,6 +355,46 @@ class ParsedNetlist:
         if adaptive:
             kwargs["adaptive"] = True
         return kwargs
+
+    def operating_temperature_kelvin(
+        self,
+        temperature_index: int = 0,
+        *,
+        default: float = 300.0,
+    ) -> float:
+        """Return the selected `.temp` operating temperature in Kelvin."""
+
+        if temperature_index < 0:
+            raise NetlistParseError("temperature index must be non-negative")
+        temperatures = [
+            celsius
+            for card in self.temp_cards()
+            for celsius in card.temperatures_celsius
+        ]
+        if not temperatures:
+            return default
+        try:
+            return temperatures[temperature_index] + 273.15
+        except IndexError as exc:
+            raise NetlistParseError(
+                f"temperature index {temperature_index} exceeds .temp entries"
+            ) from exc
+
+    def noise_temperature_kelvin(
+        self,
+        noise: NoiseAnalysis | None = None,
+        *,
+        temperature_index: int = 0,
+        default: float = 300.0,
+    ) -> float:
+        """Return the temperature to pass to `spice_engine.noise_ac`."""
+
+        if noise is not None and noise.temperature_is_explicit:
+            return noise.temperature
+        return self.operating_temperature_kelvin(
+            temperature_index=temperature_index,
+            default=default,
+        )
 
 
 _VALUE_RE = re.compile(
@@ -961,6 +1002,7 @@ def _parse_directive(fields: list[str]) -> Analysis:
         _require_min_fields(fields, 3, ".noise")
         freqs: list[float] = []
         temperature = 300.0
+        temperature_is_explicit = False
         tail_index = 3
         while tail_index < len(fields):
             token = fields[tail_index]
@@ -969,10 +1011,12 @@ def _parse_directive(fields: list[str]) -> Analysis:
                 if tail_index + 1 >= len(fields):
                     raise NetlistParseError(".noise temp requires a temperature value")
                 temperature = parse_value(fields[tail_index + 1])
+                temperature_is_explicit = True
                 tail_index += 2
                 continue
             if lower_token.startswith("temp="):
                 temperature = parse_value(token.split("=", 1)[1])
+                temperature_is_explicit = True
                 tail_index += 1
                 continue
             freqs.append(parse_value(token))
@@ -982,6 +1026,7 @@ def _parse_directive(fields: list[str]) -> Analysis:
             input_source=fields[2],
             freqs=tuple(freqs),
             temperature=temperature,
+            temperature_is_explicit=temperature_is_explicit,
         )
     if directive == ".temp":
         _require_min_fields(fields, 2, ".temp")

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -246,6 +246,16 @@ def test_parse_temp_analysis_card() -> None:
 
     assert parsed.analyses == [TempAnalysis((27.0, 75.0, -40.0))]
     assert parsed.temp_cards() == parsed.analyses
+    assert isclose(parsed.operating_temperature_kelvin(), 300.15, abs_tol=1e-12)
+    assert isclose(parsed.operating_temperature_kelvin(1), 348.15, abs_tol=1e-12)
+
+
+def test_operating_temperature_defaults_without_temp_cards() -> None:
+    parsed = parse_netlist("R1 in out 1k")
+
+    assert parsed.operating_temperature_kelvin(default=301.0) == 301.0
+    with pytest.raises(NetlistParseError, match=r"temperature index 3 exceeds \.temp entries"):
+        parse_netlist(".temp 27").operating_temperature_kelvin(3)
 
 
 def test_temp_card_rejects_missing_temperatures() -> None:
@@ -499,6 +509,7 @@ R1 in out 1k
 def test_parse_noise_analysis_card_and_run_noise_ac() -> None:
     parsed = parse_netlist(
         """
+.temp 75
 Vin in 0 DC 1
 Rtop in out 1k
 Rbot out 0 1k
@@ -507,26 +518,45 @@ Rbot out 0 1k
     )
 
     assert parsed.analyses == [
+        TempAnalysis((75.0,)),
         NoiseAnalysis(
             output_node="out",
             input_source="Vin",
             freqs=(1000.0,),
             temperature=300.0,
+            temperature_is_explicit=True,
         )
     ]
-    assert parsed.noise_cards() == parsed.analyses
+    assert parsed.noise_cards() == [parsed.analyses[1]]
     card = parsed.noise_cards()[0]
+    assert parsed.noise_temperature_kelvin(card) == 300.0
     result = noise_ac(
         parsed.circuit,
         card.output_node,
         card.input_source,
         freqs=list(card.freqs),
-        temperature=card.temperature,
+        temperature=parsed.noise_temperature_kelvin(card),
     )
     assert result.output_node == "out"
     assert result.input_source == "Vin"
     assert len(result.points) == 1
     assert result.points[0].output_psd > 0.0
+
+
+def test_noise_analysis_uses_temp_card_when_noise_temp_is_omitted() -> None:
+    parsed = parse_netlist(
+        """
+.temp 50
+Vin in 0 DC 1
+Rtop in out 1k
+Rbot out 0 1k
+.noise V(out) Vin 1k
+"""
+    )
+    card = parsed.noise_cards()[0]
+
+    assert not card.temperature_is_explicit
+    assert isclose(parsed.noise_temperature_kelvin(card), 323.15, abs_tol=1e-12)
 
 
 def test_noise_analysis_card_rejects_non_voltage_output_probe() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve `.temp` cards into Kelvin engine-call temperatures and let explicit
+  `.noise temp=<kelvin>` overrides win over deck-level operating temperatures.
 - Route selected `.options` keys into engine-call helpers:
   `dc_op_options()` for DC Newton options and `adaptive_transient_options()`
   for adaptive transient options.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -35,3 +35,8 @@ Transient cards can carry `method=euler|trap|gear2`; when omitted,
 present.
 Selected `.options` keys can also be turned into engine-call options with
 `parsed.dc_op_options()?` and `parsed.adaptive_transient_options(None)?`.
+Deck-level `.temp` cards can be resolved into Kelvin with
+`parsed.operating_temperature_kelvin(0, 300.0)?`, and
+`parsed.noise_temperature_kelvin(Some(noise_card), 0, 300.0)?` applies the
+SPICE precedence where an explicit `.noise temp=<kelvin>` overrides the deck
+operating temperature.

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -80,6 +80,7 @@ pub struct NoiseAnalysis {
     pub input_source: String,
     pub frequencies_hz: Vec<f64>,
     pub temperature: f64,
+    pub temperature_is_explicit: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -390,6 +391,41 @@ impl ParsedNetlist {
             options.max_step = Some(max_step);
         }
         Ok(options)
+    }
+
+    pub fn operating_temperature_kelvin(
+        &self,
+        temperature_index: usize,
+        default_temperature_kelvin: f64,
+    ) -> Result<f64, NetlistParseError> {
+        let temperatures_celsius = self
+            .temp_cards()
+            .into_iter()
+            .flat_map(|card| card.temperatures_celsius.iter().copied())
+            .collect::<Vec<_>>();
+        if temperatures_celsius.is_empty() {
+            return Ok(default_temperature_kelvin);
+        }
+        let Some(temperature_celsius) = temperatures_celsius.get(temperature_index) else {
+            return Err(NetlistParseError::new(format!(
+                "temperature index {temperature_index} exceeds .temp entries"
+            )));
+        };
+        Ok(temperature_celsius + 273.15)
+    }
+
+    pub fn noise_temperature_kelvin(
+        &self,
+        noise: Option<&NoiseAnalysis>,
+        temperature_index: usize,
+        default_temperature_kelvin: f64,
+    ) -> Result<f64, NetlistParseError> {
+        if let Some(noise) = noise {
+            if noise.temperature_is_explicit {
+                return Ok(noise.temperature);
+            }
+        }
+        self.operating_temperature_kelvin(temperature_index, default_temperature_kelvin)
     }
 
     fn merged_options(&self) -> HashMap<String, OptionValue> {
@@ -1520,6 +1556,7 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
             require_min_fields(fields, 3, ".noise")?;
             let mut frequencies_hz = Vec::new();
             let mut temperature = 300.0;
+            let mut temperature_is_explicit = false;
             let mut tail_index = 3;
             while tail_index < fields.len() {
                 let token = &fields[tail_index];
@@ -1531,9 +1568,11 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
                         ));
                     }
                     temperature = parse_value(&fields[tail_index + 1])?;
+                    temperature_is_explicit = true;
                     tail_index += 2;
                 } else if let Some(value) = lower_token.strip_prefix("temp=") {
                     temperature = parse_value(value)?;
+                    temperature_is_explicit = true;
                     tail_index += 1;
                 } else {
                     frequencies_hz.push(parse_value(token)?);
@@ -1545,6 +1584,7 @@ fn parse_directive(fields: &[String]) -> Result<Analysis, NetlistParseError> {
                 input_source: fields[2].clone(),
                 frequencies_hz,
                 temperature,
+                temperature_is_explicit,
             }))
         }
         ".temp" => {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -282,6 +282,31 @@ fn parses_temp_analysis_cards() {
         panic!("expected one temp card");
     };
     assert_eq!(card.temperatures_celsius, vec![27.0, 75.0, -40.0]);
+    assert_close(
+        parsed.operating_temperature_kelvin(0, 300.0).unwrap(),
+        300.15,
+    );
+    assert_close(
+        parsed.operating_temperature_kelvin(1, 300.0).unwrap(),
+        348.15,
+    );
+}
+
+#[test]
+fn defaults_operating_temperature_without_temp_cards() {
+    let parsed = parse_netlist("R1 in out 1k").unwrap();
+
+    assert_close(
+        parsed.operating_temperature_kelvin(0, 301.0).unwrap(),
+        301.0,
+    );
+    let error = parse_netlist(".temp 27")
+        .unwrap()
+        .operating_temperature_kelvin(3, 300.0)
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("temperature index 3 exceeds .temp entries"));
 }
 
 #[test]
@@ -695,6 +720,7 @@ R1 in out 1k
 fn parses_noise_ac_analysis_cards() {
     let parsed = parse_netlist(
         r#"
+.temp 75
 Vin in 0 DC 1
 Rtop in out 1k
 Rbot out 0 1k
@@ -705,33 +731,70 @@ Rbot out 0 1k
 
     assert_eq!(
         parsed.analyses,
-        vec![Analysis::Noise(NoiseAnalysis {
-            output_node: "out".to_string(),
-            input_source: "Vin".to_string(),
-            frequencies_hz: vec![1000.0],
-            temperature: 300.0,
-        })]
+        vec![
+            Analysis::Temp(TempAnalysis {
+                temperatures_celsius: vec![75.0],
+            }),
+            Analysis::Noise(NoiseAnalysis {
+                output_node: "out".to_string(),
+                input_source: "Vin".to_string(),
+                frequencies_hz: vec![1000.0],
+                temperature: 300.0,
+                temperature_is_explicit: true,
+            })
+        ]
     );
     assert_eq!(
         parsed.noise_cards(),
-        vec![match &parsed.analyses[0] {
+        vec![match &parsed.analyses[1] {
             Analysis::Noise(card) => card,
             _ => panic!("expected noise card"),
         }]
     );
     let card = parsed.noise_cards()[0];
+    assert_close(
+        parsed
+            .noise_temperature_kelvin(Some(card), 0, 300.0)
+            .unwrap(),
+        300.0,
+    );
     let result = noise_ac(
         &parsed.circuit,
         &card.output_node,
         &card.input_source,
         &card.frequencies_hz,
-        card.temperature,
+        parsed
+            .noise_temperature_kelvin(Some(card), 0, 300.0)
+            .unwrap(),
     )
     .unwrap();
     assert_eq!(result.output_node, "out");
     assert_eq!(result.input_source, "Vin");
     assert_eq!(result.points.len(), 1);
     assert!(result.points[0].output_psd > 0.0);
+}
+
+#[test]
+fn noise_analysis_uses_temp_card_when_noise_temp_is_omitted() {
+    let parsed = parse_netlist(
+        r#"
+.temp 50
+Vin in 0 DC 1
+Rtop in out 1k
+Rbot out 0 1k
+.noise V(out) Vin 1k
+"#,
+    )
+    .unwrap();
+    let card = parsed.noise_cards()[0];
+
+    assert!(!card.temperature_is_explicit);
+    assert_close(
+        parsed
+            .noise_temperature_kelvin(Some(card), 0, 300.0)
+            .unwrap(),
+        323.15,
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve `.temp` cards into Kelvin engine-call temperatures and let explicit
+  `.noise temp=<kelvin>` overrides win over deck-level operating temperatures.
 - Route selected `.options` keys into engine-call helpers:
   `dcOpOptions()` for DC Newton options and `adaptiveTransientOptions()` for
   adaptive transient options.

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -37,3 +37,7 @@ omitted, `netlist.transientMethod()` falls back to `.options method=<...>` if
 present.
 Selected `.options` keys can also be turned into engine-call options with
 `netlist.dcOpOptions()` and `netlist.adaptiveTransientOptions()`.
+Deck-level `.temp` cards can be resolved into Kelvin with
+`netlist.operatingTemperatureKelvin()`, and
+`netlist.noiseTemperatureKelvin(noiseCard)` applies the SPICE precedence where
+an explicit `.noise temp=<kelvin>` overrides the deck operating temperature.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -93,6 +93,7 @@ export interface NoiseAnalysis {
   readonly inputSource: string;
   readonly frequenciesHz: readonly number[];
   readonly temperature: number;
+  readonly temperatureIsExplicit?: boolean;
 }
 
 export interface TempAnalysis {
@@ -311,6 +312,35 @@ export class ParsedNetlist {
       options.maxStep = maxStep;
     }
     return options;
+  }
+
+  operatingTemperatureKelvin(
+    temperatureIndex = 0,
+    defaultTemperatureKelvin = 300.0,
+  ): number {
+    if (!Number.isInteger(temperatureIndex) || temperatureIndex < 0) {
+      throw new NetlistParseError("temperature index must be non-negative");
+    }
+    const temperaturesCelsius = this.tempCards().flatMap((card) => card.temperaturesCelsius);
+    if (temperaturesCelsius.length === 0) {
+      return defaultTemperatureKelvin;
+    }
+    const temperature = temperaturesCelsius[temperatureIndex];
+    if (temperature === undefined) {
+      throw new NetlistParseError(`temperature index ${temperatureIndex} exceeds .temp entries`);
+    }
+    return temperature + 273.15;
+  }
+
+  noiseTemperatureKelvin(
+    noise?: NoiseAnalysis,
+    temperatureIndex = 0,
+    defaultTemperatureKelvin = 300.0,
+  ): number {
+    if (noise?.temperatureIsExplicit === true) {
+      return noise.temperature;
+    }
+    return this.operatingTemperatureKelvin(temperatureIndex, defaultTemperatureKelvin);
   }
 
   private mergedOptions(): Map<string, OptionValue> {
@@ -1218,6 +1248,7 @@ function parseDirective(fields: readonly string[]): Analysis {
     requireMinFields(fields, 3, ".noise");
     const frequenciesHz: number[] = [];
     let temperature = 300.0;
+    let temperatureIsExplicit = false;
     let tailIndex = 3;
     while (tailIndex < fields.length) {
       const token = fields[tailIndex];
@@ -1227,9 +1258,11 @@ function parseDirective(fields: readonly string[]): Analysis {
           throw new NetlistParseError(".noise temp requires a temperature value");
         }
         temperature = parseValue(fields[tailIndex + 1]);
+        temperatureIsExplicit = true;
         tailIndex += 2;
       } else if (lowerToken.startsWith("temp=")) {
         temperature = parseValue(token.split("=", 2)[1]);
+        temperatureIsExplicit = true;
         tailIndex += 1;
       } else {
         frequenciesHz.push(parseValue(token));
@@ -1242,6 +1275,7 @@ function parseDirective(fields: readonly string[]): Analysis {
       inputSource: fields[2],
       frequenciesHz,
       temperature,
+      ...(temperatureIsExplicit ? { temperatureIsExplicit: true } : {}),
     };
   }
   if (directive === ".temp") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -196,6 +196,17 @@ R2 mid 0 1k
 
     expect(parsed.analyses).toEqual([card]);
     expect(parsed.tempCards()).toEqual([card]);
+    expect(parsed.operatingTemperatureKelvin()).toBeCloseTo(300.15, 12);
+    expect(parsed.operatingTemperatureKelvin(1)).toBeCloseTo(348.15, 12);
+  });
+
+  it("defaults operating temperature without .temp cards", () => {
+    const parsed = parseNetlist("R1 in out 1k");
+
+    expect(parsed.operatingTemperatureKelvin(0, 301.0)).toBe(301.0);
+    expect(() => parseNetlist(".temp 27").operatingTemperatureKelvin(3)).toThrow(
+      /temperature index 3 exceeds \.temp entries/,
+    );
   });
 
   it("rejects .temp cards without temperatures", () => {
@@ -468,6 +479,7 @@ R1 in out 1k
 
   it("parses .noise AC noise analysis cards", () => {
     const parsed = parseNetlist(`
+.temp 75
 Vin in 0 DC 1
 Rtop in out 1k
 Rbot out 0 1k
@@ -476,26 +488,46 @@ Rbot out 0 1k
 
     expect(parsed.analyses).toEqual([
       {
+        kind: "temp",
+        temperaturesCelsius: [75.0],
+      },
+      {
         kind: "noise",
         outputNode: "out",
         inputSource: "Vin",
         frequenciesHz: [1000.0],
         temperature: 300.0,
+        temperatureIsExplicit: true,
       },
     ]);
-    expect(parsed.noiseCards()).toEqual(parsed.analyses);
+    expect(parsed.noiseCards()).toEqual([parsed.analyses[1]]);
     const [card] = parsed.noiseCards();
+    expect(parsed.noiseTemperatureKelvin(card)).toBe(300.0);
     const result = noiseAc(
       parsed.circuit,
       card.outputNode,
       card.inputSource,
       card.frequenciesHz,
-      card.temperature,
+      parsed.noiseTemperatureKelvin(card),
     );
     expect(result.outputNode).toBe("out");
     expect(result.inputSource).toBe("Vin");
     expect(result.points).toHaveLength(1);
     expect(result.points[0].outputPsd).toBeGreaterThan(0.0);
+  });
+
+  it("uses .temp for noise analysis when .noise omits temp", () => {
+    const parsed = parseNetlist(`
+.temp 50
+Vin in 0 DC 1
+Rtop in out 1k
+Rbot out 0 1k
+.noise V(out) Vin 1k
+`);
+    const [card] = parsed.noiseCards();
+
+    expect(card.temperatureIsExplicit).toBeUndefined();
+    expect(parsed.noiseTemperatureKelvin(card)).toBeCloseTo(323.15, 12);
   });
 
   it("rejects .noise cards without a voltage output probe", () => {

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -262,6 +262,9 @@ Status:
 - Selected `.options` keys are wired into engine-call helpers across Python,
   TypeScript, and Rust, covering DC solver tolerances/iteration limits and
   transient method/adaptive-step options.
+- Deck-level `.temp` cards are resolved into Kelvin helper temperatures across
+  Python, TypeScript, and Rust, and explicit `.noise temp=<kelvin>` values take
+  precedence for noise-engine calls.
 - `.disto` and `.pz` parser/control-card records plus first distortion and
   pole-zero result shapes are implemented across Python, TypeScript, and Rust,
   with smoke fixtures for nonlinear-device distortion output and a simple RC


### PR DESCRIPTION
## Summary
- add parser helpers that resolve deck-level `.temp` cards into Kelvin operating temperatures across Python, TypeScript, and Rust
- track explicit `.noise temp=<kelvin>` overrides so noise analysis uses `.noise` temperature before falling back to `.temp` and then the 300 K default
- update parser tests, README/changelog notes, and the SPICE 1970s compatibility status

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-temp-noise-helper sh BUILD` in `code/packages/python/spice-netlist-parser`
- `npm run build && npm test -- --run tests/spice-netlist-parser.test.ts` in `code/packages/typescript/spice-netlist-parser`
- `sh BUILD` in `code/packages/typescript/spice-netlist-parser`
- `cargo fmt -p spice-netlist-parser --check` in `code/packages/rust`
- `cargo test -p spice-netlist-parser` in `code/packages/rust`
- `sh BUILD` in `code/packages/rust/spice-netlist-parser`
- `git diff --check`