### PR TITLE
feat(cas-summation): Phase 58 — Bounded × Log × polynomial numerator (1.6.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.6.0 — 2026-05-25
+
+**Phase 58 — Bounded × Log(diverging) × polynomial numerator (Python).**
+
+Closes the three-way gap between Phase 54 (Log × polynomial, refuses
+bounded factors), Phase 55 (bounded × Log, refuses polynomial factors),
+and Phase 57 (bounded × Log × Sqrt, the Sqrt specialisation).
+
+A numerator with one ``Log(diverging)`` factor, any polynomial factors
+(total degree ``m``), and any bounded factors has effective growth
+``log(k)·k^m = o(k^{m+ε})`` and vanishes when the denominator grows
+strictly faster than ``k^m``.
+
+### Added
+
+- **``_bounded_log_poly_degree``** — returns total polynomial degree for
+  ``Mul(bounded..., Log(diverging), polynomial_factors...)``.  Refuses
+  two-Log, any Sqrt (→ Phase 57), or unrecognised factors.
+
+### Changed
+
+- ``_g_vanishes_at_infinity`` adds Phase 58 branch after Phase 57:
+  ``den_deg > poly_deg`` for polynomial denominators, or
+  ``_h_diverges_at_infinity`` for non-polynomial diverging denominators.
+
+### Tests
+
+6 new ``TestEvaluateSumPhase58BoundedLogPolyNumerator`` cases.
+Full suite: **145 passed** (was 139; +6).
+
 ## 1.5.0 — 2026-05-23
 
 **Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.5.0"
+version = "1.6.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -795,6 +795,24 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 58: ``Mul(bounded, Log(diverging), polynomial)`` numerator.
+    # Bounded × Log × polynomial: effective growth ``log(k)·k^m`` which is
+    # ``o(k^{m+ε})`` for any ``ε > 0``.  Vanishes when the denominator
+    # grows strictly faster than ``k^m``:
+    #   - polynomial denominator with ``den_deg > poly_deg``, OR
+    #   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+    # This closes the gap left by Phase 54 (Log × polynomial, refuses
+    # bounded factors) and Phase 55 (bounded × Log, refuses polynomial
+    # factors).  Sqrt factors are intentionally refused and handled by
+    # Phase 57.
+    blp_deg = _bounded_log_poly_degree(num, k)
+    if blp_deg is not None:
+        den_deg_blp = _polynomial_degree_in_k(den, k)
+        if den_deg_blp is not None:
+            if den_deg_blp > blp_deg:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1201,6 +1219,82 @@ def _bounded_log_sqrt_inner_deg(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 1 or sqrt_inner_deg is None:
         return None
     return sqrt_inner_deg
+
+
+def _bounded_log_poly_degree(node: IRNode, k: IRSymbol) -> int | None:
+    """Return the total polynomial degree when ``node`` is a ``Mul`` with
+    exactly one ``Log(diverging)`` factor, any polynomial factors (degree
+    ≥ 0), and any number of bounded (but non-polynomial) factors in ``k``;
+    ``None`` otherwise.
+
+    Phase 58 — Bounded × Log(diverging) × polynomial numerator.
+
+    This phase fills the gap between:
+
+    * **Phase 54** — ``Mul(Log, polynomial_only)``; refuses the moment any
+      factor is neither Log nor polynomial, so ``Sin(k)·Log(k)·k`` fails.
+    * **Phase 55** — ``Mul(bounded, Log)``; requires *all* non-Log factors
+      to be bounded, so ``Sin(k)·Log(k)·k`` fails (``k`` diverges).
+
+    Here we allow any mix of polynomial and bounded factors alongside one
+    Log:
+
+    +---------------------------------------+--------------+
+    | Input                                 | Return       |
+    +=======================================+==============+
+    | ``Mul(Sin(k), Log(k), k)``            | ``1``        |
+    | ``Mul(Cos(k), Log(k), k²)``           | ``2``        |
+    | ``Mul(Sin(k), Cos(k), Log(k), k)``    | ``1``        |
+    | ``Mul(Sin(k), Log(k))``               | ``0``        |
+    | ``Mul(Sin(k), Log(k), Log(k))``       | None (2 Log) |
+    | ``Mul(Sqrt(k), Log(k), k)``           | None (Sqrt)  |
+    | ``Mul(Sin(k), k)``                    | None (no Log)|
+    +---------------------------------------+--------------+
+
+    Mathematical basis:
+      ``|Sin(k)·Log(k)·k^m| = O(k^m · log k) = o(k^{m+ε})`` for any
+      ``ε > 0``.  The quotient therefore vanishes whenever the denominator
+      grows strictly faster than ``k^m`` (i.e. ``den_deg > m`` or the
+      denominator is non-polynomial diverging).
+
+    The Sqrt case is intentionally refused here — that is handled by
+    Phase 57 (``bounded × Log × Sqrt``).
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - Exactly one ``Log(diverging)`` → record it; bail on second.
+         - Polynomial in ``k`` → add its degree to ``poly_deg_sum``.
+         - Bounded in ``k`` (non-polynomial) → accept silently.
+         - Sqrt or anything else → bail (unrecognised).
+      3. Require exactly one Log factor found.
+      4. Return ``poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 1:
+                # Two or more Log factors — refuse (combined rate logic needed).
+                return None
+            continue
+        # Polynomial factor (including degree-0 constants)?
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        # Bounded but non-polynomial (e.g. Sin, Cos, bounded Mul)?
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor (Sqrt, Exp, free diverging, …) — bail.
+        # Sqrt is handled by Phase 57; we don't want to silently consume it.
+        return None
+    if log_count != 1:
+        return None
+    return poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -2019,3 +2019,123 @@ class TestEvaluateSumPhase57BoundedLogSqrtNumerator:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         # Phase 55 catches this (bounded × Log).
         assert not (isinstance(result, IRApply) and result.head == SUM)
+
+
+# Phase 58 — Bounded × Log(diverging) × polynomial numerator.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSumPhase58BoundedLogPolyNumerator:
+    def test_sin_log_k_times_k_over_k_cubed_closes(self):
+        """sin(k)·log(k)·k / k³: poly_deg=1, den_deg=3, 3>1 → vanishes."""
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_cos_log_k_times_k_sq_over_k_fourth_closes(self):
+        """cos(k)·log(k)·k² / k⁴: poly_deg=2, den_deg=4, 4>2 → vanishes."""
+        from symbolic_ir import COS, POW, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (cos_k, log_k, k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (cos_kp1, log_kp1, kp1_2))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(4)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(4)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_bounded_log_k_times_k_over_k_cubed_closes(self):
+        """sin(k)·cos(k)·log(k)·k / k³: two bounded + log + poly → vanishes."""
+        from symbolic_ir import COS, POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, cos_k, log_k, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, cos_kp1, log_kp1, kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (_k, IRInteger(3)))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_k_times_k_sq_over_exponential_closes(self):
+        """sin(k)·log(k)·k² / 2ᵏ: exponential denominator → vanishes."""
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (sin_k, log_k, k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, kp1_2))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_k_times_k_sq_over_k_sq_refused(self):
+        """sin(k)·log(k)·k² / k²: equal degrees → log(k)·C → ∞, refused."""
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (sin_k, log_k, k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, kp1_2))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_sin_log_k_times_k_cubed_over_k_sq_refused(self):
+        """sin(k)·log(k)·k³ / k²: poly_deg>den_deg → numerator wins, refused."""
+        from symbolic_ir import POW, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        num_k = IRApply(MUL, (sin_k, log_k, k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, kp1_3))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.6.0 — 2026-05-25
+
+**Phase 58 — Bounded × Log(diverging) × polynomial numerator (Rust port).**
+
+Ports Python ``cas-summation`` 1.6.0.  Fills the gap between Phase 54
+(Log × polynomial, refuses bounded) and Phase 55 (bounded × Log, refuses
+polynomial).
+
+### Added
+
+- **`bounded_log_poly_degree(node, k) -> Option<i64>`** — returns total
+  polynomial degree for ``Mul(bounded..., Log(diverging), poly_factors...)``.
+  Refuses two-Log, Sqrt (→ Phase 57), or unrecognised factors.
+
+### Changed
+
+- ``g_vanishes_at_infinity`` adds Phase 58 branch after Phase 57:
+  ``den_deg > poly_deg`` for polynomial denominators, or
+  ``h_diverges_at_infinity`` for non-polynomial diverging denominators.
+
+### Tests
+
+3 new ``phase58_*`` cases.  Full suite: **75 passed** (was 72; +3).
+
 ## 1.5.0 — 2026-05-24
 
 **Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1269,6 +1269,68 @@ fn bounded_log_sqrt_inner_deg(node: &IRNode, k: &IRNode) -> Option<i64> {
     sqrt_inner_deg
 }
 
+/// Phase 58 (Rust port): Return the total polynomial degree when ``node`` is
+/// a ``Mul`` with exactly one ``Log(diverging)`` factor, any polynomial
+/// factors (total degree ``m``), and any bounded (non-polynomial) factors;
+/// ``None`` otherwise.
+///
+/// Fills the gap between:
+/// - **Phase 54** — ``Mul(Log, polynomial_only)``; refuses bounded factors.
+/// - **Phase 55** — ``Mul(bounded, Log)``; refuses polynomial factors.
+/// - **Phase 57** — ``Mul(bounded, Log, Sqrt)``; the Sqrt specialisation.
+///
+/// Effective growth ``log(k)·k^m = o(k^{m+ε})`` for any ``ε > 0``.
+/// Caller compares ``den_deg > poly_deg`` (strictly) for polynomial
+/// denominators, or short-circuits on non-polynomial diverging denominator.
+///
+/// Sqrt factors are refused here — use ``bounded_log_sqrt_inner_deg``
+/// (Phase 57) for those.
+///
+/// Algorithm:
+///   1. Require ``node = Mul(...)``.
+///   2. For each factor:
+///      - ``is_log_of_diverging_in_k`` → count; bail if count > 1.
+///      - ``polynomial_degree_in_k`` → Some(d) → add d to ``poly_deg``.
+///      - ``is_bounded_in_k`` → accept silently.
+///      - otherwise (Sqrt, Exp, free diverging, …) → return None.
+///   3. Require ``log_count == 1``.
+///   4. Return ``poly_deg``.
+fn bounded_log_poly_degree(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut log_count = 0usize;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 1 {
+                // Two or more Log factors — refuse.
+                return None;
+            }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg += deg;
+            continue;
+        }
+        if is_bounded_in_k(arg, k) {
+            // Bounded but non-polynomial (e.g. Sin, Cos) — accept silently.
+            continue;
+        }
+        // Sqrt or unrecognised factor — bail (Sqrt handled by Phase 57).
+        return None;
+    }
+    if log_count != 1 {
+        return None;
+    }
+    Some(poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1368,6 +1430,21 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(bls_inner_deg) = bounded_log_sqrt_inner_deg(num, k) {
         if let Some(den_deg_bls) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_bls > bls_inner_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 58: Mul(bounded, Log(diverging), polynomial) numerator.
+    // Effective growth ``log(k)·k^m = o(k^{m+ε})``.  Closes when:
+    //   - polynomial denominator with ``den_deg > poly_deg`` (strictly), OR
+    //   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+    // Fills the gap between Phase 54 (Log × poly, refuses bounded) and
+    // Phase 55 (bounded × Log, refuses poly).  Sqrt refused → Phase 57.
+    if let Some(blp_deg) = bounded_log_poly_degree(num, k) {
+        if let Some(den_deg_blp) = polynomial_degree_in_k(den, k) {
+            if den_deg_blp > blp_deg {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1476,3 +1476,67 @@ fn phase57_sin_log_k_sqrt_k_cubed_over_k_refused() {
     // 3/2 > 1 → does not vanish.
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// Phase 58 (Rust port): bounded × Log(diverging) × polynomial numerator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase58_sin_log_k_times_k_over_k_cubed_closes() {
+    // sin(k)·log(k)·k / k³: poly_deg=1, den_deg=3, 3>1 → vanishes.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase58_sin_log_k_times_k_sq_over_exponential_closes() {
+    // sin(k)·log(k)·k² / 2^k: exponential denominator dominates.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, k2]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase58_sin_log_k_times_k_sq_over_k_sq_refused() {
+    // sin(k)·log(k)·k² / k²: equal degrees → log(k)·C diverges, refused.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym("Log"), vec![k.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, k2.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym("Log"), vec![kp1.clone()]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, kp1_2.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k2]),
+        apply(sym(DIV), vec![num_kp1, kp1_2]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.6.0 — 2026-05-25
+
+**Phase 58 — Bounded × Log(diverging) × polynomial numerator
+(TypeScript port).**
+
+Ports Python ``cas-summation`` 1.6.0.  Fills the gap between Phase 54
+(Log × polynomial, refuses bounded factors) and Phase 55 (bounded × Log,
+refuses polynomial factors).
+
+### Added
+
+- **`boundedLogPolyDegree(node, k)`** — returns total polynomial degree
+  for ``Mul(bounded..., Log(diverging), polynomial_factors...)``.  Refuses
+  two-Log, Sqrt (→ Phase 57), or unrecognised factors.
+
+### Changed
+
+- ``gVanishesAtInfinity`` adds Phase 58 branch after Phase 57:
+  ``denDeg > polyDeg`` for polynomial denominators, or
+  ``hDivergesAtInfinity`` for non-polynomial diverging denominators.
+
+### Tests
+
+4 new ``summation: Phase 58 bounded × log × polynomial numerator`` cases.
+Full suite: **77 passed** (was 73; +4).
+
 ## 1.5.0 — 2026-05-24
 
 **Phase 57 — Bounded × Log(diverging) × Sqrt(positive-poly) numerator

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -971,6 +971,62 @@ function boundedLogSqrtHalfDegree(node: IRNode, k: IRNode): number | undefined {
   return sqrtHalfDeg;
 }
 
+/**
+ * Phase 58 (TypeScript port): Return the total polynomial degree when
+ * ``node`` is a ``Mul`` with exactly one ``Log(diverging)`` factor, any
+ * polynomial factors, and any number of bounded (non-polynomial) factors;
+ * ``undefined`` otherwise.
+ *
+ * Fills the gap between:
+ * - **Phase 54** — ``Mul(Log, polynomial_only)``; refuses bounded factors.
+ * - **Phase 55** — ``Mul(bounded, Log)``; refuses polynomial factors.
+ * - **Phase 57** — ``Mul(bounded, Log, Sqrt)``; the Sqrt specialisation.
+ *
+ * Effective growth ``log(k)·k^m = o(k^{m+ε})``.  Caller compares
+ * ``denDeg > polyDeg`` (strict).  Sqrt factors are refused here and
+ * handled by Phase 57.
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Log(diverging)`` → count; refuse if count > 1.
+ *      - polynomial → add its degree to ``polyDeg``.
+ *      - ``bounded`` (non-polynomial, non-Sqrt) → accept silently.
+ *      - Sqrt or unrecognised → return undefined.
+ *   3. Require exactly one Log.
+ *   4. Return ``polyDeg``.
+ */
+function boundedLogPolyDegree(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 1) {
+        // Two or more Log factors — refuse.
+        return undefined;
+      }
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) {
+      polyDeg += deg;
+      continue;
+    }
+    if (isBoundedInK(arg, k)) {
+      // Bounded but non-polynomial (e.g. Sin, Cos) — accept.
+      continue;
+    }
+    // Sqrt or unrecognised factor — bail (Sqrt is handled by Phase 57).
+    return undefined;
+  }
+  if (logCount !== 1) {
+    return undefined;
+  }
+  return polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1067,6 +1123,24 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBls = polynomialDegreeInK(den, k);
     if (denDegBls !== undefined) {
       if (denDegBls > blsHalfDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 58: Mul(bounded, Log(diverging), polynomial) numerator.
+  // Effective growth ``log(k)·k^m = o(k^{m+ε})``.  Vanishes when:
+  //   - polynomial denominator with ``denDeg > polyDeg`` (strict), OR
+  //   - non-polynomial diverging denominator (Exp / Pow / Log×poly).
+  // Fills the gap between Phase 54 (Log × poly, refuses bounded) and
+  // Phase 55 (bounded × Log, refuses poly).  Sqrt is refused here →
+  // Phase 57 handles that case.
+  const blpDeg = boundedLogPolyDegree(num, k);
+  if (blpDeg !== undefined) {
+    const denDegBlp = polynomialDegreeInK(den, k);
+    if (denDegBlp !== undefined) {
+      if (denDegBlp > blpDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1212,3 +1212,80 @@ describe("summation: Phase 57 bounded × log × sqrt numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+// Phase 58 (TS port): bounded × Log(diverging) × polynomial numerator.
+// ---------------------------------------------------------------------------
+
+describe("summation: Phase 58 bounded × log × polynomial numerator", () => {
+  it("∑ [sin(k)·log(k)·k/k³ − ...] closes (polyDeg=1 < denDeg=3)", () => {
+    // sin(k)·log(k)·k / k³: log sub-polynomial, effective poly deg = 1,
+    // denominator deg = 3, 3 > 1 ✓.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const numK = app(MUL, [sinK, logK, k]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·log(k)·k²/2^k − ...] closes (exp denominator dominates)", () => {
+    // Exponential denominator — non-polynomial diverging, dominates any k^m.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const numK = app(MUL, [sinK, logK, app(POW, [k, int(2)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [cos(k)·log(k)·k²/k⁴ − ...] closes (polyDeg=2 < denDeg=4)", () => {
+    const k = sym("k");
+    const cosK = app(sym("Cos"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const numK = app(MUL, [cosK, logK, app(POW, [k, int(2)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const cosKp1 = app(sym("Cos"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const numKp1 = app(MUL, [cosKp1, logKp1, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(4)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(4)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin(k)·log(k)·k²/k² stays unevaluated (equal degrees)", () => {
+    // polyDeg = denDeg = 2: log(k)·C diverges → refused.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(sym("Log"), [k]);
+    const numK = app(MUL, [sinK, logK, app(POW, [k, int(2)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(sym("Log"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Phase 58 across all three languages (Python, TypeScript, Rust) bringing all packages to 1.6.0
- Closes the three-way gap between Phase 54 (Log × polynomial, refuses bounded factors), Phase 55 (bounded × Log, refuses polynomial factors), and Phase 57 (bounded × Log × Sqrt, the Sqrt specialisation)
- A numerator `Mul(bounded..., Log(diverging), polynomial_factors...)` has effective growth `log(k)·k^m = o(k^{m+ε})` and vanishes when `den_deg > m` or the denominator is non-polynomial diverging

**Python (1.5.0 → 1.6.0):**
- `_bounded_log_poly_degree` helper + Phase 58 branch
- 6 new test cases → 145 total

**TypeScript (1.5.0 → 1.6.0):**
- `boundedLogPolyDegree` helper + Phase 58 branch
- 4 new test cases → 77 total

**Rust (1.5.0 → 1.6.0):**
- `bounded_log_poly_degree` helper + Phase 58 branch
- 3 new `phase58_*` test cases → 75 total

## Test plan

- [x] Python: 145 passed (was 139; +6)
- [x] TypeScript: 77 passed (was 73; +4)
- [x] Rust: 75 passed (was 72; +3)
- [x] Security review passed (pure symbolic math, no I/O, no unsafe)
- [ ] CI green on ubuntu/macos/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)