### PR TITLE
feat(cas-summation): Phase 61 — Two-Sqrt × polynomial numerator (1.9.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 1.9.0 — 2026-05-25
+
+**Phase 61 — Two-Sqrt × polynomial numerator (Python).**
+
+Closes the gap where all existing Sqrt phases (51, 53, 56, 59, 60) require
+exactly one Sqrt and hard-reject a second.  Handles numerators of the form
+``Mul(Sqrt(P1), Sqrt(P2), polynomial_factors..., bounded_factors...)``.
+
+Effective growth: ``k^{deg(P1)/2 + deg(P2)/2 + m}``.
+Using the ×2 integer trick: ``effective_x2 = deg(P1) + deg(P2) + 2·m``.
+Vanishes when ``2·den_deg > effective_x2`` (polynomial denominator) or
+when the denominator is non-polynomial diverging.
+
+``Log`` factors are refused (belong to future Log×two-Sqrt phases).
+
+### Added
+
+- **``_two_sqrt_poly_effective_x2``** — returns
+  ``deg(P1) + deg(P2) + 2·poly_deg`` for
+  ``Mul(Sqrt(P1), Sqrt(P2), polynomial_factors..., bounded_factors...)``.
+  Refuses three-or-more Sqrt, any Log factor, or unrecognised factors.
+- **Phase 61 branch** in ``_g_vanishes_at_infinity`` — checks
+  ``2·den_deg > tsp_x2`` for polynomial denominators; falls back to
+  ``_h_diverges_at_infinity`` for non-polynomial diverging denominators.
+- **6 new tests** in ``TestEvaluateSumPhase61TwoSqrtPolyNumerator``.
+
+### Changed
+
+- Renamed ``test_two_sqrt_factors_refused`` → ``test_two_sqrt_factors_now_closed_by_phase61``
+  in Phase 56 tests: Phase 61 now correctly closes what Phase 56 conservatively refused.
+
 ## 1.8.0 — 2026-05-24
 
 **Phase 60 — Bounded × Log(diverging) × Sqrt(positive-poly) × polynomial numerator (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.8.0"
+version = "1.9.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -845,6 +845,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 61: ``Mul(Sqrt(P1), Sqrt(P2), polynomial..., bounded...)``
+    # numerator.  Extends Phases 53/56/59 to the case of two Sqrt factors.
+    # effective_x2 = deg(P1) + deg(P2) + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    tsp_x2 = _two_sqrt_poly_effective_x2(num, k)
+    if tsp_x2 is not None:
+        den_deg_tsp = _polynomial_degree_in_k(den, k)
+        if den_deg_tsp is not None:
+            if 2 * den_deg_tsp > tsp_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1489,6 +1502,83 @@ def _bounded_log_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None
     if log_count != 1 or sqrt_inner_deg is None:
         return None
     return sqrt_inner_deg + 2 * poly_deg_sum
+
+
+def _two_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``deg(P1) + deg(P2) + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly two** ``Sqrt(positive-leading polynomial)`` factors, any
+    polynomial factors (total degree ``m``), and any number of bounded
+    factors; ``None`` otherwise.
+
+    Phase 61 — Two-Sqrt × polynomial numerator.
+
+    Extends Phase 53 (``Mul(Sqrt(P), polynomial_only)``), Phase 56
+    (``bounded × Sqrt``), and Phase 59 (``bounded × Sqrt × poly``) to the
+    case where two distinct square-root factors appear, e.g.
+    ``Sqrt(k) · Sqrt(k + 1) · k`` (product of consecutive Sqrt factors).
+
+    Effective growth:
+    ``Sqrt(P1(k)) · Sqrt(P2(k)) · k^m ≈ k^{deg(P1)/2 + deg(P2)/2 + m}``.
+    Using the ×2 integer trick:
+    ``effective_x2 = deg(P1) + deg(P2) + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    ``Log`` factors are refused (belong to Phase 60 / a future phase).
+
+    +-----------------------------------------------------+-------------------+
+    | Input                                               | Return            |
+    +=====================================================+===================+
+    | ``Mul(Sqrt(k), Sqrt(k+1), k)``                      | ``1 + 1 + 2 = 4`` |
+    | ``Mul(Sqrt(k²), Sqrt(k), k²)``                      | ``2 + 1 + 4 = 7`` |
+    | ``Mul(Sin(k), Sqrt(k), Sqrt(k+1), k)``              | ``1 + 1 + 2 = 4`` |
+    | ``Mul(Sqrt(k), Sqrt(k))``                           | ``1 + 1 + 0 = 2`` |
+    | ``Mul(Sqrt(k), k)``                                 | None (only 1 Sqrt)|
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k))``                  | None (3 Sqrt)     |
+    | ``Mul(Log(k), Sqrt(k), Sqrt(k+1))``                 | None (Log present)|
+    +-----------------------------------------------------+-------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree in a
+           list; bail after the second one.
+         - ``Log(diverging)`` → bail immediately (log-bearing patterns
+           belong to Phase 60 and future log-Sqrt phases).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly two Sqrt factors.
+      4. Return ``sqrt_deg1_x2 + sqrt_deg2_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs: list[int] = []
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        # Sqrt(positive-leading polynomial) factor?
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            sqrt_degs.append(deg_x2)
+            if len(sqrt_degs) > 2:
+                # Three or more Sqrt factors — refuse (conservative).
+                return None
+            continue
+        # Log(diverging) factor — refuse (belongs to phase 60+ territory).
+        if _is_log_of_diverging_in_k(arg, k):
+            return None
+        # Polynomial factor?
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        # Bounded (non-polynomial, non-Log, non-Sqrt)?
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor — bail.
+        return None
+    if len(sqrt_degs) != 2:
+        return None
+    return sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1865,12 +1865,10 @@ class TestEvaluateSumPhase56BoundedTimesSqrtNumerator:
         # half-deg(num) = 3/2 > 1 = deg(den) → does not vanish.
         assert isinstance(result, IRApply) and result.head == SUM
 
-    def test_two_sqrt_factors_refused(self):
+    def test_two_sqrt_factors_now_closed_by_phase61(self):
         """``Mul(sin(k), sqrt(k), sqrt(k))/k³`` — two sqrt factors.
-        Phase 56 refuses (would require combining growth rates we
-        haven't justified yet; multiplying sqrt(k)·sqrt(k) = k could
-        be simplified before reaching us, but Phase 56 stays
-        conservative).
+        Phase 56 used to refuse this conservatively.  Phase 61 now
+        handles it: effective_x2 = 1 + 1 = 2; 2·3 = 6 > 2 → closes.
         """
         from symbolic_ir import POW, SIN, SQRT, SUB
 
@@ -1885,8 +1883,8 @@ class TestEvaluateSumPhase56BoundedTimesSqrtNumerator:
         g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(3)))))
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
-        # Phase 56 conservative: refuses two-sqrt patterns.
-        assert isinstance(result, IRApply) and result.head == SUM
+        # Phase 61 handles two-sqrt: x2=2, 2·3=6 > 2 → closes.
+        assert not (isinstance(result, IRApply) and result.head == SUM)
 
 
 # ---------------------------------------------------------------------------
@@ -2414,6 +2412,136 @@ class TestEvaluateSumPhase60BoundedLogSqrtPolyNumerator:
         kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
         num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, sqrt_kp1, kp1_3))
         k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase61TwoSqrtPolyNumerator:
