### PR TITLE
spice: cover jfet transient participation

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -25,6 +25,9 @@
 - **Pole-zero text output table** — `format_pole_zero_table()` now emits a
   stable tab-separated row set for `.PZ` poles and zeros.
 
+- **JFET transient coverage** — source-follower transient fixtures now cover
+  JFET participation in nonlinear companion-model solves.
+
 - **Fourier transient analysis** — `fourier()` now computes SPICE-style DC,
   harmonic sine/cosine coefficients, magnitudes, phases, and THD from
   transient samples for `V(node)` and `I(source)` probes.

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1354,6 +1354,31 @@ def test_jfet_common_source_ac_gain_from_bias_point() -> None:
     assert out.imag == pytest.approx(0.0, abs=1.0e-12)
 
 
+def test_jfet_transient_source_follower_charges_output_capacitor() -> None:
+    c = Circuit()
+    c.add(VoltageSource("Vdd", "vdd", "0", voltage=10.0))
+    c.add(
+        VoltageSource(
+            "Vg",
+            "gate",
+            "0",
+            voltage=0.0,
+            waveform=PwlWaveform([(0.0, 0.0), (1.0e-6, 1.0), (2.0e-6, 1.0)]),
+        )
+    )
+    c.add(JFET("J1", "vdd", "gate", "out", beta=1.0e-3, vto=-2.0))
+    c.add(Resistor("Rs", "out", "0", 1_000.0))
+    c.add(Capacitor("Cout", "out", "0", 1.0e-9))
+
+    result = transient(c, t_step=1.0e-7, t_stop=2.0e-6)
+
+    initial_out = result.points[0].node_voltages["out"]
+    final_out = result.points[-1].node_voltages["out"]
+    assert final_out > initial_out + 1.0
+    assert final_out > 1.5
+    assert final_out < 2.0
+
+
 def test_bjt_npn_off():
     """NPN BJT with zero base voltage — device is off (no collector current).
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -15,6 +15,8 @@
   node-voltage and branch-current text output snapshots.
 - Add `format_pole_zero_table` for stable tab-separated `.PZ` pole-zero text
   output snapshots.
+- Add JFET source-follower transient fixtures covering nonlinear
+  companion-model solves.
 - Add `fourier`, which computes SPICE-style DC, harmonic sine/cosine
   coefficients, magnitudes, phases, and THD from transient samples for
   `V(node)` and `I(source)` probes.

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -8,7 +8,7 @@ use spice_engine::{
     pss_with_tolerance, transient, transient_adaptive, transient_with_method,
     AdaptiveTransientOptions, AdaptiveTransientResult, Capacitor, Cccs, Ccvs, Circuit,
     CurrentSource, DistortionHarmonic, DistortionPoint, DistortionResult, Element, ExpWaveform,
-    Inductor, MutualInductor, PoleZeroEntry, PoleZeroEntryKind, PoleZeroResult,
+    Inductor, Jfet, JfetPolarity, MutualInductor, PoleZeroEntry, PoleZeroEntryKind, PoleZeroResult,
     PssNewtonCandidateResult, PssNewtonIterationResult, PssNewtonSolveResult,
     PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult, PssResult, PulseWaveform,
     PwlWaveform, Resistor, SinWaveform, SpiceError, TransientMethod, TransientPoint,
@@ -19,6 +19,56 @@ fn assert_close(actual: f64, expected: f64) {
     assert!(
         (actual - expected).abs() < 1.0e-9,
         "expected {expected}, got {actual}"
+    );
+}
+
+#[test]
+fn transient_jfet_source_follower_charges_output_capacitor() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 10.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+        "Vg",
+        "gate",
+        "0",
+        0.0,
+        Waveform::Pwl(PwlWaveform::new(vec![
+            (0.0, 0.0),
+            (1.0e-6, 1.0),
+            (2.0e-6, 1.0),
+        ])),
+    )));
+    circuit.add(Element::Jfet(Jfet::with_model(
+        "J1",
+        "vdd",
+        "gate",
+        "out",
+        JfetPolarity::Njf,
+        1.0e-3,
+        -2.0,
+        0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rs", "out", "0", 1_000.0)));
+    circuit.add(Element::Capacitor(Capacitor::new(
+        "Cout", "out", "0", 1.0e-9,
+    )));
+
+    let points = transient(&circuit, 1.0e-7, 2.0e-6).unwrap();
+
+    let initial_out = points[0].voltage("out").unwrap();
+    let final_out = points.last().unwrap().voltage("out").unwrap();
+    assert!(
+        final_out > initial_out + 1.0,
+        "expected JFET output to charge from {initial_out}, got {final_out}"
+    );
+    assert!(
+        final_out > 1.5,
+        "expected JFET output to charge, got {final_out}"
+    );
+    assert!(
+        final_out < 2.0,
+        "expected source below gate plus threshold, got {final_out}"
     );
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -15,6 +15,8 @@
   node-voltage and branch-current text output snapshots.
 - Add `formatPoleZeroTable` for stable tab-separated `.PZ` pole-zero text
   output snapshots.
+- Add JFET source-follower transient fixtures covering nonlinear
+  companion-model solves.
 - Add `fourier`, which computes SPICE-style DC, harmonic sine/cosine
   coefficients, magnitudes, phases, and THD from transient samples for
   `V(node)` and `I(source)` probes.

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -24,6 +24,7 @@ import {
   fourier,
   inductor,
   inductorWithInitialCurrent,
+  jfet,
   mutualInductor,
   pss,
   pssNewtonCandidate,
@@ -53,6 +54,31 @@ function expectClose(actual: number | undefined, expected: number): void {
 }
 
 describe("transient", () => {
+  it("lets a JFET source follower charge an output capacitor", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 10.0));
+    circuit.add(
+      voltageSourceWithWaveform(
+        "Vg",
+        "gate",
+        "0",
+        0.0,
+        new PwlWaveform([[0.0, 0.0], [1.0e-6, 1.0], [2.0e-6, 1.0]]),
+      ),
+    );
+    circuit.add(jfet("J1", "vdd", "gate", "out", "NJF", 1.0e-3, -2.0));
+    circuit.add(resistor("Rs", "out", "0", 1_000.0));
+    circuit.add(capacitor("Cout", "out", "0", 1.0e-9));
+
+    const points = transient(circuit, 1.0e-7, 2.0e-6);
+
+    const initialOut = points[0].voltage("out");
+    const finalOut = points[points.length - 1].voltage("out");
+    expect(finalOut).toBeGreaterThan(initialOut! + 1.0);
+    expect(finalOut).toBeGreaterThan(1.5);
+    expect(finalOut).toBeLessThan(2.0);
+  });
+
   it("reports periods for periodic source waveforms", () => {
     expectClose(waveformPeriod(new SinWaveform(0.0, 1.0, 2.0)), 0.5);
     expect(waveformPeriod(new SinWaveform(0.0, 1.0, 2.0, 0.0, 1.0))).toBeUndefined();

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -77,6 +77,18 @@ Acceptance:
 - Cross-language AC tests for a small-signal common-source JFET stage.
 - Parser tests for model cards, device cards, and subcircuit terminal remapping.
 
+Status:
+
+- JFET element data structures, `.model <name> NJF(...)` /
+  `.model <name> PJF(...)` cards, and `J` device cards are implemented across
+  Python, TypeScript, and Rust.
+- JFET nonlinear DC operating-point stamping and small-signal AC stamping are
+  implemented across Python, TypeScript, and Rust.
+- JFET transient participation through the shared nonlinear transient solve path
+  is covered across Python, TypeScript, and Rust with source-follower output
+  capacitor fixtures.
+- Phase 1 is complete for the current compatibility target.
+
 ### Phase 2 - Mutual Inductors (`K` Cards)
 
 Add classic coupled inductors.


### PR DESCRIPTION
## Summary

- add cross-language JFET source-follower transient fixtures covering nonlinear companion-model solves
- document Phase 1 JFET status as complete for parser, DC, AC, and transient participation
- update Python, TypeScript, and Rust spice-engine changelogs

## Validation

- Python: `MISE_TRUSTED_CONFIG_PATHS=/Users/adhithya/Downloads/Codex/coding-adventures-spice-jfet-parser-api sh BUILD` in `code/packages/python/spice-engine`
- TypeScript: `sh BUILD` in `code/packages/typescript/spice-engine`
- Rust: `cargo fmt -p spice-engine --check && cargo test -p spice-engine --test transient_tests transient_jfet_source_follower_charges_output_capacitor` in `code/packages/rust`
- `git diff --check`
