### PR TITLE
[codex] Add Board VM input callback transport availability

### DIFF
--- a/code/packages/rust/board-vm-language-core/README.md
+++ b/code/packages/rust/board-vm-language-core/README.md
@@ -246,6 +246,11 @@ transport health without rebuilding diagnostic policy.
 transport readiness records with Rust-owned readiness names, labels,
 queue-depth metadata, terminal/retry flags, and messages, so frontends can gate
 callback transport readiness without rebuilding health policy.
+`input_callback_transport_availability_summary` exposes that readiness as
+stable transport availability records with Rust-owned availability names,
+labels, queue-depth metadata, terminal/retry flags, and messages, so frontends
+can present callback transport availability without rebuilding readiness
+policy.
 `input_callback_plan_diagnostic`, `input_callback_event_diagnostic`, and
 `input_callback_queue_plan_diagnostic` turn those planner, event, and queue
 errors into stable Rust-owned kind names, labels, and messages, so frontends

--- a/code/packages/rust/board-vm-language-core/src/lib.rs
+++ b/code/packages/rust/board-vm-language-core/src/lib.rs
@@ -2428,6 +2428,103 @@ pub struct LanguageInputCallbackTransportReadinessSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageInputCallbackTransportAvailabilityKind {
+    CallbackRunnerHandoffAvailability,
+    AdapterEventPublicationAvailability,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageInputCallbackTransportAvailabilitySummary {
+    pub endpoint: LanguageHostEndpointSummary,
+    pub connection_label: String,
+    pub availability_label: String,
+    pub availability_kind: LanguageInputCallbackTransportAvailabilityKind,
+    pub availability_name: String,
+    pub readiness_kind: LanguageInputCallbackTransportReadinessKind,
+    pub readiness_name: String,
+    pub health_kind: LanguageInputCallbackTransportHealthKind,
+    pub health_name: String,
+    pub diagnostic_kind: LanguageInputCallbackTransportDiagnosticKind,
+    pub diagnostic_name: String,
+    pub completion_kind: LanguageInputCallbackTransportCompletionKind,
+    pub completion_name: String,
+    pub finalization_kind: LanguageInputCallbackTransportFinalizationKind,
+    pub finalization_name: String,
+    pub resolution_kind: LanguageInputCallbackTransportResolutionKind,
+    pub resolution_name: String,
+    pub decision_kind: LanguageInputCallbackTransportDecisionKind,
+    pub decision_name: String,
+    pub logic_kind: LanguageInputCallbackTransportLogicKind,
+    pub logic_name: String,
+    pub reference_kind: LanguageInputCallbackTransportReferenceKind,
+    pub reference_name: String,
+    pub bookmark_kind: LanguageInputCallbackTransportBookmarkKind,
+    pub bookmark_name: String,
+    pub cursor_kind: LanguageInputCallbackTransportCursorKind,
+    pub cursor_name: String,
+    pub marker_kind: LanguageInputCallbackTransportMarkerKind,
+    pub marker_name: String,
+    pub checkpoint_kind: LanguageInputCallbackTransportCheckpointKind,
+    pub checkpoint_name: String,
+    pub snapshot_kind: LanguageInputCallbackTransportSnapshotKind,
+    pub snapshot_name: String,
+    pub archive_kind: LanguageInputCallbackTransportArchiveKind,
+    pub archive_name: String,
+    pub journal_kind: LanguageInputCallbackTransportJournalKind,
+    pub journal_name: String,
+    pub log_kind: LanguageInputCallbackTransportLogKind,
+    pub log_name: String,
+    pub audit_kind: LanguageInputCallbackTransportAuditKind,
+    pub audit_name: String,
+    pub trace_kind: LanguageInputCallbackTransportTraceKind,
+    pub trace_name: String,
+    pub outcome_kind: LanguageInputCallbackTransportOutcomeKind,
+    pub outcome_name: String,
+    pub receipt_kind: LanguageInputCallbackTransportReceiptKind,
+    pub receipt_name: String,
+    pub acknowledgement_kind: LanguageInputCallbackTransportAcknowledgementKind,
+    pub acknowledgement_name: String,
+    pub delivery_route: LanguageInputCallbackTransportDeliveryRoute,
+    pub delivery_route_name: String,
+    pub event_kind: LanguageInputCallbackTransportEventKind,
+    pub event_name: String,
+    pub report_kind: LanguageInputCallbackTransportReportKind,
+    pub report_name: String,
+    pub action: LanguageInputCallbackTransportAction,
+    pub action_name: String,
+    pub callback_runner_handoff: bool,
+    pub adapter_event_published: bool,
+    pub delivery_acknowledged: bool,
+    pub receipt_recorded: bool,
+    pub outcome_recorded: bool,
+    pub trace_recorded: bool,
+    pub audit_recorded: bool,
+    pub log_recorded: bool,
+    pub journal_recorded: bool,
+    pub archive_recorded: bool,
+    pub snapshot_recorded: bool,
+    pub checkpoint_recorded: bool,
+    pub marker_recorded: bool,
+    pub cursor_recorded: bool,
+    pub bookmark_recorded: bool,
+    pub reference_recorded: bool,
+    pub logic_recorded: bool,
+    pub decision_recorded: bool,
+    pub resolution_recorded: bool,
+    pub finalization_recorded: bool,
+    pub completion_recorded: bool,
+    pub diagnostic_recorded: bool,
+    pub health_recorded: bool,
+    pub readiness_recorded: bool,
+    pub availability_recorded: bool,
+    pub terminal: bool,
+    pub retryable: bool,
+    pub queue_depth_after_availability: u8,
+    pub message: String,
+    pub readiness_summary: LanguageInputCallbackTransportReadinessSummary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageInputCallbackDiagnosticStage {
     Plan,
     Event,
@@ -3214,6 +3311,19 @@ pub const fn input_callback_transport_readiness_kind_name(
         }
         LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness => {
             "adapter_event_publication_readiness"
+        }
+    }
+}
+
+pub const fn input_callback_transport_availability_kind_name(
+    kind: LanguageInputCallbackTransportAvailabilityKind,
+) -> &'static str {
+    match kind {
+        LanguageInputCallbackTransportAvailabilityKind::CallbackRunnerHandoffAvailability => {
+            "callback_runner_handoff_availability"
+        }
+        LanguageInputCallbackTransportAvailabilityKind::AdapterEventPublicationAvailability => {
+            "adapter_event_publication_availability"
         }
     }
 }
