### PR TITLE
Add browser responsive image metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -326,8 +326,29 @@ def check_browser_expected_lists(
 
     for index, image in enumerate(object_list_items(expected, "images")):
         image_path = f"{case_path}.expected.images[{index}]"
-        for field in ("src", "resolved_src", "alt", "width", "height"):
+        for field in (
+            "src",
+            "resolved_src",
+            "alt",
+            "width",
+            "height",
+            "srcset",
+            "resolved_srcset",
+            "sizes",
+            "loading",
+            "decoding",
+            "fetchpriority",
+            "crossorigin",
+            "referrerpolicy",
+            "usemap",
+        ):
             require_optional_nullable_string(image_path, image, field, errors)
+        require_optional_boolean(image_path, image, "ismap", errors)
+        require_optional_object_list(image_path, image, "sources", errors)
+        for source_index, source in enumerate(object_list_items(image, "sources")):
+            source_path = f"{image_path}.sources[{source_index}]"
+            for field in ("srcset", "resolved_srcset", "sizes", "media", "type_hint"):
+                require_optional_nullable_string(source_path, source, field, errors)
 
     for index, media in enumerate(object_list_items(expected, "media")):
         media_path = f"{case_path}.expected.media[{index}]"

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -215,6 +215,10 @@ documented in this file.
   metadata, including script kind, async/defer/nomodule flags, inline
   script/style text, integrity/crossorigin/referrer-policy hints, fetch
   priority, blocking, alternate stylesheets, and disabled stylesheet state.
+- Browser-facing image summaries now carry responsive image selection metadata,
+  including `srcset`/`sizes`, resolved candidate URLs, `picture/source`
+  media/type hints, lazy loading, decoding, fetch priority, CORS/referrer
+  policy, usemap, and server-side image-map state.
 - Browser-facing table summaries and tree projections now carry table layout and
   accessibility metadata, including effective column counts, column hints,
   row-group identity, column and cell spans, header associations, scopes, and

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -75,6 +75,10 @@ The current parser surface includes:
 - browser-facing URL resolution metadata for links, loadable resources, images,
   and form actions using the document `base` href when available, while keeping
   raw authored URLs available to browser policy code
+- browser-facing responsive image metadata for `img` and `picture/source`
+  combinations, including raw/resolved `srcset`, `sizes`, source media/type
+  hints, lazy loading, decoding, fetch priority, CORS/referrer policy, usemap,
+  and server-side image-map state
 - browser-facing identity and language metadata for document/body fields plus
   renderable content nodes, including `id`, tokenized `class`, `title`, `lang`,
   and `dir` values for selector matching, UI policy, and early layout

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1070,6 +1070,26 @@ pub struct BrowserImage {
     pub alt: Option<String>,
     pub width: Option<String>,
     pub height: Option<String>,
+    pub srcset: Option<String>,
+    pub resolved_srcset: Option<String>,
+    pub sizes: Option<String>,
+    pub loading: Option<String>,
+    pub decoding: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub crossorigin: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub usemap: Option<String>,
+    pub ismap: bool,
+    pub sources: Vec<BrowserImageSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserImageSource {
+    pub srcset: Option<String>,
+    pub resolved_srcset: Option<String>,
+    pub sizes: Option<String>,
+    pub media: Option<String>,
+    pub type_hint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1177,7 +1197,7 @@ impl BrowserDocument {
             collect_head_browser_facts(&head.children, &mut summary);
         }
         let labels = collect_label_texts_by_control_id(body_children);
-        collect_browser_facts(body_children, &mut summary, &labels);
+        collect_browser_facts(body_children, &mut summary, &labels, &[]);
         summary
     }
 }
@@ -8204,7 +8224,9 @@ fn collect_browser_facts(
     nodes: &[Node],
     summary: &mut BrowserDocument,
     labels: &[(String, String)],
+    picture_sources: &[BrowserImageSource],
 ) {
+    let mut pending_picture_sources = Vec::new();
     for node in nodes {
         let Node::Element(element) = node else {
             continue;
@@ -8225,15 +8247,27 @@ fn collect_browser_facts(
                 title: element.attribute("title").map(ToOwned::to_owned),
                 text: visible_text_for_nodes(&element.children),
             }),
-            "img" => summary.images.push(BrowserImage {
-                src: element.attribute("src").map(ToOwned::to_owned),
-                resolved_src: element
-                    .attribute("src")
-                    .and_then(|src| resolve_browser_url(src, summary.base_href.as_deref())),
-                alt: element.attribute("alt").map(ToOwned::to_owned),
-                width: element.attribute("width").map(ToOwned::to_owned),
-                height: element.attribute("height").map(ToOwned::to_owned),
-            }),
+            "picture" => {
+                collect_browser_facts(&element.children, summary, labels, &[]);
+                continue;
+            }
+            "source" => {
+                if picture_sources.is_empty() {
+                    pending_picture_sources.push(browser_image_source_element(
+                        element,
+                        summary.base_href.as_deref(),
+                    ));
+                }
+            }
+            "img" => summary.images.push(browser_image_element(
+                element,
+                summary.base_href.as_deref(),
+                if picture_sources.is_empty() {
+                    &pending_picture_sources
+                } else {
+                    picture_sources
+                },
+            )),
             "audio" | "video" => summary
                 .media
                 .push(browser_media_element(element, summary.base_href.as_deref())),
@@ -8273,7 +8307,10 @@ fn collect_browser_facts(
             _ => {}
         }
 
-        collect_browser_facts(&element.children, summary, labels);
+        collect_browser_facts(&element.children, summary, labels, picture_sources);
+        if element.name == "img" {
+            pending_picture_sources.clear();
+        }
     }
 }
 
@@ -8900,6 +8937,75 @@ fn browser_content_resource_kind(element: &Element) -> Option<String> {
         "audio" | "video" => Some(element.name.clone()),
         "canvas" => Some("canvas".to_string()),
         _ => None,
+    }
+}
+
+fn browser_image_element(
+    element: &Element,
+    base_href: Option<&str>,
+    picture_sources: &[BrowserImageSource],
+) -> BrowserImage {
+    let src = element.attribute("src").map(ToOwned::to_owned);
+    let srcset = element.attribute("srcset").map(ToOwned::to_owned);
+    BrowserImage {
+        resolved_src: src
+            .as_deref()
+            .and_then(|src| resolve_browser_url(src, base_href)),
+        src,
+        alt: element.attribute("alt").map(ToOwned::to_owned),
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
+        resolved_srcset: srcset
+            .as_deref()
+            .map(|srcset| resolve_browser_srcset(srcset, base_href)),
+        srcset,
+        sizes: element.attribute("sizes").map(ToOwned::to_owned),
+        loading: element.attribute("loading").map(ToOwned::to_owned),
+        decoding: element.attribute("decoding").map(ToOwned::to_owned),
+        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        usemap: element.attribute("usemap").map(ToOwned::to_owned),
+        ismap: element.attribute("ismap").is_some(),
+        sources: picture_sources.to_vec(),
+    }
+}
+
+fn browser_image_source_element(element: &Element, base_href: Option<&str>) -> BrowserImageSource {
+    let srcset = element.attribute("srcset").map(ToOwned::to_owned);
+    BrowserImageSource {
+        resolved_srcset: srcset
+            .as_deref()
+            .map(|srcset| resolve_browser_srcset(srcset, base_href)),
+        srcset,
+        sizes: element.attribute("sizes").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+    }
+}
+
+fn resolve_browser_srcset(srcset: &str, base_href: Option<&str>) -> String {
+    srcset
+        .split(',')
+        .map(|candidate| resolve_browser_srcset_candidate(candidate, base_href))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn resolve_browser_srcset_candidate(candidate: &str, base_href: Option<&str>) -> String {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let Some((url, descriptor)) = trimmed.split_once(char::is_whitespace) else {
+        return resolve_browser_url(trimmed, base_href).unwrap_or_else(|| trimmed.to_string());
+    };
+    let resolved_url = resolve_browser_url(url, base_href).unwrap_or_else(|| url.to_string());
+    let descriptor = descriptor.trim();
+    if descriptor.is_empty() {
+        resolved_url
+    } else {
+        format!("{resolved_url} {descriptor}")
     }
 }
 
@@ -9877,6 +9983,54 @@ mod tests {
         let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
         assert_eq!(render_tree.children[0].display, "inline-replaced");
         assert_eq!(render_tree.children[1].display, "inline-replaced");
+    }
+
+    #[test]
+    fn browser_responsive_image_metadata_tracks_sources_and_loading_hints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/gallery/index.html\"><body>\
+             <picture>\
+               <source media=\"(min-width: 800px)\" type=image/avif srcset=\"hero-wide.avif 1x, hero-wide@2x.avif 2x\" sizes=\"80vw\">\
+               <source media=\"(min-width: 400px)\" type=image/webp srcset=\"hero.webp 640w, hero-large.webp 1280w\" sizes=\"100vw\">\
+               <img src=hero.jpg srcset=\"hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w\" sizes=\"(max-width: 600px) 100vw, 50vw\" alt=\"Hero\" width=640 height=360 loading=lazy decoding=async fetchpriority=high crossorigin=anonymous referrerpolicy=no-referrer usemap=#hero-map ismap>\
+             </picture>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.images.len(), 1);
+        let image = &summary.images[0];
+        assert_eq!(image.alt.as_deref(), Some("Hero"));
+        assert_eq!(
+            image.resolved_src.as_deref(),
+            Some("https://example.test/gallery/hero.jpg")
+        );
+        assert_eq!(
+            image.resolved_srcset.as_deref(),
+            Some("https://example.test/gallery/hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w")
+        );
+        assert_eq!(
+            image.sizes.as_deref(),
+            Some("(max-width: 600px) 100vw, 50vw")
+        );
+        assert_eq!(image.loading.as_deref(), Some("lazy"));
+        assert_eq!(image.decoding.as_deref(), Some("async"));
+        assert_eq!(image.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(image.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(image.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(image.usemap.as_deref(), Some("#hero-map"));
+        assert!(image.ismap);
+        assert_eq!(image.sources.len(), 2);
+        assert_eq!(
+            image.sources[0].media.as_deref(),
+            Some("(min-width: 800px)")
+        );
+        assert_eq!(image.sources[0].type_hint.as_deref(), Some("image/avif"));
+        assert_eq!(
+            image.sources[0].resolved_srcset.as_deref(),
+            Some("https://example.test/gallery/hero-wide.avif 1x, https://example.test/gallery/hero-wide@2x.avif 2x")
+        );
+        assert_eq!(image.sources[1].sizes.as_deref(), Some("100vw"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,7 +1,7 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserForm, BrowserFormControl,
-    BrowserHeading, BrowserImage, BrowserLink, BrowserMedia, BrowserMeta, BrowserResource,
-    BrowserScript, BrowserStylesheet, BrowserTable,
+    BrowserHeading, BrowserImage, BrowserImageSource, BrowserLink, BrowserMedia, BrowserMeta,
+    BrowserResource, BrowserScript, BrowserStylesheet, BrowserTable,
 };
 use serde::Deserialize;
 
@@ -172,6 +172,42 @@ struct ExpectedImage {
     alt: Option<String>,
     width: Option<String>,
     height: Option<String>,
+    #[serde(default)]
+    srcset: Option<String>,
+    #[serde(default)]
+    resolved_srcset: Option<String>,
+    #[serde(default)]
+    sizes: Option<String>,
+    #[serde(default)]
+    loading: Option<String>,
+    #[serde(default)]
+    decoding: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    usemap: Option<String>,
+    #[serde(default)]
+    ismap: bool,
+    #[serde(default)]
+    sources: Vec<ExpectedImageSource>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedImageSource {
+    #[serde(default)]
+    srcset: Option<String>,
+    #[serde(default)]
+    resolved_srcset: Option<String>,
+    #[serde(default)]
+    sizes: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -460,6 +496,33 @@ impl ExpectedImage {
             alt: self.alt,
             width: self.width,
             height: self.height,
+            srcset: self.srcset,
+            resolved_srcset: self.resolved_srcset,
+            sizes: self.sizes,
+            loading: self.loading,
+            decoding: self.decoding,
+            fetchpriority: self.fetchpriority,
+            crossorigin: self.crossorigin,
+            referrerpolicy: self.referrerpolicy,
+            usemap: self.usemap,
+            ismap: self.ismap,
+            sources: self
+                .sources
+                .into_iter()
+                .map(ExpectedImageSource::into_browser_image_source)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedImageSource {
+    fn into_browser_image_source(self) -> BrowserImageSource {
+        BrowserImageSource {
+            srcset: self.srcset,
+            resolved_srcset: self.resolved_srcset,
+            sizes: self.sizes,
+            media: self.media,
+            type_hint: self.type_hint,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -22,7 +22,10 @@ required/readonly/multiple control state. Media cases pin audio/video playback
 flags and preload/poster metadata. Script/style cases pin module/classic script
 kind, async/defer/nomodule flags, inline script/style text, and loading-policy
 hints such as integrity, crossorigin, referrer policy, fetch priority,
-blocking, disabled state, and alternate stylesheets.
+blocking, disabled state, and alternate stylesheets. Responsive image cases pin
+`srcset`/`sizes`, resolved candidate URLs, `picture/source` media/type hints,
+lazy loading, decoding, fetch priority, CORS/referrer policy, usemap, and
+server-side image-map state.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -87,6 +87,49 @@
       }
     },
     {
+      "id": "responsive-image-metadata-page",
+      "description": "Browser document image summaries expose responsive source selection metadata and loading hints.",
+      "input": "<base href=\"https://example.test/gallery/index.html\"><body><picture><source media=\"(min-width: 800px)\" type=image/avif srcset=\"hero-wide.avif 1x, hero-wide@2x.avif 2x\" sizes=\"80vw\"><source media=\"(min-width: 400px)\" type=image/webp srcset=\"hero.webp 640w, hero-large.webp 1280w\" sizes=\"100vw\"><img src=hero.jpg srcset=\"hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w\" sizes=\"(max-width: 600px) 100vw, 50vw\" alt=\"Hero\" width=640 height=360 loading=lazy decoding=async fetchpriority=high crossorigin=anonymous referrerpolicy=no-referrer usemap=#hero-map ismap></picture>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/gallery/index.html",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "image", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "async_script": false, "defer_script": false }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [
+          {
+            "src": "hero.jpg",
+            "resolved_src": "https://example.test/gallery/hero.jpg",
+            "alt": "Hero",
+            "width": "640",
+            "height": "360",
+            "srcset": "hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w",
+            "resolved_srcset": "https://example.test/gallery/hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w",
+            "sizes": "(max-width: 600px) 100vw, 50vw",
+            "loading": "lazy",
+            "decoding": "async",
+            "fetchpriority": "high",
+            "crossorigin": "anonymous",
+            "referrerpolicy": "no-referrer",
+            "usemap": "#hero-map",
+            "ismap": true,
+            "sources": [
+              { "srcset": "hero-wide.avif 1x, hero-wide@2x.avif 2x", "resolved_srcset": "https://example.test/gallery/hero-wide.avif 1x, https://example.test/gallery/hero-wide@2x.avif 2x", "sizes": "80vw", "media": "(min-width: 800px)", "type_hint": "image/avif" },
+              { "srcset": "hero.webp 640w, hero-large.webp 1280w", "resolved_srcset": "https://example.test/gallery/hero.webp 640w, https://example.test/gallery/hero-large.webp 1280w", "sizes": "100vw", "media": "(min-width: 400px)", "type_hint": "image/webp" }
+            ]
+          }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "form-accessibility-document-page",
       "description": "Browser document form summaries include labels, accessible names, placeholders, autocomplete, and required/readonly/multiple control state.",
       "input": "<body><form id=search aria-label=\"Search form\" autocomplete=on><label for=q>Query</label><input id=q name=q placeholder=\"Search terms\" required autocomplete=search><label>Notes<textarea id=notes name=notes placeholder=Details readonly>Keep me</textarea></label><fieldset><legend>Options</legend><label>Fast<input id=fast type=checkbox name=fast checked></label></fieldset><select id=kind name=kind title=Kind multiple><option selected>Books<option>Manuals</select><button id=go type=submit aria-label=\"Run search\">Go</button></form><input id=external form=search name=outside placeholder=Outside>",


### PR DESCRIPTION
## Summary
- add responsive image metadata to browser document image summaries, including srcset/sizes, loading, decoding, fetch priority, CORS/referrer policy, usemap, and image-map state
- associate picture/source candidates with fallback img summaries and resolve srcset candidate URLs against document base hrefs
- extend browser readiness schema, fixtures, docs, and tests for responsive image startup planning

## Testing
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_responsive_image_metadata_tracks_sources_and_loading_hints
- cargo test -p coding-adventures-html-parser browser_script_style_metadata_tracks_loading_and_inline_text
- cargo test -p coding-adventures-html-parser browser_media_metadata_tracks_playback_and_poster_state
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser