### PR TITLE
feat(ruby-parser): Phase 6q — modifier conditionals/loops x if y, x unless y, x while y, x until y

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,43 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | return_statement | break_statement | next_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | return_statement | break_statement | next_statement | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+# Phase 6q — modifier conditionals/loops `x if y`, `x unless y`,
+# `x while y`, `x until y`.
+#
+# Placed AFTER the keyword-starting forms (`if_statement`, `while_statement`,
+# etc.) so they win first when a line *begins* with one of those keywords,
+# and BEFORE the bare statement forms (`assignment`, `method_call_no_paren`,
+# `expression_stmt`) so we try the modifier wrapper before committing to a
+# plain statement.  PEG-style backtracking on alternation failure unwinds
+# cleanly when the trailing `if|unless|while|until expression` clause isn't
+# present, falling through to the plain forms.
+#
+# The leading alternation duplicates the LHS forms that can sensibly carry
+# a trailing modifier:
+#   - assignment        — `x = 1 if cond`
+#   - method_call_no_paren — `puts "hi" if cond`
+#   - method_call       — `puts(1) if cond`
+#   - expression_stmt   — `x + 1 if cond`, `42 if cond`
+#
+# `method_with_block` is intentionally omitted; trailing modifiers on blocks
+# are rare in idiomatic Ruby and the AST shape doesn't need it.
+#
+# Lowering (in ruby-to-semantic-ir):
+#   `lhs if cond`    → ExprStmt(If(cond, Block{stmts:[lhs]}, NilLit))
+#   `lhs unless cond`→ ExprStmt(If(not cond, Block{stmts:[lhs]}, NilLit))
+#   `lhs while cond` → While(cond, Block{stmts:[lhs]})
+#   `lhs until cond` → While(not cond, Block{stmts:[lhs]})
+# The trailing keyword tokens are LEXER-DISAMBIGUATED: ruby-lexer's
+# `tag_modifier_keywords` post-pass re-tags `if`/`unless`/`while`/`until`
+# to `if_modifier`/`unless_modifier`/`while_modifier`/`until_modifier`
+# when they follow an expression-ending token on the same line.  The
+# leading-keyword statement rules (`if_statement`, etc.) match the bare
+# `"if"` literal — those tokens are never re-tagged because they sit at
+# the start of a line / after a semicolon / after a non-expression-ending
+# token.  This split sidesteps the grammar's newline-insensitive default
+# mode (modifier syntax is intrinsically a same-line construct in Ruby).
+modifier_statement = ( assignment | method_call_no_paren | method_call | expression_stmt ) ( "if_modifier" | "unless_modifier" | "while_modifier" | "until_modifier" ) expression ;
 def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
 # Phase 6f — class/module namespace declarations.  The body is a
 # sequence of statements (which may include nested `def`s).  Like

--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.22.0] - 2026-05-24
+
+### Added (Phase 6q companion — re-tag trailing-modifier keywords)
+
+New post-pass `tag_modifier_keywords` rewrites `if`/`unless`/`while`/`until` Keyword tokens to `if_modifier`/`unless_modifier`/`while_modifier`/`until_modifier` when they appear after an expression-ending token on the same line.  This is the lexer-side disambiguation that lets the grammar distinguish trailing-modifier syntax (`x if y`) from leading-keyword statement forms (`if y\n  x\nend`) without making newlines globally significant.
+
+Re-tag trigger:
+
+- Token value is `if`, `unless`, `while`, or `until` (Keyword type).
+- A preceding non-Newline token exists on the same `line`.
+- That preceding token's type is one of: `Number`, `String`, `Name`, `RParen`, `RBracket`, `RBrace`, or `Keyword` with value in `{nil, true, false, self, end}`.
+
+Effect: only the token's `value` is mutated (to `<kw>_modifier`); the `type_` stays `Keyword`.  Leading-position keywords (at file start, after a newline, after `;`/`,`/`(`/etc.) are untouched and continue to drive the `if_statement` / `while_statement` / etc. grammar rules.
+
+Era: pre-1.0 Ruby (modifier conditionals predate 1.0).  No era gating.
+
+### Tests
+
+- `coding-adventures-ruby-lexer`: 164 → **169** (+5):
+  - `modifier_if_after_method_call_no_paren_is_retagged` — `puts "hi" if cond` produces `if_modifier`.
+  - `modifier_unless_while_until_all_retagged` — all four forms re-tag uniformly.
+  - `leading_if_at_statement_start_is_not_retagged` — `if y ... end` survives bare.
+  - `newline_between_expr_and_if_prevents_retag` — `x = 1\nif y...` keeps bare `if`.
+  - `modifier_retag_uniform_across_all_eras` — same shape from 1.8 through 3.0.
+
 ## [0.21.0] - 2026-05-24
 
 ### Added (Phase 4o — heredoc opener variants `<<-TAG` and `<<~TAG`)

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -451,6 +451,20 @@ impl RubyLexer {
         // no era gating.  Runs AFTER float/radix fusions (which fold
         // numeric forms) so `x +=` doesn't fight with `1e+10` etc.
         self.fuse_compound_assigns();
+        // Phase 6q companion — re-tag the trailing-modifier keywords
+        // (`if`, `unless`, `while`, `until`) to `if_modifier`,
+        // `unless_modifier`, `while_modifier`, `until_modifier` when
+        // they appear after an expression-ending token on the same
+        // line.  The grammar's `modifier_statement` rule keys off the
+        // re-tagged values; the leading-keyword statement rules
+        // (`if_statement`, etc.) still key off the bare `if`/`while`
+        // values.  This lexer-side disambiguation sidesteps the
+        // grammar's newline-insensitive default mode (modifier syntax
+        // is a same-line construct in Ruby).  Pre-1.0 Ruby — no era
+        // gating.  Runs LAST among the fusions so it sees the final
+        // fused-token shape (notably `end` of a same-line block
+        // already in place if relevant).
+        self.tag_modifier_keywords();
         if era_at_least(&self.era, "1.9.1") {
             self.fuse_lambda_arrow();
         }
@@ -816,6 +830,91 @@ impl RubyLexer {
                 let _ = is_arith;
                 i += 1;
             }
+        }
+    }
+
+    /// Phase 6q companion — re-tag trailing-modifier keywords.
+    ///
+    /// Ruby's modifier conditionals and loops (`x if y`, `x unless y`,
+    /// `x while y`, `x until y`) are a same-line surface syntax that's
+    /// semantically distinct from the leading-keyword statement forms
+    /// (`if y\n  x\nend`).  The lexer needs to disambiguate the two
+    /// surface forms because the grammar runs in newline-insensitive
+    /// mode — a naive `modifier_statement = expression (...) expression`
+    /// rule would greedily eat newlines and mis-parse two-line
+    /// programs like:
+    ///
+    /// ```text
+    /// x = 1
+    /// if x ...
+    /// ```
+    ///
+    /// as `(x = 1) if x` rather than two statements.
+    ///
+    /// Trigger:
+    /// - Token is `Keyword("if"|"unless"|"while"|"until")`.
+    /// - The preceding non-`Newline` token exists, AND
+    /// - That preceding token is on the *same* `line`, AND
+    /// - That preceding token is an expression-ending token (numbers,
+    ///   strings, names, closers `)`/`]`/`}`, and the
+    ///   expression-ending keywords `nil`/`true`/`false`/`self`/`end`).
+    ///
+    /// Effect: the token's `value` is rewritten to
+    /// `if_modifier` / `unless_modifier` / `while_modifier` /
+    /// `until_modifier`.  Its `type_` stays `Keyword`.
+    ///
+    /// The grammar literal matches by value, so:
+    ///   - `if_statement = "if" expression { ... } "end" ;` continues
+    ///     to match the BARE `if` token at statement-start position.
+    ///   - `modifier_statement = ... ( "if_modifier" | ... ) expression ;`
+    ///     matches the RE-TAGGED `if_modifier` token after an
+    ///     expression on the same line.
+    ///
+    /// Era: pre-1.0 Ruby (modifier `if` predates 1.0).  No gating.
+    fn tag_modifier_keywords(&mut self) {
+        let n = self.tokens.len();
+        for i in 0..n {
+            // Cheap value match first.
+            let is_target = matches!(
+                self.tokens[i].value.as_str(),
+                "if" | "unless" | "while" | "until"
+            ) && self.tokens[i].type_ == TokenType::Keyword;
+            if !is_target {
+                continue;
+            }
+            // Find the preceding non-Newline token (if any).
+            let prev_idx = (0..i).rev().find(|&k| {
+                self.tokens[k].type_ != TokenType::Newline
+            });
+            let Some(j) = prev_idx else { continue; };
+            // Same line?  Different line ⇒ statement-start position,
+            // not a modifier.
+            if self.tokens[j].line != self.tokens[i].line {
+                continue;
+            }
+            // Is the preceding token expression-ending?  This is what
+            // gates `x ; if y ... end` (semicolon is NOT
+            // expression-ending) versus `puts 1 if y` (the `1` IS
+            // expression-ending).
+            let prev_ends_expr = match self.tokens[j].type_ {
+                TokenType::Number
+                | TokenType::String
+                | TokenType::Name
+                | TokenType::RParen
+                | TokenType::RBracket
+                | TokenType::RBrace => true,
+                TokenType::Keyword => matches!(
+                    self.tokens[j].value.as_str(),
+                    "nil" | "true" | "false" | "self" | "end"
+                ),
+                _ => false,
+            };
+            if !prev_ends_expr {
+                continue;
+            }
+            // Re-tag.  Mutating `value` only — `type_` stays Keyword.
+            let new_value = format!("{}_modifier", self.tokens[i].value);
+            self.tokens[i].value = new_value;
         }
     }
 
@@ -4045,6 +4144,102 @@ mod tests {
             "expected unterminated_percent_r diagnostic, got {:?}",
             diags
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 6q companion — re-tag trailing-modifier keywords
+    // -----------------------------------------------------------------
+    //
+    // `tag_modifier_keywords` rewrites `if`/`unless`/`while`/`until`
+    // Keyword tokens to `if_modifier`/`unless_modifier`/`while_modifier`/
+    // `until_modifier` when they follow an expression-ending token on
+    // the same line.  The leading-keyword forms (`if y ... end`) are
+    // never re-tagged — at statement-start position the preceding
+    // non-Newline token is either absent or not expression-ending.
+    //
+    // Pre-1.0 Ruby — modifier conditionals predate the era split, so
+    // all eras emit the same shape (covered by the cross-era test).
+
+    fn has_token(toks: &[Token], type_: TokenType, value: &str) -> bool {
+        toks.iter().any(|t| t.type_ == type_ && t.value == value)
+    }
+
+    #[test]
+    fn modifier_if_after_method_call_no_paren_is_retagged() {
+        // `puts "hi" if cond` — the `if` follows a String token on the
+        // same line, so it's re-tagged.
+        let toks = tokenize_ruby_for_version("puts \"hi\" if cond", "1.8").unwrap();
+        assert!(
+            has_token(&toks, TokenType::Keyword, "if_modifier"),
+            "expected `if_modifier` token, got {toks:?}"
+        );
+        assert!(
+            !has_token(&toks, TokenType::Keyword, "if"),
+            "bare `if` token should be gone, got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn modifier_unless_while_until_all_retagged() {
+        // Smoke-test all four modifier forms on the same shape.
+        for (src, expected) in [
+            ("x = 1 if y",     "if_modifier"),
+            ("x = 1 unless y", "unless_modifier"),
+            ("x = 1 while y",  "while_modifier"),
+            ("x = 1 until y",  "until_modifier"),
+        ] {
+            let toks = tokenize_ruby_for_version(src, "1.8").unwrap();
+            assert!(
+                has_token(&toks, TokenType::Keyword, expected),
+                "expected `{expected}` in {src:?}, got {toks:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn leading_if_at_statement_start_is_not_retagged() {
+        // `if y\n  x = 1\nend` — the `if` is at the start of the file,
+        // no preceding token, so NOT re-tagged.  The trailing `end`
+        // is also untouched (no modifier after it).
+        let toks = tokenize_ruby_for_version("if y\n  x = 1\nend", "1.8").unwrap();
+        assert!(
+            has_token(&toks, TokenType::Keyword, "if"),
+            "bare `if` should survive at line start, got {toks:?}"
+        );
+        assert!(
+            !has_token(&toks, TokenType::Keyword, "if_modifier"),
+            "leading `if` must NOT be re-tagged, got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn newline_between_expr_and_if_prevents_retag() {
+        // `x = 1\nif y` — two statements.  Even though `1` is an
+        // expression-ending token, the newline shifts `if` to a
+        // different line, so the same-line guard prevents re-tagging.
+        let toks = tokenize_ruby_for_version("x = 1\nif y\nend", "1.8").unwrap();
+        assert!(
+            has_token(&toks, TokenType::Keyword, "if"),
+            "expected bare `if` across newline, got {toks:?}"
+        );
+        assert!(
+            !has_token(&toks, TokenType::Keyword, "if_modifier"),
+            "newline must block re-tag, got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn modifier_retag_uniform_across_all_eras() {
+        // Trailing modifiers predate the era split — every era ≥ 1.8
+        // must emit the same `*_modifier` token shape.
+        let src = "x = 1 if y";
+        for era in ["1.8", "1.9.1", "2.0", "2.3", "2.7", "3.0"] {
+            let toks = tokenize_ruby_for_version(src, era).unwrap();
+            assert!(
+                has_token(&toks, TokenType::Keyword, "if_modifier"),
+                "expected `if_modifier` in era {era}, got {toks:?}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.18.0] - 2026-05-24
+
+### Added (Phase 6q — modifier conditionals/loops `x if y`, `x unless y`, `x while y`, `x until y`)
+
+Trailing-modifier surface syntax for one-line `if`/`unless`/`while`/`until`.
+
+#### Grammar change
+
+```
+statement          = ... | return_statement | break_statement | next_statement |
+                     modifier_statement | assignment | method_with_block | method_call |
+                     method_call_no_paren | expression_stmt ;
+modifier_statement = ( assignment | method_call_no_paren | method_call | expression_stmt )
+                     ( "if_modifier" | "unless_modifier" | "while_modifier" | "until_modifier" )
+                     expression ;
+```
+
+Placement: AFTER the keyword-led statements (so `if y ... end` still wins) and BEFORE the bare statement forms (so we try the modifier wrapper before committing to a plain statement).  PEG-style alternation backtracking unwinds cleanly when the trailing keyword isn't present, falling through to the plain forms.
+
+#### Lexer-side disambiguation
+
+The trailing keyword tokens use special values (`if_modifier` etc., not bare `if`/etc.) because ruby-lexer's `tag_modifier_keywords` post-pass re-tags `if`/`unless`/`while`/`until` Keyword tokens to `*_modifier` when they follow an expression-ending token on the same line.  Leading-keyword forms keep the bare values and continue to match the existing `if_statement` / `unless_statement` / `while_statement` / `until_statement` rules.
+
+This sidesteps the grammar's newline-insensitive default mode (modifier syntax is intrinsically a same-line construct in Ruby).  Without the lexer split, two-line programs like `x = 1\nif y ... end` would mis-parse as `(x = 1) if y` followed by orphaned `end`.
+
+#### Lowering (in `ruby-to-semantic-ir`)
+
+| Source              | Lowered SIR                                              |
+|---------------------|----------------------------------------------------------|
+| `lhs if cond`       | `Stmt::ExprStmt(Expr::If(cond, [lhs], Nil))`             |
+| `lhs unless cond`   | `Stmt::ExprStmt(Expr::If(not(cond), [lhs], Nil))`        |
+| `lhs while cond`    | `Stmt::While(cond, [lhs])`                               |
+| `lhs until cond`    | `Stmt::While(not(cond), [lhs])`                          |
+
+Same `Expr::If` / `Stmt::While` shapes as the leading-keyword forms — downstream emitters (semantic-ir-to-python, -rust, -typescript, -go) need zero new code paths.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 78 → **84** (+6):
+  - `test_parse_if_modifier_simple` — `puts "hi" if cond` parses with `if_modifier`.
+  - `test_parse_unless_modifier_with_assignment_lhs` — `x = 1 unless cond`.
+  - `test_parse_while_modifier` — `puts "tick" while cond`.
+  - `test_parse_until_modifier_with_assignment_lhs` — `x = 1 until cond`.
+  - `test_parse_leading_if_not_tagged_as_modifier` — regression: `if y ... end` stays `if_statement`.
+  - `test_parse_two_statements_across_newline` — regression: `x = 1\nif y ... end` stays two statements.
+
 ## [0.17.0] - 2026-05-24
 
 ### Added (Phase 6p — compound assignment `+=`, `-=`, `*=`, `/=`, `||=`, `&&=`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -28,6 +28,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"return_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_with_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
@@ -35,6 +36,25 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"expression_stmt"#.to_string() },
             ] },
             line_number: 28,
+        },
+        GrammarRule {
+            name: r#"modifier_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"method_call_no_paren"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expression_stmt"#.to_string() },
+                    ] }) },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"if_modifier"#.to_string() },
+                        GrammarElement::Literal { value: r#"unless_modifier"#.to_string() },
+                        GrammarElement::Literal { value: r#"while_modifier"#.to_string() },
+                        GrammarElement::Literal { value: r#"until_modifier"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+            ] },
+            line_number: 64,
         },
         GrammarRule {
             name: r#"def_statement"#.to_string(),
@@ -52,7 +72,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 29,
+            line_number: 65,
         },
         GrammarRule {
             name: r#"class_statement"#.to_string(),
@@ -65,7 +85,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 34,
+            line_number: 70,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -78,7 +98,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 35,
+            line_number: 71,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -100,7 +120,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 37,
+            line_number: 73,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -108,7 +128,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 38,
+            line_number: 74,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -121,7 +141,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 39,
+            line_number: 75,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -131,7 +151,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 40,
+            line_number: 76,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -144,7 +164,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 41,
+            line_number: 77,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -152,7 +172,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 43,
+            line_number: 79,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -160,7 +180,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 44,
+            line_number: 80,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -168,7 +188,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 45,
+            line_number: 81,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -179,7 +199,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 46,
+            line_number: 82,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -196,7 +216,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 47,
+            line_number: 83,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -210,7 +230,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 48,
+            line_number: 84,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -221,7 +241,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 49,
+            line_number: 85,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -236,7 +256,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 50,
+            line_number: 86,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -249,7 +269,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 51,
+            line_number: 87,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -262,7 +282,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 52,
+            line_number: 88,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -279,7 +299,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 72,
+            line_number: 108,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -299,7 +319,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 83,
+            line_number: 119,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -321,7 +341,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 84,
+            line_number: 120,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -336,17 +356,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 98,
+            line_number: 134,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 99,
+            line_number: 135,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 185,
+            line_number: 221,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -359,7 +379,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 186,
+            line_number: 222,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -373,7 +393,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 187,
+            line_number: 223,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -387,7 +407,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 188,
+            line_number: 224,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -401,7 +421,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 189,
+            line_number: 225,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -412,7 +432,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 196,
+            line_number: 232,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -430,7 +450,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 197,
+            line_number: 233,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -444,7 +464,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 198,
+            line_number: 234,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -458,7 +478,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 199,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -481,7 +501,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 209,
+            line_number: 245,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -489,7 +509,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 210,
+            line_number: 246,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -501,7 +521,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 211,
+            line_number: 247,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -516,7 +536,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 212,
+            line_number: 248,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -531,7 +551,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 213,
+            line_number: 249,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -547,7 +567,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 214,
+            line_number: 250,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1247,6 +1247,127 @@ mod tests {
         assert!(tree_has_token_value(arr, ":"));
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 6q — modifier conditionals/loops `x if y`, `x unless y`,
+    // `x while y`, `x until y`.
+    //
+    // The grammar rule is:
+    //   modifier_statement = ( assignment | method_call_no_paren
+    //                        | method_call | expression_stmt )
+    //                        ( "if_modifier" | ... )
+    //                        expression ;
+    //
+    // The trailing keyword's value is `if_modifier`/etc. (not bare
+    // `if`/etc.) because ruby-lexer's `tag_modifier_keywords` post-pass
+    // rewrites `if`/`unless`/`while`/`until` tokens that follow an
+    // expression-ending token on the same line.  Tests below assert the
+    // rewrite happened by looking for the `*_modifier` value in the AST.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_if_modifier_simple() {
+        // `puts "hi" if cond` — paren-less method call + trailing if.
+        let ast = parse_ruby("puts \"hi\" if cond");
+        let m = find_descendant(&ast, "modifier_statement")
+            .expect("expected modifier_statement node");
+        assert!(
+            tree_has_token_value(m, "if_modifier"),
+            "expected `if_modifier` re-tagged keyword"
+        );
+        // The LHS should be a `method_call_no_paren` child.
+        assert!(
+            find_descendant(m, "method_call_no_paren").is_some(),
+            "expected method_call_no_paren as LHS"
+        );
+    }
+
+    #[test]
+    fn test_parse_unless_modifier_with_assignment_lhs() {
+        // `x = 1 unless cond` — the LHS is an assignment.
+        let ast = parse_ruby("x = 1 unless cond");
+        let m = find_descendant(&ast, "modifier_statement")
+            .expect("expected modifier_statement node");
+        assert!(
+            tree_has_token_value(m, "unless_modifier"),
+            "expected `unless_modifier` re-tagged keyword"
+        );
+        assert!(
+            find_descendant(m, "assignment").is_some(),
+            "expected assignment as LHS"
+        );
+    }
+
+    #[test]
+    fn test_parse_while_modifier() {
+        // `puts "tick" while cond`.
+        let ast = parse_ruby("puts \"tick\" while cond");
+        let m = find_descendant(&ast, "modifier_statement")
+            .expect("expected modifier_statement node");
+        assert!(
+            tree_has_token_value(m, "while_modifier"),
+            "expected `while_modifier` re-tagged keyword"
+        );
+    }
+
+    #[test]
+    fn test_parse_until_modifier_with_assignment_lhs() {
+        // `x = 1 until cond` — until modifier on an assignment.
+        let ast = parse_ruby("x = 1 until cond");
+        let m = find_descendant(&ast, "modifier_statement")
+            .expect("expected modifier_statement node");
+        assert!(
+            tree_has_token_value(m, "until_modifier"),
+            "expected `until_modifier` re-tagged keyword"
+        );
+    }
+
+    #[test]
+    fn test_parse_leading_if_not_tagged_as_modifier() {
+        // Regression: `if y\n  x\nend` is a leading-keyword
+        // if_statement, NOT a modifier_statement.  The lexer's re-tag
+        // only fires when the modifier keyword follows an
+        // expression-ending token on the same line — at statement
+        // start (after a newline) it's left alone.
+        let ast = parse_ruby("if y\n  x = 1\nend");
+        assert!(
+            find_descendant(&ast, "if_statement").is_some(),
+            "expected if_statement (leading keyword form)"
+        );
+        assert!(
+            find_descendant(&ast, "modifier_statement").is_none(),
+            "must NOT parse leading-keyword `if` as a modifier_statement"
+        );
+        // And the bare `if` token value must survive (no re-tag).
+        assert!(
+            tree_has_token_value(&ast, "if"),
+            "leading `if` token value should be untouched"
+        );
+        assert!(
+            !tree_has_token_value(&ast, "if_modifier"),
+            "leading `if` must NOT be re-tagged to `if_modifier`"
+        );
+    }
+
+    #[test]
+    fn test_parse_two_statements_across_newline() {
+        // Regression: `x = 1\nif y ... end` is TWO statements
+        // (assignment + if_statement), not one modifier_statement.
+        // Without the lexer's same-line guard, the grammar's
+        // newline-insensitive default mode would otherwise mis-parse
+        // this as `(x = 1) if y` followed by an orphaned `end`.
+        let ast = parse_ruby("x = 1\nif y\n  z = 2\nend");
+        let stmts = count_statements(&ast);
+        assert_eq!(stmts, 2, "expected 2 top-level statements, got {stmts}");
+        assert!(
+            find_descendant(&ast, "if_statement").is_some(),
+            "second statement should be if_statement"
+        );
+        assert!(
+            find_descendant(&ast, "modifier_statement").is_none(),
+            "must NOT collapse two statements into a modifier_statement"
+        );
+    }
+
     #[test]
     fn test_parse_range_with_paren_logical_operands() {
         // `(a || b)..(c || d)` — explicit parens make precedence

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.18.0] - 2026-05-24
+
+### Added (Phase 6q — modifier conditionals/loops lowering)
+
+New `lower_modifier_statement` handler dispatches on the parser's `modifier_statement` node.
+
+Lowering table:
+
+| Source              | Lowered SIR                                              |
+|---------------------|----------------------------------------------------------|
+| `lhs if cond`       | `Stmt::ExprStmt(Expr::If(cond, [lhs], Nil))`             |
+| `lhs unless cond`   | `Stmt::ExprStmt(Expr::If(not(cond), [lhs], Nil))`        |
+| `lhs while cond`    | `Stmt::While(cond, [lhs])`                               |
+| `lhs until cond`    | `Stmt::While(not(cond), [lhs])`                          |
+
+The lowering produces the same canonical `Expr::If` / `Stmt::While` shapes as the leading-keyword `if_statement` / `while_statement` lowerings — every downstream emitter (semantic-ir-to-python, -rust, -typescript, -go) handles modifier forms transparently with no new code paths.
+
+`while`/`until` modifier variants set `Feature::Loops` automatically, matching the leading-keyword loop behaviour.
+
+The LHS statement is wrapped in a single-statement `Block` whose `value` is `NilLit` — the modifier form is never tail-promoted to an expression (it sits in statement position only).
+
+### Tests
+
+- `ruby-to-semantic-ir`: 81 → **86** (+5):
+  - `if_modifier_lowers_to_expr_if_statement` — produces `ExprStmt(If)` with bare cond.
+  - `unless_modifier_wraps_condition_in_not` — cond becomes `BuiltinCall(not, …)`.
+  - `while_modifier_lowers_to_stmt_while` — `Stmt::While` with bare cond.
+  - `until_modifier_negates_condition_in_while` — `Stmt::While` with `not(cond)`.
+  - `modifier_module_passes_sir_validator` — end-to-end validator smoke test across all four forms.
+
 ## [0.17.0] - 2026-05-24
 
 ### Added (Phase 6p — compound assignment lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1559,4 +1559,122 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6q — modifier conditionals/loops
+    // -----------------------------------------------------------------
+    //
+    // `lhs if cond`    → ExprStmt(If(cond, [lhs], Nil))
+    // `lhs unless cond`→ ExprStmt(If(not(cond), [lhs], Nil))
+    // `lhs while cond` → While(cond, [lhs])
+    // `lhs until cond` → While(not(cond), [lhs])
+    //
+    // Lowering identity: the modifier forms emit the same canonical
+    // `Expr::If` / `Stmt::While` shapes as the leading-keyword forms,
+    // so every downstream emitter sees them transparently.
+
+    #[test]
+    fn if_modifier_lowers_to_expr_if_statement() {
+        // `puts "hi" if cond` → ExprStmt(If(VarRef(cond),
+        //    Block{stmts:[ExprStmt(BuiltinCall(puts, ...))], value:Nil},
+        //    Block{stmts:[], value:Nil}))
+        let m = lower("cond = true\nputs \"hi\" if cond\n");
+        let b = main_body(&m);
+        // The second statement is the modifier's lowered form.
+        match &b.stmts[1] {
+            Stmt::ExprStmt {
+                expr: Expr::If { cond, then_branch, else_branch, .. },
+                ..
+            } => {
+                // Cond is a bare VarRef("cond") — no `not` wrapper.
+                assert!(
+                    matches!(cond.as_ref(), Expr::VarRef { name, .. } if name == "cond"),
+                    "expected VarRef(cond), got {:?}",
+                    cond
+                );
+                // then_branch carries the LHS statement.
+                assert_eq!(then_branch.stmts.len(), 1, "expected one stmt in then-branch");
+                // else_branch is empty.
+                assert!(else_branch.stmts.is_empty(), "expected empty else-branch");
+            }
+            other => panic!("expected ExprStmt(If), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unless_modifier_wraps_condition_in_not() {
+        // `x = 1 unless cond` — cond becomes `not(cond)`.
+        let m = lower("cond = true\nx = 1 unless cond\n");
+        let b = main_body(&m);
+        match &b.stmts[1] {
+            Stmt::ExprStmt {
+                expr: Expr::If { cond, .. },
+                ..
+            } => {
+                assert!(
+                    matches!(cond.as_ref(), Expr::BuiltinCall { name, .. } if name == "not"),
+                    "expected BuiltinCall(not, ...), got {:?}",
+                    cond
+                );
+            }
+            other => panic!("expected ExprStmt(If) for unless modifier, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn while_modifier_lowers_to_stmt_while() {
+        // `puts "tick" while cond` → Stmt::While(cond, [puts]).
+        let m = lower("cond = true\nputs \"tick\" while cond\n");
+        let b = main_body(&m);
+        let while_cond = b.stmts.iter().find_map(|s| match s {
+            Stmt::While { cond, body, .. } => Some((cond, body)),
+            _ => None,
+        }).expect("expected While stmt from `while` modifier");
+        // Cond is bare VarRef (no `not`).
+        assert!(
+            matches!(while_cond.0, Expr::VarRef { name, .. } if name == "cond"),
+            "expected VarRef(cond) for while modifier, got {:?}",
+            while_cond.0
+        );
+        // Body carries the LHS as its one statement.
+        assert_eq!(while_cond.1.stmts.len(), 1, "expected one stmt in body");
+    }
+
+    #[test]
+    fn until_modifier_negates_condition_in_while() {
+        // `x = 1 until cond` → Stmt::While(not(cond), [x = 1]).
+        let m = lower("cond = false\nx = 1 until cond\n");
+        let b = main_body(&m);
+        let while_cond = b.stmts.iter().find_map(|s| match s {
+            Stmt::While { cond, .. } => Some(cond),
+            _ => None,
+        }).expect("expected While stmt from `until` modifier");
+        assert!(
+            matches!(while_cond, Expr::BuiltinCall { name, .. } if name == "not"),
+            "expected `until` to negate cond, got {:?}",
+            while_cond
+        );
+    }
+
+    #[test]
+    fn modifier_module_passes_sir_validator() {
+        // End-to-end smoke check: every modifier form goes through
+        // the validator cleanly.  The `while` modifier sets the
+        // `loops` feature automatically (just like the leading
+        // `while_statement` form).
+        let m = lower(concat!(
+            "cond = true\n",
+            "y = 0\n",
+            "y = 1 if cond\n",
+            "y = 2 unless cond\n",
+            "y = 3 while cond\n",
+            "y = 4 until cond\n",
+        ));
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected modifier-statement output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -368,6 +368,14 @@ impl Lowerer {
                     span: self.span_of(node),
                 });
             }
+            "modifier_statement" => {
+                // Phase 6q: trailing-modifier conditionals/loops.
+                // `lhs if cond`    → ExprStmt(If(cond, [lhs], Nil))
+                // `lhs unless cond`→ ExprStmt(If(not cond, [lhs], Nil))
+                // `lhs while cond` → While(cond, [lhs])
+                // `lhs until cond` → While(not cond, [lhs])
+                self.lower_modifier_statement(node)
+            }
             "return_statement" | "break_statement" | "next_statement" => {
                 // Phase 6j: control-flow keywords lower to BuiltinCall
                 // with Effect::Divergent.  Optional trailing expression
@@ -611,6 +619,190 @@ impl Lowerer {
             body,
             span: self.span_of(node),
         })
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6q — modifier conditionals/loops
+    // -------------------------------------------------------------------
+
+    /// Lower a `modifier_statement` node — Ruby's trailing-modifier
+    /// surface syntax for one-line `if`/`unless`/`while`/`until`.
+    ///
+    /// Grammar shape (per `ruby.grammar`):
+    /// ```text
+    /// modifier_statement = ( assignment
+    ///                      | method_call_no_paren
+    ///                      | method_call
+    ///                      | expression_stmt )
+    ///                      ( "if_modifier" | "unless_modifier"
+    ///                      | "while_modifier" | "until_modifier" )
+    ///                      expression ;
+    /// ```
+    ///
+    /// AST children layout: `[ lhs_node, modifier_kw_token, cond_node ]`
+    /// — the leading group lands a single inner-rule node (one of the
+    /// four LHS alternatives), then a keyword token whose value is
+    /// `if_modifier`/`unless_modifier`/`while_modifier`/`until_modifier`
+    /// (re-tagged by the lexer's `tag_modifier_keywords` post-pass),
+    /// then the trailing `expression` node for the condition.
+    ///
+    /// Lowering table (the table form is reproduced in `ruby.grammar`):
+    ///
+    /// | Source              | Lowered SIR                                              |
+    /// |---------------------|----------------------------------------------------------|
+    /// | `lhs if cond`       | `Stmt::ExprStmt(Expr::If(cond, [lhs], Nil))`             |
+    /// | `lhs unless cond`   | `Stmt::ExprStmt(Expr::If(not(cond), [lhs], Nil))`        |
+    /// | `lhs while cond`    | `Stmt::While(cond, [lhs])`                               |
+    /// | `lhs until cond`    | `Stmt::While(not(cond), [lhs])`                          |
+    ///
+    /// Lowering identity with the leading-keyword forms — same `Expr::If` /
+    /// `Stmt::While` shapes — means every downstream emitter
+    /// (semantic-ir-to-python / -rust / -typescript / -go) needs zero
+    /// new code paths.  The Ruby user sees a syntactic shortcut; the
+    /// SIR sees the canonical conditional/loop.
+    ///
+    /// The LHS body is wrapped in a single-statement `Block` (with
+    /// `value: NilLit` — the modifier form is statement-position only,
+    /// never tail-promoted to expression).
+    fn lower_modifier_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Stmt, RubyLowerError> {
+        // 1. Find the LHS inner-rule node.  It's the first child that's
+        //    one of the four LHS-eligible rules.
+        let lhs_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n)
+                    if matches!(
+                        n.rule_name.as_str(),
+                        "assignment"
+                            | "method_call"
+                            | "method_call_no_paren"
+                            | "expression_stmt"
+                    ) =>
+                {
+                    Some(n)
+                }
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "modifier_statement missing LHS inner-rule node".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+
+        // 2. Find the modifier keyword token value.  The lexer
+        //    guarantees one of the four `*_modifier` values lives in
+        //    a Keyword token between LHS and cond.
+        let modifier_kw = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t)
+                    if matches!(
+                        t.value.as_str(),
+                        "if_modifier"
+                            | "unless_modifier"
+                            | "while_modifier"
+                            | "until_modifier"
+                    ) =>
+                {
+                    Some(t.value.as_str())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "modifier_statement missing modifier keyword token".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+
+        // 3. Find the cond expression — the LAST `expression` rule
+        //    node among direct children.  (LHS may contain nested
+        //    `expression` nodes, but those are grand-children of
+        //    `modifier_statement`, not direct children.  Using the
+        //    last-direct-child position is robust against future
+        //    grammar tweaks that might insert intermediate nodes.)
+        let cond_node = node
+            .children
+            .iter()
+            .rev()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "modifier_statement missing condition expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+
+        // 4. Lower the LHS into a Stmt, then wrap in a single-stmt
+        //    Block.  Block.value is NilLit — modifier forms never sit
+        //    in tail position.
+        let lhs_stmt = self.lower_statement_inner(lhs_node)?;
+        let body_block = Block {
+            stmts: vec![lhs_stmt],
+            value: Expr::NilLit {
+                span: self.span_of(node),
+            },
+            span: self.span_of(node),
+        };
+
+        // 5. Lower the condition.  For `unless_modifier` / `until_modifier`,
+        //    wrap it in `not` — identical to the leading-keyword
+        //    `unless_statement` / `until_statement` lowerings.
+        let mut cond = self.lower_expression(cond_node)?;
+        let negate =
+            matches!(modifier_kw, "unless_modifier" | "until_modifier");
+        if negate {
+            cond = Expr::BuiltinCall {
+                name: "not".to_string(),
+                args: vec![cond],
+                effects: EffectSet::PURE,
+                span: self.span_of(cond_node),
+            };
+        }
+
+        // 6. Emit If (conditional modifiers) or While (loop modifiers).
+        match modifier_kw {
+            "if_modifier" | "unless_modifier" => {
+                let else_block = Block {
+                    stmts: Vec::new(),
+                    value: Expr::NilLit {
+                        span: self.span_of(node),
+                    },
+                    span: self.span_of(node),
+                };
+                Ok(Stmt::ExprStmt {
+                    expr: Expr::If {
+                        cond: Box::new(cond),
+                        then_branch: Box::new(body_block),
+                        else_branch: Box::new(else_block),
+                        span: self.span_of(node),
+                    },
+                    span: self.span_of(node),
+                })
+            }
+            "while_modifier" | "until_modifier" => {
+                self.features_used.insert(Feature::Loops);
+                Ok(Stmt::While {
+                    cond,
+                    body: body_block,
+                    span: self.span_of(node),
+                })
+            }
+            // The token-value filter above already rejected anything
+            // outside the four valid modifier values; this arm is
+            // unreachable.
+            other => Err(RubyLowerError {
+                message: format!("unknown modifier keyword `{other}`"),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }),
+        }
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three-part change spanning the lexer, parser, and SIR lowerer to add Ruby's trailing-modifier surface syntax: `x if y`, `x unless y`, `x while y`, `x until y`.

## Lexer (`ruby-lexer`)

New post-pass `tag_modifier_keywords` re-tags `if`/`unless`/`while`/`until` Keyword token *values* (not types) to `if_modifier`/`unless_modifier`/`while_modifier`/`until_modifier` when they follow an expression-ending token on the same line.

| Trigger condition | Source |
|---|---|
| Preceding token on same line | `puts 1 if y` → `if` re-tagged |
| File start / after newline | `if y\n  ...end` → bare `if`, untouched |
| After `;` / `,` / non-expression-ending | not re-tagged |
| Newline between preceding token & keyword | not re-tagged |

Effect: token's `value` mutates; `type_` stays `Keyword`.  Pre-1.0 Ruby — no era gating.

This is the lexer-side disambiguation that sidesteps the grammar's newline-insensitive default mode.

## Parser (`ruby-parser`)

```
statement          = ... | next_statement | modifier_statement | assignment | ... ;
modifier_statement = ( assignment | method_call_no_paren | method_call | expression_stmt )
                     ( "if_modifier" | "unless_modifier" | "while_modifier" | "until_modifier" )
                     expression ;
```

Placement: AFTER the keyword-led statements (so `if y ... end` wins) and BEFORE the bare forms (so we try the modifier wrapper first).  PEG backtracking handles the no-trailing-keyword case.

## SIR (`ruby-to-semantic-ir`)

| Source | Lowered |
|---|---|
| `lhs if cond` | `ExprStmt(If(cond, [lhs], Nil))` |
| `lhs unless cond` | `ExprStmt(If(not cond, [lhs], Nil))` |
| `lhs while cond` | `While(cond, [lhs])` |
| `lhs until cond` | `While(not cond, [lhs])` |

Same canonical shapes as the leading-keyword forms — downstream emitters (semantic-ir-to-python, -rust, -typescript, -go) need zero new code paths.  `while`/`until` variants auto-set `Feature::Loops`.

## Tests

- `coding-adventures-ruby-lexer`: 164 → **169** (+5 re-tag tests, including era-invariance and same-line / newline-boundary regressions).
- `coding-adventures-ruby-parser`: 78 → **84** (+6 grammar tests, including the critical two-statements-across-newline regression).
- `ruby-to-semantic-ir`: 81 → **86** (+5 lowering tests + validator smoke).

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (84/84 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (86/86 pass)
- [x] Security review via `/security-review` — passed
- [ ] CI green

Follows PR #4303 (Phase 4o — heredoc opener variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
