### PR TITLE
Add browser script and stylesheet metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -235,6 +235,8 @@ def check_browser_readiness_case(
     require_string(f"{case_path}.expected", expected, "body_text", errors)
     require_object_list(f"{case_path}.expected", expected, "metas", errors)
     require_object_list(f"{case_path}.expected", expected, "resources", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "scripts", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "stylesheets", errors)
     require_object_list(f"{case_path}.expected", expected, "anchors", errors)
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
@@ -265,6 +267,45 @@ def check_browser_expected_lists(
             require_optional_nullable_string(resource_path, resource, field, errors)
         require_boolean(resource_path, resource, "async_script", errors)
         require_boolean(resource_path, resource, "defer_script", errors)
+
+    for index, script in enumerate(object_list_items(expected, "scripts")):
+        script_path = f"{case_path}.expected.scripts[{index}]"
+        require_string(script_path, script, "script_kind", errors)
+        for field in (
+            "src",
+            "resolved_src",
+            "type_hint",
+            "integrity",
+            "crossorigin",
+            "referrerpolicy",
+            "fetchpriority",
+            "blocking",
+            "text",
+        ):
+            require_optional_nullable_string(script_path, script, field, errors)
+        for field in ("async_script", "defer_script", "nomodule"):
+            require_optional_boolean(script_path, script, field, errors)
+
+    for index, stylesheet in enumerate(object_list_items(expected, "stylesheets")):
+        stylesheet_path = f"{case_path}.expected.stylesheets[{index}]"
+        require_string(stylesheet_path, stylesheet, "source", errors)
+        for field in (
+            "href",
+            "resolved_href",
+            "rel",
+            "type_hint",
+            "media",
+            "title",
+            "integrity",
+            "crossorigin",
+            "referrerpolicy",
+            "fetchpriority",
+            "blocking",
+            "text",
+        ):
+            require_optional_nullable_string(stylesheet_path, stylesheet, field, errors)
+        for field in ("disabled", "alternate"):
+            require_optional_boolean(stylesheet_path, stylesheet, field, errors)
 
     for index, anchor in enumerate(object_list_items(expected, "anchors")):
         anchor_path = f"{case_path}.expected.anchors[{index}]"

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -211,6 +211,10 @@ documented in this file.
 - Browser-facing document, content-tree, and render-tree projections now carry
   media playback metadata for `audio` and `video`, including playback flags,
   and preload/poster fields.
+- Browser-facing document summaries now carry script and stylesheet loading
+  metadata, including script kind, async/defer/nomodule flags, inline
+  script/style text, integrity/crossorigin/referrer-policy hints, fetch
+  priority, blocking, alternate stylesheets, and disabled stylesheet state.
 - Browser-facing table summaries and tree projections now carry table layout and
   accessibility metadata, including effective column counts, column hints,
   row-group identity, column and cell spans, header associations, scopes, and

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -83,6 +83,10 @@ The current parser surface includes:
   URLs, resource kind, type hints, media attributes, and authored dimensions
 - browser-facing media playback metadata for `audio` and `video`, including
   playback flags and preload/poster fields
+- browser-facing script and stylesheet loading metadata, including
+  module/classic script kind, async/defer/nomodule flags, inline script/style
+  text, integrity/crossorigin/referrer-policy hints, fetch priority, blocking,
+  alternate stylesheet, and disabled stylesheet state
 - browser-facing table layout and accessibility metadata, including effective
   column counts, column hints, row-group identity, column spans, cell spans,
   header associations, scopes, and abbreviated header labels

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -827,6 +827,8 @@ pub struct BrowserDocument {
     pub body_text: String,
     pub metas: Vec<BrowserMeta>,
     pub resources: Vec<BrowserResource>,
+    pub scripts: Vec<BrowserScript>,
+    pub stylesheets: Vec<BrowserStylesheet>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub links: Vec<BrowserLink>,
@@ -858,6 +860,42 @@ pub struct BrowserResource {
     pub height: Option<String>,
     pub async_script: bool,
     pub defer_script: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserScript {
+    pub script_kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub type_hint: Option<String>,
+    pub async_script: bool,
+    pub defer_script: bool,
+    pub nomodule: bool,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserStylesheet {
+    pub source: String,
+    pub href: Option<String>,
+    pub resolved_href: Option<String>,
+    pub rel: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+    pub title: Option<String>,
+    pub disabled: bool,
+    pub alternate: bool,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub text: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8199,6 +8237,13 @@ fn collect_browser_facts(
             "audio" | "video" => summary
                 .media
                 .push(browser_media_element(element, summary.base_href.as_deref())),
+            "script" => summary.scripts.push(browser_script_element(
+                element,
+                summary.base_href.as_deref(),
+            )),
+            "style" => summary
+                .stylesheets
+                .push(browser_style_element(element, summary.base_href.as_deref())),
             "form" => summary.forms.push(BrowserForm {
                 action: element.attribute("action").map(ToOwned::to_owned),
                 resolved_action: element
@@ -8261,6 +8306,11 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         async_script: false,
                         defer_script: false,
                     });
+                    if browser_link_is_stylesheet(element) {
+                        summary
+                            .stylesheets
+                            .push(browser_style_element(element, summary.base_href.as_deref()));
+                    }
                 }
             }
             "script" => {
@@ -8279,7 +8329,14 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         defer_script: element.attribute("defer").is_some(),
                     });
                 }
+                summary.scripts.push(browser_script_element(
+                    element,
+                    summary.base_href.as_deref(),
+                ));
             }
+            "style" => summary
+                .stylesheets
+                .push(browser_style_element(element, summary.base_href.as_deref())),
             _ => {}
         }
 
@@ -8492,10 +8549,15 @@ fn link_resource_kind(rel: Option<&str>) -> String {
     let Some(rel) = rel else {
         return "link".to_string();
     };
-    let rel_tokens = rel.split_ascii_whitespace().map(str::to_ascii_lowercase);
+    let rel_tokens: Vec<String> = rel
+        .split_ascii_whitespace()
+        .map(str::to_ascii_lowercase)
+        .collect();
+    if rel_tokens.iter().any(|token| token == "stylesheet") {
+        return "stylesheet".to_string();
+    }
     for token in rel_tokens {
         match token.as_str() {
-            "stylesheet" => return "stylesheet".to_string(),
             "icon" | "shortcut" => return "icon".to_string(),
             "preload" => return "preload".to_string(),
             "modulepreload" => return "modulepreload".to_string(),
@@ -8838,6 +8900,104 @@ fn browser_content_resource_kind(element: &Element) -> Option<String> {
         "audio" | "video" => Some(element.name.clone()),
         "canvas" => Some("canvas".to_string()),
         _ => None,
+    }
+}
+
+fn browser_script_element(element: &Element, base_href: Option<&str>) -> BrowserScript {
+    let src = element.attribute("src").map(ToOwned::to_owned);
+    BrowserScript {
+        script_kind: browser_script_kind(element),
+        resolved_src: src
+            .as_deref()
+            .and_then(|src| resolve_browser_url(src, base_href)),
+        src,
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        async_script: element.attribute("async").is_some(),
+        defer_script: element.attribute("defer").is_some(),
+        nomodule: element.attribute("nomodule").is_some(),
+        integrity: element.attribute("integrity").map(ToOwned::to_owned),
+        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        text: element_text_if_non_empty(element),
+    }
+}
+
+fn browser_script_kind(element: &Element) -> String {
+    let Some(type_hint) = element.attribute("type") else {
+        return "classic".to_string();
+    };
+    let normalized_type = type_hint.trim().to_ascii_lowercase();
+    let type_essence = normalized_type
+        .split_once(';')
+        .map(|(essence, _)| essence.trim())
+        .unwrap_or(normalized_type.as_str());
+    match type_essence {
+        ""
+        | "text/javascript"
+        | "application/javascript"
+        | "text/ecmascript"
+        | "application/ecmascript"
+        | "module" => {
+            if type_essence == "module" {
+                "module".to_string()
+            } else {
+                "classic".to_string()
+            }
+        }
+        "importmap" => "importmap".to_string(),
+        "speculationrules" => "speculationrules".to_string(),
+        _ => "data".to_string(),
+    }
+}
+
+fn browser_style_element(element: &Element, base_href: Option<&str>) -> BrowserStylesheet {
+    let href = element.attribute("href").map(ToOwned::to_owned);
+    BrowserStylesheet {
+        source: element.name.clone(),
+        resolved_href: href
+            .as_deref()
+            .and_then(|href| resolve_browser_url(href, base_href)),
+        href,
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        disabled: element.attribute("disabled").is_some(),
+        alternate: browser_rel_contains(element, "alternate"),
+        integrity: element.attribute("integrity").map(ToOwned::to_owned),
+        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        text: if element.name == "style" {
+            element_text_if_non_empty(element)
+        } else {
+            None
+        },
+    }
+}
+
+fn browser_link_is_stylesheet(element: &Element) -> bool {
+    element.name == "link" && browser_rel_contains(element, "stylesheet")
+}
+
+fn browser_rel_contains(element: &Element, token: &str) -> bool {
+    element
+        .attribute("rel")
+        .map(split_html_classes)
+        .unwrap_or_default()
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(token))
+}
+
+fn element_text_if_non_empty(element: &Element) -> Option<String> {
+    let text = element_text(element);
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
     }
 }
 
@@ -9940,6 +10100,89 @@ mod tests {
                 .as_deref(),
             Some("Query")
         );
+    }
+
+    #[test]
+    fn browser_script_style_metadata_tracks_loading_and_inline_text() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/index.html\">\
+             <link rel=\"stylesheet preload\" href=app.css media=screen title=main integrity=sha256-css crossorigin=anonymous referrerpolicy=no-referrer fetchpriority=high blocking=render>\
+             <link rel=\"alternate stylesheet\" href=print.css title=print disabled>\
+             <style media=print title=print>body { color: black; }</style>\
+             <script type=module src=app.js async integrity=sha384-js crossorigin=use-credentials referrerpolicy=origin fetchpriority=low blocking=render></script>\
+             <script type=\"text/javascript; charset=utf-8\">classicMime();</script>\
+             <script nomodule defer>legacy();</script>\
+             <body><script src=late.js defer></script>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.stylesheets.len(), 3);
+        let main_style = &summary.stylesheets[0];
+        assert_eq!(main_style.source, "link");
+        assert_eq!(
+            main_style.resolved_href.as_deref(),
+            Some("https://example.test/app/app.css")
+        );
+        assert_eq!(main_style.rel.as_deref(), Some("stylesheet preload"));
+        assert_eq!(main_style.media.as_deref(), Some("screen"));
+        assert_eq!(main_style.integrity.as_deref(), Some("sha256-css"));
+        assert_eq!(main_style.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(main_style.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(main_style.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(main_style.blocking.as_deref(), Some("render"));
+        assert!(!main_style.alternate);
+
+        let alternate_style = &summary.stylesheets[1];
+        assert!(alternate_style.alternate);
+        assert!(alternate_style.disabled);
+        assert_eq!(
+            alternate_style.resolved_href.as_deref(),
+            Some("https://example.test/app/print.css")
+        );
+
+        let inline_style = &summary.stylesheets[2];
+        assert_eq!(inline_style.source, "style");
+        assert_eq!(inline_style.media.as_deref(), Some("print"));
+        assert_eq!(inline_style.text.as_deref(), Some("body { color: black; }"));
+
+        assert_eq!(summary.scripts.len(), 4);
+        let module_script = &summary.scripts[0];
+        assert_eq!(module_script.script_kind, "module");
+        assert_eq!(
+            module_script.resolved_src.as_deref(),
+            Some("https://example.test/app/app.js")
+        );
+        assert!(module_script.async_script);
+        assert_eq!(module_script.integrity.as_deref(), Some("sha384-js"));
+        assert_eq!(
+            module_script.crossorigin.as_deref(),
+            Some("use-credentials")
+        );
+        assert_eq!(module_script.referrerpolicy.as_deref(), Some("origin"));
+        assert_eq!(module_script.fetchpriority.as_deref(), Some("low"));
+        assert_eq!(module_script.blocking.as_deref(), Some("render"));
+
+        let classic_mime_script = &summary.scripts[1];
+        assert_eq!(classic_mime_script.script_kind, "classic");
+        assert_eq!(
+            classic_mime_script.type_hint.as_deref(),
+            Some("text/javascript; charset=utf-8")
+        );
+        assert_eq!(classic_mime_script.text.as_deref(), Some("classicMime();"));
+
+        let legacy_script = &summary.scripts[2];
+        assert_eq!(legacy_script.script_kind, "classic");
+        assert!(legacy_script.nomodule);
+        assert!(legacy_script.defer_script);
+        assert_eq!(legacy_script.text.as_deref(), Some("legacy();"));
+
+        let late_script = &summary.scripts[3];
+        assert_eq!(
+            late_script.resolved_src.as_deref(),
+            Some("https://example.test/app/late.js")
+        );
+        assert!(late_script.defer_script);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,7 +1,7 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserForm, BrowserFormControl,
     BrowserHeading, BrowserImage, BrowserLink, BrowserMedia, BrowserMeta, BrowserResource,
-    BrowserTable,
+    BrowserScript, BrowserStylesheet, BrowserTable,
 };
 use serde::Deserialize;
 
@@ -41,6 +41,10 @@ struct ExpectedBrowserDocument {
     body_text: String,
     metas: Vec<ExpectedMeta>,
     resources: Vec<ExpectedResource>,
+    #[serde(default)]
+    scripts: Vec<ExpectedScript>,
+    #[serde(default)]
+    stylesheets: Vec<ExpectedStylesheet>,
     anchors: Vec<ExpectedAnchor>,
     headings: Vec<ExpectedHeading>,
     links: Vec<ExpectedLink>,
@@ -75,6 +79,66 @@ struct ExpectedResource {
     height: Option<String>,
     async_script: bool,
     defer_script: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedScript {
+    script_kind: String,
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    type_hint: Option<String>,
+    #[serde(default)]
+    async_script: bool,
+    #[serde(default)]
+    defer_script: bool,
+    #[serde(default)]
+    nomodule: bool,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedStylesheet {
+    source: String,
+    #[serde(default)]
+    href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    alternate: bool,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -234,6 +298,16 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedResource::into_browser_resource)
                 .collect(),
+            scripts: self
+                .scripts
+                .into_iter()
+                .map(ExpectedScript::into_browser_script)
+                .collect(),
+            stylesheets: self
+                .stylesheets
+                .into_iter()
+                .map(ExpectedStylesheet::into_browser_stylesheet)
+                .collect(),
             anchors: self
                 .anchors
                 .into_iter()
@@ -299,6 +373,48 @@ impl ExpectedResource {
             height: self.height,
             async_script: self.async_script,
             defer_script: self.defer_script,
+        }
+    }
+}
+
+impl ExpectedScript {
+    fn into_browser_script(self) -> BrowserScript {
+        BrowserScript {
+            script_kind: self.script_kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            type_hint: self.type_hint,
+            async_script: self.async_script,
+            defer_script: self.defer_script,
+            nomodule: self.nomodule,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedStylesheet {
+    fn into_browser_stylesheet(self) -> BrowserStylesheet {
+        BrowserStylesheet {
+            source: self.source,
+            href: self.href,
+            resolved_href: self.resolved_href,
+            rel: self.rel,
+            type_hint: self.type_hint,
+            media: self.media,
+            title: self.title,
+            disabled: self.disabled,
+            alternate: self.alternate,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            text: self.text,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -19,7 +19,10 @@ and document/body identity and language metadata such as `lang`, `dir`, body
 `id`, and tokenized body classes. Form cases also pin labels, derived
 accessible names, owner references, placeholder/autocomplete hints, and
 required/readonly/multiple control state. Media cases pin audio/video playback
-flags and preload/poster metadata.
+flags and preload/poster metadata. Script/style cases pin module/classic script
+kind, async/defer/nomodule flags, inline script/style text, and loading-policy
+hints such as integrity, crossorigin, referrer policy, fetch priority,
+blocking, disabled state, and alternate stylesheets.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -19,6 +19,9 @@
           { "kind": "stylesheet", "url": "style.css", "resolved_url": "https://example.test/docs/style.css", "rel": "stylesheet", "type_hint": null, "media": "screen", "title": "default", "async_script": false, "defer_script": false },
           { "kind": "image", "url": "logo.gif", "resolved_url": "https://example.test/docs/logo.gif", "rel": null, "type_hint": null, "media": null, "title": null, "width": "88", "height": "31", "async_script": false, "defer_script": false }
         ],
+        "stylesheets": [
+          { "source": "link", "href": "style.css", "resolved_href": "https://example.test/docs/style.css", "rel": "stylesheet", "media": "screen", "title": "default" }
+        ],
         "anchors": [
           { "id": "index", "name": null, "text": "Example Directory" }
         ],
@@ -138,6 +141,12 @@
         "resources": [
           { "kind": "script", "url": "app.js", "resolved_url": null, "rel": null, "type_hint": null, "media": null, "title": null, "async_script": true, "defer_script": true }
         ],
+        "scripts": [
+          { "script_kind": "classic", "src": "app.js", "resolved_src": null, "type_hint": null, "async_script": true, "defer_script": true, "text": "document.write(\"x\")" }
+        ],
+        "stylesheets": [
+          { "source": "style", "text": "p{color:red}" }
+        ],
         "anchors": [
           { "id": null, "name": "top", "text": "" }
         ],
@@ -231,6 +240,40 @@
             "preload": "none"
           }
         ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "script-style-loading-page",
+      "description": "Browser document summaries expose stylesheet and script loading metadata for early fetch, execution, and style planning.",
+      "input": "<base href=\"https://example.test/app/index.html\"><link rel=\"stylesheet preload\" href=app.css media=screen title=main integrity=sha256-css crossorigin=anonymous referrerpolicy=no-referrer fetchpriority=high blocking=render><link rel=\"alternate stylesheet\" href=print.css title=print disabled><style media=print title=print>body { color: black; }</style><script type=module src=app.js async integrity=sha384-js crossorigin=use-credentials referrerpolicy=origin fetchpriority=low blocking=render></script><script nomodule defer>legacy();</script><body><script src=late.js defer></script>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/app/index.html",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "stylesheet", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "type_hint": null, "media": "screen", "title": "main", "async_script": false, "defer_script": false },
+          { "kind": "stylesheet", "url": "print.css", "resolved_url": "https://example.test/app/print.css", "rel": "alternate stylesheet", "type_hint": null, "media": null, "title": "print", "async_script": false, "defer_script": false },
+          { "kind": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "rel": null, "type_hint": "module", "media": null, "title": null, "async_script": true, "defer_script": false },
+          { "kind": "script", "url": "late.js", "resolved_url": "https://example.test/app/late.js", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": true }
+        ],
+        "scripts": [
+          { "script_kind": "module", "src": "app.js", "resolved_src": "https://example.test/app/app.js", "type_hint": "module", "async_script": true, "integrity": "sha384-js", "crossorigin": "use-credentials", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render" },
+          { "script_kind": "classic", "src": null, "resolved_src": null, "type_hint": null, "defer_script": true, "nomodule": true, "text": "legacy();" },
+          { "script_kind": "classic", "src": "late.js", "resolved_src": "https://example.test/app/late.js", "type_hint": null, "defer_script": true }
+        ],
+        "stylesheets": [
+          { "source": "link", "href": "app.css", "resolved_href": "https://example.test/app/app.css", "rel": "stylesheet preload", "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render" },
+          { "source": "link", "href": "print.css", "resolved_href": "https://example.test/app/print.css", "rel": "alternate stylesheet", "title": "print", "disabled": true, "alternate": true },
+          { "source": "style", "media": "print", "title": "print", "text": "body { color: black; }" }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- add browser-facing script metadata for classic/module/importmap/speculationrules/data scripts
- add stylesheet loading metadata for link/style elements, including alternate/disabled and policy hints
- extend browser readiness fixture schema, fixtures, docs, and tests for script/style startup planning

## Testing
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_script_style_metadata_tracks_loading_and_inline_text
- cargo test -p coding-adventures-html-parser browser_media_metadata_tracks_playback_and_poster_state
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser