### PR TITLE
Track browser output metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -500,6 +500,7 @@ def check_browser_expected_lists(
                 require_optional_nullable_string(control_path, control, field, errors)
             require_optional_string_list(control_path, control, "labels", errors)
             require_optional_string_list(control_path, control, "datalist_options", errors)
+            require_optional_string_list(control_path, control, "output_for", errors)
             require_optional_nullable_string(control_path, control, "value", errors)
             require_boolean(control_path, control, "disabled", errors)
             require_optional_boolean(control_path, control, "required", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1334,6 +1334,7 @@ pub struct BrowserFormControl {
     pub size: Option<String>,
     pub list: Option<String>,
     pub datalist_options: Vec<String>,
+    pub output_for: Vec<String>,
     pub form_action: Option<String>,
     pub resolved_form_action: Option<String>,
     pub form_enctype: Option<String>,
@@ -10018,7 +10019,7 @@ fn collect_element_texts_by_id_into(nodes: &[Node], id_texts: &mut Vec<(String, 
 }
 
 fn is_browser_form_control_element(name: &str) -> bool {
-    matches!(name, "button" | "input" | "select" | "textarea")
+    matches!(name, "button" | "input" | "output" | "select" | "textarea")
 }
 
 fn browser_control_labels(
@@ -10540,7 +10541,7 @@ fn browser_content_control_type(element: &Element) -> Option<String> {
                 .map(|button_type| button_type.to_ascii_lowercase())
                 .unwrap_or_else(|| "submit".to_string()),
         ),
-        "select" | "textarea" => Some(element.name.clone()),
+        "output" | "select" | "textarea" => Some(element.name.clone()),
         _ => None,
     }
 }
@@ -10550,6 +10551,7 @@ fn browser_content_value(element: &Element) -> Option<String> {
         "button" => element.attribute("value").map(ToOwned::to_owned),
         "input" => browser_input_value(element),
         "option" => Some(browser_option_value(element)),
+        "output" => Some(element_text(element)),
         "select" => selected_option_value(&element.children),
         "textarea" => Some(element_text(element)),
         _ => None,
@@ -10567,6 +10569,17 @@ fn browser_control_datalist_options(element: &Element, body_root: &[Node]) -> Ve
     browser_control_list(element)
         .as_deref()
         .and_then(|list_id| datalist_options_by_id(body_root, list_id))
+        .unwrap_or_default()
+}
+
+fn browser_output_for(element: &Element) -> Vec<String> {
+    if element.name != "output" {
+        return Vec::new();
+    }
+
+    element
+        .attribute("for")
+        .map(split_html_classes)
         .unwrap_or_default()
 }
 
@@ -10776,7 +10789,7 @@ fn collect_form_controls_for_form_into(
 
         if matches!(
             element.name.as_str(),
-            "input" | "button" | "select" | "textarea"
+            "input" | "button" | "output" | "select" | "textarea"
         ) {
             let form_owner = browser_form_owner(element);
             let associated_with_target = match form_owner.as_deref() {
@@ -10820,7 +10833,7 @@ fn browser_form_control(
         .expect("browser_form_control is only called for form controls");
     let control_labels = browser_control_labels(element, labels, current_label_text);
     let text = match element.name.as_str() {
-        "button" | "select" => visible_text_for_nodes(&element.children),
+        "button" | "output" | "select" => visible_text_for_nodes(&element.children),
         "textarea" => element_text(element),
         _ => String::new(),
     };
@@ -10856,6 +10869,7 @@ fn browser_form_control(
         size: browser_control_size(element),
         list: browser_control_list(element),
         datalist_options: browser_control_datalist_options(element, body_root),
+        output_for: browser_output_for(element),
         resolved_form_action: browser_control_form_action(element)
             .as_deref()
             .and_then(|action| resolve_browser_url(action, base_href)),
@@ -11626,7 +11640,8 @@ mod tests {
              formenctype=\"application/x-www-form-urlencoded\" formmethod=post \
              formtarget=results formnovalidate>Go</button>\
              <input id=imageGo type=image name=image-go src=buttons/search.png \
-             alt=\"Search image\" width=32 height=16></form>\
+             alt=\"Search image\" width=32 height=16>\
+             <output id=total name=total for=\"q kind\">Ready</output></form>\
              <input id=external form=f name=outside placeholder=Outside>",
         )
         .unwrap();
@@ -11702,11 +11717,16 @@ mod tests {
         assert_eq!(controls[6].alt.as_deref(), Some("Search image"));
         assert_eq!(controls[6].width.as_deref(), Some("32"));
         assert_eq!(controls[6].height.as_deref(), Some("16"));
-        assert_eq!(controls[7].id.as_deref(), Some("external"));
-        assert_eq!(controls[7].name.as_deref(), Some("outside"));
-        assert_eq!(controls[7].form_owner.as_deref(), Some("f"));
-        assert_eq!(controls[7].accessible_name.as_deref(), Some("Outside"));
-        assert_eq!(controls[7].placeholder.as_deref(), Some("Outside"));
+        assert_eq!(controls[7].control_type, "output");
+        assert_eq!(controls[7].name.as_deref(), Some("total"));
+        assert_eq!(controls[7].output_for, vec!["q", "kind"]);
+        assert_eq!(controls[7].value.as_deref(), Some("Ready"));
+        assert_eq!(controls[7].text, "Ready");
+        assert_eq!(controls[8].id.as_deref(), Some("external"));
+        assert_eq!(controls[8].name.as_deref(), Some("outside"));
+        assert_eq!(controls[8].form_owner.as_deref(), Some("f"));
+        assert_eq!(controls[8].accessible_name.as_deref(), Some("Outside"));
+        assert_eq!(controls[8].placeholder.as_deref(), Some("Outside"));
 
         let content_tree = BrowserContentTree::from_document(&document);
         let form = &content_tree.children[0];
@@ -11761,6 +11781,9 @@ mod tests {
         assert_eq!(image_button.alt.as_deref(), Some("Search image"));
         assert_eq!(image_button.width.as_deref(), Some("32"));
         assert_eq!(image_button.height.as_deref(), Some("16"));
+        let output = &form.children[8];
+        assert_eq!(output.control_type.as_deref(), Some("output"));
+        assert_eq!(output.value.as_deref(), Some("Ready"));
         let external = &content_tree.children[1];
         assert_eq!(external.form_owner.as_deref(), Some("f"));
         assert_eq!(external.accessible_name.as_deref(), Some("Outside"));

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -411,6 +411,8 @@ struct ExpectedFormControl {
     #[serde(default)]
     datalist_options: Vec<String>,
     #[serde(default)]
+    output_for: Vec<String>,
+    #[serde(default)]
     form_action: Option<String>,
     #[serde(default)]
     resolved_form_action: Option<String>,
@@ -827,6 +829,7 @@ impl ExpectedFormControl {
             size: self.size,
             list: self.list,
             datalist_options: self.datalist_options,
+            output_for: self.output_for,
             form_action: self.form_action,
             resolved_form_action: self.resolved_form_action,
             form_enctype: self.form_enctype,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -135,16 +135,16 @@
     {
       "id": "form-accessibility-document-page",
       "description": "Browser document form summaries include labels, accessible names, submission metadata, validation hints, autocomplete, and control state.",
-      "input": "<base href=\"https://example.test/search/index.html\"><body><form id=search name=searchForm aria-label=\"Search form\" action=find.html method=post accept-charset=utf-8 autocomplete=on rel=noreferrer novalidate><label for=q>Query</label><input id=q name=q placeholder=\"Search terms\" required autocomplete=search autocapitalize=words enterkeyhint=search dirname=q.dir autofocus inputmode=search pattern=\"[A-Za-z ]+\" minlength=2 maxlength=80 size=40 list=query-suggestions><datalist id=query-suggestions><option value=Rust><option value=HTML label=Markup><option>Browser APIs</datalist><label>Notes<textarea id=notes name=notes placeholder=Details readonly maxlength=500 autocapitalize=sentences enterkeyhint=done dirname=notes.dir>Keep me</textarea></label><fieldset><legend>Options</legend><label>Fast<input id=fast type=checkbox name=fast checked></label></fieldset><select id=kind name=kind title=Kind multiple size=5><option selected>Books<option>Manuals</select><input id=upload type=file name=upload accept=\"image/png,image/jpeg\" capture=environment><button id=go type=submit aria-label=\"Run search\" formaction=run.html formenctype=\"application/x-www-form-urlencoded\" formmethod=post formtarget=results formnovalidate>Go</button><input id=imageGo type=image name=image-go src=buttons/search.png alt=\"Search image\" width=32 height=16></form><input id=external form=search name=outside placeholder=Outside>",
+      "input": "<base href=\"https://example.test/search/index.html\"><body><form id=search name=searchForm aria-label=\"Search form\" action=find.html method=post accept-charset=utf-8 autocomplete=on rel=noreferrer novalidate><label for=q>Query</label><input id=q name=q placeholder=\"Search terms\" required autocomplete=search autocapitalize=words enterkeyhint=search dirname=q.dir autofocus inputmode=search pattern=\"[A-Za-z ]+\" minlength=2 maxlength=80 size=40 list=query-suggestions><datalist id=query-suggestions><option value=Rust><option value=HTML label=Markup><option>Browser APIs</datalist><label>Notes<textarea id=notes name=notes placeholder=Details readonly maxlength=500 autocapitalize=sentences enterkeyhint=done dirname=notes.dir>Keep me</textarea></label><fieldset><legend>Options</legend><label>Fast<input id=fast type=checkbox name=fast checked></label></fieldset><select id=kind name=kind title=Kind multiple size=5><option selected>Books<option>Manuals</select><input id=upload type=file name=upload accept=\"image/png,image/jpeg\" capture=environment><button id=go type=submit aria-label=\"Run search\" formaction=run.html formenctype=\"application/x-www-form-urlencoded\" formmethod=post formtarget=results formnovalidate>Go</button><input id=imageGo type=image name=image-go src=buttons/search.png alt=\"Search image\" width=32 height=16><output id=total name=total for=\"q kind\">Ready</output></form><input id=external form=search name=outside placeholder=Outside>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/search/index.html",
         "base_target": null,
-        "body_text": "Query NotesKeep me Options Fast Books Manuals Go",
+        "body_text": "Query NotesKeep me Options Fast Books Manuals Go Ready",
         "metas": [],
         "resources": [],
         "anchors": [
-          { "id": "search", "name": null, "text": "Query NotesKeep me Options Fast Books Manuals Go" },
+          { "id": "search", "name": null, "text": "Query NotesKeep me Options Fast Books Manuals Go Ready" },
           { "id": "q", "name": null, "text": "" },
           { "id": "query-suggestions", "name": null, "text": "Browser APIs" },
           { "id": "notes", "name": null, "text": "Keep me" },
@@ -153,6 +153,7 @@
           { "id": "upload", "name": null, "text": "" },
           { "id": "go", "name": null, "text": "Go" },
           { "id": "imageGo", "name": null, "text": "" },
+          { "id": "total", "name": null, "text": "Ready" },
           { "id": "external", "name": null, "text": "" }
         ],
         "headings": [],
@@ -179,6 +180,7 @@
               { "id": "upload", "control_type": "file", "name": "upload", "accept": "image/png,image/jpeg", "capture": "environment", "value": null, "disabled": false, "checked": false, "text": "", "options": [] },
               { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "form_action": "run.html", "resolved_form_action": "https://example.test/search/run.html", "form_enctype": "application/x-www-form-urlencoded", "form_method": "post", "form_target": "results", "form_novalidate": true, "value": null, "disabled": false, "checked": false, "text": "Go", "options": [] },
               { "id": "imageGo", "control_type": "image", "name": "image-go", "src": "buttons/search.png", "resolved_src": "https://example.test/search/buttons/search.png", "alt": "Search image", "width": "32", "height": "16", "value": null, "disabled": false, "checked": false, "text": "", "options": [] },
+              { "id": "total", "control_type": "output", "name": "total", "output_for": ["q", "kind"], "value": "Ready", "disabled": false, "checked": false, "text": "Ready", "options": [] },
               { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "disabled": false, "checked": false, "text": "", "options": [] }
             ]
           }


### PR DESCRIPTION
## Summary
- Treat `<output>` as a browser form-associated control in document/content summaries.
- Capture output `for` token references as `output_for` and expose rendered output text as control value/text.
- Extend the browser-readiness form fixture and schema governance for output metadata.

## Validation
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_content_tree_cases_extract_renderable_body_structure
- cargo test -p coding-adventures-html-parser browser_render_tree_cases_extract_default_display_structure
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser