### PR TITLE
Add browser link resource metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -263,7 +263,24 @@ def check_browser_expected_lists(
         resource_path = f"{case_path}.expected.resources[{index}]"
         require_string(resource_path, resource, "kind", errors)
         require_string(resource_path, resource, "url", errors)
-        for field in ("resolved_url", "rel", "type_hint", "media", "title", "width", "height"):
+        for field in (
+            "resolved_url",
+            "rel",
+            "as_hint",
+            "type_hint",
+            "media",
+            "title",
+            "width",
+            "height",
+            "integrity",
+            "crossorigin",
+            "referrerpolicy",
+            "fetchpriority",
+            "blocking",
+            "imagesrcset",
+            "resolved_imagesrcset",
+            "imagesizes",
+        ):
             require_optional_nullable_string(resource_path, resource, field, errors)
         require_boolean(resource_path, resource, "async_script", errors)
         require_boolean(resource_path, resource, "defer_script", errors)

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -200,6 +200,10 @@ documented in this file.
   resolved URL metadata for links, resources, images, and form actions using
   the document `base` href when available, while preserving raw authored
   attributes for downstream policy decisions.
+- Browser-facing resource summaries now carry link/resource scheduling
+  metadata for preconnect, preload, modulepreload, prefetch, manifest,
+  canonical, and icon links, including `as`, integrity, CORS/referrer policy,
+  fetch priority, blocking, and responsive image preload hints.
 - Browser-facing document, content-tree, and render-tree projections now carry
   identity and language metadata, including document/body `lang` and `dir`,
   body `id`/classes, and node-level `id`, tokenized `class`, `title`, `lang`,

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -75,6 +75,10 @@ The current parser surface includes:
 - browser-facing URL resolution metadata for links, loadable resources, images,
   and form actions using the document `base` href when available, while keeping
   raw authored URLs available to browser policy code
+- browser-facing link/resource scheduling metadata for preconnect, preload,
+  modulepreload, prefetch, manifest, canonical, and icon links, including
+  `as`, integrity, CORS/referrer policy, fetch priority, blocking, and
+  responsive image preload hints
 - browser-facing responsive image metadata for `img` and `picture/source`
   combinations, including raw/resolved `srcset`, `sizes`, source media/type
   hints, lazy loading, decoding, fetch priority, CORS/referrer policy, usemap,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -853,11 +853,20 @@ pub struct BrowserResource {
     pub url: String,
     pub resolved_url: Option<String>,
     pub rel: Option<String>,
+    pub as_hint: Option<String>,
     pub type_hint: Option<String>,
     pub media: Option<String>,
     pub title: Option<String>,
     pub width: Option<String>,
     pub height: Option<String>,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub imagesrcset: Option<String>,
+    pub resolved_imagesrcset: Option<String>,
+    pub imagesizes: Option<String>,
     pub async_script: bool,
     pub defer_script: bool,
 }
@@ -8330,19 +8339,11 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             }),
             "link" => {
                 if let Some(href) = element.attribute("href") {
-                    summary.resources.push(BrowserResource {
-                        kind: link_resource_kind(element.attribute("rel")),
-                        url: href.to_string(),
-                        resolved_url: resolve_browser_url(href, summary.base_href.as_deref()),
-                        rel: element.attribute("rel").map(ToOwned::to_owned),
-                        type_hint: element.attribute("type").map(ToOwned::to_owned),
-                        media: element.attribute("media").map(ToOwned::to_owned),
-                        title: element.attribute("title").map(ToOwned::to_owned),
-                        width: None,
-                        height: None,
-                        async_script: false,
-                        defer_script: false,
-                    });
+                    summary.resources.push(browser_link_resource(
+                        element,
+                        href,
+                        summary.base_href.as_deref(),
+                    ));
                     if browser_link_is_stylesheet(element) {
                         summary
                             .stylesheets
@@ -8357,11 +8358,20 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
                         url: src.to_string(),
                         resolved_url: resolve_browser_url(src, summary.base_href.as_deref()),
                         rel: None,
+                        as_hint: None,
                         type_hint: element.attribute("type").map(ToOwned::to_owned),
                         media: None,
                         title: None,
                         width: None,
                         height: None,
+                        integrity: element.attribute("integrity").map(ToOwned::to_owned),
+                        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+                        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+                        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+                        blocking: element.attribute("blocking").map(ToOwned::to_owned),
+                        imagesrcset: None,
+                        resolved_imagesrcset: None,
+                        imagesizes: None,
                         async_script: element.attribute("async").is_some(),
                         defer_script: element.attribute("defer").is_some(),
                     });
@@ -8405,11 +8415,20 @@ fn collect_body_resource(element: &Element, summary: &mut BrowserDocument) {
         resolved_url: resolve_browser_url(&url, summary.base_href.as_deref()),
         url,
         rel: None,
+        as_hint: None,
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         media: element.attribute("media").map(ToOwned::to_owned),
         title: element.attribute("title").map(ToOwned::to_owned),
         width: element.attribute("width").map(ToOwned::to_owned),
         height: element.attribute("height").map(ToOwned::to_owned),
+        integrity: element.attribute("integrity").map(ToOwned::to_owned),
+        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        imagesrcset: None,
+        resolved_imagesrcset: None,
+        imagesizes: None,
         async_script: element.name == "script" && element.attribute("async").is_some(),
         defer_script: element.name == "script" && element.attribute("defer").is_some(),
     });
@@ -8598,12 +8617,49 @@ fn link_resource_kind(rel: Option<&str>) -> String {
             "icon" | "shortcut" => return "icon".to_string(),
             "preload" => return "preload".to_string(),
             "modulepreload" => return "modulepreload".to_string(),
+            "prefetch" => return "prefetch".to_string(),
+            "preconnect" => return "preconnect".to_string(),
+            "dns-prefetch" => return "dns-prefetch".to_string(),
+            "prerender" => return "prerender".to_string(),
             "manifest" => return "manifest".to_string(),
+            "canonical" => return "canonical".to_string(),
             "alternate" => return "alternate".to_string(),
             _ => {}
         }
     }
     "link".to_string()
+}
+
+fn browser_link_resource(
+    element: &Element,
+    href: &str,
+    base_href: Option<&str>,
+) -> BrowserResource {
+    let imagesrcset = element.attribute("imagesrcset").map(ToOwned::to_owned);
+    BrowserResource {
+        kind: link_resource_kind(element.attribute("rel")),
+        url: href.to_string(),
+        resolved_url: resolve_browser_url(href, base_href),
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        as_hint: element.attribute("as").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        width: None,
+        height: None,
+        integrity: element.attribute("integrity").map(ToOwned::to_owned),
+        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        resolved_imagesrcset: imagesrcset
+            .as_deref()
+            .map(|srcset| resolve_browser_srcset(srcset, base_href)),
+        imagesrcset,
+        imagesizes: element.attribute("imagesizes").map(ToOwned::to_owned),
+        async_script: false,
+        defer_script: false,
+    }
 }
 
 fn collect_browser_content_nodes(
@@ -10337,6 +10393,72 @@ mod tests {
             Some("https://example.test/app/late.js")
         );
         assert!(late_script.defer_script);
+    }
+
+    #[test]
+    fn browser_link_resource_metadata_tracks_fetch_hints_and_responsive_preloads() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/index.html\">\
+             <link rel=preconnect href=\"https://cdn.example.test\" crossorigin>\
+             <link rel=preload href=\"fonts/site.woff2\" as=font type=font/woff2 crossorigin=anonymous integrity=sha384-font fetchpriority=high>\
+             <link rel=modulepreload href=\"scripts/app.mjs\" integrity=sha384-module referrerpolicy=no-referrer blocking=render>\
+             <link rel=preload href=\"hero.jpg\" as=image imagesrcset=\"hero-small.jpg 480w, hero-large.jpg 960w\" imagesizes=\"50vw\" fetchpriority=high>\
+             <link rel=prefetch href=\"next.html\" as=document>\
+             <link rel=manifest href=\"site.webmanifest\" crossorigin=use-credentials>\
+             <link rel=canonical href=\"https://example.test/app/\">\
+             <link rel=\"shortcut icon\" href=\"favicon.ico\" sizes=any type=image/x-icon>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.resources.len(), 8);
+        let preconnect = &summary.resources[0];
+        assert_eq!(preconnect.kind, "preconnect");
+        assert_eq!(
+            preconnect.resolved_url.as_deref(),
+            Some("https://cdn.example.test")
+        );
+        assert_eq!(preconnect.crossorigin.as_deref(), Some(""));
+
+        let font = &summary.resources[1];
+        assert_eq!(font.kind, "preload");
+        assert_eq!(font.as_hint.as_deref(), Some("font"));
+        assert_eq!(font.type_hint.as_deref(), Some("font/woff2"));
+        assert_eq!(
+            font.resolved_url.as_deref(),
+            Some("https://example.test/app/fonts/site.woff2")
+        );
+        assert_eq!(font.integrity.as_deref(), Some("sha384-font"));
+        assert_eq!(font.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(font.fetchpriority.as_deref(), Some("high"));
+
+        let module = &summary.resources[2];
+        assert_eq!(module.kind, "modulepreload");
+        assert_eq!(module.integrity.as_deref(), Some("sha384-module"));
+        assert_eq!(module.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(module.blocking.as_deref(), Some("render"));
+
+        let image = &summary.resources[3];
+        assert_eq!(image.as_hint.as_deref(), Some("image"));
+        assert_eq!(
+            image.resolved_imagesrcset.as_deref(),
+            Some("https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w")
+        );
+        assert_eq!(image.imagesizes.as_deref(), Some("50vw"));
+
+        assert_eq!(summary.resources[4].kind, "prefetch");
+        assert_eq!(summary.resources[4].as_hint.as_deref(), Some("document"));
+        assert_eq!(summary.resources[5].kind, "manifest");
+        assert_eq!(
+            summary.resources[5].crossorigin.as_deref(),
+            Some("use-credentials")
+        );
+        assert_eq!(summary.resources[6].kind, "canonical");
+        assert_eq!(summary.resources[7].kind, "icon");
+        assert_eq!(
+            summary.resources[7].type_hint.as_deref(),
+            Some("image/x-icon")
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -70,6 +70,8 @@ struct ExpectedResource {
     url: String,
     resolved_url: Option<String>,
     rel: Option<String>,
+    #[serde(default)]
+    as_hint: Option<String>,
     type_hint: Option<String>,
     media: Option<String>,
     title: Option<String>,
@@ -77,6 +79,22 @@ struct ExpectedResource {
     width: Option<String>,
     #[serde(default)]
     height: Option<String>,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    imagesrcset: Option<String>,
+    #[serde(default)]
+    resolved_imagesrcset: Option<String>,
+    #[serde(default)]
+    imagesizes: Option<String>,
     async_script: bool,
     defer_script: bool,
 }
@@ -402,11 +420,20 @@ impl ExpectedResource {
             url: self.url,
             resolved_url: self.resolved_url,
             rel: self.rel,
+            as_hint: self.as_hint,
             type_hint: self.type_hint,
             media: self.media,
             title: self.title,
             width: self.width,
             height: self.height,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            imagesrcset: self.imagesrcset,
+            resolved_imagesrcset: self.resolved_imagesrcset,
+            imagesizes: self.imagesizes,
             async_script: self.async_script,
             defer_script: self.defer_script,
         }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -25,7 +25,9 @@ hints such as integrity, crossorigin, referrer policy, fetch priority,
 blocking, disabled state, and alternate stylesheets. Responsive image cases pin
 `srcset`/`sizes`, resolved candidate URLs, `picture/source` media/type hints,
 lazy loading, decoding, fetch priority, CORS/referrer policy, usemap, and
-server-side image-map state.
+server-side image-map state. Link resource cases pin relation-derived resource
+kinds, `as` hints, integrity/CORS/referrer policy, fetch priority, blocking,
+and responsive image preload hints.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -97,7 +97,7 @@
         "body_text": "",
         "metas": [],
         "resources": [
-          { "kind": "image", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "async_script": false, "defer_script": false }
+          { "kind": "image", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "rel": null, "type_hint": null, "media": null, "title": null, "width": "640", "height": "360", "crossorigin": "anonymous", "referrerpolicy": "no-referrer", "fetchpriority": "high", "async_script": false, "defer_script": false }
         ],
         "anchors": [],
         "headings": [],
@@ -168,6 +168,34 @@
             ]
           }
         ],
+        "tables": []
+      }
+    },
+    {
+      "id": "link-resource-metadata-page",
+      "description": "Browser document resource summaries expose link relation kinds, fetch hints, policy attributes, and responsive image preload metadata.",
+      "input": "<base href=\"https://example.test/app/index.html\"><link rel=preconnect href=\"https://cdn.example.test\" crossorigin><link rel=preload href=\"fonts/site.woff2\" as=font type=font/woff2 crossorigin=anonymous integrity=sha384-font fetchpriority=high><link rel=modulepreload href=\"scripts/app.mjs\" integrity=sha384-module referrerpolicy=no-referrer blocking=render><link rel=preload href=\"hero.jpg\" as=image imagesrcset=\"hero-small.jpg 480w, hero-large.jpg 960w\" imagesizes=\"50vw\" fetchpriority=high><link rel=prefetch href=\"next.html\" as=document><link rel=manifest href=\"site.webmanifest\" crossorigin=use-credentials><link rel=canonical href=\"https://example.test/app/\"><link rel=\"shortcut icon\" href=\"favicon.ico\" sizes=any type=image/x-icon>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/app/index.html",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel": "preconnect", "crossorigin": "", "async_script": false, "defer_script": false },
+          { "kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel": "preload", "as_hint": "font", "type_hint": "font/woff2", "integrity": "sha384-font", "crossorigin": "anonymous", "fetchpriority": "high", "async_script": false, "defer_script": false },
+          { "kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel": "modulepreload", "integrity": "sha384-module", "referrerpolicy": "no-referrer", "blocking": "render", "async_script": false, "defer_script": false },
+          { "kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel": "preload", "as_hint": "image", "fetchpriority": "high", "imagesrcset": "hero-small.jpg 480w, hero-large.jpg 960w", "resolved_imagesrcset": "https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w", "imagesizes": "50vw", "async_script": false, "defer_script": false },
+          { "kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel": "prefetch", "as_hint": "document", "async_script": false, "defer_script": false },
+          { "kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest", "crossorigin": "use-credentials", "async_script": false, "defer_script": false },
+          { "kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical", "async_script": false, "defer_script": false },
+          { "kind": "icon", "url": "favicon.ico", "resolved_url": "https://example.test/app/favicon.ico", "rel": "shortcut icon", "type_hint": "image/x-icon", "async_script": false, "defer_script": false }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
         "tables": []
       }
     },