+    """Phase 61: Mul(Sqrt(P1), Sqrt(P2), polynomial..., bounded...) numerator.
+
+    effective_x2 = deg(P1) + deg(P2) + 2·poly_deg.
+    Vanishes when 2·den_deg > effective_x2 or non-polynomial diverging denom.
+    """
+
+    def test_sqrt_k_times_sqrt_k_cubed_over_k_cubed_closes(self):
+        """√k · √(k³) / k³: x2=1+3=4; 2·3=6 > 4 → closes.
+
+        g(k) = √k · √(k³) / k³ — all factors plain functions of k.
+        g(k+1) = √(k+1) · √((k+1)³) / (k+1)³  [clean substitution]
+        """
+        from symbolic_ir import SQRT, SUB
+
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        sqrt_k = IRApply(SQRT, (_k,))
+        sqrt_k3 = IRApply(SQRT, (k3,))
+        num_k = IRApply(MUL, (sqrt_k, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (kp1_3,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_sq_times_sqrt_k_times_k_over_k_cubed_closes(self):
+        """√(k²) · √k · k / k³: x2=2+1+2=5; 2·3=6 > 5 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2 = IRApply(SQRT, (k2,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sqrt_k2, sqrt_k, _k))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1_2,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_2, sqrt_kp1, kp1))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_sqrt_k_times_sqrt_k_over_k_sq_closes(self):
+        """sin(k) · √k · √k / k²: x2=1+1=2; 2·2=4 > 2 → closes (bounded factor)."""
+        from symbolic_ir import SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k1 = IRApply(SQRT, (_k,))
+        sqrt_k2 = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, sqrt_k1, sqrt_k2))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1_1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1_1, sqrt_kp1_2))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_times_sqrt_k_over_exponential_closes(self):
+        """√k · √k / 2^k: non-polynomial diverging denominator."""
+        from symbolic_ir import SQRT, SUB
+
+        sqrt_k1 = IRApply(SQRT, (_k,))
+        sqrt_k2 = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sqrt_k1, sqrt_k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_kp1_1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_1, sqrt_kp1_2))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_sq_times_sqrt_k_sq_over_k_sq_refused(self):
+        """√(k²) · √(k²) / k²: x2=2+2=4; 2·2=4 not > 4 → equal, refused."""
+        from symbolic_ir import SQRT, SUB
+
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2_1 = IRApply(SQRT, (k2,))
+        sqrt_k2_2 = IRApply(SQRT, (k2,))
+        num_k = IRApply(MUL, (sqrt_k2_1, sqrt_k2_2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2_1 = IRApply(SQRT, (kp1_2,))
+        sqrt_kp1_2_2 = IRApply(SQRT, (kp1_2,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_2_1, sqrt_kp1_2_2))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_sqrt_k_times_sqrt_k_cubed_over_k_sq_refused(self):
+        """√k · √(k³) / k²: x2=1+3=4; 2·2=4 not > 4 → equal, refused."""
+        from symbolic_ir import SQRT, SUB
+
+        sqrt_k = IRApply(SQRT, (_k,))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        sqrt_k3 = IRApply(SQRT, (k3,))
+        num_k = IRApply(MUL, (sqrt_k, sqrt_k3))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_3 = IRApply(SQRT, (kp1_3,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1, sqrt_kp1_3))
         kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.9.0 — 2026-05-25
+
+**Phase 61 — Two-Sqrt × polynomial numerator (Rust port).**
+
+Ports Python ``cas-summation`` 1.9.0.  Closes the gap where all prior Sqrt
+phases (51, 53, 56, 59, 60) hard-reject a second Sqrt operand.
+
+Effective growth: ``k^{deg(P1)/2 + deg(P2)/2 + m}``.
+×2 trick: ``effective_x2 = deg(P1) + deg(P2) + 2·m``.
+Vanishes when ``2·den_deg > effective_x2`` or non-polynomial diverging denom.
+
+### Added
+
+- **`two_sqrt_poly_effective_x2(node, k) -> Option<i64>`** — returns
+  ``deg(P1) + deg(P2) + 2·poly_deg`` for
+  ``Mul(Sqrt(P1), Sqrt(P2), poly_factors..., bounded_factors...)``.
+  Refuses three-or-more Sqrt, any Log factor, or unrecognised factors.
+- **Phase 61 branch** in ``g_vanishes_at_infinity`` — checks
+  ``2·den_deg > tsp_x2`` for polynomial denominators; falls back to
+  ``h_diverges_at_infinity`` for non-polynomial diverging denominators.
+- **3 new tests**: ``phase61_*`` in ``tests/tests.rs``.
+
 ## 1.8.0 — 2026-05-24
 
 **Phase 60 — Bounded × Log(diverging) × Sqrt(positive-poly) × polynomial

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1466,6 +1466,63 @@ fn bounded_log_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> 
     Some(sid + 2 * poly_deg)
 }
 
+/// Phase 61 (Rust port): Return ``deg(P1) + deg(P2) + 2·poly_deg`` when
+/// ``node`` is a ``Mul`` with **exactly two** ``Sqrt(positive-leading
+/// polynomial)`` factors, any polynomial factors (total degree ``m``), and
+/// any number of bounded factors; ``None`` otherwise.
+///
+/// Closes the gap where Phases 51, 53, 56, 59, 60 each require exactly one
+/// Sqrt and hard-reject a second.
+///
+/// # Growth analysis (×2 trick)
+///
+/// ``Sqrt(P1(k)) · Sqrt(P2(k)) · k^m ≈ k^{deg(P1)/2 + deg(P2)/2 + m}``.
+/// ``effective_x2 = deg(P1) + deg(P2) + 2·m``.
+/// Caller checks ``2·den_deg > effective_x2``.
+///
+/// ``Log`` factors are refused (future Log×two-Sqrt phase territory).
+fn two_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return None,
+    };
+    if !head_is(&apply_node.head, MUL) {
+        return None;
+    }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        // Sqrt(positive-leading polynomial) factor?
+        if let Some(deg_x2) = sqrt_effective_half_degree_x2(arg, k) {
+            sqrt_degs.push(deg_x2);
+            if sqrt_degs.len() > 2 {
+                // Three or more Sqrt factors — refuse.
+                return None;
+            }
+            continue;
+        }
+        // Log(diverging) factor — refuse.
+        if is_log_of_diverging_in_k(arg, k) {
+            return None;
+        }
+        // Polynomial factor?
+        if let Some(deg) = polynomial_degree_in_k(arg, k) {
+            poly_deg += deg;
+            continue;
+        }
+        // Bounded (non-polynomial, non-Sqrt, non-Log)?
+        if is_bounded_in_k(arg, k) {
+            continue;
+        }
+        // Unrecognised factor — bail.
+        return None;
+    }
+    if sqrt_degs.len() != 2 {
+        return None;
+    }
+    Some(sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1608,6 +1665,20 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(blsp_x2) = bounded_log_sqrt_poly_effective_x2(num, k) {
         if let Some(den_deg_blsp) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_blsp > blsp_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 61: `Mul(Sqrt(P1), Sqrt(P2), polynomial..., bounded...)` numerator.
+    // Closes the gap where all prior Sqrt phases require exactly one Sqrt.
+    // effective_x2 = deg(P1) + deg(P2) + 2·poly_deg.
+    // Vanishes when `2·den_deg > effective_x2` (polynomial) or non-polynomial
+    // diverging denominator.
+    if let Some(tsp_x2) = two_sqrt_poly_effective_x2(num, k) {
+        if let Some(den_deg_tsp) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_tsp > tsp_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1682,3 +1682,71 @@ fn phase60_sin_log_sqrt_k_sq_times_k_over_k_sq_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 61: Mul(Sqrt(P1), Sqrt(P2), polynomial..., bounded...) ──────────────
+// effective_x2 = deg(P1) + deg(P2) + 2·poly_deg.
+// Vanishes when 2·den_deg > effective_x2 or non-polynomial diverging denom.
+// Closes the gap where all prior Sqrt phases require exactly one Sqrt.
+
+#[test]
+fn phase61_sqrt_k_times_sqrt_k3_over_k3_closes() {
+    // √k · √(k³) / k³: x2=1+3=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k, sqrt_k3]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1, sqrt_kp1_3]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k3]),
+        apply(sym(DIV), vec![num_kp1, kp1_3]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase61_sin_sqrt_k_times_sqrt_k_over_k_sq_closes() {
+    // sin(k) · √k · √k / k²: x2=1+1=2; 2·2=4 > 2 → closes (bounded + two Sqrt).
+    let k = sym("k");
+    let sin_k = apply(sym("Sin"), vec![k.clone()]);
+    let sqrt_k1 = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k.clone()]);
+    let num_k = apply(sym(MUL), vec![sin_k, sqrt_k1, sqrt_k2]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sin_kp1 = apply(sym("Sin"), vec![kp1.clone()]);
+    let sqrt_kp1_1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sin_kp1, sqrt_kp1_1, sqrt_kp1_2]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, apply(sym(POW), vec![k.clone(), int(2)])]),
+        apply(sym(DIV), vec![num_kp1, apply(sym(POW), vec![kp1, int(2)])]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase61_sqrt_k2_times_sqrt_k2_over_k2_refused() {
+    // √(k²) · √(k²) / k²: x2=2+2=4; 2·2=4 not > 4 → equal, refused.
+    let k = sym("k");
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let sqrt_k2_1 = apply(sym("Sqrt"), vec![k2.clone()]);
+    let sqrt_k2_2 = apply(sym("Sqrt"), vec![k2.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k2_1, sqrt_k2_2]);
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_kp1_2_1 = apply(sym("Sqrt"), vec![kp1_2.clone()]);
+    let sqrt_kp1_2_2 = apply(sym("Sqrt"), vec![kp1_2.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_2_1, sqrt_kp1_2_2]);
+    let f = apply(sym(SUB), vec![
+        apply(sym(DIV), vec![num_k, k2]),
+        apply(sym(DIV), vec![num_kp1, kp1_2]),
+    ]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.9.0 — 2026-05-25
+
+**Phase 61 — Two-Sqrt × polynomial numerator (TypeScript port).**
+
+Ports Python ``cas-summation`` 1.9.0.  Closes the gap where all prior Sqrt
+phases (51, 53, 56, 59, 60) hard-reject a second Sqrt operand.
+
+Effective growth: ``k^{sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg}``.
+TypeScript convention: compare ``denDeg > tspDeg`` (actual half-degrees, no ×2).
+
+### Added
+
+- **`twoSqrtPolyEffectiveDeg(node, k)`** — returns
+  ``sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg`` for
+  ``Mul(Sqrt(P1), Sqrt(P2), poly_factors..., bounded_factors...)``.
+  Refuses three-or-more Sqrt, any Log factor, or unrecognised factors.
+- **Phase 61 branch** in ``gVanishesAtInfinity`` — checks
+  ``denDeg > tspDeg`` for polynomial denominators; falls back to
+  ``hDivergesAtInfinity`` for non-polynomial diverging denominators.
+- **4 new tests** in the Phase 61 ``describe`` block.
+
 ## 1.8.0 — 2026-05-24
 
 **Phase 60 — Bounded × Log(diverging) × Sqrt(positive-poly) × polynomial

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1165,6 +1165,68 @@ function boundedLogSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undef
   return sqrtHalfDeg + polyDeg;
 }
 
+/**
+ * Phase 61 (TypeScript port): Return the effective degree when ``node`` is a
+ * ``Mul`` with **exactly two** ``Sqrt(positive-leading polynomial)`` factors,
+ * any polynomial factors (total degree ``m``), and any number of bounded
+ * factors; ``undefined`` otherwise.
+ *
+ * Closes the gap where Phases 51, 53, 56, 59 each require exactly one Sqrt
+ * and hard-reject a second.
+ *
+ * Effective growth: ``k^{deg(P1)/2 + deg(P2)/2 + m}``.
+ * TypeScript convention: compare ``denDeg > sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg``
+ * (actual half-degrees, no ×2).
+ *
+ * ``Log`` factors are refused (belong to future Log×two-Sqrt phases).
+ *
+ * Algorithm:
+ *   1. Require ``node = Mul(...)``.
+ *   2. For each factor:
+ *      - ``Sqrt(positive-poly)`` → accumulate half-degrees; refuse if third one.
+ *      - ``Log(diverging)`` → refuse immediately.
+ *      - polynomial → add degree to ``polyDeg``.
+ *      - ``bounded`` → accept silently.
+ *      - Unrecognised → return undefined.
+ *   3. Require exactly two Sqrt factors.
+ *   4. Return ``sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg``.
+ */
+function twoSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    // Sqrt(positive-poly) factor?
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      sqrtHalfDegs.push(halfDeg);
+      if (sqrtHalfDegs.length > 2) {
+        // Three or more Sqrt factors — refuse (conservative).
+        return undefined;
+      }
+      continue;
+    }
+    // Log(diverging) factor — refuse (future Log×two-Sqrt phase territory).
+    if (isLogOfDivergingInK(arg, k)) {
+      return undefined;
+    }
+    // Polynomial factor?
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) {
+      polyDeg += deg;
+      continue;
+    }
+    // Bounded (non-polynomial, non-Sqrt, non-Log)?
+    if (isBoundedInK(arg, k)) {
+      continue;
+    }
+    // Unrecognised factor — bail.
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1311,6 +1373,21 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegBlsp = polynomialDegreeInK(den, k);
     if (denDegBlsp !== undefined) {
       if (denDegBlsp > blspDeg) {
+        return true;
+      }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 61: Mul(Sqrt(P1), Sqrt(P2), polynomial..., bounded...) numerator.
+  // Extends Phases 53/56/59 to two Sqrt factors.
+  // Effective degree: sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  // Vanishes when denDeg > tspDeg (polynomial) or non-polynomial diverging.
+  const tspDeg = twoSqrtPolyEffectiveDeg(num, k);
+  if (tspDeg !== undefined) {
+    const denDegTsp = polynomialDegreeInK(den, k);
+    if (denDegTsp !== undefined) {
+      if (denDegTsp > tspDeg) {
         return true;
       }
     } else if (hDivergesAtInfinity(den, k)) {

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1456,3 +1456,87 @@ describe("summation: Phase 60 bounded × Log(diverging) × Sqrt(positive-poly) �
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+describe("summation: Phase 61 two Sqrt × polynomial numerator", () => {
+  // Phase 61: Mul(Sqrt(P1), Sqrt(P2), poly..., bounded...) numerator.
+  // Effective degree: sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  // Vanishes when denDeg > effectiveDeg or non-polynomial diverging denom.
+
+  it("∑ [√k · √(k³) / k³ − ...] closes (halfDeg1=0.5, halfDeg2=1.5, eff=2, denDeg=3)", () => {
+    // Two distinct Sqrt degrees: x2=1+3=4; TS: eff=0.5+1.5=2; denDeg=3 > 2 → closes.
+    const k = sym("k");
+    const k3 = app(POW, [k, int(3)]);
+    const sqrtK = app(sym("Sqrt"), [k]);
+    const sqrtK3 = app(sym("Sqrt"), [k3]);
+    const numK = app(MUL, [sqrtK, sqrtK3]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const kp1_3 = app(POW, [kp1, int(3)]);
+    const sqrtKp1 = app(sym("Sqrt"), [kp1]);
+    const sqrtKp1_3 = app(sym("Sqrt"), [kp1_3]);
+    const numKp1 = app(MUL, [sqrtKp1, sqrtKp1_3]);
+    const f = app(SUB, [
+      app(DIV, [numK, k3]),
+      app(DIV, [numKp1, kp1_3]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [sin(k)·√k·√k / k² − ...] closes (halfDeg1=0.5, halfDeg2=0.5, eff=1, denDeg=2)", () => {
+    // bounded × two Sqrt: eff=0.5+0.5=1; denDeg=2 > 1 → closes.
+    const k = sym("k");
+    const sinK = app(sym("Sin"), [k]);
+    const sqrtK1 = app(sym("Sqrt"), [k]);
+    const sqrtK2 = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sinK, sqrtK1, sqrtK2]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sinKp1 = app(sym("Sin"), [kp1]);
+    const sqrtKp1_1 = app(sym("Sqrt"), [kp1]);
+    const sqrtKp1_2 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sinKp1, sqrtKp1_1, sqrtKp1_2]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [k, int(2)])]),
+      app(DIV, [numKp1, app(POW, [kp1, int(2)])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("∑ [√k·√k / 2^k − ...] closes (exp denominator dominates)", () => {
+    // Non-polynomial diverging denominator dominates any two-Sqrt growth.
+    const k = sym("k");
+    const sqrtK1 = app(sym("Sqrt"), [k]);
+    const sqrtK2 = app(sym("Sqrt"), [k]);
+    const numK = app(MUL, [sqrtK1, sqrtK2]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const sqrtKp1_1 = app(sym("Sqrt"), [kp1]);
+    const sqrtKp1_2 = app(sym("Sqrt"), [kp1]);
+    const numKp1 = app(MUL, [sqrtKp1_1, sqrtKp1_2]);
+    const f = app(SUB, [
+      app(DIV, [numK, app(POW, [int(2), k])]),
+      app(DIV, [numKp1, app(POW, [int(2), kp1])]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).not.toEqual(SUM);
+  });
+
+  it("regression: √(k²)·√(k²)/k² stays unevaluated (equal: eff=2, denDeg=2)", () => {
+    // halfDeg1=1, halfDeg2=1, polyDeg=0, eff=2; denDeg=2 not > 2 → refused.
+    const k = sym("k");
+    const k2 = app(POW, [k, int(2)]);
+    const sqrtK2_1 = app(sym("Sqrt"), [k2]);
+    const sqrtK2_2 = app(sym("Sqrt"), [k2]);
+    const numK = app(MUL, [sqrtK2_1, sqrtK2_2]);
+    const kp1 = app(ADD, [k, int(1)]);
+    const kp1_2 = app(POW, [kp1, int(2)]);
+    const sqrtKp1_2_1 = app(sym("Sqrt"), [kp1_2]);
+    const sqrtKp1_2_2 = app(sym("Sqrt"), [kp1_2]);
+    const numKp1 = app(MUL, [sqrtKp1_2_1, sqrtKp1_2_2]);
+    const f = app(SUB, [
+      app(DIV, [numK, k2]),
+      app(DIV, [numKp1, kp1_2]),
+    ]);
+    const out = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds convergence-recogniser **Phase 61** across Python, TypeScript, and Rust `cas-summation` packages (all → v1.9.0).
- Recognises numerators of shape `Mul(Sqrt(P1), Sqrt(P2), polynomial_factors..., bounded_factors...)`, closing the gap where all prior Sqrt phases (51, 53, 56, 59, 60) hard-reject a second Sqrt operand.
- Growth analysis: `k^{deg(P1)/2 + deg(P2)/2 + m}`. ×2 trick: `effective_x2 = deg(P1) + deg(P2) + 2·m`. Vanishes when `2·den_deg > effective_x2` or denominator is non-polynomial diverging.
- Also promotes the old Phase 56 "two-sqrt refused" regression test → "now closed by Phase 61".
- 13 new tests total (6 Python, 4 TypeScript, 3 Rust); all existing tests pass.

## New helpers

| Language | Helper | Returns |
|----------|--------|---------|
| Python | `_two_sqrt_poly_effective_x2` | `int \| None` (×2 trick) |
| TypeScript | `twoSqrtPolyEffectiveDeg` | `number \| undefined` (actual half-deg) |
| Rust | `two_sqrt_poly_effective_x2` | `Option<i64>` (×2 trick) |

## Test plan

- [x] Python: `pytest tests/ -x -q` → 163 passed
- [x] TypeScript: `vitest run` → 89 passed
- [x] Rust: `cargo test -p cas-summation` → 84 passed
- [x] Security review: passed (pure symbolic math, no I/O, no unsafe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)