### PR TITLE
Track browser interactive element metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -571,6 +571,10 @@ def check_browser_content_node(
         "contenteditable",
         "draggable",
         "popover",
+        "popover_target",
+        "popover_target_action",
+        "command",
+        "command_for",
         "placeholder",
         "autocomplete",
         "accept",
@@ -612,6 +616,7 @@ def check_browser_content_node(
     require_optional_string_list(node_path, node, "headers", errors)
     require_optional_string_list(node_path, node, "labels", errors)
     require_optional_string_list(node_path, node, "sandbox", errors)
+    require_optional_string_list(node_path, node, "accesskey", errors)
     require_optional_string_list(node_path, node, "aria_labelledby", errors)
     require_optional_string_list(node_path, node, "aria_describedby", errors)
     require_optional_string_list(node_path, node, "aria_controls", errors)
@@ -634,6 +639,7 @@ def check_browser_content_node(
         "aria_hidden",
         "hidden",
         "inert",
+        "open",
         "focusable",
     ):
         require_optional_boolean(node_path, node, field, errors)
@@ -720,6 +726,10 @@ def check_browser_render_node(
         "contenteditable",
         "draggable",
         "popover",
+        "popover_target",
+        "popover_target_action",
+        "command",
+        "command_for",
         "placeholder",
         "autocomplete",
         "accept",
@@ -761,6 +771,7 @@ def check_browser_render_node(
     require_optional_string_list(node_path, node, "headers", errors)
     require_optional_string_list(node_path, node, "labels", errors)
     require_optional_string_list(node_path, node, "sandbox", errors)
+    require_optional_string_list(node_path, node, "accesskey", errors)
     require_optional_string_list(node_path, node, "aria_labelledby", errors)
     require_optional_string_list(node_path, node, "aria_describedby", errors)
     require_optional_string_list(node_path, node, "aria_controls", errors)
@@ -783,6 +794,7 @@ def check_browser_render_node(
         "aria_hidden",
         "hidden",
         "inert",
+        "open",
         "focusable",
     ):
         require_optional_boolean(node_path, node, field, errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1010,11 +1010,17 @@ pub struct BrowserContentNode {
     pub aria_hidden: bool,
     pub hidden: bool,
     pub inert: bool,
+    pub open: bool,
     pub tabindex: Option<String>,
+    pub accesskey: Vec<String>,
     pub focusable: Option<bool>,
     pub contenteditable: Option<String>,
     pub draggable: Option<String>,
     pub popover: Option<String>,
+    pub popover_target: Option<String>,
+    pub popover_target_action: Option<String>,
+    pub command: Option<String>,
+    pub command_for: Option<String>,
     pub placeholder: Option<String>,
     pub autocomplete: Option<String>,
     pub accept: Option<String>,
@@ -1122,11 +1128,17 @@ pub struct BrowserRenderNode {
     pub aria_hidden: bool,
     pub hidden: bool,
     pub inert: bool,
+    pub open: bool,
     pub tabindex: Option<String>,
+    pub accesskey: Vec<String>,
     pub focusable: Option<bool>,
     pub contenteditable: Option<String>,
     pub draggable: Option<String>,
     pub popover: Option<String>,
+    pub popover_target: Option<String>,
+    pub popover_target_action: Option<String>,
+    pub command: Option<String>,
+    pub command_for: Option<String>,
     pub placeholder: Option<String>,
     pub autocomplete: Option<String>,
     pub accept: Option<String>,
@@ -1449,11 +1461,17 @@ impl BrowserRenderNode {
             aria_hidden: content_node.aria_hidden,
             hidden: content_node.hidden,
             inert: content_node.inert,
+            open: content_node.open,
             tabindex: content_node.tabindex.clone(),
+            accesskey: content_node.accesskey.clone(),
             focusable: content_node.focusable,
             contenteditable: content_node.contenteditable.clone(),
             draggable: content_node.draggable.clone(),
             popover: content_node.popover.clone(),
+            popover_target: content_node.popover_target.clone(),
+            popover_target_action: content_node.popover_target_action.clone(),
+            command: content_node.command.clone(),
+            command_for: content_node.command_for.clone(),
             placeholder: content_node.placeholder.clone(),
             autocomplete: content_node.autocomplete.clone(),
             accept: content_node.accept.clone(),
@@ -9091,11 +9109,17 @@ fn collect_browser_content_nodes_with_mode(
                         aria_hidden: false,
                         hidden: false,
                         inert: false,
+                        open: false,
                         tabindex: None,
+                        accesskey: Vec::new(),
                         focusable: None,
                         contenteditable: None,
                         draggable: None,
                         popover: None,
+                        popover_target: None,
+                        popover_target_action: None,
+                        command: None,
+                        command_for: None,
                         placeholder: None,
                         autocomplete: None,
                         accept: None,
@@ -9270,11 +9294,17 @@ fn browser_content_node_for_element(
         aria_hidden: browser_aria_hidden(element),
         hidden: browser_hidden(element),
         inert: browser_inert(element),
+        open: browser_open(element),
         tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
+        accesskey: browser_accesskey(element),
         focusable: browser_focusable(element),
         contenteditable: element.attribute("contenteditable").map(ToOwned::to_owned),
         draggable: element.attribute("draggable").map(ToOwned::to_owned),
         popover: element.attribute("popover").map(ToOwned::to_owned),
+        popover_target: browser_popover_target(element),
+        popover_target_action: browser_popover_target_action(element),
+        command: browser_command(element),
+        command_for: browser_command_for(element),
         placeholder: browser_placeholder(element),
         autocomplete: browser_autocomplete(element),
         accept: browser_control_accept(element),
@@ -9938,6 +9968,39 @@ fn browser_hidden(element: &Element) -> bool {
 
 fn browser_inert(element: &Element) -> bool {
     element.attribute("inert").is_some()
+}
+
+fn browser_open(element: &Element) -> bool {
+    matches!(element.name.as_str(), "details" | "dialog") && element.attribute("open").is_some()
+}
+
+fn browser_accesskey(element: &Element) -> Vec<String> {
+    element
+        .attribute("accesskey")
+        .map(split_html_classes)
+        .unwrap_or_default()
+}
+
+fn browser_popover_target(element: &Element) -> Option<String> {
+    element.attribute("popovertarget").map(ToOwned::to_owned)
+}
+
+fn browser_popover_target_action(element: &Element) -> Option<String> {
+    element
+        .attribute("popovertargetaction")
+        .map(collapse_html_whitespace)
+        .filter(|action| !action.is_empty())
+}
+
+fn browser_command(element: &Element) -> Option<String> {
+    element
+        .attribute("command")
+        .map(collapse_html_whitespace)
+        .filter(|command| !command.is_empty())
+}
+
+fn browser_command_for(element: &Element) -> Option<String> {
+    element.attribute("commandfor").map(ToOwned::to_owned)
 }
 
 fn browser_focusable(element: &Element) -> Option<bool> {
@@ -11260,11 +11323,13 @@ mod tests {
     fn browser_aria_interaction_metadata_tracks_roles_states_and_focus() {
         let document = parse_html(
             "<body><main id=app aria-label=\"App shell\">\
-             <button id=menu aria-expanded=false aria-controls=panel tabindex=0>Menu</button>\
+             <button id=menu aria-expanded=false aria-controls=panel tabindex=0 accesskey=\"m /\" popovertarget=panel-pop popovertargetaction=toggle command=show-modal commandfor=dialog>Menu</button>\
              <section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help inert>\
                <h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p>\
                <div role=button tabindex=-1 aria-pressed=mixed aria-current=page contenteditable=true draggable=true popover=manual>Inline action</div>\
              </section>\
+             <dialog id=dialog open aria-label=\"Dialog\" accesskey=\"d x\"><p>Dialog copy</p></dialog>\
+             <details id=more open><summary>More</summary><p>Extra</p></details>\
              <p hidden>Hidden copy</p><span aria-hidden=true>Decorative</span></main>",
         )
         .unwrap();
@@ -11281,7 +11346,12 @@ mod tests {
         assert_eq!(menu.aria_expanded.as_deref(), Some("false"));
         assert_eq!(menu.aria_controls, vec!["panel"]);
         assert_eq!(menu.tabindex.as_deref(), Some("0"));
+        assert_eq!(menu.accesskey, vec!["m", "/"]);
         assert_eq!(menu.focusable, Some(true));
+        assert_eq!(menu.popover_target.as_deref(), Some("panel-pop"));
+        assert_eq!(menu.popover_target_action.as_deref(), Some("toggle"));
+        assert_eq!(menu.command.as_deref(), Some("show-modal"));
+        assert_eq!(menu.command_for.as_deref(), Some("dialog"));
 
         let panel = &main.children[1];
         assert_eq!(panel.role, "section");
@@ -11302,8 +11372,17 @@ mod tests {
         assert_eq!(action.draggable.as_deref(), Some("true"));
         assert_eq!(action.popover.as_deref(), Some("manual"));
 
-        assert!(main.children[2].hidden);
-        assert!(main.children[3].aria_hidden);
+        let dialog = &main.children[2];
+        assert_eq!(dialog.role, "block");
+        assert!(dialog.open);
+        assert_eq!(dialog.accesskey, vec!["d", "x"]);
+
+        let details = &main.children[3];
+        assert_eq!(details.role, "block");
+        assert!(details.open);
+
+        assert!(main.children[4].hidden);
+        assert!(main.children[5].aria_hidden);
 
         let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
         let render_panel = &render_tree.children[0].children[1];
@@ -11311,6 +11390,14 @@ mod tests {
         assert_eq!(render_panel.accessible_name.as_deref(), Some("Settings"));
         assert!(render_panel.inert);
         assert_eq!(render_tree.children[0].children[0].focusable, Some(true));
+        assert_eq!(
+            render_tree.children[0].children[0]
+                .popover_target
+                .as_deref(),
+            Some("panel-pop")
+        );
+        assert!(render_tree.children[0].children[2].open);
+        assert!(render_tree.children[0].children[3].open);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -122,7 +122,11 @@ struct ExpectedContentNode {
     #[serde(default)]
     inert: bool,
     #[serde(default)]
+    open: bool,
+    #[serde(default)]
     tabindex: Option<String>,
+    #[serde(default)]
+    accesskey: Vec<String>,
     #[serde(default)]
     focusable: Option<bool>,
     #[serde(default)]
@@ -131,6 +135,14 @@ struct ExpectedContentNode {
     draggable: Option<String>,
     #[serde(default)]
     popover: Option<String>,
+    #[serde(default)]
+    popover_target: Option<String>,
+    #[serde(default)]
+    popover_target_action: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    command_for: Option<String>,
     #[serde(default)]
     placeholder: Option<String>,
     #[serde(default)]
@@ -312,11 +324,17 @@ impl ExpectedContentNode {
             aria_hidden: self.aria_hidden,
             hidden: self.hidden,
             inert: self.inert,
+            open: self.open,
             tabindex: self.tabindex,
+            accesskey: self.accesskey,
             focusable: self.focusable,
             contenteditable: self.contenteditable,
             draggable: self.draggable,
             popover: self.popover,
+            popover_target: self.popover_target,
+            popover_target_action: self.popover_target_action,
+            command: self.command,
+            command_for: self.command_for,
             placeholder: self.placeholder,
             autocomplete: self.autocomplete,
             accept: self.accept,

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -123,7 +123,11 @@ struct ExpectedRenderNode {
     #[serde(default)]
     inert: bool,
     #[serde(default)]
+    open: bool,
+    #[serde(default)]
     tabindex: Option<String>,
+    #[serde(default)]
+    accesskey: Vec<String>,
     #[serde(default)]
     focusable: Option<bool>,
     #[serde(default)]
@@ -132,6 +136,14 @@ struct ExpectedRenderNode {
     draggable: Option<String>,
     #[serde(default)]
     popover: Option<String>,
+    #[serde(default)]
+    popover_target: Option<String>,
+    #[serde(default)]
+    popover_target_action: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    command_for: Option<String>,
     #[serde(default)]
     placeholder: Option<String>,
     #[serde(default)]
@@ -314,11 +326,17 @@ impl ExpectedRenderNode {
             aria_hidden: self.aria_hidden,
             hidden: self.hidden,
             inert: self.inert,
+            open: self.open,
             tabindex: self.tabindex,
+            accesskey: self.accesskey,
             focusable: self.focusable,
             contenteditable: self.contenteditable,
             draggable: self.draggable,
             popover: self.popover,
+            popover_target: self.popover_target,
+            popover_target_action: self.popover_target_action,
+            command: self.command,
+            command_for: self.command_for,
             placeholder: self.placeholder,
             autocomplete: self.autocomplete,
             accept: self.accept,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -285,8 +285,8 @@
     },
     {
       "id": "aria-interaction-metadata",
-      "description": "Authored ARIA roles, labelled-by naming, state attributes, hidden/inert flags, and explicit focus metadata survive content-tree extraction.",
-      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel tabindex=0>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help inert><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div role=button tabindex=-1 aria-pressed=mixed aria-current=page contenteditable=true draggable=true popover=manual>Inline action</div></section><p hidden>Hidden copy</p><span aria-hidden=true>Decorative</span></main>",
+      "description": "Authored ARIA roles, labelled-by naming, state attributes, hidden/inert flags, focus metadata, and interactive command hints survive content-tree extraction.",
+      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel tabindex=0 accesskey=\"m /\" popovertarget=panel-pop popovertargetaction=toggle command=show-modal commandfor=dialog>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help inert><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div role=button tabindex=-1 aria-pressed=mixed aria-current=page contenteditable=true draggable=true popover=manual>Inline action</div></section><dialog id=dialog open aria-label=\"Dialog\" accesskey=\"d x\"><p>Dialog copy</p></dialog><details id=more open><summary>More</summary><p>Extra</p></details><p hidden>Hidden copy</p><span aria-hidden=true>Decorative</span></main>",
       "expected": {
         "children": [
           {
@@ -303,7 +303,7 @@
             "accessible_name": "App shell",
             "aria_label": "App shell",
             "children": [
-              { "role": "control", "name": "button", "id": "menu", "text": "Menu", "href": null, "src": null, "alt": null, "control_type": "submit", "accessible_name": "Menu", "aria_controls": ["panel"], "aria_expanded": "false", "tabindex": "0", "focusable": true, "children": [] },
+              { "role": "control", "name": "button", "id": "menu", "text": "Menu", "href": null, "src": null, "alt": null, "control_type": "submit", "accessible_name": "Menu", "aria_controls": ["panel"], "aria_expanded": "false", "tabindex": "0", "accesskey": ["m", "/"], "focusable": true, "popover_target": "panel-pop", "popover_target_action": "toggle", "command": "show-modal", "command_for": "dialog", "children": [] },
               {
                 "role": "section",
                 "name": "section",
@@ -325,6 +325,8 @@
                   { "role": "block", "name": "div", "authored_role": "button", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "aria_current": "page", "aria_pressed": "mixed", "tabindex": "-1", "focusable": false, "contenteditable": "true", "draggable": "true", "popover": "manual", "children": [{ "role": "text", "name": null, "text": "Inline action", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                 ]
               },
+              { "role": "block", "name": "dialog", "id": "dialog", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "accessible_name": "Dialog", "aria_label": "Dialog", "open": true, "accesskey": ["d", "x"], "children": [{ "role": "paragraph", "name": "p", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Dialog copy", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }] },
+              { "role": "block", "name": "details", "id": "more", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "open": true, "children": [{ "role": "block", "name": "summary", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "More", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }, { "role": "paragraph", "name": "p", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "role": "text", "name": null, "text": "Extra", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }] },
               { "role": "paragraph", "name": "p", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "hidden": true, "children": [{ "role": "text", "name": null, "text": "Hidden copy", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
               { "role": "inline", "name": "span", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "aria_hidden": true, "children": [{ "role": "text", "name": null, "text": "Decorative", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
             ]

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -249,8 +249,8 @@
     },
     {
       "id": "aria-interaction-display-metadata",
-      "description": "ARIA interaction metadata survives the render-tree projection while default display categories remain semantic.",
-      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel tabindex=0>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help inert><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div role=button tabindex=-1 aria-pressed=mixed aria-current=page contenteditable=true draggable=true popover=manual>Inline action</div></section><p hidden>Hidden copy</p><span aria-hidden=true>Decorative</span></main>",
+      "description": "ARIA and interactive command metadata survive the render-tree projection while default display categories remain semantic.",
+      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel tabindex=0 accesskey=\"m /\" popovertarget=panel-pop popovertargetaction=toggle command=show-modal commandfor=dialog>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help inert><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div role=button tabindex=-1 aria-pressed=mixed aria-current=page contenteditable=true draggable=true popover=manual>Inline action</div></section><dialog id=dialog open aria-label=\"Dialog\" accesskey=\"d x\"><p>Dialog copy</p></dialog><details id=more open><summary>More</summary><p>Extra</p></details><p hidden>Hidden copy</p><span aria-hidden=true>Decorative</span></main>",
       "expected": {
         "children": [
           {
@@ -268,7 +268,7 @@
             "accessible_name": "App shell",
             "aria_label": "App shell",
             "children": [
-              { "display": "inline-replaced", "role": "control", "name": "button", "id": "menu", "text": "Menu", "href": null, "src": null, "alt": null, "control_type": "submit", "accessible_name": "Menu", "aria_controls": ["panel"], "aria_expanded": "false", "tabindex": "0", "focusable": true, "children": [] },
+              { "display": "inline-replaced", "role": "control", "name": "button", "id": "menu", "text": "Menu", "href": null, "src": null, "alt": null, "control_type": "submit", "accessible_name": "Menu", "aria_controls": ["panel"], "aria_expanded": "false", "tabindex": "0", "accesskey": ["m", "/"], "focusable": true, "popover_target": "panel-pop", "popover_target_action": "toggle", "command": "show-modal", "command_for": "dialog", "children": [] },
               {
                 "display": "block",
                 "role": "section",
@@ -291,6 +291,8 @@
                   { "display": "block", "role": "block", "name": "div", "authored_role": "button", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "aria_current": "page", "aria_pressed": "mixed", "tabindex": "-1", "focusable": false, "contenteditable": "true", "draggable": "true", "popover": "manual", "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Inline action", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
                 ]
               },
+              { "display": "block", "role": "block", "name": "dialog", "id": "dialog", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "accessible_name": "Dialog", "aria_label": "Dialog", "open": true, "accesskey": ["d", "x"], "children": [{ "display": "block", "role": "paragraph", "name": "p", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Dialog copy", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }] },
+              { "display": "block", "role": "block", "name": "details", "id": "more", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "open": true, "children": [{ "display": "block", "role": "block", "name": "summary", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "More", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }, { "display": "block", "role": "paragraph", "name": "p", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Extra", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }] },
               { "display": "block", "role": "paragraph", "name": "p", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "hidden": true, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Hidden copy", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] },
               { "display": "inline", "role": "inline", "name": "span", "text": null, "href": null, "src": null, "alt": null, "control_type": null, "aria_hidden": true, "children": [{ "display": "inline-text", "role": "text", "name": null, "text": "Decorative", "href": null, "src": null, "alt": null, "control_type": null, "children": [] }] }
             ]


### PR DESCRIPTION
## Summary
- add browser content/render metadata for open details/dialog state, accesskey tokens, popover targeting, and command hints
- preserve popovertarget/action and command/commandfor through browser fixture projections
- update the ARIA interaction fixtures/schema for dialog, details, and popover command coverage

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo fmt -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser browser_aria_interaction_metadata_tracks_roles_states_and_focus
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser