### PR TITLE
Add browser document metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -229,6 +229,7 @@ def check_browser_readiness_case(
     require_optional_nullable_string(case_path, expected, "title", errors)
     require_optional_nullable_string(case_path, expected, "base_href", errors)
     require_optional_nullable_string(case_path, expected, "base_target", errors)
+    check_browser_document_metadata(case_path, expected, errors)
     for field in ("document_lang", "document_dir", "body_id", "body_lang", "body_dir"):
         require_optional_nullable_string(case_path, expected, field, errors)
     require_optional_string_list(case_path, expected, "body_classes", errors)
@@ -247,6 +248,50 @@ def check_browser_readiness_case(
     check_browser_expected_lists(case_path, expected, errors)
 
     return errors
+
+
+def check_browser_document_metadata(
+    case_path: str,
+    expected: dict[str, Any],
+    errors: list[str],
+) -> None:
+    metadata = expected.get("metadata")
+    if metadata is None:
+        return
+    metadata_path = f"{case_path}.expected.metadata"
+    if not isinstance(metadata, dict):
+        errors.append(f"{metadata_path} must be an object")
+        return
+
+    for field in (
+        "charset",
+        "viewport",
+        "description",
+        "application_name",
+        "referrer_policy",
+        "robots",
+        "color_scheme",
+        "canonical_url",
+        "resolved_canonical_url",
+        "manifest_url",
+        "resolved_manifest_url",
+    ):
+        require_optional_nullable_string(metadata_path, metadata, field, errors)
+
+    require_optional_object_list(metadata_path, metadata, "theme_colors", errors)
+    for index, theme_color in enumerate(object_list_items(metadata, "theme_colors")):
+        theme_color_path = f"{metadata_path}.theme_colors[{index}]"
+        require_string(theme_color_path, theme_color, "color", errors)
+        require_optional_nullable_string(theme_color_path, theme_color, "media", errors)
+
+    refresh = metadata.get("refresh")
+    if refresh is not None:
+        refresh_path = f"{metadata_path}.refresh"
+        if not isinstance(refresh, dict):
+            errors.append(f"{refresh_path} must be an object")
+        else:
+            for field in ("delay", "url", "resolved_url"):
+                require_optional_nullable_string(refresh_path, refresh, field, errors)
 
 
 def check_browser_expected_lists(

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -818,6 +818,7 @@ pub struct BrowserDocument {
     pub title: Option<String>,
     pub base_href: Option<String>,
     pub base_target: Option<String>,
+    pub metadata: BrowserDocumentMetadata,
     pub document_lang: Option<String>,
     pub document_dir: Option<String>,
     pub body_id: Option<String>,
@@ -836,6 +837,36 @@ pub struct BrowserDocument {
     pub media: Vec<BrowserMedia>,
     pub forms: Vec<BrowserForm>,
     pub tables: Vec<BrowserTable>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BrowserDocumentMetadata {
+    pub charset: Option<String>,
+    pub viewport: Option<String>,
+    pub description: Option<String>,
+    pub application_name: Option<String>,
+    pub referrer_policy: Option<String>,
+    pub robots: Option<String>,
+    pub color_scheme: Option<String>,
+    pub theme_colors: Vec<BrowserThemeColor>,
+    pub refresh: Option<BrowserRefresh>,
+    pub canonical_url: Option<String>,
+    pub resolved_canonical_url: Option<String>,
+    pub manifest_url: Option<String>,
+    pub resolved_manifest_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserThemeColor {
+    pub color: String,
+    pub media: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserRefresh {
+    pub delay: Option<String>,
+    pub url: Option<String>,
+    pub resolved_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8439,8 +8470,142 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             _ => {}
         }
 
+        collect_document_metadata(element, summary);
         collect_head_browser_facts(&element.children, summary);
     }
+}
+
+fn collect_document_metadata(element: &Element, summary: &mut BrowserDocument) {
+    match element.name.as_str() {
+        "meta" => collect_meta_document_metadata(element, summary),
+        "link" => collect_link_document_metadata(element, summary),
+        _ => {}
+    }
+}
+
+fn collect_meta_document_metadata(element: &Element, summary: &mut BrowserDocument) {
+    if summary.metadata.charset.is_none() {
+        summary.metadata.charset = browser_meta_charset(element);
+    }
+
+    if let Some(content) = element.attribute("content") {
+        if browser_meta_name_is(element, "viewport") && summary.metadata.viewport.is_none() {
+            summary.metadata.viewport = Some(content.to_string());
+        }
+        if browser_meta_name_is(element, "description") && summary.metadata.description.is_none() {
+            summary.metadata.description = Some(content.to_string());
+        }
+        if browser_meta_name_is(element, "application-name")
+            && summary.metadata.application_name.is_none()
+        {
+            summary.metadata.application_name = Some(content.to_string());
+        }
+        if browser_meta_name_is(element, "referrer") && summary.metadata.referrer_policy.is_none() {
+            summary.metadata.referrer_policy = Some(content.to_string());
+        }
+        if browser_meta_name_is(element, "robots") && summary.metadata.robots.is_none() {
+            summary.metadata.robots = Some(content.to_string());
+        }
+        if browser_meta_name_is(element, "color-scheme") && summary.metadata.color_scheme.is_none()
+        {
+            summary.metadata.color_scheme = Some(content.to_string());
+        }
+        if browser_meta_name_is(element, "theme-color") {
+            summary.metadata.theme_colors.push(BrowserThemeColor {
+                color: content.to_string(),
+                media: element.attribute("media").map(ToOwned::to_owned),
+            });
+        }
+        if browser_meta_http_equiv_is(element, "refresh") && summary.metadata.refresh.is_none() {
+            summary.metadata.refresh = Some(browser_refresh_metadata(
+                content,
+                summary.base_href.as_deref(),
+            ));
+        }
+    }
+}
+
+fn collect_link_document_metadata(element: &Element, summary: &mut BrowserDocument) {
+    if let Some(href) = element.attribute("href") {
+        if browser_rel_contains(element, "canonical") && summary.metadata.canonical_url.is_none() {
+            summary.metadata.canonical_url = Some(href.to_string());
+            summary.metadata.resolved_canonical_url =
+                resolve_browser_url(href, summary.base_href.as_deref());
+        }
+        if browser_rel_contains(element, "manifest") && summary.metadata.manifest_url.is_none() {
+            summary.metadata.manifest_url = Some(href.to_string());
+            summary.metadata.resolved_manifest_url =
+                resolve_browser_url(href, summary.base_href.as_deref());
+        }
+    }
+}
+
+fn browser_meta_name_is(element: &Element, expected: &str) -> bool {
+    element
+        .attribute("name")
+        .is_some_and(|name| name.eq_ignore_ascii_case(expected))
+}
+
+fn browser_meta_http_equiv_is(element: &Element, expected: &str) -> bool {
+    element
+        .attribute("http-equiv")
+        .is_some_and(|name| name.eq_ignore_ascii_case(expected))
+}
+
+fn browser_meta_charset(element: &Element) -> Option<String> {
+    if let Some(charset) = element.attribute("charset") {
+        return Some(charset.to_string());
+    }
+    if !browser_meta_http_equiv_is(element, "content-type") {
+        return None;
+    }
+    element.attribute("content").and_then(extract_meta_charset)
+}
+
+fn extract_meta_charset(content: &str) -> Option<String> {
+    content
+        .split(';')
+        .map(str::trim)
+        .find_map(|part| {
+            let (name, value) = part.split_once('=')?;
+            name.trim().eq_ignore_ascii_case("charset").then_some(value)
+        })
+        .map(trim_browser_metadata_token)
+        .filter(|charset| !charset.is_empty())
+}
+
+fn browser_refresh_metadata(content: &str, base_href: Option<&str>) -> BrowserRefresh {
+    let mut parts = content.split(';');
+    let delay = parts
+        .next()
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(ToOwned::to_owned);
+    let url = parts.find_map(browser_refresh_url);
+    let resolved_url = url
+        .as_deref()
+        .and_then(|url| resolve_browser_url(url, base_href));
+    BrowserRefresh {
+        delay,
+        url,
+        resolved_url,
+    }
+}
+
+fn browser_refresh_url(part: &str) -> Option<String> {
+    let (name, value) = part.split_once('=')?;
+    if !name.trim().eq_ignore_ascii_case("url") {
+        return None;
+    }
+    let url = trim_browser_metadata_token(value);
+    (!url.is_empty()).then_some(url)
+}
+
+fn trim_browser_metadata_token(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches(|character| character == '"' || character == '\'')
+        .to_string()
 }
 
 fn collect_anchor_target(element: &Element, summary: &mut BrowserDocument) {
@@ -10186,6 +10351,70 @@ mod tests {
         assert_eq!(
             resolve_browser_url("relative.html", Some("/local/base/")),
             None
+        );
+    }
+
+    #[test]
+    fn browser_document_metadata_tracks_head_policy_hints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/page.html\">\
+             <meta http-equiv=content-type content=\"text/html; charset=windows-1252\">\
+             <meta charset=utf-8>\
+             <meta name=viewport content=\"width=device-width, initial-scale=1\">\
+             <meta name=description content=\"HTML parser workbench\">\
+             <meta name=application-name content=Venture>\
+             <meta name=referrer content=no-referrer>\
+             <meta name=robots content=\"index,follow\">\
+             <meta name=color-scheme content=\"light dark\">\
+             <meta name=theme-color content=\"#ffffff\" media=\"(prefers-color-scheme: light)\">\
+             <meta name=theme-color content=\"#111111\" media=\"(prefers-color-scheme: dark)\">\
+             <meta http-equiv=refresh content=\"5; url=next.html\">\
+             <link rel=canonical href=\"https://example.test/app/\">\
+             <link rel=manifest href=\"site.webmanifest\">",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.metadata.charset.as_deref(), Some("windows-1252"));
+        assert_eq!(
+            summary.metadata.viewport.as_deref(),
+            Some("width=device-width, initial-scale=1")
+        );
+        assert_eq!(
+            summary.metadata.description.as_deref(),
+            Some("HTML parser workbench")
+        );
+        assert_eq!(
+            summary.metadata.application_name.as_deref(),
+            Some("Venture")
+        );
+        assert_eq!(
+            summary.metadata.referrer_policy.as_deref(),
+            Some("no-referrer")
+        );
+        assert_eq!(summary.metadata.robots.as_deref(), Some("index,follow"));
+        assert_eq!(summary.metadata.color_scheme.as_deref(), Some("light dark"));
+        assert_eq!(summary.metadata.theme_colors.len(), 2);
+        assert_eq!(summary.metadata.theme_colors[0].color, "#ffffff");
+        assert_eq!(
+            summary.metadata.theme_colors[0].media.as_deref(),
+            Some("(prefers-color-scheme: light)")
+        );
+        assert_eq!(
+            summary.metadata.refresh,
+            Some(BrowserRefresh {
+                delay: Some("5".to_string()),
+                url: Some("next.html".to_string()),
+                resolved_url: Some("https://example.test/app/next.html".to_string()),
+            })
+        );
+        assert_eq!(
+            summary.metadata.resolved_canonical_url.as_deref(),
+            Some("https://example.test/app/")
+        );
+        assert_eq!(
+            summary.metadata.resolved_manifest_url.as_deref(),
+            Some("https://example.test/app/site.webmanifest")
         );
     }
 

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,7 +1,8 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserAnchor, BrowserDocument, BrowserForm, BrowserFormControl,
-    BrowserHeading, BrowserImage, BrowserImageSource, BrowserLink, BrowserMedia, BrowserMeta,
-    BrowserResource, BrowserScript, BrowserStylesheet, BrowserTable,
+    parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata, BrowserForm,
+    BrowserFormControl, BrowserHeading, BrowserImage, BrowserImageSource, BrowserLink,
+    BrowserMedia, BrowserMeta, BrowserRefresh, BrowserResource, BrowserScript, BrowserStylesheet,
+    BrowserTable, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -26,6 +27,8 @@ struct ExpectedBrowserDocument {
     title: Option<String>,
     base_href: Option<String>,
     base_target: Option<String>,
+    #[serde(default)]
+    metadata: ExpectedDocumentMetadata,
     #[serde(default)]
     document_lang: Option<String>,
     #[serde(default)]
@@ -53,6 +56,53 @@ struct ExpectedBrowserDocument {
     media: Vec<ExpectedMedia>,
     forms: Vec<ExpectedForm>,
     tables: Vec<ExpectedTable>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ExpectedDocumentMetadata {
+    #[serde(default)]
+    charset: Option<String>,
+    #[serde(default)]
+    viewport: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    application_name: Option<String>,
+    #[serde(default)]
+    referrer_policy: Option<String>,
+    #[serde(default)]
+    robots: Option<String>,
+    #[serde(default)]
+    color_scheme: Option<String>,
+    #[serde(default)]
+    theme_colors: Vec<ExpectedThemeColor>,
+    #[serde(default)]
+    refresh: Option<ExpectedRefresh>,
+    #[serde(default)]
+    canonical_url: Option<String>,
+    #[serde(default)]
+    resolved_canonical_url: Option<String>,
+    #[serde(default)]
+    manifest_url: Option<String>,
+    #[serde(default)]
+    resolved_manifest_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedThemeColor {
+    color: String,
+    #[serde(default)]
+    media: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedRefresh {
+    #[serde(default)]
+    delay: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    resolved_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -335,6 +385,7 @@ impl ExpectedBrowserDocument {
             title: self.title,
             base_href: self.base_href,
             base_target: self.base_target,
+            metadata: self.metadata.into_browser_document_metadata(),
             document_lang: self.document_lang,
             document_dir: self.document_dir,
             body_id: self.body_id,
@@ -397,6 +448,49 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedTable::into_browser_table)
                 .collect(),
+        }
+    }
+}
+
+impl ExpectedDocumentMetadata {
+    fn into_browser_document_metadata(self) -> BrowserDocumentMetadata {
+        BrowserDocumentMetadata {
+            charset: self.charset,
+            viewport: self.viewport,
+            description: self.description,
+            application_name: self.application_name,
+            referrer_policy: self.referrer_policy,
+            robots: self.robots,
+            color_scheme: self.color_scheme,
+            theme_colors: self
+                .theme_colors
+                .into_iter()
+                .map(ExpectedThemeColor::into_browser_theme_color)
+                .collect(),
+            refresh: self.refresh.map(ExpectedRefresh::into_browser_refresh),
+            canonical_url: self.canonical_url,
+            resolved_canonical_url: self.resolved_canonical_url,
+            manifest_url: self.manifest_url,
+            resolved_manifest_url: self.resolved_manifest_url,
+        }
+    }
+}
+
+impl ExpectedThemeColor {
+    fn into_browser_theme_color(self) -> BrowserThemeColor {
+        BrowserThemeColor {
+            color: self.color,
+            media: self.media,
+        }
+    }
+}
+
+impl ExpectedRefresh {
+    fn into_browser_refresh(self) -> BrowserRefresh {
+        BrowserRefresh {
+            delay: self.delay,
+            url: self.url,
+            resolved_url: self.resolved_url,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -16,18 +16,21 @@ image, form, and table facts that a browser pipeline can consume before layout
 and Paint VM rendering. The fixture also pins resolved URL metadata derived
 from `base` hrefs while preserving raw authored link and resource attributes,
 and document/body identity and language metadata such as `lang`, `dir`, body
-`id`, and tokenized body classes. Form cases also pin labels, derived
-accessible names, owner references, placeholder/autocomplete hints, and
-required/readonly/multiple control state. Media cases pin audio/video playback
-flags and preload/poster metadata. Script/style cases pin module/classic script
-kind, async/defer/nomodule flags, inline script/style text, and loading-policy
-hints such as integrity, crossorigin, referrer policy, fetch priority,
-blocking, disabled state, and alternate stylesheets. Responsive image cases pin
-`srcset`/`sizes`, resolved candidate URLs, `picture/source` media/type hints,
-lazy loading, decoding, fetch priority, CORS/referrer policy, usemap, and
-server-side image-map state. Link resource cases pin relation-derived resource
-kinds, `as` hints, integrity/CORS/referrer policy, fetch priority, blocking,
-and responsive image preload hints.
+`id`, and tokenized body classes. Document metadata cases pin charset,
+viewport, description, application name, referrer/robots/color-scheme policy,
+theme colors, refresh URL resolution, and canonical/manifest URLs. Form cases
+also pin labels, derived accessible names, owner references,
+placeholder/autocomplete hints, and required/readonly/multiple control state.
+Media cases pin audio/video playback flags and preload/poster metadata.
+Script/style cases pin module/classic script kind, async/defer/nomodule flags,
+inline script/style text, and loading-policy hints such as integrity,
+crossorigin, referrer policy, fetch priority, blocking, disabled state, and
+alternate stylesheets. Responsive image cases pin `srcset`/`sizes`, resolved
+candidate URLs, `picture/source` media/type hints, lazy loading, decoding, fetch
+priority, CORS/referrer policy, usemap, and server-side image-map state. Link
+resource cases pin relation-derived resource kinds, `as` hints,
+integrity/CORS/referrer policy, fetch priority, blocking, and responsive image
+preload hints.
 
 `html-browser-content-tree.json` is a checked parser acceptance corpus for the
 browser-facing content-tree projection. It verifies that broad HTML body

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -11,6 +11,7 @@
         "title": "Example & Links",
         "base_href": "https://example.test/docs/",
         "base_target": "_top",
+        "metadata": { "charset": "utf-8" },
         "body_text": "Example Directory Welcome to Venture HTML. One Two",
         "metas": [
           { "name": null, "http_equiv": null, "property": null, "charset": "utf-8", "content": null }
@@ -46,6 +47,7 @@
         "title": "Search",
         "base_href": null,
         "base_target": null,
+        "metadata": { "refresh": { "delay": "30", "url": "/next", "resolved_url": null } },
         "document_lang": "en",
         "document_dir": "ltr",
         "body_id": "catalog",
@@ -172,6 +174,58 @@
       }
     },
     {
+      "id": "document-metadata-policy-page",
+      "description": "Browser document metadata extracts head policy hints from meta tags and canonical/manifest links.",
+      "input": "<base href=\"https://example.test/app/page.html\"><meta http-equiv=content-type content=\"text/html; charset=windows-1252\"><meta charset=utf-8><meta name=viewport content=\"width=device-width, initial-scale=1\"><meta name=description content=\"HTML parser workbench\"><meta name=application-name content=Venture><meta name=referrer content=no-referrer><meta name=robots content=\"index,follow\"><meta name=color-scheme content=\"light dark\"><meta name=theme-color content=\"#ffffff\" media=\"(prefers-color-scheme: light)\"><meta name=theme-color content=\"#111111\" media=\"(prefers-color-scheme: dark)\"><meta http-equiv=refresh content=\"5; url=next.html\"><link rel=canonical href=\"https://example.test/app/\"><link rel=manifest href=\"site.webmanifest\">",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/app/page.html",
+        "base_target": null,
+        "metadata": {
+          "charset": "windows-1252",
+          "viewport": "width=device-width, initial-scale=1",
+          "description": "HTML parser workbench",
+          "application_name": "Venture",
+          "referrer_policy": "no-referrer",
+          "robots": "index,follow",
+          "color_scheme": "light dark",
+          "theme_colors": [
+            { "color": "#ffffff", "media": "(prefers-color-scheme: light)" },
+            { "color": "#111111", "media": "(prefers-color-scheme: dark)" }
+          ],
+          "refresh": { "delay": "5", "url": "next.html", "resolved_url": "https://example.test/app/next.html" },
+          "canonical_url": "https://example.test/app/",
+          "resolved_canonical_url": "https://example.test/app/",
+          "manifest_url": "site.webmanifest",
+          "resolved_manifest_url": "https://example.test/app/site.webmanifest"
+        },
+        "body_text": "",
+        "metas": [
+          { "name": null, "http_equiv": "content-type", "property": null, "charset": null, "content": "text/html; charset=windows-1252" },
+          { "name": null, "http_equiv": null, "property": null, "charset": "utf-8", "content": null },
+          { "name": "viewport", "http_equiv": null, "property": null, "charset": null, "content": "width=device-width, initial-scale=1" },
+          { "name": "description", "http_equiv": null, "property": null, "charset": null, "content": "HTML parser workbench" },
+          { "name": "application-name", "http_equiv": null, "property": null, "charset": null, "content": "Venture" },
+          { "name": "referrer", "http_equiv": null, "property": null, "charset": null, "content": "no-referrer" },
+          { "name": "robots", "http_equiv": null, "property": null, "charset": null, "content": "index,follow" },
+          { "name": "color-scheme", "http_equiv": null, "property": null, "charset": null, "content": "light dark" },
+          { "name": "theme-color", "http_equiv": null, "property": null, "charset": null, "content": "#ffffff" },
+          { "name": "theme-color", "http_equiv": null, "property": null, "charset": null, "content": "#111111" },
+          { "name": null, "http_equiv": "refresh", "property": null, "charset": null, "content": "5; url=next.html" }
+        ],
+        "resources": [
+          { "kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical", "async_script": false, "defer_script": false },
+          { "kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest", "async_script": false, "defer_script": false }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "link-resource-metadata-page",
       "description": "Browser document resource summaries expose link relation kinds, fetch hints, policy attributes, and responsive image preload metadata.",
       "input": "<base href=\"https://example.test/app/index.html\"><link rel=preconnect href=\"https://cdn.example.test\" crossorigin><link rel=preload href=\"fonts/site.woff2\" as=font type=font/woff2 crossorigin=anonymous integrity=sha384-font fetchpriority=high><link rel=modulepreload href=\"scripts/app.mjs\" integrity=sha384-module referrerpolicy=no-referrer blocking=render><link rel=preload href=\"hero.jpg\" as=image imagesrcset=\"hero-small.jpg 480w, hero-large.jpg 960w\" imagesizes=\"50vw\" fetchpriority=high><link rel=prefetch href=\"next.html\" as=document><link rel=manifest href=\"site.webmanifest\" crossorigin=use-credentials><link rel=canonical href=\"https://example.test/app/\"><link rel=\"shortcut icon\" href=\"favicon.ico\" sizes=any type=image/x-icon>",
@@ -179,6 +233,7 @@
         "title": null,
         "base_href": "https://example.test/app/index.html",
         "base_target": null,
+        "metadata": { "canonical_url": "https://example.test/app/", "resolved_canonical_url": "https://example.test/app/", "manifest_url": "site.webmanifest", "resolved_manifest_url": "https://example.test/app/site.webmanifest" },
         "body_text": "",
         "metas": [],
         "resources": [


### PR DESCRIPTION
## Summary
- add structured BrowserDocument metadata for charset, viewport, description/application name, referrer/robots/color-scheme policy, theme colors, refresh URLs, and canonical/manifest links
- keep raw meta/resource extraction intact while adding fixture coverage for document policy hints
- extend browser readiness fixture schema/docs for the new metadata block

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile fixture governance scripts
- cargo test -p coding-adventures-html-parser browser_document_metadata_tracks_head_policy_hints
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-parser browser_aria_interaction_metadata_tracks_roles_states_and_focus
- cargo test -p coding-adventures-html-parser browser_link_resource_metadata_tracks_fetch_hints_and_responsive_preloads
- cargo test -p coding-adventures-html-parser browser_responsive_image_metadata_tracks_sources_and_loading_hints
- cargo test -p coding-adventures-html-parser browser_script_style_metadata_tracks_loading_and_inline_text
- cargo test -p coding-adventures-html-parser browser_media_metadata_tracks_playback_and_poster_state
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_outline_metadata_tracks_sections_landmarks_and_heading_levels
- cargo test -p coding-adventures-html-parser browser_text_flow_metadata_tracks_lists_quotes_and_breaks
- cargo test -p coding-adventures-html-parser browser_table_metadata_tracks_columns_spans_and_headers
- cargo test -p coding-adventures-html-parser browser_embedded_resource_metadata_tracks_fetch_and_layout_fields
- cargo test -p coding-adventures-html-parser browser_identity_metadata_tracks_language_direction_and_classes
- cargo test -p coding-adventures-html-parser resolves_browser_urls_against_document_base
- cargo test -p coding-adventures-html-parser browser_url_resolution_keeps_absolute_urls_and_marks_unresolved_relatives
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser