### PR TITLE
chief: add host-run escalation lane queues

### DIFF
--- a/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/CHANGELOG.md
@@ -215,6 +215,9 @@ All notable changes to this package will be documented in this file.
 - Host-run escalation dashboard lane digests that bind lane classifiers back
   to compact rollup keys for supervisor drain run host-log grouping and drift
   checks.
+- Host-run escalation dashboard lane queue keys that bind lane digests to route,
+  priority, and readiness queues for supervisor drain run host-log grouping and
+  drift checks.
 - Aggregate health-label integrity helpers for inventory, write, replay,
   checkpoint replay, and checkpoint page summaries.
 - Stable, parseable supervisor drain scheduler action recommendations for host

--- a/code/packages/rust/chief-of-staff-tool-audit-store/README.md
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/README.md
@@ -263,6 +263,9 @@ The crate keeps the boundary narrow:
 - supervisor drain reports and summaries expose host-run escalation dashboard
   lane digests that bind lane classifiers back to their compact rollup keys for
   host-log grouping and drift checks
+- supervisor drain reports and summaries expose host-run escalation dashboard
+  lane queue keys that bind lane digests to route, priority, and readiness
+  queues for host-log grouping and drift checks
 - supervisor drain reports and summaries expose stable, parseable scheduler action
   recommendations for continuation, follow-up routing, and plan-drift
   investigation

--- a/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-audit-store/src/lib.rs
@@ -5398,6 +5398,133 @@ impl ToolAuditSupervisorDrainRunReport {
         self.host_run_escalation_dashboard_lane_digest().has_route()
     }
 
+    /// Return the compact escalation dashboard lane queue key.
+    pub fn host_run_escalation_dashboard_lane_queue_key(
+        &self,
+    ) -> ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey {
+        self.host_run_escalation_dashboard_key().lane_queue_key()
+    }
+
+    /// Return the stable escalation dashboard lane queue-key label.
+    pub fn host_run_escalation_dashboard_lane_queue_key_label(&self) -> String {
+        self.host_run_escalation_dashboard_lane_queue_key().label()
+    }
+
+    /// Return whether the lane queue-key label parses back to its typed key.
+    pub fn host_run_escalation_dashboard_lane_queue_key_label_matches_key(&self) -> bool {
+        ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+            &self.host_run_escalation_dashboard_lane_queue_key_label(),
+        ) == Some(self.host_run_escalation_dashboard_lane_queue_key())
+    }
+
+    /// Return whether the lane queue-key route matches the lane digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_route_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_key()
+            .lane_queue_key_route_matches_digest()
+    }
+
+    /// Return whether the lane queue-key priority matches the lane digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_priority_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_key()
+            .lane_queue_key_priority_matches_digest()
+    }
+
+    /// Return whether the lane queue-key readiness matches the lane digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_key()
+            .lane_queue_key_readiness_matches_digest()
+    }
+
+    /// Return whether the lane queue-key digest matches the typed digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_digest_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_key()
+            .lane_queue_key_digest_matches_digest()
+    }
+
+    /// Return whether every lane queue-key component matches its source classifiers.
+    pub fn host_run_escalation_dashboard_lane_queue_key_parts_match(&self) -> bool {
+        self.host_run_escalation_dashboard_key()
+            .lane_queue_key_parts_match()
+    }
+
+    /// Return whether any escalation dashboard lane queue-key component drifted.
+    pub fn has_host_run_escalation_dashboard_lane_queue_key_integrity_drift(&self) -> bool {
+        self.host_run_escalation_dashboard_key()
+            .has_lane_queue_key_integrity_drift()
+    }
+
+    /// Return whether dashboard lane queue-key labels match their source classifiers.
+    pub fn host_run_escalation_dashboard_lane_queue_key_labels_match(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_digest_labels_match()
+            && self.host_run_escalation_dashboard_lane_queue_key_label_matches_key()
+            && self.host_run_escalation_dashboard_lane_queue_key_parts_match()
+            && self.host_run_escalation_dashboard_lane_queue_key_route_matches_digest()
+            && self.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest()
+            && self.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest()
+            && self.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest()
+    }
+
+    /// Return whether any dashboard lane queue-key label drifted.
+    pub fn has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift(&self) -> bool {
+        !self.host_run_escalation_dashboard_lane_queue_key_labels_match()
+    }
+
+    /// Return whether the dashboard lane queue is fully settled.
+    pub fn host_run_escalation_dashboard_lane_queue_is_settled(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .is_settled()
+    }
+
+    /// Return whether the dashboard lane queue requires host action.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_action(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .requires_action()
+    }
+
+    /// Return the sortable dashboard lane queue-key priority rank.
+    pub fn host_run_escalation_dashboard_lane_queue_priority_rank(&self) -> u8 {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .priority_rank()
+    }
+
+    /// Return whether the dashboard lane queue can route automatically.
+    pub fn host_run_escalation_dashboard_lane_queue_is_auto_routable(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .is_auto_routable()
+    }
+
+    /// Return whether the dashboard lane queue requires manual review.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_manual_review(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .requires_manual_review()
+    }
+
+    /// Return whether the dashboard lane queue requires investigation.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_investigation(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .requires_investigation()
+    }
+
+    /// Return whether the dashboard lane queue requires host-log integrity investigation.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_integrity_investigation(
+        &self,
+    ) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .requires_integrity_investigation()
+    }
+
+    /// Return whether the dashboard lane queue requires triage.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_triage(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .requires_triage()
+    }
+
+    /// Return whether the dashboard lane queue has a concrete escalation route.
+    pub fn host_run_escalation_dashboard_lane_queue_has_route(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key()
+            .has_route()
+    }
+
     /// Return the reader or supervisor checkpoint name drained by this run.
     pub fn checkpoint_name(&self) -> &str {
         &self.plan.checkpoint_name
@@ -6517,6 +6644,46 @@ impl ToolAuditSupervisorDrainRunReport {
                 .host_run_escalation_dashboard_lane_digest_requires_triage(),
             host_run_escalation_dashboard_lane_digest_has_route: self
                 .host_run_escalation_dashboard_lane_digest_has_route(),
+            host_run_escalation_dashboard_lane_queue_key: self
+                .host_run_escalation_dashboard_lane_queue_key(),
+            host_run_escalation_dashboard_lane_queue_key_label: self
+                .host_run_escalation_dashboard_lane_queue_key_label(),
+            host_run_escalation_dashboard_lane_queue_key_label_matches_key: self
+                .host_run_escalation_dashboard_lane_queue_key_label_matches_key(),
+            host_run_escalation_dashboard_lane_queue_key_route_matches_digest: self
+                .host_run_escalation_dashboard_lane_queue_key_route_matches_digest(),
+            host_run_escalation_dashboard_lane_queue_key_priority_matches_digest: self
+                .host_run_escalation_dashboard_lane_queue_key_priority_matches_digest(),
+            host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest: self
+                .host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest(),
+            host_run_escalation_dashboard_lane_queue_key_digest_matches_digest: self
+                .host_run_escalation_dashboard_lane_queue_key_digest_matches_digest(),
+            host_run_escalation_dashboard_lane_queue_key_parts_match: self
+                .host_run_escalation_dashboard_lane_queue_key_parts_match(),
+            has_host_run_escalation_dashboard_lane_queue_key_integrity_drift: self
+                .has_host_run_escalation_dashboard_lane_queue_key_integrity_drift(),
+            host_run_escalation_dashboard_lane_queue_key_labels_match: self
+                .host_run_escalation_dashboard_lane_queue_key_labels_match(),
+            has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift: self
+                .has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift(),
+            host_run_escalation_dashboard_lane_queue_is_settled: self
+                .host_run_escalation_dashboard_lane_queue_is_settled(),
+            host_run_escalation_dashboard_lane_queue_requires_action: self
+                .host_run_escalation_dashboard_lane_queue_requires_action(),
+            host_run_escalation_dashboard_lane_queue_priority_rank: self
+                .host_run_escalation_dashboard_lane_queue_priority_rank(),
+            host_run_escalation_dashboard_lane_queue_is_auto_routable: self
+                .host_run_escalation_dashboard_lane_queue_is_auto_routable(),
+            host_run_escalation_dashboard_lane_queue_requires_manual_review: self
+                .host_run_escalation_dashboard_lane_queue_requires_manual_review(),
+            host_run_escalation_dashboard_lane_queue_requires_investigation: self
+                .host_run_escalation_dashboard_lane_queue_requires_investigation(),
+            host_run_escalation_dashboard_lane_queue_requires_integrity_investigation: self
+                .host_run_escalation_dashboard_lane_queue_requires_integrity_investigation(),
+            host_run_escalation_dashboard_lane_queue_requires_triage: self
+                .host_run_escalation_dashboard_lane_queue_requires_triage(),
+            host_run_escalation_dashboard_lane_queue_has_route: self
+                .host_run_escalation_dashboard_lane_queue_has_route(),
             matches_planned_record_count: self.matches_planned_record_count(),
             matches_record_count: self.matches_record_count(),
             matches_planned_follow_up_record_count: self.matches_planned_follow_up_record_count(),
@@ -8246,6 +8413,47 @@ pub struct ToolAuditSupervisorDrainRunSummary {
     pub host_run_escalation_dashboard_lane_digest_requires_triage: bool,
     /// Whether the dashboard lane digest has a concrete route.
     pub host_run_escalation_dashboard_lane_digest_has_route: bool,
+    /// Compact host-run escalation dashboard lane queue key.
+    pub host_run_escalation_dashboard_lane_queue_key:
+        ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey,
+    /// Stable host-run escalation dashboard lane queue-key label.
+    pub host_run_escalation_dashboard_lane_queue_key_label: String,
+    /// Whether the dashboard lane queue-key label parses back to its typed key.
+    pub host_run_escalation_dashboard_lane_queue_key_label_matches_key: bool,
+    /// Whether the lane queue-key route component matches the lane digest.
+    pub host_run_escalation_dashboard_lane_queue_key_route_matches_digest: bool,
+    /// Whether the lane queue-key priority component matches the lane digest.
+    pub host_run_escalation_dashboard_lane_queue_key_priority_matches_digest: bool,
+    /// Whether the lane queue-key readiness component matches the lane digest.
+    pub host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest: bool,
+    /// Whether the lane queue-key digest component matches the typed digest.
+    pub host_run_escalation_dashboard_lane_queue_key_digest_matches_digest: bool,
+    /// Whether every lane queue-key component matches its source classifiers.
+    pub host_run_escalation_dashboard_lane_queue_key_parts_match: bool,
+    /// Whether any dashboard lane queue-key component drifted.
+    pub has_host_run_escalation_dashboard_lane_queue_key_integrity_drift: bool,
+    /// Whether dashboard lane queue-key labels match their source classifiers.
+    pub host_run_escalation_dashboard_lane_queue_key_labels_match: bool,
+    /// Whether any dashboard lane queue-key label drifted.
+    pub has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift: bool,
+    /// Whether the dashboard lane queue is fully settled.
+    pub host_run_escalation_dashboard_lane_queue_is_settled: bool,
+    /// Whether the dashboard lane queue requires host action.
+    pub host_run_escalation_dashboard_lane_queue_requires_action: bool,
+    /// Sortable dashboard lane queue-key priority rank.
+    pub host_run_escalation_dashboard_lane_queue_priority_rank: u8,
+    /// Whether the dashboard lane queue can route automatically.
+    pub host_run_escalation_dashboard_lane_queue_is_auto_routable: bool,
+    /// Whether the dashboard lane queue requires manual review.
+    pub host_run_escalation_dashboard_lane_queue_requires_manual_review: bool,
+    /// Whether the dashboard lane queue requires investigation.
+    pub host_run_escalation_dashboard_lane_queue_requires_investigation: bool,
+    /// Whether the dashboard lane queue requires host-log integrity investigation.
+    pub host_run_escalation_dashboard_lane_queue_requires_integrity_investigation: bool,
+    /// Whether the dashboard lane queue requires triage.
+    pub host_run_escalation_dashboard_lane_queue_requires_triage: bool,
+    /// Whether the dashboard lane queue has a concrete route.
+    pub host_run_escalation_dashboard_lane_queue_has_route: bool,
     /// Whether the actual run delivered the planned number of rows.
     pub matches_planned_record_count: bool,
     /// Whether planned and replayed row counts match.
@@ -11564,6 +11772,110 @@ impl ToolAuditSupervisorDrainRunSummary {
     /// Return whether the dashboard lane digest has a concrete escalation route.
     pub fn host_run_escalation_dashboard_lane_digest_has_route(&self) -> bool {
         self.host_run_escalation_dashboard_lane_digest_has_route
+    }
+
+    /// Return the compact escalation dashboard lane queue key.
+    pub fn host_run_escalation_dashboard_lane_queue_key(
+        &self,
+    ) -> ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey {
+        self.host_run_escalation_dashboard_lane_queue_key
+    }
+
+    /// Return the stable escalation dashboard lane queue-key label.
+    pub fn host_run_escalation_dashboard_lane_queue_key_label(&self) -> &str {
+        &self.host_run_escalation_dashboard_lane_queue_key_label
+    }
+
+    /// Return whether the lane queue-key label parses back to its typed key.
+    pub fn host_run_escalation_dashboard_lane_queue_key_label_matches_key(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_label_matches_key
+    }
+
+    /// Return whether the lane queue-key route matches the lane digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_route_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_route_matches_digest
+    }
+
+    /// Return whether the lane queue-key priority matches the lane digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_priority_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest
+    }
+
+    /// Return whether the lane queue-key readiness matches the lane digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest
+    }
+
+    /// Return whether the lane queue-key digest matches the typed digest.
+    pub fn host_run_escalation_dashboard_lane_queue_key_digest_matches_digest(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest
+    }
+
+    /// Return whether every lane queue-key component matches its source classifiers.
+    pub fn host_run_escalation_dashboard_lane_queue_key_parts_match(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_parts_match
+    }
+
+    /// Return whether any dashboard lane queue-key component drifted.
+    pub fn has_host_run_escalation_dashboard_lane_queue_key_integrity_drift(&self) -> bool {
+        self.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift
+    }
+
+    /// Return whether dashboard lane queue-key labels match their source classifiers.
+    pub fn host_run_escalation_dashboard_lane_queue_key_labels_match(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_key_labels_match
+    }
+
+    /// Return whether any dashboard lane queue-key label drifted.
+    pub fn has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift(&self) -> bool {
+        self.has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift
+    }
+
+    /// Return whether the dashboard lane queue is fully settled.
+    pub fn host_run_escalation_dashboard_lane_queue_is_settled(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_is_settled
+    }
+
+    /// Return whether the dashboard lane queue requires host action.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_action(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_requires_action
+    }
+
+    /// Return the sortable dashboard lane queue-key priority rank.
+    pub fn host_run_escalation_dashboard_lane_queue_priority_rank(&self) -> u8 {
+        self.host_run_escalation_dashboard_lane_queue_priority_rank
+    }
+
+    /// Return whether the dashboard lane queue can route automatically.
+    pub fn host_run_escalation_dashboard_lane_queue_is_auto_routable(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_is_auto_routable
+    }
+
+    /// Return whether the dashboard lane queue requires manual review.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_manual_review(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_requires_manual_review
+    }
+
+    /// Return whether the dashboard lane queue requires investigation.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_investigation(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_requires_investigation
+    }
+
+    /// Return whether the dashboard lane queue requires host-log integrity investigation.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_integrity_investigation(
+        &self,
+    ) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_requires_integrity_investigation
+    }
+
+    /// Return whether the dashboard lane queue requires triage.
+    pub fn host_run_escalation_dashboard_lane_queue_requires_triage(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_requires_triage
+    }
+
+    /// Return whether the dashboard lane queue has a concrete escalation route.
+    pub fn host_run_escalation_dashboard_lane_queue_has_route(&self) -> bool {
+        self.host_run_escalation_dashboard_lane_queue_has_route
     }
 
     /// Return whether the actual run replayed more rows than planned.
@@ -16232,6 +16544,21 @@ impl ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest {
         self.lane_rollup_key
     }
 
+    /// Return the escalation route carried by the lane digest.
+    pub fn route(self) -> ToolAuditSupervisorDrainHostRunEscalationRoute {
+        self.lane_rollup_key.route()
+    }
+
+    /// Return the dashboard lane queue priority.
+    pub fn queue_priority(self) -> ToolAuditSupervisorDrainHostRunQueuePriority {
+        self.lane_rollup_key.priority()
+    }
+
+    /// Return the dashboard lane queue readiness.
+    pub fn queue_readiness(self) -> ToolAuditSupervisorDrainHostRunQueueReadiness {
+        self.lane_rollup_key.readiness()
+    }
+
     /// Return a stable compact label for dashboard lane digest grouping.
     pub fn label(self) -> String {
         format!(
@@ -16340,6 +16667,223 @@ impl ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest {
 }
 
 impl Display for ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.label())
+    }
+}
+
+/// Stable queue key for host-run escalation dashboard lane digests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey {
+    route: ToolAuditSupervisorDrainHostRunEscalationRoute,
+    priority: ToolAuditSupervisorDrainHostRunQueuePriority,
+    readiness: ToolAuditSupervisorDrainHostRunQueueReadiness,
+    lane_digest: ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest,
+}
+
+impl ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey {
+    /// Create a dashboard lane queue key from compact digest classifiers.
+    pub fn new(
+        route: ToolAuditSupervisorDrainHostRunEscalationRoute,
+        priority: ToolAuditSupervisorDrainHostRunQueuePriority,
+        readiness: ToolAuditSupervisorDrainHostRunQueueReadiness,
+        lane_digest: ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest,
+    ) -> Self {
+        Self {
+            route,
+            priority,
+            readiness,
+            lane_digest,
+        }
+    }
+
+    /// Create a dashboard lane queue key from a lane digest.
+    pub fn from_lane_digest(
+        lane_digest: ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest,
+    ) -> Self {
+        Self::new(
+            lane_digest.route(),
+            lane_digest.queue_priority(),
+            lane_digest.queue_readiness(),
+            lane_digest,
+        )
+    }
+
+    /// Parse a stable compact dashboard lane queue-key label.
+    pub fn from_label(label: &str) -> Option<Self> {
+        let rest = label.strip_prefix("route=")?;
+        let (route_label, rest) = rest.split_once("|priority=")?;
+        let (priority_label, rest) = rest.split_once("|readiness=")?;
+        let (readiness_label, digest_label) = rest.split_once("|lane_digest=")?;
+        let route = ToolAuditSupervisorDrainHostRunEscalationRoute::from_label(route_label)?;
+        let priority = ToolAuditSupervisorDrainHostRunQueuePriority::from_label(priority_label)?;
+        let readiness = ToolAuditSupervisorDrainHostRunQueueReadiness::from_label(readiness_label)?;
+        let lane_digest =
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest::from_label(digest_label)?;
+        Some(Self::new(route, priority, readiness, lane_digest))
+    }
+
+    /// Return the dashboard lane escalation route.
+    pub fn route(self) -> ToolAuditSupervisorDrainHostRunEscalationRoute {
+        self.route
+    }
+
+    /// Return the dashboard lane queue priority.
+    pub fn priority(self) -> ToolAuditSupervisorDrainHostRunQueuePriority {
+        self.priority
+    }
+
+    /// Return the dashboard lane queue readiness.
+    pub fn readiness(self) -> ToolAuditSupervisorDrainHostRunQueueReadiness {
+        self.readiness
+    }
+
+    /// Return the compact dashboard lane digest.
+    pub fn lane_digest(self) -> ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest {
+        self.lane_digest
+    }
+
+    /// Return a stable compact label for dashboard lane queue grouping.
+    pub fn label(self) -> String {
+        format!(
+            "route={}|priority={}|readiness={}|lane_digest={}",
+            self.route.as_str(),
+            self.priority.as_str(),
+            self.readiness.as_str(),
+            self.lane_digest.label()
+        )
+    }
+
+    /// Return whether this lane queue-key label parses back to this typed key.
+    pub fn label_matches_key(self) -> bool {
+        Self::from_label(&self.label()) == Some(self)
+    }
+
+    /// Return whether this key's route component matches the supplied route.
+    pub fn route_matches(self, route: ToolAuditSupervisorDrainHostRunEscalationRoute) -> bool {
+        self.route == route
+    }
+
+    /// Return whether this key's priority component matches the supplied priority.
+    pub fn priority_matches(self, priority: ToolAuditSupervisorDrainHostRunQueuePriority) -> bool {
+        self.priority == priority
+    }
+
+    /// Return whether this key's readiness component matches the supplied readiness.
+    pub fn readiness_matches(
+        self,
+        readiness: ToolAuditSupervisorDrainHostRunQueueReadiness,
+    ) -> bool {
+        self.readiness == readiness
+    }
+
+    /// Return whether this key's digest component matches the supplied digest.
+    pub fn lane_digest_matches(
+        self,
+        lane_digest: ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest,
+    ) -> bool {
+        self.lane_digest == lane_digest
+    }
+
+    /// Return whether this key's route component matches its digest.
+    pub fn route_matches_lane_digest(self) -> bool {
+        self.route == self.lane_digest.route()
+    }
+
+    /// Return whether this key's priority component matches its digest.
+    pub fn priority_matches_lane_digest(self) -> bool {
+        self.priority == self.lane_digest.queue_priority()
+    }
+
+    /// Return whether this key's readiness component matches its digest.
+    pub fn readiness_matches_lane_digest(self) -> bool {
+        self.readiness == self.lane_digest.queue_readiness()
+    }
+
+    /// Return whether every queue-key component matches its source classifiers.
+    pub fn parts_match(
+        self,
+        route: ToolAuditSupervisorDrainHostRunEscalationRoute,
+        priority: ToolAuditSupervisorDrainHostRunQueuePriority,
+        readiness: ToolAuditSupervisorDrainHostRunQueueReadiness,
+        lane_digest: ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest,
+    ) -> bool {
+        self.route_matches(route)
+            && self.priority_matches(priority)
+            && self.readiness_matches(readiness)
+            && self.lane_digest_matches(lane_digest)
+    }
+
+    /// Return whether this lane queue key is fully settled.
+    pub fn is_settled(self) -> bool {
+        self.route.is_settled()
+            && self.priority.is_settled()
+            && self.readiness.is_settled()
+            && self.lane_digest.is_settled()
+    }
+
+    /// Return whether this lane queue key needs host action.
+    pub fn requires_action(self) -> bool {
+        self.route.requires_action()
+            || self.readiness.is_actionable()
+            || self.lane_digest.requires_action()
+    }
+
+    /// Return the sortable dashboard lane queue-key priority rank.
+    pub fn priority_rank(self) -> u8 {
+        self.route
+            .priority_rank()
+            .max(self.priority.rank())
+            .max(self.lane_digest.priority_rank())
+    }
+
+    /// Return whether this lane queue key can route automatically.
+    pub fn is_auto_routable(self) -> bool {
+        self.route.is_auto_routable()
+            && self.priority.is_routine_action()
+            && self.readiness.is_auto_routable()
+            && self.lane_digest.is_auto_routable()
+    }
+
+    /// Return whether this lane queue key requires manual review.
+    pub fn requires_manual_review(self) -> bool {
+        self.route.requires_manual_review()
+            || self.priority.requires_manual_review()
+            || self.readiness.requires_manual_review()
+            || self.lane_digest.requires_manual_review()
+    }
+
+    /// Return whether this lane queue key requires investigation.
+    pub fn requires_investigation(self) -> bool {
+        self.route.requires_investigation()
+            || self.priority.requires_investigation()
+            || self.readiness.requires_investigation()
+            || self.lane_digest.requires_investigation()
+    }
+
+    /// Return whether this lane queue key requires host-log integrity investigation.
+    pub fn requires_integrity_investigation(self) -> bool {
+        self.route.requires_integrity_investigation()
+            || self.priority.requires_integrity_investigation()
+            || self.readiness.requires_integrity_investigation()
+            || self.lane_digest.requires_integrity_investigation()
+    }
+
+    /// Return whether this lane queue key requires triage.
+    pub fn requires_triage(self) -> bool {
+        self.route.requires_triage()
+            || self.priority.requires_triage()
+            || self.readiness.requires_triage()
+            || self.lane_digest.requires_triage()
+    }
+
+    /// Return whether this lane queue key has a concrete escalation route.
+    pub fn has_route(self) -> bool {
+        self.route.has_route()
+    }
+}
+
+impl Display for ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(&self.label())
     }
@@ -16656,6 +17200,125 @@ impl ToolAuditSupervisorDrainHostRunEscalationDashboardKey {
     /// Return whether this lane digest has a concrete escalation route.
     pub fn lane_digest_has_route(self) -> bool {
         self.lane_digest().has_route()
+    }
+
+    /// Return the compact dashboard lane queue key.
+    pub fn lane_queue_key(self) -> ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey {
+        ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_lane_digest(
+            self.lane_digest(),
+        )
+    }
+
+    /// Return the stable dashboard lane queue-key label.
+    pub fn lane_queue_key_label(self) -> String {
+        self.lane_queue_key().label()
+    }
+
+    /// Return whether this dashboard lane queue-key label parses back to its typed key.
+    pub fn lane_queue_key_label_matches_key(self) -> bool {
+        ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+            &self.lane_queue_key_label(),
+        ) == Some(self.lane_queue_key())
+    }
+
+    /// Return whether the lane queue-key route component matches the lane digest.
+    pub fn lane_queue_key_route_matches_digest(self) -> bool {
+        self.lane_queue_key().route_matches_lane_digest()
+    }
+
+    /// Return whether the lane queue-key priority component matches the lane digest.
+    pub fn lane_queue_key_priority_matches_digest(self) -> bool {
+        self.lane_queue_key().priority_matches_lane_digest()
+    }
+
+    /// Return whether the lane queue-key readiness component matches the lane digest.
+    pub fn lane_queue_key_readiness_matches_digest(self) -> bool {
+        self.lane_queue_key().readiness_matches_lane_digest()
+    }
+
+    /// Return whether the lane queue-key digest component matches the typed digest.
+    pub fn lane_queue_key_digest_matches_digest(self) -> bool {
+        self.lane_queue_key()
+            .lane_digest_matches(self.lane_digest())
+    }
+
+    /// Return whether every lane queue-key component matches its source classifiers.
+    pub fn lane_queue_key_parts_match(self) -> bool {
+        self.lane_queue_key().parts_match(
+            self.lane_digest().route(),
+            self.lane_digest().queue_priority(),
+            self.lane_digest().queue_readiness(),
+            self.lane_digest(),
+        )
+    }
+
+    /// Return whether any lane queue-key component drifted from its sources.
+    pub fn has_lane_queue_key_integrity_drift(self) -> bool {
+        !self.lane_queue_key_parts_match()
+            || !self.lane_queue_key_route_matches_digest()
+            || !self.lane_queue_key_priority_matches_digest()
+            || !self.lane_queue_key_readiness_matches_digest()
+    }
+
+    /// Return whether dashboard lane queue-key labels match their source classifiers.
+    pub fn lane_queue_key_labels_match(self) -> bool {
+        self.lane_digest_labels_match()
+            && self.lane_queue_key_label_matches_key()
+            && self.lane_queue_key_parts_match()
+            && self.lane_queue_key_route_matches_digest()
+            && self.lane_queue_key_priority_matches_digest()
+            && self.lane_queue_key_readiness_matches_digest()
+            && self.lane_queue_key_digest_matches_digest()
+    }
+
+    /// Return whether any dashboard lane queue-key label drifted.
+    pub fn has_lane_queue_key_label_integrity_drift(self) -> bool {
+        !self.lane_queue_key_labels_match()
+    }
+
+    /// Return whether this lane queue key is fully settled.
+    pub fn lane_queue_is_settled(self) -> bool {
+        self.lane_queue_key().is_settled()
+    }
+
+    /// Return whether this lane queue key needs host action.
+    pub fn lane_queue_requires_action(self) -> bool {
+        self.lane_queue_key().requires_action()
+    }
+
+    /// Return the sortable lane queue-key priority rank.
+    pub fn lane_queue_priority_rank(self) -> u8 {
+        self.lane_queue_key().priority_rank()
+    }
+
+    /// Return whether this lane queue key can route automatically.
+    pub fn lane_queue_is_auto_routable(self) -> bool {
+        self.lane_queue_key().is_auto_routable()
+    }
+
+    /// Return whether this lane queue key requires manual review.
+    pub fn lane_queue_requires_manual_review(self) -> bool {
+        self.lane_queue_key().requires_manual_review()
+    }
+
+    /// Return whether this lane queue key requires investigation.
+    pub fn lane_queue_requires_investigation(self) -> bool {
+        self.lane_queue_key().requires_investigation()
+    }
+
+    /// Return whether this lane queue key requires host-log integrity investigation.
+    pub fn lane_queue_requires_integrity_investigation(self) -> bool {
+        self.lane_queue_key().requires_integrity_investigation()
+    }
+
+    /// Return whether this lane queue key requires triage.
+    pub fn lane_queue_requires_triage(self) -> bool {
+        self.lane_queue_key().requires_triage()
+    }
+
+    /// Return whether this lane queue key has a concrete escalation route.
+    pub fn lane_queue_has_route(self) -> bool {
+        self.lane_queue_key().has_route()
     }
 
     /// Return whether this key's supervision component matches.
@@ -27079,7 +27742,130 @@ mod tests {
                 lane_digest.requires_triage()
             );
             assert_eq!(key.lane_digest_has_route(), lane_digest.has_route());
+
+            let lane_queue_key =
+                ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_lane_digest(
+                    lane_digest,
+                );
+            assert_eq!(lane_queue_key.route(), lane_digest.route());
+            assert_eq!(lane_queue_key.priority(), lane_digest.queue_priority());
+            assert_eq!(lane_queue_key.readiness(), lane_digest.queue_readiness());
+            assert_eq!(lane_queue_key.lane_digest(), lane_digest);
+            assert_eq!(
+                lane_queue_key.label(),
+                format!(
+                    "route={}|priority={}|readiness={}|lane_digest={}",
+                    lane_digest.route().as_str(),
+                    lane_digest.queue_priority().as_str(),
+                    lane_digest.queue_readiness().as_str(),
+                    lane_digest.label()
+                )
+            );
+            assert_eq!(
+                ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+                    &lane_queue_key.label()
+                ),
+                Some(lane_queue_key)
+            );
+            assert!(lane_queue_key.label_matches_key());
+            assert!(lane_queue_key.route_matches(lane_digest.route()));
+            assert!(lane_queue_key.priority_matches(lane_digest.queue_priority()));
+            assert!(lane_queue_key.readiness_matches(lane_digest.queue_readiness()));
+            assert!(lane_queue_key.lane_digest_matches(lane_digest));
+            assert!(lane_queue_key.route_matches_lane_digest());
+            assert!(lane_queue_key.priority_matches_lane_digest());
+            assert!(lane_queue_key.readiness_matches_lane_digest());
+            assert!(lane_queue_key.parts_match(
+                lane_digest.route(),
+                lane_digest.queue_priority(),
+                lane_digest.queue_readiness(),
+                lane_digest,
+            ));
+            assert_eq!(lane_queue_key.is_settled(), lane_digest.is_settled());
+            assert_eq!(
+                lane_queue_key.requires_action(),
+                lane_digest.requires_action()
+            );
+            assert_eq!(lane_queue_key.priority_rank(), expected_rank);
+            assert_eq!(lane_queue_key.is_auto_routable(), auto_routable);
+            assert_eq!(lane_queue_key.requires_manual_review(), manual_review);
+            assert_eq!(lane_queue_key.requires_investigation(), investigation);
+            assert_eq!(
+                lane_queue_key.requires_integrity_investigation(),
+                integrity_investigation
+            );
+            assert_eq!(
+                lane_queue_key.requires_triage(),
+                matches!(
+                    lane,
+                    ToolAuditSupervisorDrainHostRunEscalationDashboardLane::Triage
+                )
+            );
+            assert_eq!(lane_queue_key.has_route(), lane_digest.has_route());
+            assert_eq!(lane_queue_key.to_string(), lane_queue_key.label());
+            assert_eq!(key.lane_queue_key(), lane_queue_key);
+            assert_eq!(key.lane_queue_key_label(), lane_queue_key.label());
+            assert!(key.lane_queue_key_label_matches_key());
+            assert!(key.lane_queue_key_route_matches_digest());
+            assert!(key.lane_queue_key_priority_matches_digest());
+            assert!(key.lane_queue_key_readiness_matches_digest());
+            assert!(key.lane_queue_key_digest_matches_digest());
+            assert!(key.lane_queue_key_parts_match());
+            assert!(!key.has_lane_queue_key_integrity_drift());
+            assert!(key.lane_queue_key_labels_match());
+            assert!(!key.has_lane_queue_key_label_integrity_drift());
+            assert_eq!(key.lane_queue_is_settled(), lane_queue_key.is_settled());
+            assert_eq!(
+                key.lane_queue_requires_action(),
+                lane_queue_key.requires_action()
+            );
+            assert_eq!(
+                key.lane_queue_priority_rank(),
+                lane_queue_key.priority_rank()
+            );
+            assert_eq!(
+                key.lane_queue_is_auto_routable(),
+                lane_queue_key.is_auto_routable()
+            );
+            assert_eq!(
+                key.lane_queue_requires_manual_review(),
+                lane_queue_key.requires_manual_review()
+            );
+            assert_eq!(
+                key.lane_queue_requires_investigation(),
+                lane_queue_key.requires_investigation()
+            );
+            assert_eq!(
+                key.lane_queue_requires_integrity_investigation(),
+                lane_queue_key.requires_integrity_investigation()
+            );
+            assert_eq!(
+                key.lane_queue_requires_triage(),
+                lane_queue_key.requires_triage()
+            );
+            assert_eq!(key.lane_queue_has_route(), lane_queue_key.has_route());
         }
+
+        let dashboard_lane_digest =
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest::from_dashboard_key(
+                dashboard_key,
+            );
+        let stale_lane_queue_key =
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::new(
+                ToolAuditSupervisorDrainHostRunEscalationRoute::NoRoute,
+                ToolAuditSupervisorDrainHostRunQueuePriority::Settled,
+                ToolAuditSupervisorDrainHostRunQueueReadiness::Settled,
+                dashboard_lane_digest,
+            );
+        assert!(!stale_lane_queue_key.route_matches_lane_digest());
+        assert!(!stale_lane_queue_key.priority_matches_lane_digest());
+        assert!(!stale_lane_queue_key.readiness_matches_lane_digest());
+        assert!(stale_lane_queue_key.parts_match(
+            ToolAuditSupervisorDrainHostRunEscalationRoute::NoRoute,
+            ToolAuditSupervisorDrainHostRunQueuePriority::Settled,
+            ToolAuditSupervisorDrainHostRunQueueReadiness::Settled,
+            dashboard_lane_digest,
+        ));
 
         let stale_queue_key = ToolAuditSupervisorDrainHostRunEscalationQueueKey::new(
             route_key,
@@ -27179,6 +27965,30 @@ mod tests {
         assert_eq!(
             ToolAuditSupervisorDrainHostRunEscalationDashboardLaneDigest::from_label(
                 "laneish=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required",
+            ),
+            None
+        );
+        assert_eq!(
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+                "route=unknown|priority=triage|readiness=triage_required|lane_digest=lane=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required",
+            ),
+            None
+        );
+        assert_eq!(
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+                "route=triage|priority=unknown|readiness=triage_required|lane_digest=lane=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required",
+            ),
+            None
+        );
+        assert_eq!(
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+                "route=triage|priority=triage|readiness=triage_required|lane_digest=lane=unknown|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required",
+            ),
+            None
+        );
+        assert_eq!(
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_label(
+                "routeish=triage|priority=triage|readiness=triage_required|lane_digest=lane=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required",
             ),
             None
         );
@@ -27939,6 +28749,109 @@ mod tests {
         assert!(!idle_summary.host_run_escalation_dashboard_lane_digest_requires_triage());
         assert!(!idle_summary.host_run_escalation_dashboard_lane_digest_has_route);
         assert!(!idle_summary.host_run_escalation_dashboard_lane_digest_has_route());
+        let idle_lane_queue_key =
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_lane_digest(
+                idle_lane_digest,
+            );
+        assert_eq!(
+            idle_report.host_run_escalation_dashboard_lane_queue_key(),
+            idle_lane_queue_key
+        );
+        assert_eq!(
+            idle_report.host_run_escalation_dashboard_lane_queue_key_label(),
+            "route=no_route|priority=settled|readiness=settled|lane_digest=lane=settled|rollup=lane=settled|route=no_route|priority=settled|readiness=settled"
+        );
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_label_matches_key());
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_route_matches_digest());
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest());
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest());
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest());
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_parts_match());
+        assert!(!idle_report.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift());
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_key_labels_match());
+        assert!(
+            !idle_report.has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift()
+        );
+        assert!(idle_report.host_run_escalation_dashboard_lane_queue_is_settled());
+        assert!(!idle_report.host_run_escalation_dashboard_lane_queue_requires_action());
+        assert_eq!(
+            idle_report.host_run_escalation_dashboard_lane_queue_priority_rank(),
+            0
+        );
+        assert!(!idle_report.host_run_escalation_dashboard_lane_queue_is_auto_routable());
+        assert!(!idle_report.host_run_escalation_dashboard_lane_queue_requires_manual_review());
+        assert!(!idle_report.host_run_escalation_dashboard_lane_queue_requires_investigation());
+        assert!(!idle_report
+            .host_run_escalation_dashboard_lane_queue_requires_integrity_investigation());
+        assert!(!idle_report.host_run_escalation_dashboard_lane_queue_requires_triage());
+        assert!(!idle_report.host_run_escalation_dashboard_lane_queue_has_route());
+        assert_eq!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_key,
+            idle_lane_queue_key
+        );
+        assert_eq!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_key(),
+            idle_lane_queue_key
+        );
+        assert_eq!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_key_label,
+            "route=no_route|priority=settled|readiness=settled|lane_digest=lane=settled|rollup=lane=settled|route=no_route|priority=settled|readiness=settled"
+        );
+        assert_eq!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_key_label(),
+            "route=no_route|priority=settled|readiness=settled|lane_digest=lane=settled|rollup=lane=settled|route=no_route|priority=settled|readiness=settled"
+        );
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key());
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_route_matches_digest);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_route_matches_digest());
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest());
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest);
+        assert!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest()
+        );
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest());
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_parts_match);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_parts_match());
+        assert!(!idle_summary.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift);
+        assert!(!idle_summary.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift());
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_labels_match);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_key_labels_match());
+        assert!(
+            !idle_summary.has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift
+        );
+        assert!(
+            !idle_summary.has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift()
+        );
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_is_settled);
+        assert!(idle_summary.host_run_escalation_dashboard_lane_queue_is_settled());
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_action);
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_action());
+        assert_eq!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_priority_rank,
+            0
+        );
+        assert_eq!(
+            idle_summary.host_run_escalation_dashboard_lane_queue_priority_rank(),
+            0
+        );
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_is_auto_routable);
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_is_auto_routable());
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_manual_review);
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_manual_review());
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_investigation);
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_investigation());
+        assert!(
+            !idle_summary.host_run_escalation_dashboard_lane_queue_requires_integrity_investigation
+        );
+        assert!(!idle_summary
+            .host_run_escalation_dashboard_lane_queue_requires_integrity_investigation());
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_triage);
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_requires_triage());
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_has_route);
+        assert!(!idle_summary.host_run_escalation_dashboard_lane_queue_has_route());
 
         let continuation_store = ToolAuditStore::new(InMemoryStorageBackend::new());
         assert!(continuation_store
@@ -28721,6 +29634,149 @@ mod tests {
         assert!(continuation_summary.host_run_escalation_dashboard_lane_digest_requires_triage());
         assert!(continuation_summary.host_run_escalation_dashboard_lane_digest_has_route);
         assert!(continuation_summary.host_run_escalation_dashboard_lane_digest_has_route());
+        let continuation_lane_queue_key =
+            ToolAuditSupervisorDrainHostRunEscalationDashboardLaneQueueKey::from_lane_digest(
+                continuation_lane_digest,
+            );
+        assert_eq!(
+            continuation_report.host_run_escalation_dashboard_lane_queue_key(),
+            continuation_lane_queue_key
+        );
+        assert_eq!(
+            continuation_report.host_run_escalation_dashboard_lane_queue_key_label(),
+            "route=triage|priority=triage|readiness=triage_required|lane_digest=lane=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required"
+        );
+        assert!(
+            continuation_report.host_run_escalation_dashboard_lane_queue_key_label_matches_key()
+        );
+        assert!(
+            continuation_report.host_run_escalation_dashboard_lane_queue_key_route_matches_digest()
+        );
+        assert!(continuation_report
+            .host_run_escalation_dashboard_lane_queue_key_priority_matches_digest());
+        assert!(continuation_report
+            .host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest());
+        assert!(continuation_report
+            .host_run_escalation_dashboard_lane_queue_key_digest_matches_digest());
+        assert!(continuation_report.host_run_escalation_dashboard_lane_queue_key_parts_match());
+        assert!(
+            !continuation_report.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift()
+        );
+        assert!(continuation_report.host_run_escalation_dashboard_lane_queue_key_labels_match());
+        assert!(!continuation_report
+            .has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift());
+        assert!(!continuation_report.host_run_escalation_dashboard_lane_queue_is_settled());
+        assert!(continuation_report.host_run_escalation_dashboard_lane_queue_requires_action());
+        assert_eq!(
+            continuation_report.host_run_escalation_dashboard_lane_queue_priority_rank(),
+            90
+        );
+        assert!(!continuation_report.host_run_escalation_dashboard_lane_queue_is_auto_routable());
+        assert!(
+            continuation_report.host_run_escalation_dashboard_lane_queue_requires_manual_review()
+        );
+        assert!(
+            !continuation_report.host_run_escalation_dashboard_lane_queue_requires_investigation()
+        );
+        assert!(!continuation_report
+            .host_run_escalation_dashboard_lane_queue_requires_integrity_investigation());
+        assert!(continuation_report.host_run_escalation_dashboard_lane_queue_requires_triage());
+        assert!(continuation_report.host_run_escalation_dashboard_lane_queue_has_route());
+        assert_eq!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key,
+            continuation_lane_queue_key
+        );
+        assert_eq!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key(),
+            continuation_lane_queue_key
+        );
+        assert_eq!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key_label,
+            "route=triage|priority=triage|readiness=triage_required|lane_digest=lane=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required"
+        );
+        assert_eq!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key_label(),
+            "route=triage|priority=triage|readiness=triage_required|lane_digest=lane=triage|rollup=lane=triage|route=triage|priority=triage|readiness=triage_required"
+        );
+        assert!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key
+        );
+        assert!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key()
+        );
+        assert!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key_route_matches_digest
+        );
+        assert!(continuation_summary
+            .host_run_escalation_dashboard_lane_queue_key_route_matches_digest());
+        assert!(
+            continuation_summary
+                .host_run_escalation_dashboard_lane_queue_key_priority_matches_digest
+        );
+        assert!(continuation_summary
+            .host_run_escalation_dashboard_lane_queue_key_priority_matches_digest());
+        assert!(
+            continuation_summary
+                .host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest
+        );
+        assert!(continuation_summary
+            .host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest());
+        assert!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest
+        );
+        assert!(continuation_summary
+            .host_run_escalation_dashboard_lane_queue_key_digest_matches_digest());
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_key_parts_match);
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_key_parts_match());
+        assert!(
+            !continuation_summary.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift
+        );
+        assert!(!continuation_summary
+            .has_host_run_escalation_dashboard_lane_queue_key_integrity_drift());
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_key_labels_match);
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_key_labels_match());
+        assert!(
+            !continuation_summary
+                .has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift
+        );
+        assert!(!continuation_summary
+            .has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift());
+        assert!(!continuation_summary.host_run_escalation_dashboard_lane_queue_is_settled);
+        assert!(!continuation_summary.host_run_escalation_dashboard_lane_queue_is_settled());
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_requires_action);
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_requires_action());
+        assert_eq!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_priority_rank,
+            90
+        );
+        assert_eq!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_priority_rank(),
+            90
+        );
+        assert!(!continuation_summary.host_run_escalation_dashboard_lane_queue_is_auto_routable);
+        assert!(!continuation_summary.host_run_escalation_dashboard_lane_queue_is_auto_routable());
+        assert!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_requires_manual_review
+        );
+        assert!(
+            continuation_summary.host_run_escalation_dashboard_lane_queue_requires_manual_review()
+        );
+        assert!(
+            !continuation_summary.host_run_escalation_dashboard_lane_queue_requires_investigation
+        );
+        assert!(
+            !continuation_summary.host_run_escalation_dashboard_lane_queue_requires_investigation()
+        );
+        assert!(
+            !continuation_summary
+                .host_run_escalation_dashboard_lane_queue_requires_integrity_investigation
+        );
+        assert!(!continuation_summary
+            .host_run_escalation_dashboard_lane_queue_requires_integrity_investigation());
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_requires_triage);
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_requires_triage());
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_has_route);
+        assert!(continuation_summary.host_run_escalation_dashboard_lane_queue_has_route());
 
         let mut drift_summary = continuation_summary.clone();
         drift_summary.host_run_supervision_key = idle_key;
