### PR TITLE
feat(ruby-parser): Phase 6p — compound assignment +=, -=, *=, /=, ||=, &&=

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -50,7 +50,26 @@ else_clause  = "else" { !"end" statement } ;
 unless_statement = "unless" expression { !"else" !"end" statement } [ else_clause ] "end" ;
 while_statement = "while" expression { !"end" statement } "end" ;
 until_statement = "until" expression { !"end" statement } "end" ;
-assignment   = NAME EQUALS expression ;
+# Phase 6p — compound assignment (`x += 1`, `x ||= 1`, etc.).
+#
+# The lexer's `fuse_compound_assigns` post-pass folds `Op =` adjacent
+# token pairs into a single `Name`-typed token whose value is the
+# fused operator (`+=`, `-=`, `*=`, `/=`, `||=`, `&&=`).  The grammar
+# matches by literal value — same convention as `"=>"`, `"<="`,
+# `"&&"`, etc.
+#
+# `EQUALS` (token-type match) handles the plain `=` case; the literal
+# alternatives below handle each compound form.  Lowerer dispatches
+# on the operator token to decide between LetBinding/Assign of the
+# RHS (`=`) versus assign-of-binary-op (the compound forms).
+#
+# Note: `==`, `!=`, `<=`, `>=`, `===` are intentionally excluded —
+# those are comparison operators, not assignments, and are handled
+# at the `comparison` layer.  The fusion pass deliberately runs only
+# on Op tokens (Plus/Minus/Star/Slash) and the two Name-typed
+# logicals (`||`/`&&`) to avoid colliding with comparison ops which
+# the lexer fuses directly.
+assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expression ;
 # Phase 6l — method receiver chains.  `foo.bar`, `foo.bar.baz`,
 # `foo.bar(args)`, `foo(1).bar`, `foo.bar(args).baz(more)`, etc.
 #

--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.20.0] - 2026-05-24
+
+### Added (Phase 6p companion — compound-assignment operator fusion)
+
+New post-pass `fuse_compound_assigns` folds adjacent `Op` + `Equals` token pairs into a single `Name`-typed token whose value is the fused operator:
+
+| Source | Lexed before fusion | After fusion |
+|---|---|---|
+| `x += 1` | `Name(x)`, `Plus`, `Equals`, `Number(1)` | `Name(x)`, `Name("+=")`, `Number(1)` |
+| `x -= 1` | `Name(x)`, `Minus`, `Equals`, `Number(1)` | `Name(x)`, `Name("-=")`, `Number(1)` |
+| `x *= 1` | `Name(x)`, `Star`, `Equals`, `Number(1)` | `Name(x)`, `Name("*=")`, `Number(1)` |
+| `x /= 1` | `Name(x)`, `Slash`, `Equals`, `Number(1)` | `Name(x)`, `Name("/=")`, `Number(1)` |
+| `x ||= 1` | `Name(x)`, `Name("||")`, `Equals`, `Number(1)` | `Name(x)`, `Name("||=")`, `Number(1)` |
+| `x &&= 1` | `Name(x)`, `Name("&&")`, `Equals`, `Number(1)` | `Name(x)`, `Name("&&=")`, `Number(1)` |
+
+The parser's `assignment` rule matches these by literal value (`"+="`, etc.) — same convention as `"=>"`, `"<="`, `"&&"`.
+
+**Adjacency gate**: the fusion requires no whitespace between the op and `=`.  `x + = 1` (with a space) stays two tokens — that's a syntax error in real Ruby but it's not a compound assignment.
+
+**Era**: pre-1.0 Ruby — every era ≥ 1.8 emits the same fused shape, so no gating.
+
+### `/=` regex disambiguation guard
+
+`x /= 1` previously lexed as `Name(x)` followed by an unterminated regex (`/...`) because the `/` after a non-local name triggers the regex-vs-divide oracle.  New `suppress_regex_open` flag set by `push` for exactly one `step_char` call when the upcoming `/` is immediately followed by `=` — forces the state machine to emit `/` as a plain Op so `fuse_compound_assigns` can fold it.
+
+### Tests (+3 new, total 159)
+- `compound_assign_arithmetic_ops_fuse_into_single_token` — `+=`, `-=`, `*=`, `/=`.
+- `compound_assign_logical_ops_fuse_into_single_token` — `||=`, `&&=`.
+- `compound_assign_does_not_fuse_with_whitespace_gap` — `x + = 1` stays two tokens.
+
 ## [0.19.0] - 2026-05-24
 
 ### Added (Phase 4n — `%r{regex}`, `%s{symbol}`, `%x{cmd}` percent literals)

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -124,6 +124,12 @@ pub struct RubyLexer {
     /// Phase 4c: scratch flag set on each whitespace consume and
     /// flushed into `whitespace_before_token` on the next emit.
     whitespace_pending: bool,
+    /// Phase 6p companion — set by `push` for one `step_char` call
+    /// when the upcoming character is `/` and its immediate follower
+    /// is `=`.  Forces `should_open_regex` to return `false` so the
+    /// state machine emits `/` as a plain Op token.  The compound-
+    /// assign fusion pass then folds `Op(/) Equals` → `Name("/=")`.
+    suppress_regex_open: bool,
 }
 
 /// Phase 3c — a heredoc opener whose body we still owe.
@@ -185,6 +191,7 @@ impl RubyLexer {
             era: canonical_era.to_string(),
             whitespace_before_token: Vec::new(),
             whitespace_pending: false,
+            suppress_regex_open: false,
         })
     }
 
@@ -210,7 +217,17 @@ impl RubyLexer {
         let mut i = 0;
         while i < chars.len() {
             let ch = chars[i];
+            // Phase 6p companion — `/=` compound-assignment guard.
+            // If we're about to feed a `/` whose immediate follower is
+            // `=`, suppress the regex-vs-divide decision and let the
+            // state machine emit `/` as a plain Op.  The compound-
+            // assign fusion pass then folds `Op(/) Equals` into a
+            // single `Name("/=")` token.  Without this guard, the
+            // oracle treats `x /= 1` as `x / <regex starting `=`...`
+            // which would never terminate.
+            self.suppress_regex_open = ch == '/' && chars.get(i + 1) == Some(&'=');
             self.step_char(ch)?;
+            self.suppress_regex_open = false;
             i += 1;
             if ch == '\n' && !self.pending_heredocs.is_empty() {
                 i = self.capture_heredoc_bodies(&chars, i)?;
@@ -379,6 +396,11 @@ impl RubyLexer {
         // so `1..5` (which the range pass converts to `Int ".." Int`)
         // doesn't get mistaken for a float.
         self.fuse_float_literals();
+        // Phase 6p companion — fuse compound-assignment operators
+        // (`+=`, `-=`, `*=`, `/=`, `||=`, `&&=`).  Pre-1.0 Ruby, so
+        // no era gating.  Runs AFTER float/radix fusions (which fold
+        // numeric forms) so `x +=` doesn't fight with `1e+10` etc.
+        self.fuse_compound_assigns();
         if era_at_least(&self.era, "1.9.1") {
             self.fuse_lambda_arrow();
         }
@@ -663,6 +685,85 @@ impl RubyLexer {
                     flags: None,
                 };
             } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Phase 6p companion — fuse compound-assignment operators
+    /// `+=`, `-=`, `*=`, `/=`, `||=`, `&&=` into a single Name-typed
+    /// token whose value is the fused operator (`+=` etc.).
+    ///
+    /// The 1.8-baseline state machine emits compound assigns as two
+    /// tokens:
+    ///   - The op (Plus / Minus / Star / Slash for `+`/`-`/`*`/`/`,
+    ///     or Name for `||` / `&&` — classify_op_token's catch-all).
+    ///   - Equals for the trailing `=`.
+    ///
+    /// This pass folds the pair into a single token so the grammar
+    /// can match by value (`"+="`, `"-="`, etc.) the same way it
+    /// matches `"=>"`, `"<="`, `"&&"`.
+    ///
+    /// Adjacency gate: the `=` must NOT have whitespace before it.
+    /// `x + = 1` (with a space) stays two tokens — that's a syntax
+    /// error in real Ruby but it's not a compound assignment.
+    ///
+    /// Era: pre-1.0 Ruby — every era ≥ 1.8 emits the same fused
+    /// shape, so no gating.
+    fn fuse_compound_assigns(&mut self) {
+        let mut i = 0;
+        while i + 1 < self.tokens.len() {
+            let (left_lexeme, is_arith): (&str, bool) = {
+                let a = &self.tokens[i];
+                match a.type_ {
+                    TokenType::Plus => ("+", true),
+                    TokenType::Minus => ("-", true),
+                    TokenType::Star => ("*", true),
+                    TokenType::Slash => ("/", true),
+                    // `||` and `&&` come through as Name (catch-all
+                    // in classify_op_token).  Filter by value so we
+                    // don't accidentally fuse `foo =` into something.
+                    TokenType::Name if a.value == "||" || a.value == "&&" => {
+                        (if a.value == "||" { "||" } else { "&&" }, false)
+                    }
+                    _ => {
+                        i += 1;
+                        continue;
+                    }
+                }
+            };
+            let merge = {
+                let b = &self.tokens[i + 1];
+                let b_is_eq = b.type_ == TokenType::Equals;
+                let same_line = self.tokens[i].line == b.line;
+                // No whitespace gap between op and `=`.
+                let no_ws = !self
+                    .whitespace_before_token
+                    .get(i + 1)
+                    .copied()
+                    .unwrap_or(false);
+                b_is_eq && same_line && no_ws
+            };
+            if merge {
+                let span_line = self.tokens[i].line;
+                let span_col = self.tokens[i].column;
+                let new_value = format!("{left_lexeme}=");
+                self.tokens.remove(i + 1);
+                self.whitespace_before_token.remove(i + 1);
+                self.tokens[i] = Token {
+                    type_: TokenType::Name,
+                    value: new_value,
+                    line: span_line,
+                    column: span_col,
+                    type_name: None,
+                    flags: None,
+                };
+                // Don't advance — chained compounds are illegal but
+                // the next iteration's guard will handle it cleanly.
+            } else {
+                // Reference `is_arith` once so the compiler doesn't
+                // warn — the variable is documentary for now.
+                let _ = is_arith;
                 i += 1;
             }
         }
@@ -1058,6 +1159,14 @@ impl RubyLexer {
     ///   the local's value).  Not-local → regex (the name was a
     ///   method call and the regex is its argument).
     fn should_open_regex(&self) -> bool {
+        // Phase 6p companion — `push` sets `suppress_regex_open` for
+        // exactly one `step_char` call when the upcoming `/` is
+        // immediately followed by `=`.  Force a plain-Op emit so
+        // `fuse_compound_assigns` can fold `Op(/) Equals` into
+        // `Name("/=")`.
+        if self.suppress_regex_open {
+            return false;
+        }
         if self.lex_state.slash_is_regex() {
             return true;
         }
@@ -3585,6 +3694,59 @@ mod tests {
             .filter(|t| t.type_ == TokenType::String && t.value.starts_with(prefix))
             .map(|t| t.value.clone())
             .collect()
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 6p companion — fuse compound-assign operators
+    // -----------------------------------------------------------------
+    //
+    // `fuse_compound_assigns` folds adjacent `Op` + `Equals` token
+    // pairs into a single Name-typed token carrying the fused
+    // operator value (`+=`, `-=`, `*=`, `/=`, `||=`, `&&=`).  For
+    // `/=`, `push` sets `suppress_regex_open` so the slash isn't
+    // mis-interpreted as a regex opener — without that gate `x /= 1`
+    // would lex as `x / <regex starting `=`...>` and never terminate.
+
+    #[test]
+    fn compound_assign_arithmetic_ops_fuse_into_single_token() {
+        for (src, fused) in [
+            ("x += 1", "+="),
+            ("x -= 1", "-="),
+            ("x *= 1", "*="),
+            ("x /= 1", "/="),
+        ] {
+            let toks = tokenize_ruby_for_version(src, "1.8").unwrap();
+            let has_fused = toks
+                .iter()
+                .any(|t| t.type_ == TokenType::Name && t.value == fused);
+            assert!(has_fused, "expected {fused} token in {src:?}, got {toks:?}");
+        }
+    }
+
+    #[test]
+    fn compound_assign_logical_ops_fuse_into_single_token() {
+        for (src, fused) in [("x ||= 1", "||="), ("x &&= 1", "&&=")] {
+            let toks = tokenize_ruby_for_version(src, "1.8").unwrap();
+            let has_fused = toks
+                .iter()
+                .any(|t| t.type_ == TokenType::Name && t.value == fused);
+            assert!(has_fused, "expected {fused} token in {src:?}, got {toks:?}");
+        }
+    }
+
+    #[test]
+    fn compound_assign_does_not_fuse_with_whitespace_gap() {
+        // `x + = 1` with a space between `+` and `=` is two tokens —
+        // the fusion gate requires no whitespace between op and `=`.
+        let toks = tokenize_ruby_for_version("x + = 1", "1.8").unwrap();
+        // No fused `+=` token expected; instead we see Plus + Equals.
+        let has_fused = toks
+            .iter()
+            .any(|t| t.type_ == TokenType::Name && t.value == "+=");
+        assert!(!has_fused, "spaced `x + = 1` should NOT fuse, got {toks:?}");
+        let has_plus = toks.iter().any(|t| t.type_ == TokenType::Plus);
+        let has_eq = toks.iter().any(|t| t.type_ == TokenType::Equals);
+        assert!(has_plus && has_eq, "expected separate Plus + Equals, got {toks:?}");
     }
 
     #[test]

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.17.0] - 2026-05-24
+
+### Added (Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`)
+
+Grammar change:
+
+```
+assignment = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expression ;
+```
+
+The lexer's companion `fuse_compound_assigns` post-pass folds adjacent `Op` + `Equals` token pairs into single Name-typed tokens carrying the fused operator value (`+=`, etc.), so the grammar matches by literal value — same convention as `"=>"`, `"<="`, `"&&"`.
+
+Excludes `==`, `!=`, `<=`, `>=`, `===` — those are comparison operators handled at the `comparison` layer.  The fusion pass deliberately only runs on Op tokens (`Plus`/`Minus`/`Star`/`Slash`) and the two Name-typed logicals (`||`/`&&`) to avoid colliding with comparison ops which the lexer fuses directly.
+
+### Tests (+4 new, total 78)
+- `test_parse_plus_equals_assignment` — `x += 1` carries `+=` token.
+- `test_parse_all_arithmetic_compound_operators` — `+=`, `-=`, `*=`, `/=` all parse.
+- `test_parse_logical_compound_operators` — `||=`, `&&=` parse.
+- `test_parse_compound_assign_with_complex_rhs` — `x += 1 + 2` parses with one `+=` and one `+`.
+
 ## [0.16.0] - 2026-05-24
 
 ### Added (Phase 6o — ternary `cond ? a : b`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -268,10 +268,18 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                        GrammarElement::Literal { value: r#"+="#.to_string() },
+                        GrammarElement::Literal { value: r#"-="#.to_string() },
+                        GrammarElement::Literal { value: r#"*="#.to_string() },
+                        GrammarElement::Literal { value: r#"/="#.to_string() },
+                        GrammarElement::Literal { value: r#"||="#.to_string() },
+                        GrammarElement::Literal { value: r#"&&="#.to_string() },
+                    ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 53,
+            line_number: 72,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -291,7 +299,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 64,
+            line_number: 83,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -313,7 +321,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 65,
+            line_number: 84,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -328,17 +336,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 79,
+            line_number: 98,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 80,
+            line_number: 99,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 166,
+            line_number: 185,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -351,7 +359,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 167,
+            line_number: 186,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -365,7 +373,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 168,
+            line_number: 187,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -379,7 +387,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 169,
+            line_number: 188,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -393,7 +401,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 170,
+            line_number: 189,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -404,7 +412,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 177,
+            line_number: 196,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -422,7 +430,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 178,
+            line_number: 197,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -436,7 +444,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 179,
+            line_number: 198,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -450,7 +458,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 180,
+            line_number: 199,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -473,7 +481,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 190,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -481,7 +489,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 191,
+            line_number: 210,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -493,7 +501,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 192,
+            line_number: 211,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -508,7 +516,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 193,
+            line_number: 212,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -523,7 +531,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 194,
+            line_number: 213,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -539,7 +547,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 195,
+            line_number: 214,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1120,6 +1120,81 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`
+    // -----------------------------------------------------------------------
+    //
+    // The lexer's `fuse_compound_assigns` post-pass folds adjacent
+    // `Op` + `Equals` token pairs into a single Name-typed token whose
+    // value is the fused operator (`+=`, etc.).  The grammar matches
+    // by value — every assignment node carries either an EQUALS token
+    // OR one of the compound-op tokens.
+
+    #[test]
+    fn test_parse_plus_equals_assignment() {
+        // `x += 1` parses as an assignment with a `+=` operator token.
+        let ast = parse_ruby("x += 1");
+        let assn = find_descendant(&ast, "assignment").expect("expected assignment");
+        assert!(
+            tree_has_token_value(assn, "+="),
+            "expected `+=` token in assignment, got {assn:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_all_arithmetic_compound_operators() {
+        // Each of `+=`, `-=`, `*=`, `/=` parses as an assignment.
+        for op in ["+=", "-=", "*=", "/="] {
+            let src = format!("x {op} 1");
+            let ast = parse_ruby(&src);
+            let assn = find_descendant(&ast, "assignment")
+                .unwrap_or_else(|| panic!("expected assignment for {src:?}"));
+            assert!(
+                tree_has_token_value(assn, op),
+                "expected `{op}` token in assignment for source {src:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_logical_compound_operators() {
+        // `||=` and `&&=` are short-circuiting compound assignments.
+        for op in ["||=", "&&="] {
+            let src = format!("x {op} 1");
+            let ast = parse_ruby(&src);
+            let assn = find_descendant(&ast, "assignment")
+                .unwrap_or_else(|| panic!("expected assignment for {src:?}"));
+            assert!(
+                tree_has_token_value(assn, op),
+                "expected `{op}` token in assignment for source {src:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_compound_assign_with_complex_rhs() {
+        // The RHS is a full `expression`, so arithmetic flows through.
+        let ast = parse_ruby("x += 1 + 2");
+        let assn = find_descendant(&ast, "assignment").expect("expected assignment");
+        assert!(tree_has_token_value(assn, "+="));
+        // Two `+` tokens overall: the `+=` operator counts because
+        // `+=` contains `+`, but tree_has_token_value matches by full
+        // value; we expect a separate `+` from the RHS sum chain.
+        fn count_value(node: &GrammarASTNode, val: &str) -> usize {
+            let mut n = 0;
+            for c in &node.children {
+                match c {
+                    ASTNodeOrToken::Token(t) if t.value == val => n += 1,
+                    ASTNodeOrToken::Node(sub) => n += count_value(sub, val),
+                    _ => {}
+                }
+            }
+            n
+        }
+        assert_eq!(count_value(assn, "+"), 1, "expected one bare `+` in the RHS");
+        assert_eq!(count_value(assn, "+="), 1, "expected one `+=` operator");
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 6o — ternary `cond ? a : b`
     // -----------------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.17.0] - 2026-05-24
+
+### Added (Phase 6p — compound assignment lowering)
+
+SIR encoding (for each `x op= rhs`):
+```
+Stmt::Assign {
+  name: "x",
+  scope: Local,
+  value: Expr::BuiltinCall {
+    name: "<op>",   // "+", "-", "*", "/", "or", "and"
+    args: [VarRef("x"), <rhs>],
+  },
+}
+```
+
+| Source | Lowered as |
+|---|---|
+| `x += y` | `x = x + y` |
+| `x -= y` | `x = x - y` |
+| `x *= y` | `x = x * y` |
+| `x /= y` | `x = x / y` |
+| `x \|\|= y` | `x = x or y` |
+| `x &&= y` | `x = x and y` |
+
+Lowering identically to `x = x op y` means downstream emitters (semantic-ir-to-python, -rust, -typescript, -go) need no new code path — the existing assignment + binary-op lowering handles both forms.
+
+### Lowerer changes
+- `lower_assignment` now reads the operator token (skipping the leading NAME) to dispatch on `EQUALS` vs the six compound forms.
+- Compound forms always emit `Stmt::Assign` (never `LetBinding`) even on first sighting — the read of `x` before the write means the binding semantically pre-exists.  Sets `Feature::MutableBindings` automatically.
+
+### Tests (+4 new, total 81)
+- `plus_equals_lowers_to_assign_with_plus_builtin`
+- `all_arithmetic_compound_assigns_lower_correctly` — `+=`, `-=`, `*=`, `/=`.
+- `logical_compound_assigns_lower_to_or_and_builtins` — `||=` → `"or"`, `&&=` → `"and"`.
+- `compound_assign_module_passes_sir_validator` — end-to-end validator smoke test.
+
 ## [0.16.0] - 2026-05-24
 
 ### Added (Phase 6o — ternary lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1462,4 +1462,101 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6p — compound assignment lowering
+    // -----------------------------------------------------------------
+    //
+    // SIR encoding (for each `x op= rhs`):
+    //   Stmt::Assign {
+    //     name: "x",
+    //     scope: Local,
+    //     value: Expr::BuiltinCall {
+    //       name: "<op>",   // "+", "-", "*", "/", "or", "and"
+    //       args: [VarRef("x"), <rhs>],
+    //     },
+    //   }
+    //
+    // Compound forms ALWAYS produce Assign (never LetBinding) even on
+    // first sighting — the read of `x` before the write means the
+    // binding semantically pre-exists.
+
+    #[test]
+    fn plus_equals_lowers_to_assign_with_plus_builtin() {
+        // `x = 1\nx += 2` — first `x = 1` is LetBinding, second `x += 2`
+        // is Assign with value = `+(x, 2)`.
+        let m = lower("x = 1\nx += 2\n");
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 2);
+        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "x"));
+        match &b.stmts[1] {
+            Stmt::Assign { name, value, .. } => {
+                assert_eq!(name, "x");
+                match value {
+                    Expr::BuiltinCall { name: op, args, .. } => {
+                        assert_eq!(op, "+");
+                        assert_eq!(args.len(), 2);
+                        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "x"));
+                        assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+                    }
+                    other => panic!("expected BuiltinCall(+, …), got {:?}", other),
+                }
+            }
+            other => panic!("expected Assign, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn all_arithmetic_compound_assigns_lower_correctly() {
+        // Each of +=, -=, *=, /= maps to the corresponding binary
+        // op builtin.
+        for (op_src, op_builtin) in [("+=", "+"), ("-=", "-"), ("*=", "*"), ("/=", "/")] {
+            let src = format!("x = 1\nx {op_src} 2\n");
+            let m = lower(&src);
+            let b = main_body(&m);
+            match &b.stmts[1] {
+                Stmt::Assign { value, .. } => match value {
+                    Expr::BuiltinCall { name, .. } => {
+                        assert_eq!(name, op_builtin, "wrong builtin for {op_src}");
+                    }
+                    other => panic!("expected BuiltinCall for {op_src}, got {:?}", other),
+                },
+                other => panic!("expected Assign for {op_src}, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn logical_compound_assigns_lower_to_or_and_builtins() {
+        // ||= → "or"; &&= → "and".  Same binary-op encoding as the
+        // arithmetic forms.
+        for (op_src, op_builtin) in [("||=", "or"), ("&&=", "and")] {
+            let src = format!("x = 1\nx {op_src} 2\n");
+            let m = lower(&src);
+            let b = main_body(&m);
+            match &b.stmts[1] {
+                Stmt::Assign { value, .. } => match value {
+                    Expr::BuiltinCall { name, .. } => {
+                        assert_eq!(name, op_builtin, "wrong builtin for {op_src}");
+                    }
+                    other => panic!("expected BuiltinCall for {op_src}, got {:?}", other),
+                },
+                other => panic!("expected Assign for {op_src}, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn compound_assign_module_passes_sir_validator() {
+        // End-to-end smoke check: validator accepts the compound-assign
+        // lowering (requires `mutable-bindings` feature, which the
+        // lowerer marks automatically).
+        let m = lower("x = 1\nx += 2\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected compound-assign output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -833,7 +833,7 @@ impl Lowerer {
     // -------------------------------------------------------------------
 
     fn lower_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
-        // Shape: NAME EQUALS expression
+        // Shape (post-6p): NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expression
         let (name, name_span) = self.expect_first_name_token(node)?;
         let expr_node = self.find_node_child(node, "expression").ok_or_else(|| {
             RubyLowerError {
@@ -842,14 +842,68 @@ impl Lowerer {
                 column: node.start_column.unwrap_or(0),
             }
         })?;
-        let value = self.lower_expression(expr_node)?;
+        let rhs = self.lower_expression(expr_node)?;
+
+        // Phase 6p — detect compound-assign operator.  The lexer
+        // pre-fuses `+=`, `-=`, `*=`, `/=`, `||=`, `&&=` into single
+        // Name-typed tokens; here we read the operator token (skipping
+        // the leading NAME) to dispatch.
+        let op_token = node.children.iter().skip(1).find_map(|c| match c {
+            ASTNodeOrToken::Token(t) => {
+                let v = t.value.as_str();
+                if matches!(v, "+=" | "-=" | "*=" | "/=" | "||=" | "&&=") {
+                    Some(v.to_string())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        });
 
         let span = self.span_of(node);
-        if self.declared_locals.contains(&name) {
-            // Phase 6b: `Stmt::Assign` re-binds an existing local —
-            // the SIR validator requires the manifest to declare
-            // `mutable-bindings` whenever this node appears.
+        // Build the effective RHS.  For plain `=`, it's just `rhs`.
+        // For compound forms, wrap it as `BuiltinCall(op, [VarRef(x), rhs])`
+        // where `op` is the underlying binary operator (`+` for `+=`,
+        // `or` for `||=`, etc.).  Lowering identically to
+        // `x = x op rhs` keeps downstream emitters simple — no new
+        // compound-assign-aware code paths required.
+        let value = if let Some(op) = op_token.as_deref() {
+            let (builtin_name, effects) = match op {
+                "+=" => ("+", EffectSet::PURE),
+                "-=" => ("-", EffectSet::PURE),
+                "*=" => ("*", EffectSet::PURE),
+                "/=" => ("/", EffectSet::PURE),
+                "||=" => ("or", EffectSet::PURE),
+                "&&=" => ("and", EffectSet::PURE),
+                _ => unreachable!("op_token matched only the six compound forms above"),
+            };
+            let lhs_ref = Expr::VarRef {
+                name: name.clone(),
+                scope: Scope::Local,
+                span: span.clone(),
+            };
+            Expr::BuiltinCall {
+                name: builtin_name.to_string(),
+                args: vec![lhs_ref, rhs],
+                effects,
+                span: span.clone(),
+            }
+        } else {
+            rhs
+        };
+
+        // A compound assignment ALWAYS reads then re-binds, so it
+        // must emit `Stmt::Assign` (never `LetBinding`).  Plain `=`
+        // keeps the original "first sighting → LetBinding, subsequent
+        // → Assign" behaviour.
+        let is_compound = op_token.is_some();
+        if is_compound || self.declared_locals.contains(&name) {
+            // Re-bind path: mutable-bindings feature required.
             self.features_used.insert(Feature::MutableBindings);
+            // Compound `x ||= 1` without a prior `x = …` is still
+            // valid Ruby (treats `x` as nil), but we record it as a
+            // local so any subsequent `x = 1` doesn't re-binding-error.
+            self.declared_locals.insert(name.clone());
             Ok(Stmt::Assign {
                 name,
                 scope: Scope::Local,


### PR DESCRIPTION
## Summary

Three-part change spanning the lexer, parser, and SIR lowerer to add compound assignment operators (`+=`, `-=`, `*=`, `/=`, `||=`, `&&=`).

## Lexer (`ruby-lexer`)

- New post-pass `fuse_compound_assigns` folds adjacent `Op` + `Equals` token pairs into a single `Name`-typed token whose value is the fused operator.
- New `suppress_regex_open` flag set by `push` for one `step_char` call when the upcoming `/` is followed by `=` — fixes `x /= 1` previously lexing as `Name(x)` + unterminated regex.
- Adjacency gate: no whitespace between op and `=`.
- Pre-1.0 Ruby — no era gating.

## Parser (`ruby-parser`)

```
assignment = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expression ;
```

Excludes comparison operators (`==`, `!=`, `<=`, `>=`, `===`) — those are handled at the `comparison` layer.

## SIR (`ruby-to-semantic-ir`)

```
x op= rhs  →  Stmt::Assign {
                name: "x",
                value: BuiltinCall(<op>, [VarRef(x), rhs]),
              }
```

Lowering identically to `x = x op rhs` means downstream emitters (semantic-ir-to-python, -rust, -typescript, -go) need no new code path.

Compound forms always emit `Stmt::Assign` (never `LetBinding`) even on first sighting — the read of `x` before the write means the binding semantically pre-exists. Auto-sets `Feature::MutableBindings`.

| Source | Lowered as |
|---|---|
| `x += y` | `x = x + y` |
| `x -= y` | `x = x - y` |
| `x *= y` | `x = x * y` |
| `x /= y` | `x = x / y` |
| `x \|\|= y` | `x = x or y` |
| `x &&= y` | `x = x and y` |

## Tests

- `coding-adventures-ruby-lexer`: 156 → 159 (+3 fusion tests).
- `coding-adventures-ruby-parser`: 74 → 78 (+4 grammar tests).
- `ruby-to-semantic-ir`: 77 → 81 (+4 lowering tests).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (159/159 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (78/78 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (81/81 pass)
- [x] Security review via `/security-review` — passed
- [ ] CI green

Follows PR #4280 (Phase 4n — %r/%s/%x percent literals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
