### PR TITLE
feat(cas-summation): Phase 59 — Bounded × Sqrt × polynomial numerator (1.7.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.7.0 — 2026-05-25
+
+**Phase 59 — Bounded × Sqrt(positive-poly) × polynomial numerator (Python).**
+
+Closes the three-way gap between Phase 53 (Sqrt × polynomial, refuses
+bounded factors), Phase 56 (bounded × Sqrt, refuses polynomial factors),
+and Phase 57 (bounded × Log × Sqrt, the Log specialisation).
+
+A numerator with one ``Sqrt(positive-leading polynomial P)`` factor, any
+polynomial factors (total degree ``m``), and any bounded factors has
+effective growth ``k^{deg(P)/2 + m}``.  Using the ×2 integer trick:
+``effective_x2 = deg(P) + 2·m``.  Vanishes when ``2·den_deg > effective_x2``
+(polynomial denominator) or when the denominator is non-polynomial diverging.
+
+### Added
+
+- **``_bounded_sqrt_poly_effective_x2``** — returns ``deg(P) + 2·poly_deg``
+  for ``Mul(bounded..., Sqrt(positive-poly), polynomial_factors...)``.
+  Refuses two-Sqrt, any Log (→ Phase 57), or unrecognised factors.
+- **Phase 59 branch** in ``_g_vanishes_at_infinity`` — checks
+  ``2·den_deg > bsp_x2`` for polynomial denominators; falls back to
+  ``_h_diverges_at_infinity`` for non-polynomial diverging denominators.
+- **6 new tests** in ``TestEvaluateSumPhase59BoundedSqrtPolyNumerator``.
+
 ## 1.6.0 — 2026-05-25
 
 **Phase 58 — Bounded × Log(diverging) × polynomial numerator (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.6.0"
+version = "1.7.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -813,6 +813,22 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 59: ``Mul(bounded, Sqrt(positive-poly), polynomial)`` numerator.
+    # Bounded × Sqrt × polynomial: effective growth ``k^{deg(P)/2 + poly_deg}``.
+    # Using ×2 trick: effective_x2 = deg(P) + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial denominator) or
+    # when the denominator is non-polynomial diverging.
+    # Closes the gap between Phase 53 (Sqrt × poly, refuses bounded) and
+    # Phase 56 (bounded × Sqrt, refuses polynomial factors).
+    # Log factors are intentionally refused — use Phase 57 (bounded × Log × Sqrt).
+    bsp_x2 = _bounded_sqrt_poly_effective_x2(num, k)
+    if bsp_x2 is not None:
+        den_deg_bsp = _polynomial_degree_in_k(den, k)
+        if den_deg_bsp is not None:
+            if 2 * den_deg_bsp > bsp_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1295,6 +1311,89 @@ def _bounded_log_poly_degree(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 1:
         return None
     return poly_deg_sum
+
+
+def _bounded_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_inner_deg_x2 + 2 * poly_deg_sum`` when ``node`` is a
+    ``Mul`` with exactly one ``Sqrt(positive-leading polynomial)`` factor,
+    any polynomial factors, and any number of bounded (non-polynomial,
+    non-Sqrt) factors in ``k``; ``None`` otherwise.
+
+    Phase 59 — Bounded × Sqrt(P) × polynomial numerator.
+
+    This phase closes the gap between:
+
+    * **Phase 53** — ``Mul(Sqrt, polynomial_only)``; refuses the moment any
+      factor is neither ``Sqrt`` nor a polynomial, so ``Sin(k)·Sqrt(k)·k``
+      fails.
+    * **Phase 56** — ``Mul(bounded, Sqrt)``; requires *all* non-Sqrt factors
+      to be bounded, so ``Sin(k)·Sqrt(k)·k`` fails (``k`` diverges
+      polynomially).
+
+    Here we allow any mix of polynomial and bounded factors alongside one
+    ``Sqrt(positive-leading polynomial)`` factor:
+
+    +---------------------------------------+-------------------+
+    | Input                                 | Return            |
+    +=======================================+===================+
+    | ``Mul(Sin(k), Sqrt(k), k)``           | ``1 + 2 = 3``     |
+    | ``Mul(Cos(k), Sqrt(k²), k²)``         | ``2 + 4 = 6``     |
+    | ``Mul(Sin(k), Cos(k), Sqrt(k), k)``   | ``1 + 2 = 3``     |
+    | ``Mul(Sin(k), Sqrt(k))``              | ``1 + 0 = 1``     |
+    | ``Mul(Sin(k), Sqrt(k), Log(k), k)``   | ``None`` (Log)    |
+    | ``Mul(Sin(k), Sqrt(k), Sqrt(k), k)``  | ``None`` (2 Sqrt) |
+    | ``Mul(Sin(k), k)``                    | ``None`` (no Sqrt)|
+    +---------------------------------------+-------------------+
+
+    Mathematical basis:
+      ``|bounded(k)·Sqrt(P(k))·k^m| = O(k^{deg(P)/2 + m})``.  Using the
+      ×2 trick to stay exact: ``effective_x2 = deg(P) + 2·m``.  Caller
+      checks ``2·den_deg > effective_x2``.
+
+    Log factors are explicitly refused here — that combination is handled
+    by Phase 57 (``bounded × Log × Sqrt``).
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - Exactly one ``Sqrt(positive-leading polynomial)`` → record
+           ``×2`` degree; refuse if a second appears.
+         - Log(diverging) → immediately return ``None`` (Phase 57 territory).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Sqrt, non-Log) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly one Sqrt factor.
+      4. Return ``sqrt_inner_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_inner_deg: int | None = None
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        # Sqrt(positive-poly) factor?
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_inner_deg is not None:
+                # Two Sqrt factors — refuse.
+                return None
+            sqrt_inner_deg = deg_x2
+            continue
+        # Log factor — refuse (belongs to Phase 57 / Phase 58 territory).
+        if _is_log_of_diverging_in_k(arg, k):
+            return None
+        # Polynomial factor (degree ≥ 0)?
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        # Bounded (non-polynomial, non-Sqrt, non-Log)?
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor — bail.
+        return None
+    if sqrt_inner_deg is None:
+        return None
+    return sqrt_inner_deg + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -2139,3 +2139,138 @@ class TestEvaluateSumPhase58BoundedLogPolyNumerator:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase59BoundedSqrtPolyNumerator:
+    """Phase 59 — ``Mul(bounded, Sqrt(positive-poly), polynomial)`` numerator.
+
+    Fills the gap between:
+      - Phase 53: ``Mul(Sqrt, polynomial_only)`` — refuses bounded factors.
+      - Phase 56: ``Mul(bounded, Sqrt)`` — refuses polynomial factors.
+
+    Effective growth: ``C · k^{deg(P)/2 + poly_deg}``.
+    ×2 trick: ``effective_x2 = deg(P) + 2·poly_deg``.
+    Vanishes when ``2·den_deg > effective_x2`` or non-polynomial diverging denom.
+    """
+
+    def test_sin_sqrt_k_times_k_over_k_cubed_closes(self):
+        """sin(k)·√k·k / k³: sqrt_inner_deg=1, poly_deg=1, x2=3; 2·3=6>3 → closes."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, sqrt_k, _k))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1, kp1))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_cos_sqrt_k_sq_times_k_sq_over_k_fourth_closes(self):
+        """cos(k)·√(k²)·k² / k⁴: sqrt_inner_deg=2, poly_deg=2, x2=6; 2·4=8>6 → closes."""
+        from symbolic_ir import COS, POW, SQRT, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2 = IRApply(SQRT, (k2,))
+        num_k = IRApply(MUL, (cos_k, sqrt_k2, k2))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1_2,))
+        num_kp1 = IRApply(MUL, (cos_kp1, sqrt_kp1_2, kp1_2))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_bounded_sqrt_k_times_k_over_k_cubed_closes(self):
+        """sin(k)·cos(k)·√k·k / k³: two bounded factors + sqrt + poly → closes."""
+        from symbolic_ir import COS, POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        cos_k = IRApply(COS, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, cos_k, sqrt_k, _k))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        cos_kp1 = IRApply(COS, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, cos_kp1, sqrt_kp1, kp1))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_sqrt_k_times_k_sq_over_exponential_closes(self):
+        """sin(k)·√k·k² / 2^k: non-polynomial diverging denom → closes."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (sin_k, sqrt_k, k2))
+        exp_k = IRApply(POW, (IRInteger(2), _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1, kp1_2))
+        exp_kp1 = IRApply(POW, (IRInteger(2), kp1))
+        g_k = IRApply(DIV, (num_k, exp_k))
+        g_kp1 = IRApply(DIV, (num_kp1, exp_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_sqrt_k_sq_times_k_over_k_sq_refused(self):
+        """sin(k)·√(k²)·k / k²: x2=2+2=4; 2·2=4 not > 4 → equal, refused."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2 = IRApply(SQRT, (k2,))
+        num_k = IRApply(MUL, (sin_k, sqrt_k2, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1_2,))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1_2, kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_sin_sqrt_k_times_k_cubed_over_k_sq_refused(self):
+        """sin(k)·√k·k³ / k²: x2=1+6=7; 2·2=4 < 7 → numerator wins, refused."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        num_k = IRApply(MUL, (sin_k, sqrt_k, k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1, kp1_3))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.7.0 — 2026-05-25
+
+**Phase 59 — Bounded × Sqrt(positive-poly) × polynomial numerator (Rust port).**
+
+Ports Python ``cas-summation`` 1.7.0.  Fills the gap between Phase 53
+(Sqrt × polynomial, refuses bounded factors) and Phase 56 (bounded × Sqrt,
+refuses polynomial factors).
+
+Effective growth: ``C·k^{deg(P)/2 + poly_deg}``.  ×2 trick:
+``effective_x2 = deg(P) + 2·poly_deg``.  Vanishes when
+``2·den_deg > effective_x2`` or non-polynomial diverging denominator.
+
+### Added
+
+- **`bounded_sqrt_poly_effective_x2(node, k) -> Option<i64>`** — returns
+  ``sqrt_inner_deg + 2·poly_deg`` for
+  ``Mul(bounded..., Sqrt(positive-poly), poly_factors...)``.
+  Refuses two-Sqrt, Log (→ Phase 57), or unrecognised factors.
+- **Phase 59 branch** in ``g_vanishes_at_infinity`` — checks
+  ``2·den_deg > bsp_x2`` for polynomial denominators; falls back to
+  ``h_diverges_at_infinity`` for non-polynomial diverging denominators.
+- **3 new tests**: ``phase59_*`` in ``tests/tests.rs``.
+
 ## 1.6.0 — 2026-05-25
 
 **Phase 58 — Bounded × Log(diverging) × polynomial numerator (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1331,6 +1331,76 @@ fn bounded_log_poly_degree(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(poly_deg)
 }
 
+/// Return `sqrt_inner_deg + 2 * poly_deg` when `node` is a `Mul` with
+/// exactly one `Sqrt(positive-leading polynomial P)` factor, any polynomial
+/// factors (total degree `poly_deg`), and any number of bounded factors in
+/// `k`; `None` otherwise.
+///
+/// Phase 59 — Bounded × Sqrt(P) × polynomial numerator.
+///
+/// Fills the gap between:
+/// * **Phase 53** — `Mul(Sqrt, polynomial_only)`: refuses bounded factors.
+/// * **Phase 56** — `Mul(bounded, Sqrt)`: refuses polynomial factors.
+///
+/// Effective growth: `C · k^{deg(P)/2 + poly_deg}`.  Using the ×2 integer
+/// trick (same as Phase 51, 53, 56, 57): `effective_x2 = deg(P) + 2·poly_deg`.
+/// The caller checks `2 * den_deg > effective_x2` to avoid floating-point
+/// comparisons involving the half-integer degree.
+///
+/// Log factors are explicitly refused — that combination belongs to
+/// Phase 57 (`bounded × Log × Sqrt`).
+///
+/// Algorithm:
+///   1. Require `node = Mul(...)`.
+///   2. For each factor:
+///      - `Sqrt(positive-leading polynomial)` → record `×2` degree via
+///        `sqrt_effective_half_degree_x2`; refuse if a second appears.
+///      - `Log(diverging)` → immediately return `None` (Phase 57 territory).
+///      - polynomial in `k` → accumulate degree.
+///      - bounded (non-polynomial, non-Sqrt, non-Log) → accept silently.
+///      - Anything else → return `None`.
+///   3. Require exactly one Sqrt factor.
+///   4. Return `sqrt_inner_deg + 2 * poly_deg`.
+fn bounded_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut sqrt_inner_deg: Option<i64> = None;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        // Sqrt(positive-leading polynomial) factor?
+        if let Some(deg_x2) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_inner_deg.is_some() {
+                // Two Sqrt factors — refuse.
+                return None;
+            }
+            sqrt_inner_deg = Some(deg_x2);
+            continue;
+        }
+        // Log factor — refuse (belongs to Phase 57 territory).
+        if is_log_of_diverging_in_k(arg, k) {
+            return None;
+        }
+        // Polynomial factor?
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg += deg;
+            continue;
+        }
+        // Bounded (non-polynomial, non-Sqrt, non-Log)?
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Unrecognised factor — bail.
+        return None;
+    }
+    let sid = sqrt_inner_deg?;
+    Some(sid + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1445,6 +1515,20 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(blp_deg) = bounded_log_poly_degree(num, k) {
         if let Some(den_deg_blp) = polynomial_degree_in_k(den, k) {
             if den_deg_blp > blp_deg {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 59: `Mul(bounded, Sqrt(positive-poly), polynomial)` numerator.
+    // Bounded × Sqrt × polynomial: effective_x2 = sqrt_inner_deg + 2·poly_deg.
+    // Vanishes when `2·den_deg > effective_x2` (polynomial) or non-polynomial diverging denom.
+    // Closes the gap between Phase 53 (Sqrt×poly, refuses bounded) and
+    // Phase 56 (bounded×Sqrt, refuses poly).  Log factors are refused → Phase 57.
+    if let Some(bsp_x2) = bounded_sqrt_poly_effective_x2(num, k) {
+        if let Some(den_deg_bsp) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_bsp > bsp_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1540,3 +1540,72 @@ fn phase58_sin_log_k_times_k_sq_over_k_sq_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 59: Mul(bounded, Sqrt(positive-poly), polynomial) ─────────────────
+// Effective_x2 = sqrt_inner_deg + 2·poly_deg.  Vanishes when
+// 2·den_deg > effective_x2 or non-polynomial diverging denominator.
+// Closes the gap between Phase 53 (Sqrt×poly, refuses bounded) and
+// Phase 56 (bounded×Sqrt, refuses poly).
+
+#[test]
+fn phase59_sin_sqrt_k_times_k_over_k_cubed_closes() {
+    // sin(k)·√k·k / k³: x2=1+2=3; 2·3=6 > 3 → closes.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k, k.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1, kp1.clone()]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k3]),
+        apply(sym(DIV), vec![num_kp1, kp1_3]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase59_sin_sqrt_k_times_k_sq_over_exponential_closes() {
+    // sin(k)·√k·k² / 2^k: non-polynomial diverging denominator.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k, k2]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase59_sin_sqrt_k_sq_times_k_over_k_sq_refused() {
+    // sin(k)·√(k²)·k / k²: x2=2+2=4; 2·2=4 not > 4 → equal, refused.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k2, k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1_2, kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k2]),
+        apply(sym(DIV), vec![num_kp1, kp1_2]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.7.0 — 2026-05-25
+
+**Phase 59 — Bounded × Sqrt(positive-poly) × polynomial numerator
+(TypeScript port).**
+
+Ports Python ``cas-summation`` 1.7.0.  Fills the gap between Phase 53
+(Sqrt × polynomial, refuses bounded factors) and Phase 56 (bounded × Sqrt,
+refuses polynomial factors).
+
+Effective growth: ``C·k^{deg(P)/2 + polyDeg}``.  ×2 trick:
+``effective_x2 = deg(P) + 2·polyDeg``.  Vanishes when
+``2·denDeg > effective_x2`` or non-polynomial diverging denominator.
+
+### Added
+
+- **`boundedSqrtPolyEffectiveX2(node, k)`** — returns
+  ``sqrtInnerDegX2 + 2·polyDeg`` for
+  ``Mul(bounded..., Sqrt(positive-poly), polynomial_factors...)``.
+  Refuses two-Sqrt, any Log (→ Phase 57), or unrecognised factors.
+- **Phase 59 branch** in ``gVanishesAtInfinity`` — checks
+  ``2·denDeg > bspX2`` for polynomial denominators; falls back to
+  ``hDivergesAtInfinity`` for non-polynomial diverging denominators.
+- **4 new tests** in the Phase 59 ``describe`` block.
+
 ## 1.6.0 — 2026-05-25
 
 **Phase 58 — Bounded × Log(diverging) × polynomial numerator

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1027,6 +1027,73 @@ function boundedLogPolyDegree(node: IRNode, k: IRNode): number | undefined {
   return polyDeg;
 }
 
+/**
+ * Return ``sqrtHalfDeg + polyDeg`` when ``node`` is a ``Mul`` with
+ * exactly one ``Sqrt(positive-leading polynomial P)`` factor, any polynomial
+ * factors (total degree ``polyDeg``), and any number of bounded factors;
+ * ``undefined`` otherwise.
+ *
+ * Phase 59 — Bounded × Sqrt(P) × polynomial numerator.
+ *
+ * Fills the gap between:
+ *   - Phase 53: ``Mul(Sqrt, polynomial_only)`` — refuses bounded factors.
+ *   - Phase 56: ``Mul(bounded, Sqrt)`` — refuses polynomial factors.
+ *
+ * Effective growth: ``C·k^{deg(P)/2 + polyDeg}``.
+ * TypeScript uses actual half-degree (unlike Python/Rust which use ×2 to stay
+ * integer-exact).  Caller checks ``denDeg > sqrtHalfDeg + polyDeg`` directly.
+ *
+ * Log factors are explicitly refused — that combination is handled by
+ * Phase 57 (bounded × Log × Sqrt).
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Sqrt(positive-leading polynomial)`` → record half-degree via
+ *        ``sqrtEffectiveHalfDegree``; refuse second Sqrt.
+ *      - ``Log(diverging)`` → return undefined (Phase 57 territory).
+ *      - polynomial → add its integer degree to ``polyDeg``.
+ *      - ``bounded`` (non-polynomial, non-Sqrt, non-Log) → accept silently.
+ *      - Unrecognised → return undefined.
+ *   3. Require exactly one Sqrt.
+ *   4. Return ``sqrtHalfDeg + polyDeg``.
+ */
+function boundedSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined = undefined;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    // Sqrt(positive-leading polynomial) factor?
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      if (sqrtHalfDeg !== undefined) {
+        // Two Sqrt factors — refuse.
+        return undefined;
+      }
+      sqrtHalfDeg = halfDeg;
+      continue;
+    }
+    // Log factor — refuse (belongs to Phase 57 territory).
+    if (isLogOfDivergingInK(arg, k)) {
+      return undefined;
+    }
+    // Polynomial factor?
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) {
+      polyDeg += deg;
+      continue;
+    }
+    // Bounded (non-polynomial, non-Sqrt, non-Log)?
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Unrecognised factor — bail.
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1141,6 +1208,22 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBlp = polynomialDegreeInK(den, k);
     if (denDegBlp !== undefined) {
       if (denDegBlp > blpDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 59: Mul(bounded, Sqrt(positive-poly), polynomial) numerator.
+  // Effective degree: sqrtHalfDeg + polyDeg.  Vanishes when
+  // denDeg > sqrtHalfDeg + polyDeg (polynomial) or non-polynomial diverging denom.
+  // Fills the gap between Phase 53 (Sqrt×poly, refuses bounded) and
+  // Phase 56 (bounded×Sqrt, refuses poly).  Log is refused → Phase 57.
+  const bspDeg = boundedSqrtPolyEffectiveDeg(num, k);
+  if (bspDeg !== undefined) {
+    const denDegBsp = polynomialDegreeInK(den, k);
+    if (denDegBsp !== undefined) {
+      if (denDegBsp > bspDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1289,3 +1289,84 @@ describe("summation: Phase 58 bounded × log × polynomial numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+describe("summation: Phase 59 bounded × Sqrt(positive-poly) × polynomial numerator", () => {
+  // Phase 59 fills the gap between:
+  //   Phase 53: Mul(Sqrt, polynomial_only) — refuses bounded factors
+  //   Phase 56: Mul(bounded, Sqrt)         — refuses polynomial factors
+  // Effective growth: C·k^{deg(P)/2 + polyDeg}.
+  // ×2 trick: effective_x2 = deg(P) + 2·polyDeg.
+  // Vanishes when 2·denDeg > effective_x2 or non-polynomial diverging denom.
+
+  it("∑ [sin(k)·√k·k/k³ − ...] closes (x2=3, 2·3=6>3)", () => {
+    // sqrt_inner_deg_x2=1, poly_deg=1, effective_x2=3; 2·3=6 > 3.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, sqrtK, k]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1, kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [cos(k)·√(k²)·k²/k⁴ − ...] closes (x2=6, 2·4=8>6)", () => {
+    // sqrt_inner_deg_x2=2, poly_deg=2, effective_x2=6; 2·4=8 > 6.
+    const k = sym("k");
+    const cosK = app(sym("Cos"), [k]);
+    const sqrtK2 = app(sym("Sqrt"), [app(POW, [k, int(2)])]);
+    const numK = app(MUL, [cosK, sqrtK2, app(POW, [k, int(2)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const cosKp1 = app(sym("Cos"), [kp1]);
+    const sqrtKp1_2 = app(sym("Sqrt"), [app(POW, [kp1, int(2)])]);
+    const numKp1 = app(MUL, [cosKp1, sqrtKp1_2, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(4)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(4)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·√k·k²/2^k − ...] closes (exp denominator dominates)", () => {
+    // Non-polynomial diverging denominator.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, sqrtK, app(POW, [k, int(2)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin(k)·√(k²)·k/k² stays unevaluated (equal: x2=4, 2·2=4)", () => {
+    // sqrt_inner_deg_x2=2, poly_deg=1, effective_x2=4; 2·2=4 not > 4 → refused.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK2 = app(sym("Sqrt"), [app(POW, [k, int(2)])]);
+    const numK = app(MUL, [sinK, sqrtK2, k]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1_2 = app(sym("Sqrt"), [app(POW, [kp1, int(2)])]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1_2, kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **Phase 59** convergence recogniser (`Mul(bounded, Sqrt(positive-poly), polynomial)` numerator) to `g_vanishes_at_infinity` across Python, TypeScript, and Rust, all bumped to **1.7.0**
- Fills the gap between Phase 53 (`Sqrt × polynomial_only`, refuses bounded) and Phase 56 (`bounded × Sqrt`, refuses polynomial); effective growth `C·k^{deg(P)/2 + poly_deg}`, vanishes when `2·den_deg > deg(P) + 2·poly_deg`
- New helpers: Python `_bounded_sqrt_poly_effective_x2`, TypeScript `boundedSqrtPolyEffectiveDeg` (actual half-degree, matching TS convention), Rust `bounded_sqrt_poly_effective_x2`

## Tests

| Language   | Before | After | Added |
|------------|--------|-------|-------|
| Python     | 145    | 151   | +6    |
| TypeScript | 77     | 81    | +4    |
| Rust       | 75     | 78    | +3    |

## Test plan

- [ ] Python: `pytest` in `code/packages/python/cas-summation/` → 151 passed
- [ ] TypeScript: `npm test` in `code/packages/typescript/cas-summation/` → 81 passed
- [ ] Rust: `cargo test` in `code/packages/rust/cas-summation/` → 78 passed
- [ ] Security review: passed (pure symbolic math, no I/O, no unsafe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)