### PR TITLE
Track browser anchor navigation metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -389,8 +389,21 @@ def check_browser_expected_lists(
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"
-        for field in ("href", "resolved_href", "name", "target", "rel", "title"):
+        for field in (
+            "href",
+            "resolved_href",
+            "name",
+            "target",
+            "rel",
+            "title",
+            "download",
+            "hreflang",
+            "type_hint",
+        ):
             require_optional_nullable_string(link_path, link, field, errors)
+        require_optional_string_list(link_path, link, "rel_tokens", errors)
+        require_optional_string_list(link_path, link, "ping", errors)
+        require_optional_string_list(link_path, link, "resolved_ping", errors)
         require_string(link_path, link, "text", errors)
 
     for index, image in enumerate(object_list_items(expected, "images")):
@@ -542,6 +555,10 @@ def check_browser_content_node(
         "text",
         "href",
         "resolved_href",
+        "target",
+        "rel",
+        "download",
+        "hreflang",
         "src",
         "resolved_src",
         "alt",
@@ -617,6 +634,9 @@ def check_browser_content_node(
         require_optional_nullable_string(node_path, node, field, errors)
     require_optional_integer(node_path, node, "heading_level", errors)
     require_optional_string_list(node_path, node, "classes", errors)
+    require_optional_string_list(node_path, node, "rel_tokens", errors)
+    require_optional_string_list(node_path, node, "ping", errors)
+    require_optional_string_list(node_path, node, "resolved_ping", errors)
     require_optional_string_list(node_path, node, "headers", errors)
     require_optional_string_list(node_path, node, "labels", errors)
     require_optional_string_list(node_path, node, "sandbox", errors)
@@ -701,6 +721,10 @@ def check_browser_render_node(
         "text",
         "href",
         "resolved_href",
+        "target",
+        "rel",
+        "download",
+        "hreflang",
         "src",
         "resolved_src",
         "alt",
@@ -776,6 +800,9 @@ def check_browser_render_node(
         require_optional_nullable_string(node_path, node, field, errors)
     require_optional_integer(node_path, node, "heading_level", errors)
     require_optional_string_list(node_path, node, "classes", errors)
+    require_optional_string_list(node_path, node, "rel_tokens", errors)
+    require_optional_string_list(node_path, node, "ping", errors)
+    require_optional_string_list(node_path, node, "resolved_ping", errors)
     require_optional_string_list(node_path, node, "headers", errors)
     require_optional_string_list(node_path, node, "labels", errors)
     require_optional_string_list(node_path, node, "sandbox", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -970,6 +970,13 @@ pub struct BrowserContentNode {
     pub text: Option<String>,
     pub href: Option<String>,
     pub resolved_href: Option<String>,
+    pub target: Option<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub download: Option<String>,
+    pub ping: Vec<String>,
+    pub resolved_ping: Vec<String>,
+    pub hreflang: Option<String>,
     pub src: Option<String>,
     pub resolved_src: Option<String>,
     pub alt: Option<String>,
@@ -1092,6 +1099,13 @@ pub struct BrowserRenderNode {
     pub text: Option<String>,
     pub href: Option<String>,
     pub resolved_href: Option<String>,
+    pub target: Option<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub download: Option<String>,
+    pub ping: Vec<String>,
+    pub resolved_ping: Vec<String>,
+    pub hreflang: Option<String>,
     pub src: Option<String>,
     pub resolved_src: Option<String>,
     pub alt: Option<String>,
@@ -1208,7 +1222,13 @@ pub struct BrowserLink {
     pub name: Option<String>,
     pub target: Option<String>,
     pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
     pub title: Option<String>,
+    pub download: Option<String>,
+    pub ping: Vec<String>,
+    pub resolved_ping: Vec<String>,
+    pub hreflang: Option<String>,
+    pub type_hint: Option<String>,
     pub text: String,
 }
 
@@ -1429,6 +1449,13 @@ impl BrowserRenderNode {
             text: content_node.text.clone(),
             href: content_node.href.clone(),
             resolved_href: content_node.resolved_href.clone(),
+            target: content_node.target.clone(),
+            rel: content_node.rel.clone(),
+            rel_tokens: content_node.rel_tokens.clone(),
+            download: content_node.download.clone(),
+            ping: content_node.ping.clone(),
+            resolved_ping: content_node.resolved_ping.clone(),
+            hreflang: content_node.hreflang.clone(),
             src: content_node.src.clone(),
             resolved_src: content_node.resolved_src.clone(),
             alt: content_node.alt.clone(),
@@ -8466,7 +8493,16 @@ fn collect_browser_facts(
                 name: element.attribute("name").map(ToOwned::to_owned),
                 target: element.attribute("target").map(ToOwned::to_owned),
                 rel: element.attribute("rel").map(ToOwned::to_owned),
+                rel_tokens: browser_rel_tokens(element),
                 title: element.attribute("title").map(ToOwned::to_owned),
+                download: browser_anchor_download(element),
+                resolved_ping: browser_anchor_ping(element)
+                    .into_iter()
+                    .filter_map(|ping| resolve_browser_url(&ping, summary.base_href.as_deref()))
+                    .collect(),
+                ping: browser_anchor_ping(element),
+                hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
+                type_hint: element.attribute("type").map(ToOwned::to_owned),
                 text: visible_text_for_nodes(&element.children),
             }),
             "picture" => {
@@ -9081,6 +9117,13 @@ fn collect_browser_content_nodes_with_mode(
                         text: Some(text),
                         href: None,
                         resolved_href: None,
+                        target: None,
+                        rel: None,
+                        rel_tokens: Vec::new(),
+                        download: None,
+                        ping: Vec::new(),
+                        resolved_ping: Vec::new(),
+                        hreflang: None,
                         src: None,
                         resolved_src: None,
                         alt: None,
@@ -9266,6 +9309,16 @@ fn browser_content_node_for_element(
             .as_deref()
             .and_then(|href| resolve_browser_url(href, base_href)),
         href,
+        target: browser_anchor_target(element),
+        rel: browser_anchor_rel(element),
+        rel_tokens: browser_anchor_rel_tokens(element),
+        download: browser_anchor_download(element),
+        resolved_ping: browser_anchor_ping(element)
+            .into_iter()
+            .filter_map(|ping| resolve_browser_url(&ping, base_href))
+            .collect(),
+        ping: browser_anchor_ping(element),
+        hreflang: browser_anchor_hreflang(element),
         resolved_src: src
             .as_deref()
             .and_then(|src| resolve_browser_url(src, base_href)),
@@ -9698,12 +9751,16 @@ fn browser_link_is_stylesheet(element: &Element) -> bool {
 }
 
 fn browser_rel_contains(element: &Element, token: &str) -> bool {
+    browser_rel_tokens(element)
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(token))
+}
+
+fn browser_rel_tokens(element: &Element) -> Vec<String> {
     element
         .attribute("rel")
         .map(split_html_classes)
         .unwrap_or_default()
-        .iter()
-        .any(|candidate| candidate.eq_ignore_ascii_case(token))
 }
 
 fn element_text_if_non_empty(element: &Element) -> Option<String> {
@@ -10021,6 +10078,53 @@ fn browser_command(element: &Element) -> Option<String> {
 
 fn browser_command_for(element: &Element) -> Option<String> {
     element.attribute("commandfor").map(ToOwned::to_owned)
+}
+
+fn is_browser_anchor_navigation_element(element: &Element) -> bool {
+    matches!(element.name.as_str(), "a" | "area")
+}
+
+fn browser_anchor_target(element: &Element) -> Option<String> {
+    is_browser_anchor_navigation_element(element)
+        .then(|| element.attribute("target").map(ToOwned::to_owned))
+        .flatten()
+}
+
+fn browser_anchor_rel(element: &Element) -> Option<String> {
+    is_browser_anchor_navigation_element(element)
+        .then(|| element.attribute("rel").map(ToOwned::to_owned))
+        .flatten()
+}
+
+fn browser_anchor_rel_tokens(element: &Element) -> Vec<String> {
+    if is_browser_anchor_navigation_element(element) {
+        browser_rel_tokens(element)
+    } else {
+        Vec::new()
+    }
+}
+
+fn browser_anchor_download(element: &Element) -> Option<String> {
+    is_browser_anchor_navigation_element(element)
+        .then(|| element.attribute("download").map(ToOwned::to_owned))
+        .flatten()
+}
+
+fn browser_anchor_ping(element: &Element) -> Vec<String> {
+    if is_browser_anchor_navigation_element(element) {
+        element
+            .attribute("ping")
+            .map(split_html_classes)
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+fn browser_anchor_hreflang(element: &Element) -> Option<String> {
+    is_browser_anchor_navigation_element(element)
+        .then(|| element.attribute("hreflang").map(ToOwned::to_owned))
+        .flatten()
 }
 
 fn browser_editing_mode(element: &Element) -> Option<String> {
@@ -10882,6 +10986,62 @@ mod tests {
             resolve_browser_url("relative.html", Some("/local/base/")),
             None
         );
+    }
+
+    #[test]
+    fn browser_anchor_navigation_metadata_tracks_targets_and_pings() {
+        let document = parse_html(
+            "<base href=\"https://example.test/docs/current.html\">\
+             <body><p>Go <a id=next href=next.html target=_blank rel=\"next external noopener\" \
+             title=\"Next page\" download=next.html ping=\"audit.html https://metrics.example/p\" \
+             hreflang=en-US type=text/html>Next</a></p>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        let link = &summary.links[0];
+        assert_eq!(link.href.as_deref(), Some("next.html"));
+        assert_eq!(
+            link.resolved_href.as_deref(),
+            Some("https://example.test/docs/next.html")
+        );
+        assert_eq!(link.target.as_deref(), Some("_blank"));
+        assert_eq!(link.rel.as_deref(), Some("next external noopener"));
+        assert_eq!(link.rel_tokens, vec!["next", "external", "noopener"]);
+        assert_eq!(link.download.as_deref(), Some("next.html"));
+        assert_eq!(link.ping, vec!["audit.html", "https://metrics.example/p"]);
+        assert_eq!(
+            link.resolved_ping,
+            vec![
+                "https://example.test/docs/audit.html",
+                "https://metrics.example/p"
+            ]
+        );
+        assert_eq!(link.hreflang.as_deref(), Some("en-US"));
+        assert_eq!(link.type_hint.as_deref(), Some("text/html"));
+
+        let content_tree = BrowserContentTree::from_document(&document);
+        let content_link = &content_tree.children[0].children[1];
+        assert_eq!(content_link.target.as_deref(), Some("_blank"));
+        assert_eq!(
+            content_link.rel_tokens,
+            vec!["next", "external", "noopener"]
+        );
+        assert_eq!(content_link.download.as_deref(), Some("next.html"));
+        assert_eq!(
+            content_link.resolved_ping,
+            vec![
+                "https://example.test/docs/audit.html",
+                "https://metrics.example/p"
+            ]
+        );
+        assert_eq!(content_link.hreflang.as_deref(), Some("en-US"));
+
+        let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
+        let render_link = &render_tree.children[0].children[1];
+        assert_eq!(render_link.target.as_deref(), Some("_blank"));
+        assert_eq!(render_link.rel_tokens, vec!["next", "external", "noopener"]);
+        assert_eq!(render_link.download.as_deref(), Some("next.html"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -44,6 +44,20 @@ struct ExpectedContentNode {
     href: Option<String>,
     #[serde(default)]
     resolved_href: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    download: Option<String>,
+    #[serde(default)]
+    ping: Vec<String>,
+    #[serde(default)]
+    resolved_ping: Vec<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
     src: Option<String>,
     #[serde(default)]
     resolved_src: Option<String>,
@@ -292,6 +306,13 @@ impl ExpectedContentNode {
             text: self.text,
             href: self.href,
             resolved_href: self.resolved_href,
+            target: self.target,
+            rel: self.rel,
+            rel_tokens: self.rel_tokens,
+            download: self.download,
+            ping: self.ping,
+            resolved_ping: self.resolved_ping,
+            hreflang: self.hreflang,
             src: self.src,
             resolved_src: self.resolved_src,
             alt: self.alt,

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -243,7 +243,19 @@ struct ExpectedLink {
     name: Option<String>,
     target: Option<String>,
     rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
     title: Option<String>,
+    #[serde(default)]
+    download: Option<String>,
+    #[serde(default)]
+    ping: Vec<String>,
+    #[serde(default)]
+    resolved_ping: Vec<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
     text: String,
 }
 
@@ -666,7 +678,13 @@ impl ExpectedLink {
             name: self.name,
             target: self.target,
             rel: self.rel,
+            rel_tokens: self.rel_tokens,
             title: self.title,
+            download: self.download,
+            ping: self.ping,
+            resolved_ping: self.resolved_ping,
+            hreflang: self.hreflang,
+            type_hint: self.type_hint,
             text: self.text,
         }
     }

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -45,6 +45,20 @@ struct ExpectedRenderNode {
     href: Option<String>,
     #[serde(default)]
     resolved_href: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    download: Option<String>,
+    #[serde(default)]
+    ping: Vec<String>,
+    #[serde(default)]
+    resolved_ping: Vec<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
     src: Option<String>,
     #[serde(default)]
     resolved_src: Option<String>,
@@ -294,6 +308,13 @@ impl ExpectedRenderNode {
             text: self.text,
             href: self.href,
             resolved_href: self.resolved_href,
+            target: self.target,
+            rel: self.rel,
+            rel_tokens: self.rel_tokens,
+            download: self.download,
+            ping: self.ping,
+            resolved_ping: self.resolved_ping,
+            hreflang: self.hreflang,
             src: self.src,
             resolved_src: self.resolved_src,
             alt: self.alt,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-content-tree.json
@@ -5,8 +5,8 @@
   "cases": [
     {
       "id": "classic-document-flow",
-      "description": "Head metadata is skipped while headings, paragraphs, base-resolved links, images, line breaks, and lists stay renderable.",
-      "input": "<!doctype html><title>Example</title><base href=\"https://example.test/docs/\"><link rel=stylesheet href=style.css><h1 id=top class=\"headline primary\" title=\"Directory\" lang=en dir=ltr>Example Directory</h1><p class=lede>Welcome to <a id=intro-link class=nav href=intro.html title=\"Read intro\">Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
+      "description": "Head metadata is skipped while headings, paragraphs, base-resolved navigation links, images, line breaks, and lists stay renderable.",
+      "input": "<!doctype html><title>Example</title><base href=\"https://example.test/docs/\"><link rel=stylesheet href=style.css><h1 id=top class=\"headline primary\" title=\"Directory\" lang=en dir=ltr>Example Directory</h1><p class=lede>Welcome to <a id=intro-link class=nav href=intro.html target=main rel=\"next external\" title=\"Read intro\" download=intro.html ping=\"track.html https://metrics.example/p\" hreflang=en type=text/html>Venture HTML</a>.<br><img src=logo.gif alt=Logo><ul><li>One<li>Two",
       "expected": {
         "children": [
           {
@@ -47,6 +47,14 @@
                 "text": "Venture HTML",
                 "href": "intro.html",
                 "resolved_href": "https://example.test/docs/intro.html",
+                "target": "main",
+                "rel": "next external",
+                "rel_tokens": ["next", "external"],
+                "download": "intro.html",
+                "ping": ["track.html", "https://metrics.example/p"],
+                "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"],
+                "hreflang": "en",
+                "type_hint": "text/html",
                 "src": null,
                 "alt": null,
                 "control_type": null,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -5,8 +5,8 @@
   "cases": [
     {
       "id": "legacy-directory-page",
-      "description": "Omitted shell, title/base metadata, anchors, image attributes, and implied list-item endings.",
-      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=next title=\"Intro\">Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
+      "description": "Omitted shell, title/base metadata, anchors, navigation attributes, image attributes, and implied list-item endings.",
+      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=\"next external noreferrer\" title=\"Intro\" download=intro.html ping=\"track.html https://metrics.example/p\" hreflang=en type=text/html>Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
       "expected": {
         "title": "Example & Links",
         "base_href": "https://example.test/docs/",
@@ -30,7 +30,7 @@
           { "level": 1, "text": "Example Directory" }
         ],
         "links": [
-          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "rel": "next", "title": "Intro", "text": "Venture HTML" }
+          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "hreflang": "en", "type_hint": "text/html", "text": "Venture HTML" }
         ],
         "images": [
           { "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "width": "88", "height": "31" }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-render-tree.json
@@ -5,8 +5,8 @@
   "cases": [
     {
       "id": "flow-inline-and-replaced",
-      "description": "Headings and paragraphs become block layout inputs while base-resolved text, links, images, and line breaks keep inline display categories.",
-      "input": "<base href=\"https://example.test/pages/current.html\"><body><h1 id=page-title class=hero>Example</h1><p id=intro class=\"lede print\" title=\"Intro paragraph\">Hello <a href=next.html class=next lang=en>Next</a><img src=../assets/logo.gif alt=Logo><br>Tail</p>",
+      "description": "Headings and paragraphs become block layout inputs while base-resolved text, navigation links, images, and line breaks keep inline display categories.",
+      "input": "<base href=\"https://example.test/pages/current.html\"><body><h1 id=page-title class=hero>Example</h1><p id=intro class=\"lede print\" title=\"Intro paragraph\">Hello <a href=next.html class=next lang=en target=_blank rel=\"next noopener\" download=next.html ping=\"audit.html https://metrics.example/p\" hreflang=en-US type=text/html>Next</a><img src=../assets/logo.gif alt=Logo><br>Tail</p>",
       "expected": {
         "children": [
           {
@@ -48,6 +48,14 @@
                 "text": "Next",
                 "href": "next.html",
                 "resolved_href": "https://example.test/pages/next.html",
+                "target": "_blank",
+                "rel": "next noopener",
+                "rel_tokens": ["next", "noopener"],
+                "download": "next.html",
+                "ping": ["audit.html", "https://metrics.example/p"],
+                "resolved_ping": ["https://example.test/pages/audit.html", "https://metrics.example/p"],
+                "hreflang": "en-US",
+                "type_hint": "text/html",
                 "src": null,
                 "alt": null,
                 "control_type": null,


### PR DESCRIPTION
## Summary
- add target, rel token, download, ping, hreflang, and type-hint metadata to browser links and anchor content/render nodes
- resolve anchor ping URLs against the document base alongside href resolution
- update browser readiness/content/render fixtures and schema governance for anchor navigation metadata

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_anchor_navigation_metadata_tracks_targets_and_pings
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser