### PR TITLE
feat(ruby-parser): Phase 6o — ternary `cond ? a : b`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -142,7 +142,29 @@ expression_stmt = expression ;
 # Operator alternation lists `"..."` before `".."` defensively, but
 # the lexer already pre-fuses the two forms into distinct tokens so
 # the order is not actually significant.
-expression   = range ;
+# Phase 6o — ternary `cond ? a : b`.
+#
+# Precedence: ternary sits ABOVE range (looser than `..`/`...`)
+# and below assignment.  In Ruby:
+#   a..b ? c : d         parses as  (a..b) ? c : d
+#   a = b ? c : d        parses as  a = (b ? c : d)
+# Our `assignment` rule is statement-level (not in the expression
+# hierarchy), so we only need to slot ternary above range:
+#
+#   expression = ternary
+#   ternary    = range [ "?" expression ":" expression ]
+#
+# Right-associativity (`a ? b : c ? d : e` → `a ? b : (c ? d : e)`)
+# falls out naturally because the false-branch recurses into
+# `expression` (which is `ternary` at the top).
+#
+# Colon ambiguity note: `:foo` opens a symbol literal in `factor`.
+# But by the time the ternary `:` is reached, the true-branch
+# (`b` in `a ? b : c`) has already completed its `factor` parse —
+# control has unwound back to the ternary rule, so the `:` it
+# consumes is the ternary separator, not a symbol opener.
+expression   = ternary ;
+ternary      = range [ "?" expression ":" expression ] ;
 range        = logical_or [ ( "..." | ".." ) logical_or ] ;
 logical_or   = logical_and { ( "||" | "or" ) logical_and } ;
 logical_and  = logical_not { ( "&&" | "and" ) logical_not } ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.16.0] - 2026-05-24
