### PR TITLE
feat(cas-summation): Phase 60 — Bounded × Log × Sqrt × polynomial numerator (1.8.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.8.0 — 2026-05-24
+
+**Phase 60 — Bounded × Log(diverging) × Sqrt(positive-poly) × polynomial numerator (Python).**
+
+Closes the gap left by Phase 57 (bounded × Log × Sqrt, refuses polynomial
+factors).  Allows any number of bounded factors, exactly one
+``Log(diverging)`` factor, exactly one ``Sqrt(positive-leading polynomial P)``,
+and any polynomial factors (total degree ``m``).
+
+Effective growth: ``k^{1/2·deg(P) + m}`` (log is sub-polynomial).
+Using the ×2 integer trick: ``effective_x2 = deg(P) + 2·m``.
+Vanishes when ``2·den_deg > effective_x2`` (polynomial denominator) or
+when the denominator is non-polynomial diverging.
+
+### Added
+
+- **``_bounded_log_sqrt_poly_effective_x2``** — returns ``deg(P) + 2·poly_deg``
+  for ``Mul(bounded..., Log(diverging), Sqrt(positive-poly), polynomial_factors...)``.
+  Requires exactly one Log and exactly one Sqrt; refuses two of either.
+- **Phase 60 branch** in ``_g_vanishes_at_infinity`` — checks
+  ``2·den_deg > blsp_x2`` for polynomial denominators; falls back to
+  ``_h_diverges_at_infinity`` for non-polynomial diverging denominators.
+- **6 new tests** in ``TestEvaluateSumPhase60BoundedLogSqrtPolyNumerator``.
+
 ## 1.7.0 — 2026-05-25
 
 **Phase 59 — Bounded × Sqrt(positive-poly) × polynomial numerator (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.7.0"
+version = "1.8.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -829,6 +829,22 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 60: ``Mul(bounded..., Log(diverging), Sqrt(positive-poly), polynomial)``
+    # numerator pattern.  Extends Phase 57 (bounded × Log × Sqrt, refuses poly) by
+    # allowing polynomial factors alongside the Log and Sqrt.
+    # Effective growth: ``log(k) · k^{deg(P)/2 + poly_deg}``
+    # = ``o(k^{deg(P)/2 + poly_deg + ε})``.
+    # ×2 trick: ``effective_x2 = sqrt_inner_deg + 2·poly_deg``.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging.
+    blsp_x2 = _bounded_log_sqrt_poly_effective_x2(num, k)
+    if blsp_x2 is not None:
+        den_deg_blsp = _polynomial_degree_in_k(den, k)
+        if den_deg_blsp is not None:
+            if 2 * den_deg_blsp > blsp_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1392,6 +1408,85 @@ def _bounded_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
         # Unrecognised factor — bail.
         return None
     if sqrt_inner_deg is None:
+        return None
+    return sqrt_inner_deg + 2 * poly_deg_sum
+
+
+def _bounded_log_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_inner_deg_x2 + 2 * poly_deg_sum`` when ``node`` is a
+    ``Mul`` with exactly one ``Log(diverging)`` factor, exactly one
+    ``Sqrt(positive-leading polynomial P)`` factor, any polynomial factors,
+    and any number of bounded factors; ``None`` otherwise.
+
+    Phase 60 — Bounded × Log(diverging) × Sqrt(P) × polynomial numerator.
+
+    Extends Phase 57 (``bounded × Log × Sqrt``, refuses polynomial factors)
+    by allowing polynomial factors alongside the ``Log`` and ``Sqrt``.
+
+    Effective growth:
+    ``|bounded · log(k) · Sqrt(P(k)) · k^m| = O(log(k) · k^{deg(P)/2 + m})``.
+    Since ``log(k) = o(k^ε)`` for any ``ε > 0``, this is
+    ``o(k^{deg(P)/2 + m + ε})``.  Using the ×2 trick:
+    ``effective_x2 = deg(P) + 2·m``.  Caller checks
+    ``2·den_deg > effective_x2``.
+
+    +--------------------------------------------------+-------------------+
+    | Input                                            | Return            |
+    +==================================================+===================+
+    | ``Mul(Sin(k), Log(k), Sqrt(k), k)``              | ``1 + 2 = 3``     |
+    | ``Mul(Cos(k), Log(k), Sqrt(k²), k²)``            | ``2 + 4 = 6``     |
+    | ``Mul(Sin(k), Cos(k), Log(k), Sqrt(k), k)``      | ``1 + 2 = 3``     |
+    | ``Mul(Sin(k), Log(k), Sqrt(k))``                 | ``1 + 0 = 1``     |
+    | ``Mul(Sin(k), Log(k), Log(k), Sqrt(k), k)``      | None (2 Log)      |
+    | ``Mul(Sin(k), Log(k), Sqrt(k), Sqrt(k), k)``     | None (2 Sqrt)     |
+    | ``Mul(Sin(k), Log(k), k)``                       | None (no Sqrt)    |
+    | ``Mul(Sin(k), Sqrt(k), k)``                      | None (no Log)     |
+    +--------------------------------------------------+-------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - Exactly one ``Log(diverging)`` → count; bail on second.
+         - Exactly one ``Sqrt(positive-leading polynomial)`` → record ×2
+           degree; bail on second.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly one Log AND exactly one Sqrt.
+      4. Return ``sqrt_inner_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count = 0
+    sqrt_inner_deg: int | None = None
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        # Log(diverging) factor?
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 1:
+                # Two Log factors — refuse.
+                return None
+            continue
+        # Sqrt(positive-leading polynomial) factor?
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_inner_deg is not None:
+                # Two Sqrt factors — refuse.
+                return None
+            sqrt_inner_deg = deg_x2
+            continue
+        # Polynomial factor (degree ≥ 0)?
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        # Bounded (non-polynomial, non-Log, non-Sqrt)?
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor — bail.
+        return None
+    if log_count != 1 or sqrt_inner_deg is None:
         return None
     return sqrt_inner_deg + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -2274,3 +2274,149 @@ class TestEvaluateSumPhase59BoundedSqrtPolyNumerator:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase60BoundedLogSqrtPolyNumerator:
+    """Phase 60 — ``Mul(bounded, Log(diverging), Sqrt(positive-poly), polynomial)`` numerator.
+
+    Extends Phase 57 (bounded × Log × Sqrt, refuses poly) by allowing
+    polynomial factors alongside Log and Sqrt.
+
+    Effective growth: ``log(k) · k^{deg(P)/2 + poly_deg}``.
+    ×2 trick: ``effective_x2 = sqrt_inner_deg + 2·poly_deg``.
+    Vanishes when ``2·den_deg > effective_x2`` or non-polynomial diverging denom.
+    """
+
+    def test_sin_log_k_sqrt_k_times_k_over_k_cubed_closes(self):
+        """sin(k)·log(k)·√k·k / k³: sqrt_x2=1, poly_deg=1, x2=3; 2·3=6>3 → closes."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k, _k))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1, kp1))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_cos_log_k_sqrt_k_sq_times_k_sq_over_k_fourth_closes(self):
+        """cos(k)·log(k)·√(k²)·k² / k⁴: sqrt_x2=2, poly_deg=2, x2=6; 2·4=8>6 → closes."""
+        from symbolic_ir import COS, POW, SQRT, SUB
+
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2 = IRApply(SQRT, (k2,))
+        num_k = IRApply(MUL, (cos_k, log_k, sqrt_k2, k2))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1_2,))
+        num_kp1 = IRApply(MUL, (cos_kp1, log_kp1, sqrt_kp1_2, kp1_2))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_bounded_log_sqrt_k_times_k_over_k_cubed_closes(self):
+        """sin(k)·cos(k)·log(k)·√k·k / k³: two bounded + log + sqrt + poly → closes."""
+        from symbolic_ir import COS, POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        cos_k = IRApply(COS, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, cos_k, log_k, sqrt_k, _k))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        cos_kp1 = IRApply(COS, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, cos_kp1, log_kp1, sqrt_kp1, kp1))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_sqrt_k_times_k_sq_over_exponential_closes(self):
+        """sin(k)·log(k)·√k·k² / 2^k: non-polynomial diverging denom → closes."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k, k2))
+        exp_k = IRApply(POW, (IRInteger(2), _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1, kp1_2))
+        exp_kp1 = IRApply(POW, (IRInteger(2), kp1))
+        g_k = IRApply(DIV, (num_k, exp_k))
+        g_kp1 = IRApply(DIV, (num_kp1, exp_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_sqrt_k_sq_times_k_over_k_sq_refused(self):
+        """sin(k)·log(k)·√(k²)·k / k²: x2=2+2=4; 2·2=4 not > 4 → equal, refused."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2 = IRApply(SQRT, (k2,))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k2, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1_2,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1_2, kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_sin_log_sqrt_k_times_k_cubed_over_k_sq_refused(self):
+        """sin(k)·log(k)·√k·k³ / k²: x2=1+6=7; 2·2=4 < 7 → numerator wins, refused."""
+        from symbolic_ir import POW, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        num_k = IRApply(MUL, (sin_k, log_k, sqrt_k, k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1, kp1_3))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.8.0 — 2026-05-24
+
+**Phase 60 — Bounded × Log(diverging) × Sqrt(positive-poly) × polynomial
+numerator (Rust port).**
+
+Ports Python ``cas-summation`` 1.8.0.  Closes the gap left by Phase 57
+(``Mul(bounded, Log, Sqrt)``; refuses polynomial factors).
+
+Effective growth: ``log(k)·k^{deg(P)/2 + m}`` — log is sub-polynomial so
+the dominant term is the Sqrt×poly part.  ×2 trick:
+``effective_x2 = deg(P) + 2·m``.  Vanishes when
+``2·den_deg > effective_x2`` (polynomial denominator) or non-polynomial
+diverging denominator.
+
+### Added
+
+- **`bounded_log_sqrt_poly_effective_x2(node, k) -> Option<i64>`** — returns
+  ``sqrt_inner_deg + 2·poly_deg`` for
+  ``Mul(bounded..., Log(diverging), Sqrt(positive-poly), poly_factors...)``.
+  Requires exactly one Log and exactly one Sqrt; refuses two of either.
+- **Phase 60 branch** in ``g_vanishes_at_infinity`` — checks
+  ``2·den_deg > blsp_x2`` for polynomial denominators; falls back to
+  ``h_diverges_at_infinity`` for non-polynomial diverging denominators.
+- **3 new tests**: ``phase60_*`` in ``tests/tests.rs``.
+
 ## 1.7.0 — 2026-05-25
 
 **Phase 59 — Bounded × Sqrt(positive-poly) × polynomial numerator (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1401,6 +1401,71 @@ fn bounded_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(sid + 2 * poly_deg)
 }
 
+/// Phase 60 (Rust port): Return ``sqrt_inner_deg + 2·poly_deg`` when ``node``
+/// is a ``Mul`` with **exactly one** ``Log(diverging)`` factor, **exactly one**
+/// ``Sqrt(positive-leading polynomial P)``, any polynomial factors (total
+/// degree ``m``), and any number of bounded factors; ``None`` otherwise.
+///
+/// Closes the gap left by Phase 57 (``Mul(bounded, Log, Sqrt)``; refuses
+/// polynomial factors).
+///
+/// # Growth analysis
+///
+/// ``log(k) · k^{deg(P)/2 + m}`` — log is sub-polynomial, so the dominant
+/// term is the Sqrt×poly part.  Using the ×2 integer trick:
+/// ``effective_x2 = deg(P) + 2·m``.
+///
+/// Caller checks ``2·den_deg > effective_x2`` (polynomial denominator) or
+/// ``h_diverges_at_infinity`` (non-polynomial diverging denominator).
+fn bounded_log_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut log_count: usize = 0;
+    let mut sqrt_inner_deg: Option<i64> = None;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        // Log(diverging) factor?
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 1 {
+                // Two or more Log factors — refuse.
+                return None;
+            }
+            continue;
+        }
+        // Sqrt(positive-poly) factor?
+        if let Some(deg_x2) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_inner_deg.is_some() {
+                // Two Sqrt factors — refuse (conservative).
+                return None;
+            }
+            sqrt_inner_deg = Some(deg_x2);
+            continue;
+        }
+        // Polynomial factor?
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg += deg;
+            continue;
+        }
+        // Bounded (non-polynomial, non-Sqrt, non-Log)?
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Unrecognised factor — bail.
+        return None;
+    }
+    if log_count != 1 {
+        return None;
+    }
+    let sid = sqrt_inner_deg?;
+    Some(sid + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1529,6 +1594,20 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(bsp_x2) = bounded_sqrt_poly_effective_x2(num, k) {
         if let Some(den_deg_bsp) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_bsp > bsp_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 60: `Mul(bounded, Log(diverging), Sqrt(positive-poly), polynomial)`
+    // numerator.  Closes the gap left by Phase 57 (bounded×Log×Sqrt, refuses
+    // polynomial factors).  effective_x2 = sqrt_inner_deg + 2·poly_deg.
+    // Vanishes when `2·den_deg > effective_x2` (polynomial) or non-polynomial
+    // diverging denominator.
+    if let Some(blsp_x2) = bounded_log_sqrt_poly_effective_x2(num, k) {
+        if let Some(den_deg_blsp) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_blsp > blsp_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1609,3 +1609,76 @@ fn phase59_sin_sqrt_k_sq_times_k_over_k_sq_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 60: Mul(bounded, Log(diverging), Sqrt(positive-poly), polynomial) ──
+// effective_x2 = sqrt_inner_deg + 2·poly_deg.  Vanishes when
+// 2·den_deg > effective_x2 or non-polynomial diverging denominator.
+// Closes the gap left by Phase 57 (bounded×Log×Sqrt, refuses polynomial
+// factors).
+
+#[test]
+fn phase60_sin_log_sqrt_k_times_k_over_k_cubed_closes() {
+    // sin(k)·log(k)·√k·k / k³: x2=1+2=3; 2·3=6 > 3 → closes.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k, k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(3)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(3)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase60_sin_log_sqrt_k_times_k_sq_over_exponential_closes() {
+    // sin(k)·log(k)·√k·k² / 2^k: non-polynomial diverging denominator.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k, k2]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![int(2), k.clone()])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![int(2), kp1])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase60_sin_log_sqrt_k_sq_times_k_over_k_sq_refused() {
+    // sin(k)·log(k)·√(k²)·k / k²: x2=2+2=4; 2·2=4 not > 4 → equal, refused.
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, log_k, sqrt_k2, k.clone()]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, log_kp1, sqrt_kp1_2, kp1.clone()]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k2]),
+        apply(sym(DIV), vec![num_kp1, kp1_2]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.8.0 — 2026-05-24
+
+**Phase 60 — Bounded × Log(diverging) × Sqrt(positive-poly) × polynomial
+numerator (TypeScript port).**
+
+Ports Python ``cas-summation`` 1.8.0.  Closes the gap left by Phase 57
+(bounded × Log × Sqrt, refuses polynomial factors).
+
+Effective growth: ``log(k)·k^{sqrtHalfDeg + polyDeg} = o(k^{sqrtHalfDeg+polyDeg+ε})``.
+TypeScript convention: compare ``denDeg > sqrtHalfDeg + polyDeg`` (actual
+half-degree, no ×2).
+
+### Added
+
+- **`boundedLogSqrtPolyEffectiveDeg(node, k)`** — returns
+  ``sqrtHalfDeg + polyDeg`` for
+  ``Mul(bounded..., Log(diverging), Sqrt(positive-poly), polynomial_factors...)``.
+  Requires exactly one Log and exactly one Sqrt; refuses two of either.
+- **Phase 60 branch** in ``gVanishesAtInfinity`` — checks
+  ``denDeg > blspDeg`` for polynomial denominators; falls back to
+  ``hDivergesAtInfinity`` for non-polynomial diverging denominators.
+- **4 new tests** in the Phase 60 ``describe`` block.
+
 ## 1.7.0 — 2026-05-25
 
 **Phase 59 — Bounded × Sqrt(positive-poly) × polynomial numerator

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1094,6 +1094,77 @@ function boundedSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefine
   return sqrtHalfDeg + polyDeg;
 }
 
+/**
+ * Phase 60 (TypeScript port): Return the effective degree when ``node`` is a
+ * ``Mul`` with **exactly one** ``Log(diverging)`` factor, **exactly one**
+ * ``Sqrt(positive-leading polynomial P)``, any polynomial factors (total
+ * degree ``m``), and any number of bounded factors; ``undefined`` otherwise.
+ *
+ * Closes the gap left by Phase 57 (``Mul(bounded, Log, Sqrt)``; refuses
+ * polynomial factors).
+ *
+ * Effective growth: ``log(k) · k^{deg(P)/2 + m}`` — log is sub-polynomial so
+ * the dominant term is the Sqrt×poly part.  Effective degree:
+ *   ``sqrtHalfDeg + polyDeg``
+ *
+ * Caller compares ``denDeg > sqrtHalfDeg + polyDeg`` (strict), matching the
+ * TypeScript convention (actual half-degrees, no ×2).
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Log(diverging)`` → count; refuse if count > 1.
+ *      - ``Sqrt(positive-poly)`` → record half-degree; refuse if second one.
+ *      - polynomial → add degree to ``polyDeg``.
+ *      - ``bounded`` → accept silently.
+ *      - Unrecognised → return undefined.
+ *   3. Require exactly one Log AND exactly one Sqrt.
+ *   4. Return ``sqrtHalfDeg + polyDeg``.
+ */
+function boundedLogSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let sqrtHalfDeg: number | undefined = undefined;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    // Log(diverging) factor?
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 1) {
+        // Two or more Log factors — refuse.
+        return undefined;
+      }
+      continue;
+    }
+    // Sqrt(positive-poly) factor?
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      if (sqrtHalfDeg !== undefined) {
+        // Two Sqrt factors — refuse (conservative).
+        return undefined;
+      }
+      sqrtHalfDeg = halfDeg;
+      continue;
+    }
+    // Polynomial factor?
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) {
+      polyDeg += deg;
+      continue;
+    }
+    // Bounded (non-polynomial, non-Sqrt, non-Log)?
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Unrecognised factor — bail.
+    return undefined;
+  }
+  if (logCount !== 1 || sqrtHalfDeg === undefined) {
+    return undefined;
+  }
+  return sqrtHalfDeg + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1224,6 +1295,22 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBsp = polynomialDegreeInK(den, k);
     if (denDegBsp !== undefined) {
       if (denDegBsp > bspDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 60: Mul(bounded, Log(diverging), Sqrt(positive-poly), polynomial)
+  // numerator.  Closes the gap left by Phase 57 (bounded×Log×Sqrt, refuses
+  // polynomial factors).  Effective degree: sqrtHalfDeg + polyDeg.  Vanishes
+  // when denDeg > sqrtHalfDeg + polyDeg (polynomial) or non-polynomial
+  // diverging denominator.
+  const blspDeg = boundedLogSqrtPolyEffectiveDeg(num, k);
+  if (blspDeg !== undefined) {
+    const denDegBlsp = polynomialDegreeInK(den, k);
+    if (denDegBlsp !== undefined) {
+      if (denDegBlsp > blspDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1370,3 +1370,89 @@ describe("summation: Phase 59 bounded × Sqrt(positive-poly) × polynomial numer
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+describe("summation: Phase 60 bounded × Log(diverging) × Sqrt(positive-poly) × polynomial numerator", () => {
+  // Phase 60 closes the gap left by Phase 57 (bounded×Log×Sqrt, refuses poly).
+  // Effective growth: log(k)·k^{sqrtHalfDeg + polyDeg} = o(k^{sqrtHalfDeg+polyDeg+ε}).
+  // TypeScript convention: compare denDeg > sqrtHalfDeg + polyDeg (no ×2).
+
+  it("∑ [sin(k)·log(k)·√k·k/k³ − ...] closes (halfDeg=0.5, polyDeg=1, eff=1.5, denDeg=3)", () => {
+    // sqrtHalfDeg=0.5, polyDeg=1, effectiveDeg=1.5; denDeg=3 > 1.5 → closes.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, logK, sqrtK, k]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1, kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(3)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(3)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [cos(k)·log(k)·√(k²)·k²/k⁴ − ...] closes (halfDeg=1, polyDeg=2, eff=3, denDeg=4)", () => {
+    // sqrtHalfDeg=1, polyDeg=2, effectiveDeg=3; denDeg=4 > 3 → closes.
+    const k = sym("k");
+    const cosK = app(sym("Cos"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK2 = app(sym("Sqrt"), [app(POW, [k, int(2)])]);
+    const numK = app(MUL, [cosK, logK, sqrtK2, app(POW, [k, int(2)])]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const cosKp1 = app(sym("Cos"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1_2 = app(sym("Sqrt"), [app(POW, [kp1, int(2)])]);
+    const numKp1 = app(MUL, [cosKp1, logKp1, sqrtKp1_2, app(POW, [kp1, int(2)])]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(4)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(4)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·log(k)·√k·k/2^k − ...] closes (exp denominator dominates)", () => {
+    // Non-polynomial diverging denominator dominates any poly×log×sqrt growth.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, logK, sqrtK, k]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1, kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: sin(k)·log(k)·√(k²)·k/k² stays unevaluated (equal: halfDeg=1, polyDeg=1, eff=2, denDeg=2)", () => {
+    // sqrtHalfDeg=1, polyDeg=1, effectiveDeg=2; denDeg=2 not > 2 → refused.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const logK = app(LOG, [k]);
+    const sqrtK2 = app(sym("Sqrt"), [app(POW, [k, int(2)])]);
+    const numK = app(MUL, [sinK, logK, sqrtK2, k]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const logKp1 = app(LOG, [kp1]);
+    const sqrtKp1_2 = app(sym("Sqrt"), [app(POW, [kp1, int(2)])]);
+    const numKp1 = app(MUL, [sinKp1, logKp1, sqrtKp1_2, kp1]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds convergence-recogniser **Phase 60** across Python, TypeScript, and Rust `cas-summation` packages (all → v1.8.0).
- Recognises numerators of shape `Mul(bounded..., Log(diverging), Sqrt(positive-poly), polynomial_factors...)`, closing the gap left by Phase 57 (bounded×Log×Sqrt, refuses polynomial factors).
- Growth analysis: `log(k)·k^{deg(P)/2 + m}` — dominant term is Sqrt×poly. Using the ×2 integer trick: `effective_x2 = deg(P) + 2·m`. Vanishes when `2·den_deg > effective_x2` or denominator is non-polynomial diverging.
- 13 new tests total (6 Python, 4 TypeScript, 3 Rust); all existing tests pass.

## New helpers

| Language | Helper | Returns |
|----------|--------|---------|
| Python | `_bounded_log_sqrt_poly_effective_x2` | `int \| None` (×2 trick) |
| TypeScript | `boundedLogSqrtPolyEffectiveDeg` | `number \| undefined` (actual half-deg) |
| Rust | `bounded_log_sqrt_poly_effective_x2` | `Option<i64>` (×2 trick) |

## Test plan

- [x] Python: `pytest tests/ -x -q` → 157 passed
- [x] TypeScript: `vitest run` → 85 passed
- [x] Rust: `cargo test -p cas-summation` → 81 passed
- [x] Security review: passed (pure symbolic math, no I/O, no unsafe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)