### PR TITLE
feat(ruby-lexer): Phase 4n — %r{regex}, %s{symbol}, %x{cmd} percent literals

### DIFF
--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.19.0] - 2026-05-24
+
+### Added (Phase 4n — `%r{regex}`, `%s{symbol}`, `%x{cmd}` percent literals)
+
+Extends the existing `%w[…]` / `%q{…}` / `%i[…]` / `%I[…]` family with the three remaining built-in percent-literal flavors:
+
+- `%r{…}` — regex literal (interpolation-free in v0).
+- `%s{…}` — symbol literal (non-interpolating).
+- `%x{…}` — command-execution literal (sibling of `` `…` ``).
+
+All three pre-date the era split — every era ≥ 1.8 emits the same token shape.
+
+#### Token shape
+
+Each emits as a `TokenType::String` whose value is the verbatim source (`%r{pat}`, `%s{name}`, `%x{cmd}`).  Parser code distinguishes them from plain strings — and from each other — by inspecting the leading `%` + type letter.  Same sentinel-by-prefix trick used by `%w[…]` / `%q{…}` / heredocs / backticks.
+
+#### State-machine additions
+
+- Alphabet: `s`, `x` added (`r` was already present for the `\r` escape).
+- New tokens: `PercentR`, `PercentS`, `PercentX` (all mapped to `TokenType::String` in the emit handler).
+- New states: `percent_{r,s,x}_open` (peek for `{`) and `percent_{r,s,x}_body` (slurp until `}`).
+- `after_percent` gains three new dispatch arms (`r` → `percent_r_open`, etc.).
+- Body states emit on the matching `}` and parse-error on EOF (`unterminated_percent_{r,s,x}`).
+- Open states parse-error if the follower isn't `{` (`percent_{r,s,x}_no_delim`) and fall back to `% is modulo, letter is identifier`.
+
+#### Out of scope (deferred to follow-up)
+
+- Alternate delimiters (`%r[…]`, `%r(…)`, `%r/…/`, etc.).  V0 supports only `{` to keep the state count down — matches the existing `%q{…}` convention.
+- `#{}` interpolation inside `%r{…}` / `%x{…}` (real Ruby allows it).  Parser-side phases can layer interpolation later.
+- Regex flags after `%r{…}imx` — out of scope; flag-letter slurping after `%r}` is a follow-up.
+
+### Tests (+7 new, total 156)
+- `percent_r_regex_literal_lexes_as_string_with_prefix`
+- `percent_s_symbol_literal_lexes_as_string_with_prefix`
+- `percent_x_command_literal_lexes_as_string_with_prefix`
+- `percent_r_empty_body_lexes` — `%r{}`
+- `percent_r_s_x_lex_uniformly_across_all_eras` — era invariance.
+- `percent_x_does_not_swallow_following_tokens` — `%x{pwd} + 1` lexes cleanly.
+- `percent_r_unterminated_reports_diagnostic` — `parse_error(unterminated_percent_r)` path.
+
 ## [0.18.0] - 2026-05-24
 
 ### Added (Phase 4m — backtick command literals `` `cmd args` ``)

--- a/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
+++ b/code/packages/rust/ruby-lexer/ruby-1.8.lexer.states.toml
@@ -65,7 +65,9 @@ alphabet = [
   # percent-literal type letters: `w` for `%w[...]`, `q` for `%q{...}`.
   # `i` and `I` (2.0+ symbol arrays) are recognised by the lexer
   # unconditionally; era < 2.0 downgrades them in the post-pass.
-  "w", "q", "i", "I",
+  # Phase 4n adds `s` (symbol), `x` (command).  `r` (regex) reuses the
+  # existing `r` alphabet entry (added earlier for the `\r` escape).
+  "w", "q", "i", "I", "s", "x",
 ]
 
 # ── Token vocabulary ──────────────────────────────────────────────
@@ -119,6 +121,20 @@ fields = ["value"]
 # the raw body (without the surrounding backticks).
 [[tokens]]
 name = "Backtick"      # `` `ls -la` `` — command-execution literal
+fields = ["value"]
+
+# Phase 4n — `%r{regex}`, `%s{symbol}`, `%x{cmd}` percent literals.
+# Emit handler maps these onto TokenType::String carrying the verbatim
+# source (`%r{pat}`, etc.) so the parser can distinguish them from
+# plain strings by lexeme prefix — same encoding as `%w[…]` / `%q{…}`.
+[[tokens]]
+name = "PercentR"      # %r{regex}   — interpolation-free regex literal
+fields = ["value"]
+[[tokens]]
+name = "PercentS"      # %s{symbol}  — symbol literal (no interpolation)
+fields = ["value"]
+[[tokens]]
+name = "PercentX"      # %x{cmd}     — command-execution literal
 fields = ["value"]
 
 [[tokens]]
@@ -258,6 +274,25 @@ id = "percent_i_body"    # inside `%i[...]` — accumulating symbol-array body.
 id = "percent_big_i_open"# saw `%I`, peeking for `[` opening delim (2.0+).
 [[states]]
 id = "percent_big_i_body"# inside `%I[...]` — accumulating interpolating symbol-array body.
+# Phase 4n — `%r{regex}`, `%s{symbol}`, `%x{cmd}`.  Like `%q{…}`
+# these use `{` as the canonical v0 delimiter.  Open states peek
+# for the `{`; if absent, the `%` falls back to a modulo operator
+# (the action interpreter unwinds the buffer accordingly).  Body
+# states accumulate the literal up to the matching `}` and emit
+# the verbatim source (`%r{pat}` etc.) as a `TokenType::String`,
+# matching the existing percent-literal encoding.
+[[states]]
+id = "percent_r_open"    # saw `%r`, peeking for `{` opening delim.
+[[states]]
+id = "percent_r_body"    # inside `%r{...}` — accumulating regex body.
+[[states]]
+id = "percent_s_open"    # saw `%s`, peeking for `{` opening delim.
+[[states]]
+id = "percent_s_body"    # inside `%s{...}` — accumulating symbol body.
+[[states]]
+id = "percent_x_open"    # saw `%x`, peeking for `{` opening delim.
+[[states]]
+id = "percent_x_body"    # inside `%x{...}` — accumulating command body.
 
 [[states]]
 id = "comment_body"      # # to end-of-line
@@ -1071,6 +1106,28 @@ matcher = { literal = "I" }
 to = "percent_big_i_open"
 actions = ["append_text(current)"]
 
+# Phase 4n — `%r` (regex), `%s` (symbol), `%x` (command).  All three
+# dispatch to a `_open` peek state that requires `{` as the v0
+# canonical delimiter.  Any other follower falls through to the
+# catch-all below ("% is modulo, letter is identifier").
+[[transitions]]
+from = "after_percent"
+matcher = { literal = "r" }
+to = "percent_r_open"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "after_percent"
+matcher = { literal = "s" }
+to = "percent_s_open"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "after_percent"
+matcher = { literal = "x" }
+to = "percent_x_open"
+actions = ["append_text(current)"]
+
 # Any other follower: `%` is a modulo operator.  Re-dispatch the
 # next char to `data` so it lexes normally.
 [[transitions]]
@@ -1252,6 +1309,132 @@ actions = ["parse_error(unterminated_percent_big_i)", "emit(Eof)"]
 from = "percent_big_i_body"
 matcher = { anything = true }
 to = "percent_big_i_body"
+actions = ["append_text(current)"]
+
+# ─── %r{…}, %s{…}, %x{…} (Phase 4n) ─────────────────────────────
+# All three share the same shape — open peek state requires `{`,
+# body slurps until matching `}`, emit verbatim source as the
+# corresponding PercentR/PercentS/PercentX token (which the emit
+# handler maps to TokenType::String with the verbatim lexeme).
+
+# %r{...} — regex literal
+[[transitions]]
+from = "percent_r_open"
+matcher = { literal = "{" }
+to = "percent_r_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "percent_r_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(percent_r_no_delim)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_r_open"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["parse_error(percent_r_no_delim)", "set_text(%)", "emit(Op)"]
+
+[[transitions]]
+from = "percent_r_body"
+matcher = { literal = "}" }
+to = "data"
+actions = ["append_text(current)", "emit(PercentR)"]
+
+[[transitions]]
+from = "percent_r_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_percent_r)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_r_body"
+matcher = { anything = true }
+to = "percent_r_body"
+actions = ["append_text(current)"]
+
+# %s{...} — symbol literal (no interpolation)
+[[transitions]]
+from = "percent_s_open"
+matcher = { literal = "{" }
+to = "percent_s_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "percent_s_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(percent_s_no_delim)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_s_open"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["parse_error(percent_s_no_delim)", "set_text(%)", "emit(Op)"]
+
+[[transitions]]
+from = "percent_s_body"
+matcher = { literal = "}" }
+to = "data"
+actions = ["append_text(current)", "emit(PercentS)"]
+
+[[transitions]]
+from = "percent_s_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_percent_s)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_s_body"
+matcher = { anything = true }
+to = "percent_s_body"
+actions = ["append_text(current)"]
+
+# %x{...} — command-execution literal
+[[transitions]]
+from = "percent_x_open"
+matcher = { literal = "{" }
+to = "percent_x_body"
+actions = ["append_text(current)"]
+
+[[transitions]]
+from = "percent_x_open"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(percent_x_no_delim)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_x_open"
+matcher = { anything = true }
+to = "data"
+consume = false
+actions = ["parse_error(percent_x_no_delim)", "set_text(%)", "emit(Op)"]
+
+[[transitions]]
+from = "percent_x_body"
+matcher = { literal = "}" }
+to = "data"
+actions = ["append_text(current)", "emit(PercentX)"]
+
+[[transitions]]
+from = "percent_x_body"
+matcher = { eof = true }
+to = "done"
+consume = false
+actions = ["parse_error(unterminated_percent_x)", "emit(Eof)"]
+
+[[transitions]]
+from = "percent_x_body"
+matcher = { anything = true }
+to = "percent_x_body"
 actions = ["append_text(current)"]
 
 # ─────────────────────────────────────────────────────────────────

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -1236,6 +1236,17 @@ impl RubyLexer {
                 let text = std::mem::take(&mut self.text_buffer);
                 self.push_token(TokenType::String, text);
             }
+            "PercentR" | "PercentS" | "PercentX" => {
+                // Phase 4n — `%r{regex}`, `%s{symbol}`, `%x{cmd}`.
+                // Like the other percent literals (`%w[…]`, `%q{…}`),
+                // emit as `TokenType::String` carrying the verbatim
+                // source (`%r{pat}`, `%s{name}`, `%x{cmd}`).  The
+                // parser distinguishes them from plain strings by the
+                // leading `%` + type letter — same sentinel-by-prefix
+                // trick the rest of the percent family uses.
+                let text = std::mem::take(&mut self.text_buffer);
+                self.push_token(TokenType::String, text);
+            }
             "Backtick" => {
                 // Phase 4m — `` `cmd args` `` command-execution literal.
                 // The text buffer holds the *body* (without the
@@ -3554,6 +3565,99 @@ mod tests {
             kinds,
             vec![TokenType::String, TokenType::Plus, TokenType::Number],
             "got tokens {toks:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 4n — `%r{regex}`, `%s{symbol}`, `%x{cmd}` percent literals
+    // -----------------------------------------------------------------
+    //
+    // The lexer emits each as a `TokenType::String` token whose value
+    // is the verbatim source (`%r{pat}`, `%s{name}`, `%x{cmd}`).
+    // Parser code distinguishes them from plain strings — and from
+    // each other — by the leading `%` + type letter.  Same encoding
+    // strategy as the existing `%w[…]` / `%q{…}` / `%i[…]` family.
+
+    /// Helper: pull all `TokenType::String` lexemes that start with a
+    /// given percent prefix (e.g. `"%r"` for regex literals).
+    fn percent_values(toks: &[Token], prefix: &str) -> Vec<String> {
+        toks.iter()
+            .filter(|t| t.type_ == TokenType::String && t.value.starts_with(prefix))
+            .map(|t| t.value.clone())
+            .collect()
+    }
+
+    #[test]
+    fn percent_r_regex_literal_lexes_as_string_with_prefix() {
+        let toks = tokenize_ruby_for_version("%r{hello}", "1.8").unwrap();
+        assert_eq!(percent_values(&toks, "%r"), vec!["%r{hello}"]);
+    }
+
+    #[test]
+    fn percent_s_symbol_literal_lexes_as_string_with_prefix() {
+        let toks = tokenize_ruby_for_version("%s{my_sym}", "1.8").unwrap();
+        assert_eq!(percent_values(&toks, "%s"), vec!["%s{my_sym}"]);
+    }
+
+    #[test]
+    fn percent_x_command_literal_lexes_as_string_with_prefix() {
+        let toks = tokenize_ruby_for_version("%x{ls -la}", "1.8").unwrap();
+        assert_eq!(percent_values(&toks, "%x"), vec!["%x{ls -la}"]);
+    }
+
+    #[test]
+    fn percent_r_empty_body_lexes() {
+        // `%r{}` — empty regex body.
+        let toks = tokenize_ruby_for_version("%r{}", "1.8").unwrap();
+        assert_eq!(percent_values(&toks, "%r"), vec!["%r{}"]);
+    }
+
+    #[test]
+    fn percent_r_s_x_lex_uniformly_across_all_eras() {
+        // The percent r/s/x family pre-dates the era split — every era
+        // (1.8, 1.9, 2.0, …) emits the same token shape.
+        let src = "%r{a} %s{b} %x{c}";
+        let baseline_r = percent_values(&tokenize_ruby_for_version(src, "1.8").unwrap(), "%r");
+        let baseline_s = percent_values(&tokenize_ruby_for_version(src, "1.8").unwrap(), "%s");
+        let baseline_x = percent_values(&tokenize_ruby_for_version(src, "1.8").unwrap(), "%x");
+        assert_eq!(baseline_r, vec!["%r{a}"]);
+        assert_eq!(baseline_s, vec!["%s{b}"]);
+        assert_eq!(baseline_x, vec!["%x{c}"]);
+        for v in machine::ERA_VERSIONS {
+            let toks = tokenize_ruby_for_version(src, v).unwrap();
+            assert_eq!(percent_values(&toks, "%r"), baseline_r, "%r diverged in era {v}");
+            assert_eq!(percent_values(&toks, "%s"), baseline_s, "%s diverged in era {v}");
+            assert_eq!(percent_values(&toks, "%x"), baseline_x, "%x diverged in era {v}");
+        }
+    }
+
+    #[test]
+    fn percent_x_does_not_swallow_following_tokens() {
+        // After the closing `}`, the dispatcher resumes normal lexing.
+        // `%x{pwd} + 1` should produce: String, Plus, Number.
+        let toks = tokenize_ruby_for_version("%x{pwd} + 1", "1.8").unwrap();
+        let kinds: Vec<TokenType> = toks
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.type_)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![TokenType::String, TokenType::Plus, TokenType::Number],
+            "got tokens {toks:?}"
+        );
+    }
+
+    #[test]
+    fn percent_r_unterminated_reports_diagnostic() {
+        let mut lx = RubyLexer::new("1.8").expect("lexer build");
+        lx.push("%r{unterminated\n").unwrap();
+        lx.finish().unwrap();
+        let diags = lx.diagnostics();
+        assert!(
+            diags.iter().any(|d| d.code.contains("unterminated_percent_r")),
+            "expected unterminated_percent_r diagnostic, got {:?}",
+            diags
         );
     }
 


### PR DESCRIPTION
## Summary

Extends the existing `%w[…]` / `%q{…}` / `%i[…]` / `%I[…]` family with the three remaining built-in percent-literal flavors:

| Form | Meaning |
|---|---|
| `%r{…}` | Regex literal (interpolation-free in v0) |
| `%s{…}` | Symbol literal (non-interpolating) |
| `%x{…}` | Command-execution literal (sibling of `` `…` ``) |

All three pre-date the era split — every era ≥ 1.8 emits the same token shape.

## Token shape

Each emits as `TokenType::String` whose value is the verbatim source (`%r{pat}`, `%s{name}`, `%x{cmd}`). Parser code distinguishes them from plain strings — and from each other — by the leading `%` + type letter. Same sentinel-by-prefix trick used by `%w[…]` / `%q{…}` / heredocs / backticks.

## State-machine additions

| State | Role |
|---|---|
| `percent_{r,s,x}_open` | After `%r`/`%s`/`%x`; peeks for `{`. |
| `percent_{r,s,x}_body` | Inside the literal; slurps until matching `}`. |

Bad-follower fallbacks (`% is modulo, letter is identifier`) and `unterminated_percent_{r,s,x}` diagnostics mirror the existing `%w` / `%q` / `%i` patterns.

## Out of scope

- Alternate delimiters (`%r[…]`, `%r(…)`, `%r/…/`). V0 uses `{` only to keep the state count down — matches the existing `%q{…}` convention.
- `#{}` interpolation inside `%r{…}` / `%x{…}`.
- Regex flags after `%r{…}imx`.

## Tests

- `coding-adventures-ruby-lexer`: 149 → **156** (+7 era-gated tests).
- `coding-adventures-ruby-parser`: 74 (unchanged).
- `ruby-to-semantic-ir`: 77 (unchanged).

Test coverage:
- Each of `%r`, `%s`, `%x` lexes with the correct verbatim prefix.
- Empty body `%r{}`.
- Era invariance across every era ≥ 1.8.
- Trailing tokens after `%x{pwd}` don't get swallowed.
- Unterminated `%r{` emits a diagnostic.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (156/156 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (74/74 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (77/77 pass)
- [x] Security review via `/security-review` — passed
- [ ] CI green

Follows PR #4273 (Phase 6o — ternary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
