### PR TITLE
spice: refresh phase 2 and 3 compatibility status

### DIFF
--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -107,6 +107,17 @@ Acceptance:
 - Transient coupled-inductor smoke test.
 - Parser rejection for missing referenced inductors and non-finite coupling.
 
+Status:
+
+- `MutualInductor` / `mutualInductor` / `MutualInductor` element surfaces are
+  implemented across Python, TypeScript, and Rust.
+- `Kname L1 L2 coefficient` parser cards are implemented across Python,
+  TypeScript, and Rust, including subcircuit reference remapping and rejection
+  for missing referenced inductors or non-finite coupling.
+- AC transformer-ratio fixtures and transient coupled-inductor smoke fixtures
+  cover the mutual terms across Python, TypeScript, and Rust.
+- Phase 2 is complete for the current compatibility target.
+
 ### Phase 3 - Ideal Transmission Lines (`T` Cards)
 
 Add ideal lossless transmission-line support as the classic distributed element.
@@ -128,8 +139,15 @@ Acceptance:
 
 Status:
 
-- Parser support and AC phase-shift behavior are on `main`; this slice adds
-  transient delayed-step behavior across Python, TypeScript, and Rust.
+- `TransmissionLine` / `transmissionLine` / `TransmissionLine` element
+  surfaces are implemented across Python, TypeScript, and Rust.
+- Conservative `Tname n1 n2 n3 n4 Z0=<z> TD=<delay>` parser cards are
+  implemented across Python, TypeScript, and Rust, including subcircuit node
+  remapping and rejection for unsupported positional and non-positive parameter
+  forms.
+- AC phase-delay fixtures and transient delayed-step fixtures cover the
+  lossless line behavior across Python, TypeScript, and Rust.
+- Phase 3 is complete for the current compatibility target.
 
 ### Phase 4 - Gear-2 / BDF2 Transient Integration
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -188,8 +188,9 @@ files.
 | v0.8.0 | #2359 | Monte Carlo (`.MC`) — Gaussian + uniform tolerance distributions |
 | v0.9.0 | #2370 | Noise analysis (`.NOISE`) — Johnson-Nyquist, MOSFET channel thermal, and shot noise; adjoint method |
 
-**Elements on main:** `Resistor`, `Capacitor`, `Inductor`, `VoltageSource`,
-`CurrentSource`, `BSource`, `Diode`, `Mosfet`, `BJT`
+**Elements on main:** `Resistor`, `Capacitor`, `Inductor`, `MutualInductor`,
+`TransmissionLine`, `VoltageSource`, `CurrentSource`, `BSource`, `Diode`,
+`Mosfet`, `BJT`, `JFET`
 
 **Analyses on main:** `dc_op`, `transient`, `ac_sweep`, `tf`, `dc_sweep`,
 `sens_dc`, `mc_dc`, `noise_ac`
@@ -197,7 +198,8 @@ files.
 **Waveforms on main:** `PwlWaveform`, `SinWaveform`, `PulseWaveform`, `ExpWaveform`
 
 **Netlist parser on main:** `spice-netlist-parser` 0.2.0 — parses R, C, L, V,
-I, M (MOSFET), D, Q (BJT), E/G/F/H (controlled sources), `.subckt` / X instances,
+I, M (MOSFET), D, Q (BJT), J (JFET), K (mutual inductor), T (lossless
+transmission line), E/G/F/H (controlled sources), `.subckt` / X instances,
 `.tran`, `.dc`, `.ac`, `.op`, `.tf`, `.sens`, `.mc`, `.noise`, `.model` cards;
 IC parameters for C/L; AC phasor specs for V/I sources.
 
@@ -205,11 +207,12 @@ IC parameters for C/L; AC phasor specs for V/I sources.
 
 ### What is in flight
 
-- 1970s SPICE compatibility planning: the next workstream is tracked in
-  `spice-1970s-compatibility.md`, starting with JFET device/model-card support,
-  then mutual inductors, ideal transmission lines, Gear-2 transient integration,
-  pseudo-transient DC continuation, model-card depth, classic text output cards,
-  and the remaining SPICE2 small-signal analysis surface.
+- 1970s SPICE compatibility planning: the active workstream is tracked in
+  `spice-1970s-compatibility.md`. JFET device/model-card support, mutual
+  inductors, ideal transmission lines, Gear-2 transient integration,
+  pseudo-transient DC continuation, 1970s model-card depth, classic text output
+  cards, and the first Phase 8 small-signal distortion / pole-zero footholds
+  are now reflected there with per-phase status.
 
 ---
 
@@ -238,11 +241,12 @@ and the sparse real solver path landed in PR #3391.
 
 #### SPICE 1970s compatibility
 
-The compatibility workstream is now split into concrete phases in
+The compatibility workstream is split into concrete phases in
 `code/specs/spice-1970s-compatibility.md`. This is the plan to move the current
 solver from a strong SPICE-compatible educational engine toward a recognizable
-Berkeley SPICE1/SPICE2-era simulator surface. The first implementation phase is
-JFET device and `.model` / `J` card support.
+Berkeley SPICE1/SPICE2-era simulator surface. Phase 1 JFET support, Phase 2
+mutual inductors, and Phase 3 ideal transmission lines are complete for the
+current compatibility target.
 
 ---
 


### PR DESCRIPTION
## Summary

- mark Phase 2 mutual-inductor support complete in the SPICE 1970s compatibility plan
- refresh Phase 3 transmission-line status to reflect parser, AC, and transient coverage on main
- update the SPICE section of the pending-work document with current elements and parser cards

## Validation

- `git diff --check`