@@ -5891,6 +6001,107 @@ pub fn input_callback_transport_readiness_summary(
     }
 }
 
+pub fn input_callback_transport_availability_summary(
+    readiness_summary: &LanguageInputCallbackTransportReadinessSummary,
+) -> LanguageInputCallbackTransportAvailabilitySummary {
+    let availability_kind =
+        input_callback_transport_availability_kind(readiness_summary.readiness_kind);
+
+    LanguageInputCallbackTransportAvailabilitySummary {
+        endpoint: readiness_summary.endpoint.clone(),
+        connection_label: readiness_summary.connection_label.clone(),
+        availability_label: input_callback_transport_availability_label(
+            readiness_summary,
+            availability_kind,
+        ),
+        availability_kind,
+        availability_name: input_callback_transport_availability_kind_name(availability_kind)
+            .to_owned(),
+        readiness_kind: readiness_summary.readiness_kind,
+        readiness_name: readiness_summary.readiness_name.clone(),
+        health_kind: readiness_summary.health_kind,
+        health_name: readiness_summary.health_name.clone(),
+        diagnostic_kind: readiness_summary.diagnostic_kind,
+        diagnostic_name: readiness_summary.diagnostic_name.clone(),
+        completion_kind: readiness_summary.completion_kind,
+        completion_name: readiness_summary.completion_name.clone(),
+        finalization_kind: readiness_summary.finalization_kind,
+        finalization_name: readiness_summary.finalization_name.clone(),
+        resolution_kind: readiness_summary.resolution_kind,
+        resolution_name: readiness_summary.resolution_name.clone(),
+        decision_kind: readiness_summary.decision_kind,
+        decision_name: readiness_summary.decision_name.clone(),
+        logic_kind: readiness_summary.logic_kind,
+        logic_name: readiness_summary.logic_name.clone(),
+        reference_kind: readiness_summary.reference_kind,
+        reference_name: readiness_summary.reference_name.clone(),
+        bookmark_kind: readiness_summary.bookmark_kind,
+        bookmark_name: readiness_summary.bookmark_name.clone(),
+        cursor_kind: readiness_summary.cursor_kind,
+        cursor_name: readiness_summary.cursor_name.clone(),
+        marker_kind: readiness_summary.marker_kind,
+        marker_name: readiness_summary.marker_name.clone(),
+        checkpoint_kind: readiness_summary.checkpoint_kind,
+        checkpoint_name: readiness_summary.checkpoint_name.clone(),
+        snapshot_kind: readiness_summary.snapshot_kind,
+        snapshot_name: readiness_summary.snapshot_name.clone(),
+        archive_kind: readiness_summary.archive_kind,
+        archive_name: readiness_summary.archive_name.clone(),
+        journal_kind: readiness_summary.journal_kind,
+        journal_name: readiness_summary.journal_name.clone(),
+        log_kind: readiness_summary.log_kind,
+        log_name: readiness_summary.log_name.clone(),
+        audit_kind: readiness_summary.audit_kind,
+        audit_name: readiness_summary.audit_name.clone(),
+        trace_kind: readiness_summary.trace_kind,
+        trace_name: readiness_summary.trace_name.clone(),
+        outcome_kind: readiness_summary.outcome_kind,
+        outcome_name: readiness_summary.outcome_name.clone(),
+        receipt_kind: readiness_summary.receipt_kind,
+        receipt_name: readiness_summary.receipt_name.clone(),
+        acknowledgement_kind: readiness_summary.acknowledgement_kind,
+        acknowledgement_name: readiness_summary.acknowledgement_name.clone(),
+        delivery_route: readiness_summary.delivery_route,
+        delivery_route_name: readiness_summary.delivery_route_name.clone(),
+        event_kind: readiness_summary.event_kind,
+        event_name: readiness_summary.event_name.clone(),
+        report_kind: readiness_summary.report_kind,
+        report_name: readiness_summary.report_name.clone(),
+        action: readiness_summary.action,
+        action_name: readiness_summary.action_name.clone(),
+        callback_runner_handoff: readiness_summary.callback_runner_handoff,
+        adapter_event_published: readiness_summary.adapter_event_published,
+        delivery_acknowledged: readiness_summary.delivery_acknowledged,
+        receipt_recorded: readiness_summary.receipt_recorded,
+        outcome_recorded: readiness_summary.outcome_recorded,
+        trace_recorded: readiness_summary.trace_recorded,
+        audit_recorded: readiness_summary.audit_recorded,
+        log_recorded: readiness_summary.log_recorded,
+        journal_recorded: readiness_summary.journal_recorded,
+        archive_recorded: readiness_summary.archive_recorded,
+        snapshot_recorded: readiness_summary.snapshot_recorded,
+        checkpoint_recorded: readiness_summary.checkpoint_recorded,
+        marker_recorded: readiness_summary.marker_recorded,
+        cursor_recorded: readiness_summary.cursor_recorded,
+        bookmark_recorded: readiness_summary.bookmark_recorded,
+        reference_recorded: readiness_summary.reference_recorded,
+        logic_recorded: readiness_summary.logic_recorded,
+        decision_recorded: readiness_summary.decision_recorded,
+        resolution_recorded: readiness_summary.resolution_recorded,
+        finalization_recorded: readiness_summary.finalization_recorded,
+        completion_recorded: readiness_summary.completion_recorded,
+        diagnostic_recorded: readiness_summary.diagnostic_recorded,
+        health_recorded: readiness_summary.health_recorded,
+        readiness_recorded: readiness_summary.readiness_recorded,
+        availability_recorded: true,
+        terminal: readiness_summary.terminal,
+        retryable: readiness_summary.retryable,
+        queue_depth_after_availability: readiness_summary.queue_depth_after_readiness,
+        message: input_callback_transport_availability_message(availability_kind).to_owned(),
+        readiness_summary: readiness_summary.clone(),
+    }
+}
+
 pub fn input_callback_plan_diagnostic(
     error: &LanguageInputCallbackPlanError,
 ) -> LanguageInputCallbackPlanDiagnostic {
@@ -8049,6 +8260,44 @@ fn input_callback_transport_readiness_message(
         }
         LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness => {
             "Transport readiness should track the adapter event publication health state."
+        }
+    }
+}
+
+fn input_callback_transport_availability_kind(
+    readiness_kind: LanguageInputCallbackTransportReadinessKind,
+) -> LanguageInputCallbackTransportAvailabilityKind {
+    match readiness_kind {
+        LanguageInputCallbackTransportReadinessKind::CallbackRunnerHandoffReadiness => {
+            LanguageInputCallbackTransportAvailabilityKind::CallbackRunnerHandoffAvailability
+        }
+        LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness => {
+            LanguageInputCallbackTransportAvailabilityKind::AdapterEventPublicationAvailability
+        }
+    }
+}
+
+fn input_callback_transport_availability_label(
+    readiness_summary: &LanguageInputCallbackTransportReadinessSummary,
+    availability_kind: LanguageInputCallbackTransportAvailabilityKind,
+) -> String {
+    format!(
+        "{} transport_availability={} availability_recorded=true queue_depth_after_availability={}",
+        readiness_summary.readiness_label,
+        input_callback_transport_availability_kind_name(availability_kind),
+        readiness_summary.queue_depth_after_readiness
+    )
+}
+
+fn input_callback_transport_availability_message(
+    availability_kind: LanguageInputCallbackTransportAvailabilityKind,
+) -> &'static str {
+    match availability_kind {
+        LanguageInputCallbackTransportAvailabilityKind::CallbackRunnerHandoffAvailability => {
+            "Transport availability should expose the callback-runner handoff readiness state."
+        }
+        LanguageInputCallbackTransportAvailabilityKind::AdapterEventPublicationAvailability => {
+            "Transport availability should expose the adapter event publication readiness state."
         }
     }
 }
@@ -19376,6 +19625,255 @@ mod tests {
             )
         );
         assert_eq!(dropped.health_summary, dropped_health);
+    }
+
+    #[test]
+    fn input_callback_transport_availability_is_owned_by_rust_language_core() {
+        fn readiness_for_lifecycle(
+            lifecycle: &LanguageInputCallbackSessionLifecycleSummary,
+        ) -> LanguageInputCallbackTransportReadinessSummary {
+            let action = input_callback_transport_action_summary(lifecycle);
+            let effect = input_callback_transport_effect_summary(&action);
+            let report = input_callback_transport_report_summary(&effect);
+            let event = input_callback_transport_event_summary(&report);
+            let delivery = input_callback_transport_delivery_summary(&event);
+            let acknowledgement = input_callback_transport_acknowledgement_summary(&delivery);
+            let receipt = input_callback_transport_receipt_summary(&acknowledgement);
+            let outcome = input_callback_transport_outcome_summary(&receipt);
+            let trace = input_callback_transport_trace_summary(&outcome);
+            let audit = input_callback_transport_audit_summary(&trace);
+            let log = input_callback_transport_log_summary(&audit);
+            let journal = input_callback_transport_journal_summary(&log);
+            let archive = input_callback_transport_archive_summary(&journal);
+            let snapshot = input_callback_transport_snapshot_summary(&archive);
+            let checkpoint = input_callback_transport_checkpoint_summary(&snapshot);
+            let marker = input_callback_transport_marker_summary(&checkpoint);
+            let cursor = input_callback_transport_cursor_summary(&marker);
+            let bookmark = input_callback_transport_bookmark_summary(&cursor);
+            let reference = input_callback_transport_reference_summary(&bookmark);
+            let logic = input_callback_transport_logic_summary(&reference);
+            let decision = input_callback_transport_decision_summary(&logic);
+            let resolution = input_callback_transport_resolution_summary(&decision);
+            let finalization = input_callback_transport_finalization_summary(&resolution);
+            let completion = input_callback_transport_completion_summary(&finalization);
+            let diagnostic = input_callback_transport_diagnostic_summary(&completion);
+            let health = input_callback_transport_health_summary(&diagnostic);
+            input_callback_transport_readiness_summary(&health)
+        }
+
+        let plan = input_callback_plan_for_target("uno-r4-wifi", 3, 7, 64).unwrap();
+        let event = input_callback_event_for_plan(&plan, LanguageInputCallbackLevel::Low, 42, 9001);
+        let invocation = input_callback_invocation_for_event(&plan, &event).unwrap();
+        let queue_plan = input_callback_queue_plan_for_invocation(&invocation, 2).unwrap();
+        let serial_session = host_endpoint_session_summary("serial:///dev/cu.usbmodem1101", 57_600)
+            .expect("serial endpoint session");
+        let completed_lifecycle = input_callback_session_lifecycle_summary(
+            &serial_session,
+            &queue_plan,
+            Some(RunStatus::Halted),
+            11,
+            3,
+        );
+        let completed_readiness = readiness_for_lifecycle(&completed_lifecycle);
+        let completed = input_callback_transport_availability_summary(&completed_readiness);
+
+        assert_eq!(completed.endpoint.endpoint, "serial:///dev/cu.usbmodem1101");
+        assert_eq!(
+            completed.availability_kind,
+            LanguageInputCallbackTransportAvailabilityKind::AdapterEventPublicationAvailability
+        );
+        assert_eq!(
+            completed.availability_name,
+            "adapter_event_publication_availability"
+        );
+        assert_eq!(
+            completed.readiness_kind,
+            LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness
+        );
+        assert_eq!(
+            completed.health_kind,
+            LanguageInputCallbackTransportHealthKind::AdapterEventPublicationHealth
+        );
+        assert_eq!(
+            completed.diagnostic_kind,
+            LanguageInputCallbackTransportDiagnosticKind::AdapterEventPublicationDiagnostic
+        );
+        assert_eq!(
+            completed.completion_kind,
+            LanguageInputCallbackTransportCompletionKind::AdapterEventPublicationCompletion
+        );
+        assert_eq!(
+            completed.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::AdapterEvent
+        );
+        assert_eq!(
+            completed.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackCompleted
+        );
+        assert_eq!(
+            completed.action,
+            LanguageInputCallbackTransportAction::CompleteCallback
+        );
+        assert!(!completed.callback_runner_handoff);
+        assert!(completed.adapter_event_published);
+        assert!(completed.delivery_acknowledged);
+        assert!(completed.receipt_recorded);
+        assert!(completed.outcome_recorded);
+        assert!(completed.trace_recorded);
+        assert!(completed.audit_recorded);
+        assert!(completed.log_recorded);
+        assert!(completed.journal_recorded);
+        assert!(completed.archive_recorded);
+        assert!(completed.snapshot_recorded);
+        assert!(completed.checkpoint_recorded);
+        assert!(completed.marker_recorded);
+        assert!(completed.cursor_recorded);
+        assert!(completed.bookmark_recorded);
+        assert!(completed.reference_recorded);
+        assert!(completed.logic_recorded);
+        assert!(completed.decision_recorded);
+        assert!(completed.resolution_recorded);
+        assert!(completed.finalization_recorded);
+        assert!(completed.completion_recorded);
+        assert!(completed.diagnostic_recorded);
+        assert!(completed.health_recorded);
+        assert!(completed.readiness_recorded);
+        assert!(completed.availability_recorded);
+        assert!(completed.terminal);
+        assert!(!completed.retryable);
+        assert_eq!(completed.queue_depth_after_availability, 2);
+        assert_eq!(
+            completed.availability_label,
+            format!(
+                "{} transport_availability=adapter_event_publication_availability availability_recorded=true queue_depth_after_availability=2",
+                completed_readiness.readiness_label
+            )
+        );
+        assert_eq!(
+            completed.message,
+            "Transport availability should expose the adapter event publication readiness state."
+        );
+        assert_eq!(completed.readiness_summary, completed_readiness);
+
+        let tcp_session = host_endpoint_session_summary("tcp://board-vm.local:4170", 57_600)
+            .expect("tcp endpoint session");
+        let pending_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &queue_plan, None, 0, 0);
+        let pending_readiness = readiness_for_lifecycle(&pending_lifecycle);
+        let pending = input_callback_transport_availability_summary(&pending_readiness);
+
+        assert_eq!(
+            pending.availability_kind,
+            LanguageInputCallbackTransportAvailabilityKind::CallbackRunnerHandoffAvailability
+        );
+        assert_eq!(
+            pending.availability_name,
+            "callback_runner_handoff_availability"
+        );
+        assert_eq!(
+            pending.readiness_kind,
+            LanguageInputCallbackTransportReadinessKind::CallbackRunnerHandoffReadiness
+        );
+        assert_eq!(
+            pending.delivery_route,
+            LanguageInputCallbackTransportDeliveryRoute::CallbackRunner
+        );
+        assert_eq!(
+            pending.event_kind,
+            LanguageInputCallbackTransportEventKind::DispatchScheduled
+        );
+        assert!(pending.callback_runner_handoff);
+        assert!(!pending.adapter_event_published);
+        assert!(pending.delivery_acknowledged);
+        assert!(pending.readiness_recorded);
+        assert!(pending.availability_recorded);
+        assert!(!pending.terminal);
+        assert!(!pending.retryable);
+        assert_eq!(pending.queue_depth_after_availability, 3);
+        assert_eq!(
+            pending.availability_label,
+            format!(
+                "{} transport_availability=callback_runner_handoff_availability availability_recorded=true queue_depth_after_availability=3",
+                pending_readiness.readiness_label
+            )
+        );
+        assert_eq!(
+            pending.message,
+            "Transport availability should expose the callback-runner handoff readiness state."
+        );
+        assert_eq!(pending.readiness_summary, pending_readiness);
+
+        let custom = input_callback_plan_with_options_for_target(
+            "uno-r4-wifi",
+            3,
+            LanguageInputCallbackOptions {
+                trigger: LanguageInputCallbackTrigger::RisingEdge,
+                pull: LanguageInputCallbackPull::Floating,
+                debounce_ms: 5,
+                queue_capacity: 1,
+                queue_policy: LanguageInputCallbackQueuePolicy::DropNewest,
+                callback_program_id: 9,
+                callback_instruction_budget: 32,
+            },
+        )
+        .unwrap();
+        let custom_event =
+            input_callback_event_for_plan(&custom, LanguageInputCallbackLevel::High, 77, 12_345);
+        let custom_invocation =
+            input_callback_invocation_for_event(&custom, &custom_event).unwrap();
+        let newest_drop = input_callback_queue_plan_for_invocation(&custom_invocation, 1).unwrap();
+        let dropped_lifecycle =
+            input_callback_session_lifecycle_summary(&tcp_session, &newest_drop, None, 0, 0);
+        let dropped_readiness = readiness_for_lifecycle(&dropped_lifecycle);
+        let dropped = input_callback_transport_availability_summary(&dropped_readiness);
+
+        assert_eq!(
+            dropped.event_kind,
+            LanguageInputCallbackTransportEventKind::CallbackDropped
+        );
+        assert_eq!(
+            dropped.availability_kind,
+            LanguageInputCallbackTransportAvailabilityKind::AdapterEventPublicationAvailability
+        );
+        assert_eq!(
+            dropped.readiness_kind,
+            LanguageInputCallbackTransportReadinessKind::AdapterEventPublicationReadiness
+        );
+        assert!(!dropped.callback_runner_handoff);
+        assert!(dropped.adapter_event_published);
+        assert!(dropped.delivery_acknowledged);
+        assert!(dropped.receipt_recorded);
+        assert!(dropped.outcome_recorded);
+        assert!(dropped.trace_recorded);
+        assert!(dropped.audit_recorded);
+        assert!(dropped.log_recorded);
+        assert!(dropped.journal_recorded);
+        assert!(dropped.archive_recorded);
+        assert!(dropped.snapshot_recorded);
+        assert!(dropped.checkpoint_recorded);
+        assert!(dropped.marker_recorded);
+        assert!(dropped.cursor_recorded);
+        assert!(dropped.bookmark_recorded);
+        assert!(dropped.reference_recorded);
+        assert!(dropped.logic_recorded);
+        assert!(dropped.decision_recorded);
+        assert!(dropped.resolution_recorded);
+        assert!(dropped.finalization_recorded);
+        assert!(dropped.completion_recorded);
+        assert!(dropped.diagnostic_recorded);
+        assert!(dropped.health_recorded);
+        assert!(dropped.readiness_recorded);
+        assert!(dropped.availability_recorded);
+        assert!(dropped.terminal);
+        assert_eq!(dropped.queue_depth_after_availability, 1);
+        assert_eq!(
+            dropped.availability_label,
+            format!(
+                "{} transport_availability=adapter_event_publication_availability availability_recorded=true queue_depth_after_availability=1",
+                dropped_readiness.readiness_label
+            )
+        );
+        assert_eq!(dropped.readiness_summary, dropped_readiness);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a Rust-owned Board VM input callback transport availability kind and summary layer over readiness
- carry readiness, health, diagnostic, completion, and transport metadata through the availability record
- document the availability surface for thin language frontends

## Validation
- cargo fmt -p board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-availability cargo test -p board-vm-language-core
- bash BUILD in code/packages/rust/board-vm-language-core
- MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-board-vm-input-callback-transport-availability cargo test -p board-vm-ir -p board-vm-runtime -p board-vm-host -p board-vm-device -p board-vm-uno-r4 -p board-vm-esp32 -p board-vm-pico -p board-vm-arduino -p board-vm-targets -p board-vm-language-core -p board-vm-cli
- git diff --check origin/main...HEAD
- git diff --check
- git diff --cached --check

Generated code/packages/rust/Cargo.lock was removed before committing. The external /Users/adhithya/Downloads/Codex/worktrees/coding-adventures-target-detect/build-tool path remains unavailable, so detector validation could not run from this worktree.