@@ -28828,6 +29884,13 @@ mod tests {
         drift_summary.has_host_run_escalation_dashboard_lane_digest_integrity_drift = true;
         drift_summary.host_run_escalation_dashboard_lane_digest_labels_match = false;
         drift_summary.has_host_run_escalation_dashboard_lane_digest_label_integrity_drift = true;
+        drift_summary.host_run_escalation_dashboard_lane_queue_key_route_matches_digest = false;
+        drift_summary.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest = false;
+        drift_summary.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest = false;
+        drift_summary.host_run_escalation_dashboard_lane_queue_key_parts_match = false;
+        drift_summary.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift = true;
+        drift_summary.host_run_escalation_dashboard_lane_queue_key_labels_match = false;
+        drift_summary.has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift = true;
         assert!(drift_summary.host_run_supervision_key_label_matches_key());
         assert!(!drift_summary.host_run_supervision_attention_matches_kind());
         assert!(!drift_summary.host_run_supervision_queue_group_matches_key());
@@ -28923,6 +29986,21 @@ mod tests {
         assert!(drift_summary.has_host_run_escalation_dashboard_lane_digest_integrity_drift());
         assert!(!drift_summary.host_run_escalation_dashboard_lane_digest_labels_match());
         assert!(drift_summary.has_host_run_escalation_dashboard_lane_digest_label_integrity_drift());
+        assert!(drift_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key());
+        assert!(!drift_summary.host_run_escalation_dashboard_lane_queue_key_route_matches_digest());
+        assert!(
+            !drift_summary.host_run_escalation_dashboard_lane_queue_key_priority_matches_digest()
+        );
+        assert!(
+            !drift_summary.host_run_escalation_dashboard_lane_queue_key_readiness_matches_digest()
+        );
+        assert!(drift_summary.host_run_escalation_dashboard_lane_queue_key_digest_matches_digest());
+        assert!(!drift_summary.host_run_escalation_dashboard_lane_queue_key_parts_match());
+        assert!(drift_summary.has_host_run_escalation_dashboard_lane_queue_key_integrity_drift());
+        assert!(!drift_summary.host_run_escalation_dashboard_lane_queue_key_labels_match());
+        assert!(
+            drift_summary.has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift()
+        );
 
         let mut stale_label_summary = continuation_summary;
         stale_label_summary.host_run_supervision_key_label =
@@ -28984,6 +30062,13 @@ mod tests {
         stale_label_summary.host_run_escalation_dashboard_lane_digest_labels_match = false;
         stale_label_summary.has_host_run_escalation_dashboard_lane_digest_label_integrity_drift =
             true;
+        stale_label_summary.host_run_escalation_dashboard_lane_queue_key_label =
+            "route=no_route|priority=settled|readiness=settled|lane_digest=lane=settled|rollup=lane=settled|route=no_route|priority=settled|readiness=settled"
+                .to_string();
+        stale_label_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key = false;
+        stale_label_summary.host_run_escalation_dashboard_lane_queue_key_labels_match = false;
+        stale_label_summary
+            .has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift = true;
         assert!(!stale_label_summary.host_run_supervision_key_label_matches_key());
         assert!(!stale_label_summary.host_run_supervision_labels_match());
         assert!(stale_label_summary.has_host_run_supervision_label_integrity_drift());
@@ -29025,6 +30110,12 @@ mod tests {
         assert!(!stale_label_summary.host_run_escalation_dashboard_lane_digest_labels_match());
         assert!(stale_label_summary
             .has_host_run_escalation_dashboard_lane_digest_label_integrity_drift());
+        assert!(
+            !stale_label_summary.host_run_escalation_dashboard_lane_queue_key_label_matches_key()
+        );
+        assert!(!stale_label_summary.host_run_escalation_dashboard_lane_queue_key_labels_match());
+        assert!(stale_label_summary
+            .has_host_run_escalation_dashboard_lane_queue_key_label_integrity_drift());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add compact host-run escalation dashboard lane queue keys that bind lane digests to route/priority/readiness
- expose report and summary accessors plus integrity, routing, action, and priority helpers
- cover stable labels, summary flattening, drift checks, and docs

## Validation
- cargo fmt -p chief-of-staff-tool-audit-store
- cargo test -p chief-of-staff-tool-audit-store
- sh BUILD
- git diff --check