@@ -298,9 +326,9 @@
         "body_text": "",
         "metas": [],
         "resources": [
-          { "kind": "stylesheet", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "type_hint": null, "media": "screen", "title": "main", "async_script": false, "defer_script": false },
+          { "kind": "stylesheet", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "type_hint": null, "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "async_script": false, "defer_script": false },
           { "kind": "stylesheet", "url": "print.css", "resolved_url": "https://example.test/app/print.css", "rel": "alternate stylesheet", "type_hint": null, "media": null, "title": "print", "async_script": false, "defer_script": false },
-          { "kind": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "rel": null, "type_hint": "module", "media": null, "title": null, "async_script": true, "defer_script": false },
+          { "kind": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "rel": null, "type_hint": "module", "media": null, "title": null, "integrity": "sha384-js", "crossorigin": "use-credentials", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render", "async_script": true, "defer_script": false },
           { "kind": "script", "url": "late.js", "resolved_url": "https://example.test/app/late.js", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": true }
         ],
         "scripts": [


### PR DESCRIPTION
## Summary
- extend browser resource summaries with link scheduling and fetch-policy hints
- classify preconnect, preload, modulepreload, prefetch, manifest, canonical, icon, and related link resources
- add a browser-readiness fixture/schema coverage for responsive image preload metadata

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_link_resource_metadata_tracks_fetch_hints_and_responsive_preloads
- cargo test -p coding-adventures-html-parser browser_responsive_image_metadata_tracks_sources_and_loading_hints
- cargo test -p coding-adventures-html-parser browser_script_style_metadata_tracks_loading_and_inline_text
- cargo test -p coding-adventures-html-parser browser_media_metadata_tracks_playback_and_poster_state
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser