### PR TITLE
Add unified Hue state updates

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   resource-type coverage over parsed Server-Sent Events batches.
 - `HueClient::get_grouped_light_state_updates` for room/zone aggregate-light
   state reads through the facade.
+- Unified Hue state update extraction from full snapshots and event-stream
+  batches, plus `HueClient::get_state_updates` for a single aggregate read.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -30,6 +30,7 @@ Included surfaces:
 - Hue light resource decoding
 - Hue light, grouped-light, motion, and button state update extraction from
   snapshots and event-stream batches
+- unified Hue state update extraction from snapshots and event-stream batches
 - grouped-light state update collection reads through the `HueClient` facade
 
 ## Dependencies

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -14,7 +14,7 @@ use hue_core::{
     HueDeviceResource, HueGroupedLightResource, HueGroupedLightStateUpdate, HueLightResource,
     HueLightStateUpdate, HueMethod, HueMotionResource, HueMotionStateUpdate, HueRequest,
     HueRequestBody, HueResourceId, HueResourceRef, HueResourceType, HueRoomResource,
-    HueSceneAction, HueSceneResource, HueZoneResource, CLIP_V2_EVENT_STREAM_PATH,
+    HueSceneAction, HueSceneResource, HueStateUpdate, HueZoneResource, CLIP_V2_EVENT_STREAM_PATH,
     CLIP_V2_RESOURCE_ROOT, HUE_APPLICATION_KEY_HEADER,
 };
 use std::fmt;
@@ -672,6 +672,11 @@ impl<T: HueTransport> HueClient<T> {
         parse_button_state_updates_from_envelope(&envelope)
     }
 
+    pub fn get_state_updates(&mut self) -> Result<Vec<HueStateUpdate>, HueClientError> {
+        let envelope = self.get_resources()?;
+        parse_state_updates_from_envelope(&envelope)
+    }
+
     pub fn send_command(&mut self, command: HueCommand) -> Result<HueEnvelope, HueClientError> {
         let request = command.to_request();
         let response = self
@@ -1110,6 +1115,18 @@ pub fn parse_button_state_updates_from_envelope(
     Ok(updates)
 }
 
+pub fn parse_state_updates_from_envelope(
+    envelope: &HueEnvelope,
+) -> Result<Vec<HueStateUpdate>, HueClientError> {
+    let mut updates = Vec::new();
+    for resource in &envelope.data {
+        if let Some(update) = parse_state_update(resource)? {
+            updates.push(update);
+        }
+    }
+    Ok(updates)
+}
+
 pub fn parse_light_state_updates_from_event_batches(
     batches: &[HueEventStreamBatch],
 ) -> Result<Vec<HueLightStateUpdate>, HueClientError> {
@@ -1175,6 +1192,22 @@ pub fn parse_button_state_updates_from_event_batches(
                     == Some(HueResourceType::Button.as_hue_type())
                 {
                     updates.push(parse_button_state_update(resource)?);
+                }
+            }
+        }
+    }
+    Ok(updates)
+}
+
+pub fn parse_state_updates_from_event_batches(
+    batches: &[HueEventStreamBatch],
+) -> Result<Vec<HueStateUpdate>, HueClientError> {
+    let mut updates = Vec::new();
+    for batch in batches {
+        for event in &batch.events {
+            for resource in &event.data {
+                if let Some(update) = parse_state_update(resource)? {
+                    updates.push(update);
                 }
             }
         }
@@ -1334,6 +1367,29 @@ fn parse_light_state_update(resource: &JsonValue) -> Result<HueLightStateUpdate,
         brightness,
         color_temperature_mirek,
     })