+
+### Added (Phase 6o — ternary `cond ? a : b`)
+
+New grammar layer inserted between `expression` and `range`:
+
+```
+expression = ternary ;
+ternary    = range [ "?" expression ":" expression ] ;
+```
+
+**Precedence**: ternary sits above range (looser than `..`/`...`) and below assignment.  So `a..b ? c : d` parses as `(a..b) ? c : d`, and `x = b ? c : d` parses as `x = (b ? c : d)` (since `assignment` is statement-level, outside the expression hierarchy).
+
+**Right-associativity**: `a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`.  The false-branch recurses through `expression` (→ ternary at the top), so the inner ternary nests inside the outer's else.
+
+**Colon ambiguity**: `:foo` opens a `symbol_literal` in `factor`.  But by the time the ternary's `:` is reached, the true-branch's factor has already completed and control has unwound back to the ternary rule.  The grammar parser consumes the `:` as the ternary separator, not as a symbol opener.
+
+**Token typing**: `?` lexes as a `Name`-typed Op token with value `?` (catch-all in `classify_op_token`); `:` lexes as `TokenType::Colon`.  Grammar matches by value (`"?"`, `":"`) — same trick as `"=>"`, `"<="`, etc.
+
+### Tests (+3 new, total 74)
+- `test_parse_simple_ternary` — `x = 1 ? 2 : 3` produces a ternary node carrying `?` and `:`.
+- `test_parse_ternary_right_associative` — `x = a ? b : c ? d : e` carries two `?` and two `:` tokens.
+- `test_parse_ternary_inside_array_literal` — `[1 ? 2 : 3]` works as an array element.
+
+All tests wrap the ternary in an assignment to dodge the bare-NAME-led statement ambiguity (lessons.md).
+
 ## [0.15.0] - 2026-05-24
 
 ### Added (Phase 6n — range expressions `..` and `...`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -337,8 +337,21 @@ pub fn parser_grammar() -> ParserGrammar {
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
-            body: GrammarElement::RuleReference { name: r#"range"#.to_string() },
-            line_number: 145,
+            body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
+            line_number: 166,
+        },
+        GrammarRule {
+            name: r#"ternary"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"range"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"?"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                        GrammarElement::Literal { value: r#":"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 167,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -352,7 +365,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 146,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -366,7 +379,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 147,
+            line_number: 169,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -380,7 +393,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 148,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -391,7 +404,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 155,
+            line_number: 177,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -409,7 +422,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 156,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -423,7 +436,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 157,
+            line_number: 179,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -437,7 +450,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 158,
+            line_number: 180,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -460,7 +473,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 168,
+            line_number: 190,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -468,7 +481,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 169,
+            line_number: 191,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -480,7 +493,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 170,
+            line_number: 192,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -495,7 +508,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 171,
+            line_number: 193,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -510,7 +523,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 172,
+            line_number: 194,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -526,7 +539,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 173,
+            line_number: 195,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1119,6 +1119,59 @@ mod tests {
         assert!(tree_has_token_value(arr, ".."));
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 6o — ternary `cond ? a : b`
+    // -----------------------------------------------------------------------
+    //
+    // The grammar rule is `ternary = range [ "?" expression ":" expression ]`.
+    // A bare expression with no `?` still produces a `ternary` node (the
+    // rule is the new expression entry point), but with exactly one
+    // `range` operand and no `?` token.
+
+    #[test]
+    fn test_parse_simple_ternary() {
+        // `x = 1 ? 2 : 3` — wrapped in an assignment to dodge the
+        // bare-NAME-led statement ambiguity (lessons.md).
+        let ast = parse_ruby("x = 1 ? 2 : 3");
+        let t = find_descendant(&ast, "ternary").expect("expected ternary node");
+        assert!(tree_has_token_value(t, "?"), "expected `?` token");
+        assert!(tree_has_token_value(t, ":"), "expected `:` token");
+    }
+
+    #[test]
+    fn test_parse_ternary_right_associative() {
+        // `x = a ? b : c ? d : e` — chained ternary, right-associative.
+        // Two `?` and two `:` tokens; SIR test will pin the nesting.
+        let ast = parse_ruby("x = a ? b : c ? d : e");
+        let t = find_descendant(&ast, "ternary").expect("expected ternary node");
+        fn count_value(node: &GrammarASTNode, val: &str) -> usize {
+            let mut n = 0;
+            for c in &node.children {
+                match c {
+                    ASTNodeOrToken::Token(t) if t.value == val => n += 1,
+                    ASTNodeOrToken::Node(sub) => n += count_value(sub, val),
+                    _ => {}
+                }
+            }
+            n
+        }
+        assert_eq!(count_value(t, "?"), 2, "expected two `?` tokens");
+        assert_eq!(count_value(t, ":"), 2, "expected two `:` tokens");
+    }
+
+    #[test]
+    fn test_parse_ternary_inside_array_literal() {
+        // `[1 ? 2 : 3]` — ternary as an array element parses cleanly.
+        let ast = parse_ruby("[1 ? 2 : 3]");
+        let arr = find_descendant(&ast, "array_literal").expect("expected array_literal");
+        assert!(
+            find_descendant(arr, "ternary").is_some(),
+            "expected ternary inside array_literal"
+        );
+        assert!(tree_has_token_value(arr, "?"));
+        assert!(tree_has_token_value(arr, ":"));
+    }
+
     #[test]
     fn test_parse_range_with_paren_logical_operands() {
         // `(a || b)..(c || d)` — explicit parens make precedence

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.16.0] - 2026-05-24
+
+### Added (Phase 6o — ternary lowering)
+
+SIR encoding:
+```
+cond ? a : b  →  Expr::If {
+                   cond,
+                   then_branch: Block { stmts: [], value: a },
+                   else_branch: Block { stmts: [], value: b },
+                 }
+```
+
+Lowering identically to `if cond then a else b end` means downstream emitters (semantic-ir-to-python, semantic-ir-to-rust, etc.) need no new code path — the existing if-lowering paths handle both syntactic forms transparently.
+
+**Right-associativity** falls out of the grammar: `a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`, so the inner ternary nests inside the outer's else-branch as another `Expr::If`.
+
+### Lowerer changes
+- `lower_expression` gained a `"ternary"` dispatch arm.
+- New helper `lower_ternary(node)` filters operand sub-nodes: one operand (pass-through) or three (cond/then/else → `Expr::If`).
+
+### Tests (+3 new, total 77)
+- `ternary_lowers_to_if_expr_with_branch_blocks` — `x = 1 ? 2 : 3` → `LetBinding { value: If { cond=1, then=2, else=3 } }`.
+- `ternary_right_associative_nests_in_else_branch` — `x = 1 ? 2 : 3 ? 4 : 5` produces a nested If in the outer else.
+- `ternary_module_passes_sir_validator` — end-to-end validator smoke test.
+
 ## [0.15.0] - 2026-05-24
 
 ### Added (Phase 6n — range expressions lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1382,4 +1382,84 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6o — ternary `cond ? a : b` lowering
+    // -----------------------------------------------------------------
+    //
+    // SIR encoding:
+    //   `cond ? a : b` → Expr::If { cond, then_branch: Block{value:a},
+    //                               else_branch: Block{value:b} }
+    //
+    // Lowering identically to `if cond then a else b end` means
+    // downstream emitters need no new dispatch — the existing
+    // if-lowering paths handle both syntactic forms transparently.
+
+    #[test]
+    fn ternary_lowers_to_if_expr_with_branch_blocks() {
+        // `x = 1 ? 2 : 3` — the RHS of the assignment is the ternary,
+        // which lowers to Expr::If { cond=1, then=2, else=3 }.
+        let m = lower("x = 1 ? 2 : 3\n");
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .unwrap_or_else(|| panic!("expected main function, got {:?}",
+                m.functions.iter().map(|f| f.name.as_str()).collect::<Vec<_>>()));
+        // The main body's first statement is a LetBinding whose value is the ternary.
+        let stmt = f.body.stmts.first().expect("expected at least one stmt");
+        let value = match stmt {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::If { cond, then_branch, else_branch, .. } => {
+                assert!(matches!(cond.as_ref(), Expr::IntLit { value: 1, .. }),
+                    "expected cond = IntLit(1), got {:?}", cond);
+                assert!(matches!(&then_branch.value, Expr::IntLit { value: 2, .. }),
+                    "expected then = IntLit(2), got {:?}", then_branch.value);
+                assert!(matches!(&else_branch.value, Expr::IntLit { value: 3, .. }),
+                    "expected else = IntLit(3), got {:?}", else_branch.value);
+            }
+            other => panic!("expected Expr::If, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ternary_right_associative_nests_in_else_branch() {
+        // `x = a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`.
+        // SIR: outer If's else-branch contains an inner If.
+        let m = lower("x = 1 ? 2 : 3 ? 4 : 5\n");
+        let f = m.functions.iter().find(|f| f.name == "main").unwrap();
+        let stmt = f.body.stmts.first().expect("expected at least one stmt");
+        let value = match stmt {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::If { else_branch, .. } => {
+                match &else_branch.value {
+                    Expr::If { cond: inner_cond, then_branch: inner_then, else_branch: inner_else, .. } => {
+                        assert!(matches!(inner_cond.as_ref(), Expr::IntLit { value: 3, .. }));
+                        assert!(matches!(&inner_then.value, Expr::IntLit { value: 4, .. }));
+                        assert!(matches!(&inner_else.value, Expr::IntLit { value: 5, .. }));
+                    }
+                    other => panic!("expected nested If in else branch, got {:?}", other),
+                }
+            }
+            other => panic!("expected outer Expr::If, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ternary_module_passes_sir_validator() {
+        // End-to-end smoke test: validator accepts the ternary lowering.
+        let m = lower("x = 1 ? 2 : 3\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected ternary output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1198,6 +1198,11 @@ impl Lowerer {
             // `BuiltinCall("or", [lhs, rhs])`.  Operator forms `||`
             // (symbol) and `or` (keyword) lower identically — see the
             // grammar comment for the v0 simplification.
+            // Phase 6o — ternary `cond ? a : b`.  Either a bare
+            // `range` pass-through or an `Expr::If` with single-expression
+            // branch blocks.  Lowers identically to `if cond then a else b end`
+            // so downstream emitters need no new code path.
+            "ternary" => self.lower_ternary(node),
             // Phase 6n — range expressions `a..b` (inclusive) and
             // `a...b` (exclusive).  Either a bare `logical_or` pass-through
             // or a `BuiltinCall("range", [start, end, BoolLit(exclusive)])`.
@@ -1536,6 +1541,76 @@ impl Lowerer {
                 message: format!(
                     "range node had {n} operand(s) and op={:?} — expected (1, None) or (2, Some(..|...))",
                     op_tok.map(|t| t.value.clone()),
+                ),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6o — ternary `cond ? a : b`
+    // -------------------------------------------------------------------
+
+    /// Lower a `ternary` node.  Grammar shape:
+    ///
+    ///   ternary = range [ "?" expression ":" expression ]
+    ///
+    /// Two cases:
+    ///   - One operand sub-node (just a `range`, no `?`) → pass through.
+    ///   - Three operand sub-nodes (`range "?" expression ":" expression`)
+    ///     → emit `Expr::If` wrapping each branch in a single-expression
+    ///     `Block`.  Lowers identically to `if cond then a else b end`
+    ///     so all downstream emitters (semantic-ir-to-python, etc.) reuse
+    ///     existing if-lowering code paths.
+    ///
+    /// Right-associativity (`a ? b : c ? d : e` → `a ? b : (c ? d : e)`)
+    /// is enforced by the grammar's recursion into `expression` for the
+    /// false branch.  Each `expression` recursion bottoms back out at
+    /// `ternary` at the top of the precedence pyramid, so the inner
+    /// ternary appears as the else-branch's value.
+    fn lower_ternary(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        // Collect operand sub-nodes (each is an `expression`-shaped
+        // subtree: the first is `range`, the trailing two are
+        // `expression`).
+        let operands: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        match operands.len() {
+            // Bare range pass-through — no `?` operator.
+            1 => self.lower_expression(operands[0]),
+            // cond ? then : else — three operand sub-nodes.
+            3 => {
+                let cond = self.lower_expression(operands[0])?;
+                let then_value = self.lower_expression(operands[1])?;
+                let else_value = self.lower_expression(operands[2])?;
+                let span = self.span_of(node);
+                let then_block = Block {
+                    stmts: Vec::new(),
+                    value: then_value,
+                    span: span.clone(),
+                };
+                let else_block = Block {
+                    stmts: Vec::new(),
+                    value: else_value,
+                    span: span.clone(),
+                };
+                Ok(Expr::If {
+                    cond: Box::new(cond),
+                    then_branch: Box::new(then_block),
+                    else_branch: Box::new(else_block),
+                    span,
+                })
+            }
+            n => Err(RubyLowerError {
+                message: format!(
+                    "ternary node had {n} operand sub-node(s) — expected 1 (pass-through) or 3 (cond/then/else)",
                 ),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),


### PR DESCRIPTION
## Summary

- Adds Ruby ternary `cond ? a : b` to the grammar.
- Inserts a new `ternary` rule between `expression` and `range`, with right-associative chaining via recursion into `expression`.
- Lowers to `Expr::If` with single-expression branch blocks — identical to `if cond then a else b end`, so downstream emitters need no new code path.

## Grammar change

```
expression = ternary ;
ternary    = range [ "?" expression ":" expression ] ;
```

- Right-associativity: `a ? b : c ? d : e` parses as `a ? b : (c ? d : e)` because the false-branch recurses through `expression` (→ ternary at the top).
- Colon ambiguity dodged: the ternary's `:` is reached only after the true-branch's `factor` parse has completed and control has unwound to the ternary rule.

## SIR lowering

```
cond ? a : b → Expr::If {
                 cond,
                 then_branch: Block { stmts: [], value: a },
                 else_branch: Block { stmts: [], value: b },
               }
```

Identical to the if-statement lowering — all backends (semantic-ir-to-python, -rust, -typescript, -go) handle both syntactic forms through the same path.

## Tests

- `coding-adventures-ruby-parser`: 71 → 74 (+3 grammar tests).
- `ruby-to-semantic-ir`: 74 → 77 (+3 lowering tests).
- `coding-adventures-ruby-lexer`: 149 (unchanged).

Test plan:

- [x] `cargo test -p coding-adventures-ruby-parser` (74/74 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (77/77 pass)
- [x] `cargo test -p coding-adventures-ruby-lexer` (149/149 pass)
- [x] Security review via `/security-review` — passed
- [ ] CI green

Follows PR #4229 (Phase 4m — backtick command literals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
