### PR TITLE
feat(cas-summation): Phase 57 — Bounded × Log × Sqrt numerator (TS + Rust port, 1.5.0)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.5.0 — 2026-05-24
+
+**Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator
+(Rust port).**
+
+Ports Python ``cas-summation`` 1.5.0 (PR #4215).  Closes the mixed
+sub-polynomial gap left by Phase 55 (bounded × Log) and Phase 56
+(bounded × Sqrt).
+
+### Added
+
+- **`bounded_log_sqrt_inner_deg(node, k) -> Option<i64>`** — returns
+  ``deg(P)`` (×2 half-degree to stay in i64 arithmetic) for ``Mul``
+  with exactly one ``Log(diverging)`` AND one ``Sqrt(positive-poly)``
+  factor (plus optional bounded factors).  Returns ``None`` for zero/
+  two-Log, zero/two-Sqrt, or unrecognised factors.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds Phase 57 branch after Phase 56,
+  comparing ``2 * den_deg > deg(P)`` for polynomial denominators or
+  short-circuiting on non-polynomial divergence.
+
+### Tests
+
+3 new ``phase57_*`` cases.  Full suite: **72 passed** (was 69; +3).
+
 ## 1.4.0 — 2026-05-23
 
 **Phase 56 — Bounded × Sqrt(diverging) numerator pattern (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1206,6 +1206,69 @@ fn bounded_times_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
     sqrt_inner_deg
 }
 
+/// Phase 57 (Rust port): Return the ``Sqrt`` inner polynomial degree (×2 to
+/// stay exact in integer arithmetic) when ``node`` is a ``Mul`` with
+/// **exactly one** ``Log(diverging)`` factor AND **exactly one**
+/// ``Sqrt(positive-leading polynomial)`` factor, plus any number of bounded
+/// factors; ``None`` otherwise.
+///
+/// Combines sub-polynomial ``Log`` growth with half-polynomial ``Sqrt``
+/// growth.  Effective ``log(k)·k^{deg(P)/2}`` is strictly dominated by
+/// ``k^{deg(P)/2+ε}`` for any ``ε > 0`` since ``log(k) = o(k^ε)``.
+/// Caller compares ``2 * den_deg > deg(P)`` using the same ×2 integer
+/// idiom as Phase 56's ``bounded_times_sqrt_inner_deg``.
+///
+/// Requires **both** Log and Sqrt — one-only patterns fall through to
+/// Phase 55 (bounded × Log) or Phase 56 (bounded × Sqrt).  Two-of-either
+/// is refused (conservative; combined growth-rate logic would be needed).
+///
+/// Algorithm:
+///   1. Require ``node = Mul(...)``.
+///   2. For each factor:
+///      - ``Log(diverging)`` → count; refuse (return None) if count > 1.
+///      - ``Sqrt(positive-poly)`` → record ×2 degree; refuse if second one.
+///      - ``is_bounded_in_k`` → accept.
+///      - otherwise → return None.
+///   3. Require ``log_count == 1`` and ``sqrt_inner_deg.is_some()``.
+fn bounded_log_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut log_count = 0usize;
+    let mut sqrt_inner_deg: Option<i64> = None;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 1 {
+                // Two or more Log factors — refuse (conservative).
+                return None;
+            }
+            continue;
+        }
+        if let Some(deg) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_inner_deg.is_some() {
+                // Two Sqrt factors — refuse (conservative).
+                return None;
+            }
+            sqrt_inner_deg = Some(deg);
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Unrecognised factor.
+        return None;
+    }
+    if log_count != 1 {
+        return None;
+    }
+    sqrt_inner_deg
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1290,6 +1353,21 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(sqrt_inner_deg) = bounded_times_sqrt_inner_deg(num, k) {
         if let Some(den_deg_bs) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_bs > sqrt_inner_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 57: Mul(bounded, Log(diverging), Sqrt(positive-poly)) numerator.
+    // Effective growth ``log(k)·k^{deg(P)/2}`` dominated by any
+    // ``k^{deg(P)/2+ε}``, so the quotient vanishes when:
+    //   - polynomial denominator with ``2 * den_deg > deg(P)`` (×2 idiom), OR
+    //   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+    // Requires both Log and Sqrt; one-only falls through to Phase 55 / 56.
+    if let Some(bls_inner_deg) = bounded_log_sqrt_inner_deg(num, k) {
+        if let Some(den_deg_bls) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_bls > bls_inner_deg {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1406,3 +1406,73 @@ fn phase56_sin_times_sqrt_k_cubed_over_k_refused() {
     // 3/2 > 1 → does not vanish.
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// Phase 57 (Rust port): bounded × Log(diverging) × Sqrt(positive-poly) numerator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase57_sin_log_k_sqrt_k_over_k_squared_closes() {
+    // sin(k)·log(k)·sqrt(k)/k²: effective growth k^½·log(k), dominated by
+    // k² (2*den_deg=4 > sqrt_inner_deg=1, the ×2 value of half-degree ½).
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase57_sin_log_k_sqrt_k_cubed_over_exponential_closes() {
+    // sin(k)·log(k)·sqrt(k³) / 2^k: exponential denominator dominates
+    // any sub-polynomial growth automatically.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase57_sin_log_k_sqrt_k_cubed_over_k_refused() {
+    // sin(k)·log(k)·sqrt(k³)/k: sqrt inner deg (×2) = 3, 2*den_deg=2 ≤ 3
+    // → does NOT vanish.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![k.clone(), int(3)])]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![apply(sym(POW), vec![kp1.clone(), int(3)])]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k.clone()]),
+        apply(sym(DIV), vec![num_kp1, kp1]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    // 3/2 > 1 → does not vanish.
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.5.0 — 2026-05-24
+
+**Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator
+(TypeScript port).**
+
+Ports Python ``cas-summation`` 1.5.0 (PR #4215).  Closes the mixed
+sub-polynomial gap left by Phase 55 (bounded × Log) and Phase 56
+(bounded × Sqrt).  The Log and Sqrt factors must both be present;
+one-only patterns continue to fall through to Phase 55 / 56.
+
+### Added
+
+- **`boundedLogSqrtHalfDegree(node, k)`** — returns the Sqrt half-degree
+  for ``Mul`` with exactly one ``Log(diverging)`` AND one ``Sqrt(positive-
+  poly)`` factor (plus optional bounded factors).  Returns ``undefined``
+  for zero/two-Log, zero/two-Sqrt, or unrecognised factors.
+
+### Changed
+
+- ``gVanishesAtInfinity`` adds Phase 57 branch after Phase 56, comparing
+  ``denDeg > halfDeg`` (polynomial) or short-circuiting on non-polynomial
+  diverging denominator.
+
+### Tests
+
+4 new ``summation: Phase 57 bounded × log × sqrt numerator`` cases.
+Full suite: **73 passed** (was 69; +4).
+
 ## 1.4.0 — 2026-05-23
 
 **Phase 56 — Bounded × Sqrt(diverging) numerator pattern (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -912,6 +912,65 @@ function boundedTimesSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined
   return sqrtHalfDeg;
 }
 
+/**
+ * Phase 57 (TypeScript port): Return the ``Sqrt`` inner half-degree when
+ * ``node`` is a ``Mul`` with **exactly one** ``Log(diverging)`` factor AND
+ * **exactly one** ``Sqrt(positive-leading polynomial)`` factor, plus any
+ * number of bounded factors; ``undefined`` otherwise.
+ *
+ * Combines sub-polynomial ``Log`` growth with half-polynomial ``Sqrt``
+ * growth.  Effective growth ``log(k)·k^{deg(P)/2}`` is strictly dominated
+ * by ``k^{deg(P)/2+ε}`` for any ``ε > 0`` since ``log(k) = o(k^ε)``.
+ * Caller compares ``denDeg > sqrtHalfDeg`` directly (same convention as
+ * Phase 56's ``boundedTimesSqrtHalfDegree``).
+ *
+ * Requires **both** Log and Sqrt — one-only patterns fall through to
+ * Phase 55 (bounded × Log) or Phase 56 (bounded × Sqrt).  Two-of-either
+ * is refused (conservative; combined growth-rate logic would be needed).
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Log(diverging)`` → count; refuse if count > 1.
+ *      - ``Sqrt(positive-poly)`` → record half-degree; refuse if second one.
+ *      - ``bounded`` → accept.
+ *      - otherwise → return undefined.
+ *   3. Require exactly one Log AND exactly one Sqrt.
+ */
+function boundedLogSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let sqrtHalfDeg: number | undefined;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 1) {
+        // Two or more Log factors — refuse (would need combined rate logic).
+        return undefined;
+      }
+      continue;
+    }
+    const deg = sqrtEffectiveHalfDegree(arg, k);
+    if (deg !== undefined) {
+      if (sqrtHalfDeg !== undefined) {
+        // Two Sqrt factors — refuse (conservative).
+        return undefined;
+      }
+      sqrtHalfDeg = deg;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Neither Log(diverging) nor Sqrt(positive-poly) nor bounded — refuse.
+    return undefined;
+  }
+  if (logCount !== 1 || sqrtHalfDeg === undefined) {
+    return undefined;
+  }
+  return sqrtHalfDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -991,6 +1050,23 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBs = polynomialDegreeInK(den, k);
     if (denDegBs !== undefined) {
       if (denDegBs > sqrtBoundedHalfDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 57: Mul(bounded, Log(diverging), Sqrt(positive-poly)) numerator.
+  // Effective growth ``log(k)·k^{deg(P)/2}`` is dominated by any
+  // ``k^{deg(P)/2+ε}``, so the quotient vanishes when:
+  //   - polynomial denominator with ``denDeg > deg(P)/2``, OR
+  //   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+  // Requires both Log and Sqrt; one-only falls through to Phase 55 / 56.
+  const blsHalfDeg = boundedLogSqrtHalfDegree(num, k);
+  if (blsHalfDeg !== undefined) {
+    const denDegBls = polynomialDegreeInK(den, k);
+    if (denDegBls !== undefined) {
+      if (denDegBls > blsHalfDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1125,3 +1125,90 @@ describe("summation: Phase 56 bounded × sqrt numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// Phase 57 (TS port): bounded × Log(diverging) × Sqrt(positive-poly) numerator.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 57 bounded × log × sqrt numerator", () => {
+  it("∑ [sin(k)·log(k)·sqrt(k)/k² − ...] closes (log·k^½ < k²)", () => {
+    // sin(k)·log(k)·sqrt(k) / k²: effective growth k^½·log(k) dominated
+    // by k² (half-degree = 1/2, den-deg = 2, 2 > 1/2 ✓).
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, logK, sqrtK]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [log(k)·sqrt(k)/k² − ...] closes (no bounded factor needed)", () => {
+    // Pure log·sqrt without a bounded factor — still Phase 57 (log_count=1,
+    // sqrt present).  half-degree = 1/2, den-deg = 2.
+    const k = sym("k");
+    const logK = app(sym("Log"), [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [logK, sqrtK]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [logKp1, sqrtKp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·log(k)·sqrt(k³)/2^k − ...] closes (exp dominates)", () => {
+    // Exponential denominator — non-polynomial diverging, dominates any
+    // half-polynomial growth.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, logK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin(k)·log(k)·sqrt(k³)/k stays unevaluated (3/2 > 1)", () => {
+    // half-degree of sqrt(k³) = 3/2 > den-deg 1 → does NOT vanish.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [app(POW, [k, int(3)])]);
+    const numK = app(MUL, [sinK, logK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [app(POW, [kp1, int(3)])]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, k]),
+      app(DIV, [numKp1, kp1]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    // sqrt(k³) half-degree 3/2 > denDeg 1 → refused.
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Ports Python `cas-summation` 1.5.0 (PR #4215) to TypeScript and Rust
- Phase 57 closes the mixed sub-polynomial gap: a numerator with **both** a `Log(diverging)` and a `Sqrt(positive-poly)` factor (plus optional bounded factors) has effective growth `log(k)·k^{deg(P)/2}`, dominated by any `k^{deg(P)/2+ε}`
- One-only patterns (only Log, or only Sqrt) continue to fall through to Phase 55 / Phase 56; two-of-either is refused (conservative)

**TypeScript (1.4.0 → 1.5.0):**
- `boundedLogSqrtHalfDegree(node, k)` helper; Phase 57 branch in `gVanishesAtInfinity`
- 4 new test cases → 73 total (was 69)

**Rust (1.4.0 → 1.5.0):**
- `bounded_log_sqrt_inner_deg(node, k) -> Option<i64>` helper using ×2 integer idiom; Phase 57 branch in `g_vanishes_at_infinity`
- 3 new `phase57_*` test cases → 72 total (was 69)

## Test plan

- [x] `cargo test -p cas-summation` → 72 passed (Rust)
- [x] `npm test` in `packages/typescript/cas-summation` → 73 passed (TS)
- [x] Security review passed (pure symbolic math, no I/O, no unsafe blocks)
- [ ] CI green on ubuntu/macos/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)