+}
+
+fn parse_state_update(resource: &JsonValue) -> Result<Option<HueStateUpdate>, HueClientError> {
+    let Some(resource_type) =
+        object_string_field(resource, "type").map(HueResourceType::from_hue_type)
+    else {
+        return Ok(None);
+    };
+    match resource_type {
+        HueResourceType::Light => parse_light_state_update(resource)
+            .map(HueStateUpdate::from)
+            .map(Some),
+        HueResourceType::GroupedLight => parse_grouped_light_state_update(resource)
+            .map(HueStateUpdate::from)
+            .map(Some),
+        HueResourceType::Motion => parse_motion_state_update(resource)
+            .map(HueStateUpdate::from)
+            .map(Some),
+        HueResourceType::Button => parse_button_state_update(resource)
+            .map(HueStateUpdate::from)
+            .map(Some),
+        _ => Ok(None),
+    }
 }
 
 fn parse_grouped_light_state_update(
@@ -2025,6 +2081,30 @@ mod tests {
     }
 
     #[test]
+    fn parses_unified_state_updates_from_event_stream_batches() {
+        let batches = parse_event_stream(
+            b"data: [{\"id\":\"event-1\",\"type\":\"update\",\"data\":[{\"id\":\"button-1\",\"type\":\"button\",\"button\":{\"last_event\":\"short_release\"}},{\"id\":\"grouped-light-1\",\"type\":\"grouped_light\",\"dimming\":{\"brightness\":67}},{\"id\":\"light-1\",\"type\":\"light\",\"on\":{\"on\":false}},{\"id\":\"motion-1\",\"type\":\"motion\",\"motion\":{\"motion\":true}}]}]\n\n",
+        )
+        .unwrap();
+
+        let updates = parse_state_updates_from_event_batches(&batches).unwrap();
+
+        assert_eq!(updates.len(), 4);
+        assert!(matches!(updates[0], HueStateUpdate::Button(_)));
+        assert!(matches!(updates[1], HueStateUpdate::GroupedLight(_)));
+        assert!(matches!(updates[2], HueStateUpdate::Light(_)));
+        assert!(matches!(updates[3], HueStateUpdate::Motion(_)));
+        assert!(updates.iter().all(HueStateUpdate::has_state));
+        assert_eq!(
+            updates
+                .iter()
+                .flat_map(HueStateUpdate::state_deltas)
+                .count(),
+            4
+        );
+    }
+
+    #[test]
     fn event_stream_parser_accepts_multiline_data() {
         let batches = parse_event_stream(
             b"data: [{\"id\":\"event-1\",\"type\":\"update\",\"data\":[]}\ndata: ,{\"id\":\"event-2\",\"type\":\"add\",\"data\":[]}]\n\n",
@@ -2132,6 +2212,25 @@ mod tests {
             transport.requests[0].path,
             "/clip/v2/resource/grouped_light"
         );
+    }
+
+    #[test]
+    fn client_reads_unified_state_updates_through_single_snapshot_request() {
+        let transport = RecordingTransport::with_response(
+            r#"{"data":[{"id":"motion-1","type":"motion","motion":{"motion":false}},{"id":"light-1","type":"light","on":{"on":true}},{"id":"button-1","type":"button","button":{"last_event":"initial_press"}},{"id":"grouped-light-1","type":"grouped_light","dimming":{"brightness":84}}],"errors":[]}"#,
+        );
+        let mut client = HueClient::new(HueClientConfig::paired("app-key"), transport);
+
+        let updates = client.get_state_updates().unwrap();
+        let transport = client.into_transport();
+
+        assert_eq!(updates.len(), 4);
+        assert_eq!(updates[0].resource_type(), HueResourceType::Motion);
+        assert_eq!(updates[1].resource_type(), HueResourceType::Light);
+        assert_eq!(updates[2].resource_type(), HueResourceType::Button);
+        assert_eq!(updates[3].resource_type(), HueResourceType::GroupedLight);
+        assert_eq!(transport.requests.len(), 1);
+        assert_eq!(transport.requests[0].path, "/clip/v2/resource");
     }
 
     #[test]
@@ -2583,6 +2682,34 @@ mod tests {
         assert_eq!(updates[0].id.as_str(), "light-1");
         assert_eq!(updates[0].on, Some(true));
         assert!(updates[0].has_state());
+    }
+
+    #[test]
+    fn parses_unified_state_updates_from_snapshot_envelope() {
+        let envelope = parse_hue_envelope(
+            br#"{"data":[{"id":"light-1","type":"light","on":{"on":true}},{"id":"grouped-light-1","type":"grouped_light","dimming":{"brightness":84}},{"id":"motion-1","type":"motion","motion":{"motion":false}},{"id":"button-1","type":"button","button":{"last_event":"initial_press"}},{"id":"room-1","type":"room"}],"errors":[]}"#,
+        )
+        .unwrap();
+
+        let updates = parse_state_updates_from_envelope(&envelope).unwrap();
+
+        assert_eq!(updates.len(), 4);
+        assert_eq!(
+            updates[0].summary().resource.resource_type,
+            HueResourceType::Light
+        );
+        assert_eq!(
+            updates[1].summary().resource.resource_type,
+            HueResourceType::GroupedLight
+        );
+        assert_eq!(
+            updates[2].summary().resource.resource_type,
+            HueResourceType::Motion
+        );
+        assert_eq!(
+            updates[3].summary().resource.resource_type,
+            HueResourceType::Button
+        );
     }
 
     #[test]

--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this package will be documented in this file.
   room/zone scope and projected action coverage.
 - Hue state update summaries for read models and event-stream telemetry across
   light, grouped-light, motion, and button updates.
+- `HueStateUpdate` and `HueStateUpdateSetSummary` for unified state update
+  streams across light, grouped-light, motion, and button resources.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -25,6 +25,8 @@ packages a typed surface for:
 - Hue light, grouped-light, motion, and button state update-to-`StateDelta`
   projection
 - Hue state update summaries for read models and event-stream telemetry
+- unified Hue state update streams and rollups across light, grouped-light,
+  motion, and button resources
 - Hue snapshot and scene desired-state values keyed by canonical D23 capability
   ids such as `light.on_off` and `light.brightness`
 - integration descriptor metadata for Chief of Staff discovery

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -964,6 +964,149 @@ impl HueStateUpdateSummary {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum HueStateUpdate {
+    Light(HueLightStateUpdate),
+    GroupedLight(HueGroupedLightStateUpdate),
+    Motion(HueMotionStateUpdate),
+    Button(HueButtonStateUpdate),
+}
+
+impl HueStateUpdate {
+    pub fn resource_type(&self) -> HueResourceType {
+        match self {
+            Self::Light(_) => HueResourceType::Light,
+            Self::GroupedLight(_) => HueResourceType::GroupedLight,
+            Self::Motion(_) => HueResourceType::Motion,
+            Self::Button(_) => HueResourceType::Button,
+        }
+    }
+
+    pub fn has_state(&self) -> bool {
+        match self {
+            Self::Light(update) => update.has_state(),
+            Self::GroupedLight(update) => update.has_state(),
+            Self::Motion(update) => update.has_state(),
+            Self::Button(update) => update.has_state(),
+        }
+    }
+
+    pub fn summary(&self) -> HueStateUpdateSummary {
+        match self {
+            Self::Light(update) => update.summary(),
+            Self::GroupedLight(update) => update.summary(),
+            Self::Motion(update) => update.summary(),
+            Self::Button(update) => update.summary(),
+        }
+    }
+
+    pub fn state_deltas(&self) -> Vec<StateDelta> {
+        match self {
+            Self::Light(update) => update.state_deltas(),
+            Self::GroupedLight(update) => update.state_deltas(),
+            Self::Motion(update) => update.state_deltas(),
+            Self::Button(update) => update.state_deltas(),
+        }
+    }
+}
+
+impl From<HueLightStateUpdate> for HueStateUpdate {
+    fn from(update: HueLightStateUpdate) -> Self {
+        Self::Light(update)
+    }
+}
+
+impl From<HueGroupedLightStateUpdate> for HueStateUpdate {
+    fn from(update: HueGroupedLightStateUpdate) -> Self {
+        Self::GroupedLight(update)
+    }
+}
+
+impl From<HueMotionStateUpdate> for HueStateUpdate {
+    fn from(update: HueMotionStateUpdate) -> Self {
+        Self::Motion(update)
+    }
+}
+
+impl From<HueButtonStateUpdate> for HueStateUpdate {
+    fn from(update: HueButtonStateUpdate) -> Self {
+        Self::Button(update)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HueStateUpdateSetSummary {
+    pub total_updates: usize,
+    pub light_updates: usize,
+    pub grouped_light_updates: usize,
+    pub motion_updates: usize,
+    pub button_updates: usize,
+    pub updates_with_state: usize,
+    pub updates_with_owner: usize,
+    pub light_surface_updates: usize,
+    pub sensor_or_input_updates: usize,
+    pub state_field_count: usize,
+    pub delta_count: usize,
+}
+
+impl HueStateUpdateSetSummary {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_updates<'a>(updates: impl IntoIterator<Item = &'a HueStateUpdate>) -> Self {
+        let mut summary = Self::empty();
+        for update in updates {
+            summary.record_summary(&update.summary());
+        }
+        summary
+    }
+
+    pub fn record_summary(&mut self, summary: &HueStateUpdateSummary) {
+        self.total_updates += 1;
+        match summary.resource.resource_type {
+            HueResourceType::Light => self.light_updates += 1,
+            HueResourceType::GroupedLight => self.grouped_light_updates += 1,
+            HueResourceType::Motion => self.motion_updates += 1,
+            HueResourceType::Button => self.button_updates += 1,
+            _ => {}
+        }
+        if summary.has_state() {
+            self.updates_with_state += 1;
+        }
+        if summary.has_owner() {
+            self.updates_with_owner += 1;
+        }
+        if summary.is_light_surface() {
+            self.light_surface_updates += 1;
+        }
+        if matches!(
+            summary.resource.resource_type,
+            HueResourceType::Motion | HueResourceType::Button
+        ) {
+            self.sensor_or_input_updates += 1;
+        }
+        self.state_field_count += summary.state_field_count;
+        self.delta_count += summary.delta_count;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_updates == 0
+    }
+
+    pub fn has_light_surfaces(&self) -> bool {
+        self.light_surface_updates > 0
+    }
+
+    pub fn has_sensor_or_input_updates(&self) -> bool {
+        self.sensor_or_input_updates > 0
+    }
+
+    pub fn projects_deltas(&self) -> bool {
+        self.delta_count > 0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HueDeviceResource {
     pub id: HueResourceId,
@@ -1866,6 +2009,72 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn hue_state_update_enum_preserves_summaries_and_deltas() {
+        let light = HueStateUpdate::from(HueLightStateUpdate {
+            id: HueResourceId::trusted("light-1"),
+            owner_device_id: Some(HueResourceId::trusted("device-1")),
+            name: Some("Kitchen".to_string()),
+            on: Some(true),
+            brightness: Some(50),
+            color_temperature_mirek: None,
+        });
+        let grouped = HueStateUpdate::from(HueGroupedLightStateUpdate {
+            id: HueResourceId::trusted("grouped-light-1"),
+            owner: Some(HueResourceRef::new(
+                HueResourceType::Room,
+                HueResourceId::trusted("room-1"),
+            )),
+            name: None,
+            on: None,
+            brightness: Some(10),
+        });
+        let motion = HueStateUpdate::from(HueMotionStateUpdate {
+            id: HueResourceId::trusted("motion-1"),
+            owner_device_id: None,
+            name: None,
+            motion: Some(true),
+            motion_valid: Some(true),
+        });
+        let button = HueStateUpdate::from(HueButtonStateUpdate {
+            id: HueResourceId::trusted("button-1"),
+            owner_device_id: None,
+            name: None,
+            last_event: Some("short_release".to_string()),
+        });
+        let updates = vec![light, grouped, motion, button];
+
+        let summary = HueStateUpdateSetSummary::from_updates(&updates);
+
+        assert_eq!(updates[0].resource_type(), HueResourceType::Light);
+        assert_eq!(updates[0].state_deltas().len(), 2);
+        assert_eq!(
+            updates[1].summary().resource.resource_type,
+            HueResourceType::GroupedLight
+        );
+        assert!(updates.iter().all(HueStateUpdate::has_state));
+        assert_eq!(
+            summary,
+            HueStateUpdateSetSummary {
+                total_updates: 4,
+                light_updates: 1,
+                grouped_light_updates: 1,
+                motion_updates: 1,
+                button_updates: 1,
+                updates_with_state: 4,
+                updates_with_owner: 2,
+                light_surface_updates: 2,
+                sensor_or_input_updates: 2,
+                state_field_count: 6,
+                delta_count: 5,
+            }
+        );
+        assert!(summary.has_light_surfaces());
+        assert!(summary.has_sensor_or_input_updates());
+        assert!(summary.projects_deltas());
+        assert!(HueStateUpdateSetSummary::empty().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add HueStateUpdate and HueStateUpdateSetSummary for aggregate read-model/event-stream state updates
- add hue-client parsers for unified snapshot and event-stream state updates while preserving event order
- add HueClient::get_state_updates plus README/changelog notes

Tests:
- cargo test --manifest-path code/packages/rust/hue-core/Cargo.toml -- --nocapture
- cargo test --manifest-path code/packages/rust/hue-client/Cargo.toml -- --nocapture