### PR TITLE
feat(ui32): UI32-K-flutter — Flutter app shell

### DIFF
--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -938,18 +938,64 @@ fn run_pipeline(
             )
             .map(|r| r.output),
         ),
-        "flutter" => emit_single_file(
-            backend,
-            output_path,
-            &mosmodel_out.component.component,
-            "dart",
-            mosaic_emit_flutter::pipeline::from_pipeline(
+        "flutter" => {
+            // UI32-K-flutter: route through `from_pipeline_with_options`
+            // so --emit-project activates the Flutter app shell.
+            // Bare invocation is byte-identical to pre-UI32.
+            let mut fl_opts = mosaic_emit_flutter::pipeline::EmitOptions::default();
+            fl_opts.emit_project = emit_project;
+            let result = mosaic_emit_flutter::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
                 &style_out.def,
+                &fl_opts,
             )
-            .map(|r| r.output),
-        ),
+            .unwrap_or_else(|e| {
+                eprintln!("mosaic-compile: flutter pipeline emit error: {e}");
+                process::exit(1);
+            });
+            let out = output_path
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{}.dart", result.component_name));
+            write_file_or_die(&out, &result.output);
+            eprintln!("Written: {out}");
+
+            // UI32-K-flutter: emit pubspec.yaml + README.md flat
+            // next to .dart; lib/main.dart nested per Flutter
+            // convention.
+            if let Some(proj) = &result.project {
+                let side_file_path = |relative: &str| -> String {
+                    match std::path::Path::new(&out).parent() {
+                        Some(p) if !p.as_os_str().is_empty() => {
+                            p.join(relative).to_string_lossy().into_owned()
+                        }
+                        _ => relative.to_string(),
+                    }
+                };
+                let flat: [(String, &str); 2] = [
+                    (side_file_path("pubspec.yaml"), &proj.pubspec_yaml),
+                    (side_file_path("README.md"), &proj.readme),
+                ];
+                for (path, src) in &flat {
+                    write_file_or_die(path, src);
+                    eprintln!("Written: {path}");
+                }
+                let main_dart_path = side_file_path("lib/main.dart");
+                if let Some(parent) = std::path::Path::new(&main_dart_path).parent() {
+                    if !parent.as_os_str().is_empty() {
+                        if let Err(e) = std::fs::create_dir_all(parent) {
+                            eprintln!(
+                                "mosaic-compile: failed to create {}: {e}",
+                                parent.display()
+                            );
+                            process::exit(1);
+                        }
+                    }
+                }
+                write_file_or_die(&main_dart_path, &proj.main_dart);
+                eprintln!("Written: {main_dart_path}");
+            }
+        }
         _ => {
             eprintln!("mosaic-compile: unsupported pipeline backend '{backend}'");
             process::exit(1);

--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,26 @@ this file.
 
 ## [Unreleased]
 
+### Added — UI32-K-flutter — `--emit-project` Flutter app shell
+
+L5 of UI32 ([spec PR #4286](https://github.com/adhithyan15/coding-adventures/pull/4286); L2 React #4297, L3 HTML #4309, L4 WebComponent #4315). `mosaic-compile --backend flutter --emit-project` now produces a flutter-create-shaped scaffold alongside the component `.dart`:
+
+- `pubspec.yaml` — pinned Flutter SDK `>=3.24.0 <4.0.0` + Dart `>=3.5.0 <4.0.0` per UI32 §3.6.3. Dart pub package name follows snake_case rules (§3.6.2 Flutter row) — auto-derived as `mosaic_{snake(name)}` (e.g., `ProfileCard` → `mosaic_profile_card`).
+- `lib/main.dart` — `MaterialApp` shell that mounts the component as `Scaffold.body`'s `Center(child: <Component>())`. Imports the component sibling-relative (`../{Component}.dart`).
+- `README.md` — `flutter pub get && flutter run` recipe + file map.
+
+New public API (matches L2/L3/L4 pattern):
+
+- `pub struct EmitOptions` — `emit_project`, `pinned_flutter_sdk`, `pinned_dart_sdk`, `package_name` override.
+- `pub struct ProjectFiles` — `pubspec_yaml`, `main_dart`, `readme`.
+- `pub enum ProjectShellError` — `InvalidDartPubName(String)` surfaced through `PipelineEmitError::UnsafeSlotName`.
+- `pub struct PipelineEmitResultWithProject` — `output`, `component_name`, `project: Option<ProjectFiles>`.
+- `pub fn from_pipeline_with_options(...)` — new entry. Existing `from_pipeline(...)` unchanged.
+
+UI32 §3.6.2 Flutter row: Dart pub names MUST match `[a-z][a-z0-9_]*` (lowercase, digits, underscores; must start with letter; no leading underscore; no hyphens; no uppercase). `is_valid_dart_pub_name` enforces this; an explicit invalid `package_name` fails-loud via `ProjectShellError::InvalidDartPubName`.
+
+11 new tests cover the spec §3 gates plus a Dart-pub-name truth table (8 accept/reject vectors) and a main.dart structural test (MaterialApp + Scaffold + Component() mount). Total tests: 48 (was 37, +11).
+
 ### Added
 
 - **UI31-K-flutter** — RTL contract for `HostTable`. The lowering

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -2882,4 +2882,251 @@ mod tests {
             r.output
         );
     }
+
+    // =================================================================
+    // UI32-K-flutter — `--emit-project` Flutter shell tests
+    //
+    // Covers UI32 spec §3.1-§3.8 per-PR gates:
+    //   §3.4 Composable     : default options = no project shell.
+    //   §3.5 Banner          : every emitted file starts with banner.
+    //   §3.1 Reproducible    : two runs produce byte-identical output.
+    //   §3.6.1 Validation    : invalid pub name → fail-loud error.
+    //   §3.6.2 Flutter row   : derived name satisfies Dart pub RFC.
+    //   §3.6.3 Pinning       : pubspec.yaml contains pinned SDKs.
+    //   §3.7 Output paths    : only the spec §2.2 enumeration.
+    //   §3.8 No env reads    : no /Users/, $HOME, etc. in output.
+    // =================================================================
+
+    #[test]
+    fn ui32_emit_project_false_is_backward_compatible_with_from_pipeline() {
+        let m = component("X", vec![], vec![]);
+        let l = layout("X", node("Box"));
+        let s = empty_style("X");
+
+        let legacy = from_pipeline(&m, &l, &s).unwrap();
+        let extended =
+            from_pipeline_with_options(&m, &l, &s, &EmitOptions::default()).unwrap();
+
+        assert_eq!(legacy.output, extended.output, ".dart bytes diverged");
+        assert_eq!(legacy.component_name, extended.component_name);
+        assert!(
+            extended.project.is_none(),
+            "default options must NOT emit a project shell"
+        );
+    }
+
+    #[test]
+    fn ui32_emit_project_true_returns_project_files() {
+        let m = component("Hello", vec![], vec![]);
+        let l = layout("Hello", node("Box"));
+        let s = empty_style("Hello");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let r = from_pipeline_with_options(&m, &l, &s, &opts).unwrap();
+        assert!(r.project.is_some(), "emit_project: true must produce a shell");
+    }
+
+    #[test]
+    fn ui32_every_emitted_side_file_carries_auto_generated_banner() {
+        let m = component("Hello", vec![], vec![]);
+        let l = layout("Hello", node("Box"));
+        let s = empty_style("Hello");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .expect("project shell expected");
+
+        // YAML uses `#` for comments.
+        assert!(
+            proj.pubspec_yaml.starts_with("# AUTO-GENERATED"),
+            "pubspec.yaml must START with `# AUTO-GENERATED`, got:\n{}",
+            &proj.pubspec_yaml[..80.min(proj.pubspec_yaml.len())]
+        );
+        // Dart uses `//` for line comments.
+        assert!(
+            proj.main_dart.starts_with("// AUTO-GENERATED"),
+            "lib/main.dart must START with `// AUTO-GENERATED`"
+        );
+        // README uses HTML-comment syntax.
+        assert!(
+            proj.readme.starts_with("<!-- AUTO-GENERATED"),
+            "README.md must START with banner"
+        );
+    }
+
+    #[test]
+    fn ui32_emit_project_is_byte_deterministic() {
+        let m = component("Deterministic", vec![], vec![]);
+        let l = layout("Deterministic", node("Box"));
+        let s = empty_style("Deterministic");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+
+        let a = from_pipeline_with_options(&m, &l, &s, &opts).unwrap();
+        let b = from_pipeline_with_options(&m, &l, &s, &opts).unwrap();
+        assert_eq!(a.output, b.output, ".dart is not deterministic");
+        assert_eq!(a.project, b.project, "project shell is not deterministic");
+    }
+
+    /// §3.6.1 + §3.6.2 Flutter row. Invalid Dart pub name (uppercase,
+    /// hyphen, leading underscore/digit) MUST fail-loud, not silently
+    /// substitute.
+    #[test]
+    fn ui32_invalid_explicit_pub_name_returns_error() {
+        let m = component("X", vec![], vec![]);
+        let l = layout("X", node("Box"));
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        opts.package_name = Some("Mosaic-Grid".to_string()); // uppercase + hyphen
+
+        let err = from_pipeline_with_options(&m, &l, &s, &opts)
+            .expect_err("invalid pub name must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Mosaic-Grid") && msg.contains("pub naming convention"),
+            "expected Dart pub RFC violation error, got: {msg}"
+        );
+    }
+
+    /// §3.6.2 Flutter row: PascalCase component name → snake_case pub
+    /// name + `mosaic_` prefix.
+    #[test]
+    fn ui32_derived_pub_name_snake_cases_pascalcase() {
+        let m = component("ProfileCard", vec![], vec![]);
+        let l = layout("ProfileCard", node("Box"));
+        let s = empty_style("ProfileCard");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        assert!(
+            proj.pubspec_yaml.contains("name: mosaic_profile_card"),
+            "expected `mosaic_profile_card` pub name, got:\n{}",
+            proj.pubspec_yaml
+        );
+    }
+
+    /// §3.6.3 Pinning. pubspec.yaml carries the default pinned
+    /// SDK ranges verbatim.
+    #[test]
+    fn ui32_pubspec_carries_pinned_default_sdks_exactly() {
+        let m = component("X", vec![], vec![]);
+        let l = layout("X", node("Box"));
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        assert!(
+            proj.pubspec_yaml.contains("sdk: '>=3.5.0 <4.0.0'"),
+            "expected Dart SDK pin, got:\n{}",
+            proj.pubspec_yaml
+        );
+        assert!(
+            proj.pubspec_yaml.contains("flutter: '>=3.24.0 <4.0.0'"),
+            "expected Flutter SDK pin, got:\n{}",
+            proj.pubspec_yaml
+        );
+    }
+
+    /// §3.7 Output paths tripwire.
+    #[test]
+    fn ui32_project_files_struct_exposes_only_spec_22_flutter_files() {
+        let m = component("X", vec![], vec![]);
+        let l = layout("X", node("Box"));
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        let ProjectFiles {
+            pubspec_yaml,
+            main_dart,
+            readme,
+        } = proj;
+        assert!(!pubspec_yaml.is_empty(), "pubspec.yaml empty");
+        assert!(!main_dart.is_empty(), "lib/main.dart empty");
+        assert!(!readme.is_empty(), "README.md empty");
+    }
+
+    #[test]
+    fn ui32_emitted_files_contain_no_environment_specific_strings() {
+        let m = component("X", vec![], vec![]);
+        let l = layout("X", node("Box"));
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        let all = format!(
+            "{}\n{}\n{}",
+            proj.pubspec_yaml, proj.main_dart, proj.readme
+        );
+        for banned in ["/Users/", "/home/", "C:\\Users\\", "$HOME"] {
+            assert!(
+                !all.contains(banned),
+                "emitted shell contains environment-specific fragment `{banned}`"
+            );
+        }
+    }
+
+    /// lib/main.dart mounts the component as the MaterialApp's
+    /// `home:` widget. Verify the relative import + constructor
+    /// invocation.
+    #[test]
+    fn ui32_main_dart_mounts_component_in_material_app_home() {
+        let m = component("MyWidget", vec![], vec![]);
+        let l = layout("MyWidget", node("Box"));
+        let s = empty_style("MyWidget");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        assert!(
+            proj.main_dart.contains("import '../MyWidget.dart';"),
+            "main.dart must import sibling-relative, got:\n{}",
+            proj.main_dart
+        );
+        assert!(
+            proj.main_dart.contains("MyWidget()"),
+            "main.dart must invoke MyWidget() constructor"
+        );
+        assert!(
+            proj.main_dart.contains("MaterialApp("),
+            "main.dart must wrap in MaterialApp"
+        );
+    }
+
+    /// Truth table for is_valid_dart_pub_name.
+    #[test]
+    fn ui32_is_valid_dart_pub_name_truth_table() {
+        // Accepts (lowercase + underscores + digits, starts with letter)
+        assert!(is_valid_dart_pub_name("foo"));
+        assert!(is_valid_dart_pub_name("foo_bar"));
+        assert!(is_valid_dart_pub_name("mosaic_grid"));
+        assert!(is_valid_dart_pub_name("foo123"));
+        assert!(is_valid_dart_pub_name("a"));
+        // Rejects
+        assert!(!is_valid_dart_pub_name(""));
+        assert!(!is_valid_dart_pub_name("Foo")); // uppercase
+        assert!(!is_valid_dart_pub_name("foo-bar")); // hyphen
+        assert!(!is_valid_dart_pub_name("_foo")); // leading underscore
+        assert!(!is_valid_dart_pub_name("1foo")); // leading digit
+        assert!(!is_valid_dart_pub_name("foo bar")); // space
+        assert!(!is_valid_dart_pub_name("foo.bar")); // dot (Dart pub rejects)
+        assert!(!is_valid_dart_pub_name(&"a".repeat(65))); // over 64 char limit
+    }
 }

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -130,6 +130,213 @@ impl std::fmt::Display for PipelineEmitError {
 impl std::error::Error for PipelineEmitError {}
 
 // =====================================================================
+// UI32-K-flutter — `--emit-project` Flutter app shell
+//
+// Mirrors L2 (React, PR #4297), L3 (HTML, PR #4309), L4
+// (WebComponent, PR #4315): EmitOptions / ProjectFiles /
+// from_pipeline_with_options.
+//
+// When `--emit-project` is on, emits a flutter-create-shaped
+// scaffold alongside the component .dart. Author runs
+// `flutter pub get && flutter run -d <device>` to see the
+// component on a connected simulator/emulator/desktop window.
+// =====================================================================
+
+/// Options controlling the Flutter emitter's behaviour.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmitOptions {
+    /// Also emit `pubspec.yaml`, `lib/main.dart`, `README.md`
+    /// alongside the component `.dart` file. Default `false`.
+    pub emit_project: bool,
+
+    /// Pinned Flutter SDK constraint to write into
+    /// `pubspec.yaml`'s `environment.flutter`. UI32 spec §3.6.3
+    /// requires exact pinning. Default `">=3.24.0 <4.0.0"` — a
+    /// known-good Flutter 3.24+ stable that supports Dart 3.5.
+    /// Caret-pinning is not idiomatic for Flutter SDK constraints
+    /// (which use range syntax), so this is the closest exact
+    /// equivalent.
+    pub pinned_flutter_sdk: String,
+
+    /// Pinned Dart SDK constraint to write into
+    /// `pubspec.yaml`'s `environment.sdk`. Default
+    /// `">=3.5.0 <4.0.0"` — paired with the Flutter 3.24 pin.
+    pub pinned_dart_sdk: String,
+
+    /// Pubspec package name to write into `pubspec.yaml` `name:`.
+    /// If `None`, derived from the component name by kebab→snake
+    /// casing and prefixing `mosaic_` (Dart pub requires snake_case
+    /// per §3.6.2 Flutter row; the prefix avoids collisions with
+    /// Dart's own packages).
+    pub package_name: Option<String>,
+}
+
+impl Default for EmitOptions {
+    fn default() -> Self {
+        Self {
+            emit_project: false,
+            pinned_flutter_sdk: ">=3.24.0 <4.0.0".to_string(),
+            pinned_dart_sdk: ">=3.5.0 <4.0.0".to_string(),
+            package_name: None,
+        }
+    }
+}
+
+/// Project-shaped artifacts emitted when `EmitOptions::emit_project`
+/// is on. Three files — enough for `flutter pub get && flutter run`
+/// to start a MaterialApp that mounts the component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectFiles {
+    /// `pubspec.yaml` — pinned Flutter + Dart SDK constraints,
+    /// `flutter:` block with the SDK dep. Package name follows
+    /// Dart pub rules (snake_case).
+    pub pubspec_yaml: String,
+    /// `lib/main.dart` — `MaterialApp` shell that mounts the
+    /// component as the `home:` widget. Imports the component
+    /// sibling-relative from the project root.
+    pub main_dart: String,
+    /// `README.md` — prereqs (Flutter SDK), `flutter pub get` +
+    /// `flutter run` commands, file map.
+    pub readme: String,
+}
+
+/// Error shapes specific to the project-shell emission path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectShellError {
+    /// The derived Dart-pub name fails the Dart pub naming
+    /// convention: lowercase letters/digits/underscores,
+    /// MUST start with a letter, no leading underscore.
+    /// Per UI32 spec §3.6.2 Flutter row.
+    InvalidDartPubName(String),
+}
+
+impl std::fmt::Display for ProjectShellError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProjectShellError::InvalidDartPubName(n) => write!(
+                f,
+                "derived Dart pub name '{n}' violates the pub naming convention (snake_case: lowercase + digits + underscores, must start with letter)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProjectShellError {}
+
+impl From<ProjectShellError> for PipelineEmitError {
+    fn from(e: ProjectShellError) -> Self {
+        PipelineEmitError::UnsafeSlotName(e.to_string())
+    }
+}
+
+/// Extended pipeline result — same as `PipelineEmitResult` but
+/// carries the optional `ProjectFiles` when `emit_project` is on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipelineEmitResultWithProject {
+    pub output: String,
+    pub component_name: String,
+    pub project: Option<ProjectFiles>,
+}
+
+/// Compile a three-file Mosaic pipeline triple to Dart with
+/// explicit emit options.
+pub fn from_pipeline_with_options(
+    interface: &MosmodelComponent,
+    layout: &LayoutDef,
+    style: &StyleDef,
+    options: &EmitOptions,
+) -> Result<PipelineEmitResultWithProject, PipelineEmitError> {
+    let component = from_pipeline(interface, layout, style)?;
+
+    let project = if options.emit_project {
+        Some(build_flutter_project_files(&component.component_name, options)?)
+    } else {
+        None
+    };
+
+    Ok(PipelineEmitResultWithProject {
+        output: component.output,
+        component_name: component.component_name,
+        project,
+    })
+}
+
+/// Build the three Flutter app-shell side files for a single
+/// component.
+fn build_flutter_project_files(
+    name: &str,
+    options: &EmitOptions,
+) -> Result<ProjectFiles, ProjectShellError> {
+    let pub_name = match &options.package_name {
+        Some(p) => p.clone(),
+        None => format!("mosaic_{}", pascal_to_snake_for_pub(name)),
+    };
+    if !is_valid_dart_pub_name(&pub_name) {
+        return Err(ProjectShellError::InvalidDartPubName(pub_name));
+    }
+
+    Ok(ProjectFiles {
+        pubspec_yaml: build_pubspec_yaml(&pub_name, options),
+        main_dart: build_main_dart(name),
+        readme: build_flutter_readme(&pub_name, name),
+    })
+}
+
+/// PascalCase → snake_case for Dart pub naming. `Hello` → `hello`;
+/// `ProfileCard` → `profile_card`.
+fn pascal_to_snake_for_pub(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, c) in name.chars().enumerate() {
+        if c.is_ascii_uppercase() && i > 0 {
+            out.push('_');
+        }
+        for d in c.to_lowercase() {
+            out.push(d);
+        }
+    }
+    out
+}
+
+/// Validate Dart pub name per §3.6.2 Flutter row:
+/// `[a-z][a-z0-9_]*` (lowercase, digits, underscores; must start
+/// with letter; no leading underscore). Dart pub rejects names
+/// with hyphens, uppercase, or leading digit/underscore.
+fn is_valid_dart_pub_name(s: &str) -> bool {
+    if s.is_empty() || s.len() > 64 {
+        return false;
+    }
+    let first = s.chars().next().unwrap();
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    s.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+const BANNER_DART: &str = "// AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit.\n// Fork the file (remove this banner) to customise.\n";
+const BANNER_YAML: &str = "# AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit.\n# Fork the file (remove this banner) to customise.\n";
+const BANNER_MD: &str = "<!-- AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit. -->\n<!-- Fork the file (remove this banner) to customise. -->\n";
+
+fn build_pubspec_yaml(pub_name: &str, options: &EmitOptions) -> String {
+    format!(
+        "{BANNER_YAML}name: {pub_name}\ndescription: Auto-generated Flutter shell for a Mosaic component.\npublish_to: 'none'\nversion: 0.0.0\n\nenvironment:\n  sdk: '{}'\n  flutter: '{}'\n\ndependencies:\n  flutter:\n    sdk: flutter\n\ndev_dependencies:\n  flutter_test:\n    sdk: flutter\n\nflutter:\n  uses-material-design: true\n",
+        options.pinned_dart_sdk, options.pinned_flutter_sdk,
+    )
+}
+
+fn build_main_dart(component_name: &str) -> String {
+    format!(
+        "{BANNER_DART}import 'package:flutter/material.dart';\nimport '../{component_name}.dart';\n\nvoid main() {{\n  runApp(const _MosaicApp());\n}}\n\nclass _MosaicApp extends StatelessWidget {{\n  const _MosaicApp();\n\n  @override\n  Widget build(BuildContext context) {{\n    return MaterialApp(\n      title: '{component_name}',\n      home: Scaffold(\n        appBar: AppBar(title: const Text('{component_name}')),\n        body: const Center(child: {component_name}()),\n      ),\n    );\n  }}\n}}\n"
+    )
+}
+
+fn build_flutter_readme(pub_name: &str, component_name: &str) -> String {
+    format!(
+        "{BANNER_MD}# {component_name} — Flutter app shell\n\nAuto-generated by `mosaic-compile --backend flutter --emit-project`.\n\n## Prerequisites\n\n- Flutter SDK 3.24+ (run `flutter --version` to check).\n- A device target: iOS simulator, Android emulator, or desktop (`flutter config --enable-macos-desktop` / `--enable-linux-desktop` / `--enable-windows-desktop`).\n\n## Run\n\n```sh\nflutter pub get\nflutter run -d <device-id>   # or `flutter run` to pick interactively\n```\n\n## What's in this directory\n\n| File | Purpose |\n|---|---|\n| `{component_name}.dart` | The Mosaic-compiled component. |\n| `pubspec.yaml` | Dart pub manifest. Pinned Flutter + Dart SDKs per UI32 spec §3.6.3. |\n| `lib/main.dart` | MaterialApp shell that mounts `{component_name}()` as `home`. |\n| `README.md` | This file. |\n\nDart pub name: `{pub_name}`.\n\n## Editing\n\nEvery file except `{component_name}.dart` carries an AUTO-GENERATED banner. Re-running `mosaic-compile --emit-project` will overwrite them. To customise the shell, remove the banner from a file and rename or relocate it; the next `--emit-project` run will recreate the original at its original name without touching your forked copy.\n"
+    )
+}
+
+// =====================================================================
 // Entry point
 // =====================================================================
 


### PR DESCRIPTION
## Summary

L5 of UI32 ([spec PR #4286](https://github.com/adhithyan15/coding-adventures/pull/4286); L2 #4297, L3 #4309, L4 #4315). `mosaic-compile --backend flutter --emit-project` now produces a flutter-create-shaped scaffold:

```sh
$ mosaic-compile --backend flutter --emit-project \
    --interface Hello.mil --layout Hello.mll --style Hello.msl \
    -o out/Hello.dart

Written: out/Hello.dart
Written: out/pubspec.yaml
Written: out/README.md
Written: out/lib/main.dart

$ cd out && flutter pub get && flutter run
```

## Architecture

Mirrors L2/L3/L4 pattern: `EmitOptions` / `ProjectFiles` / `from_pipeline_with_options`. Existing `from_pipeline(...)` unchanged.

## Emitted shell

| File | Purpose |
|---|---|
| `Hello.dart` | The Mosaic-compiled component widget. |
| `pubspec.yaml` | Dart pub manifest. Pinned Flutter `>=3.24.0 <4.0.0` + Dart `>=3.5.0 <4.0.0`. Package name follows snake_case rules. |
| `lib/main.dart` | MaterialApp shell mounting `<Component>()` as `Scaffold.body`'s `Center(child:)`. Sibling-relative import. |
| `README.md` | `flutter pub get && flutter run` recipe + file map. |

## §3.6.2 Flutter row contract

Dart pub names MUST match `[a-z][a-z0-9_]*` — lowercase, digits, underscores; must start with a letter; no leading underscore; no hyphens; no uppercase. Auto-derived as `mosaic_{snake(name)}` (\`Hello\` → \`mosaic_hello\`, \`ProfileCard\` → \`mosaic_profile_card\`). Explicit `package_name` override validated; invalid → fail-loud via \`ProjectShellError::InvalidDartPubName\`.

## Contracts verified (UI32 §3.1–§3.8)

- §3.1 Reproducible: byte-deterministic
- §3.4 Composable: bare invocation unchanged
- §3.5 Banner on every file (YAML `#`, Dart `//`, HTML-comment for README)
- §3.6.1 Validation: invalid pub name → fail-loud
- §3.6.2 Flutter row: snake_case + length cap enforced
- §3.6.3 Pinning: exact SDK ranges (no `^`/`~`/`*`/`latest`)
- §3.7 Output paths: fixed enumeration; component name never in path construction
- §3.8 No env reads: emitter is a pure function

## Tests

11 new (48 total, was 37):

- \`ui32_emit_project_false_is_backward_compatible_with_from_pipeline\`
- \`ui32_emit_project_true_returns_project_files\`
- \`ui32_every_emitted_side_file_carries_auto_generated_banner\`
- \`ui32_emit_project_is_byte_deterministic\`
- \`ui32_invalid_explicit_pub_name_returns_error\`
- \`ui32_derived_pub_name_snake_cases_pascalcase\`
- \`ui32_pubspec_carries_pinned_default_sdks_exactly\`
- \`ui32_project_files_struct_exposes_only_spec_22_flutter_files\`
- \`ui32_emitted_files_contain_no_environment_specific_strings\`
- \`ui32_main_dart_mounts_component_in_material_app_home\`
- \`ui32_is_valid_dart_pub_name_truth_table\` (8 vectors)

Security review: PASSED. Pub name flows through `is_valid_dart_pub_name` before any substitution; component name pre-validated to ASCII identifier shape that cannot break out of Dart single-quoted strings, identifiers, import paths, or YAML/Markdown contexts.

## Test plan

- [x] \`cargo build -p mosaic-emit-flutter -p mosaic-compile\` — clean
- [x] \`cargo test -p mosaic-emit-flutter\` — 48 pass
- [x] Manual: \`mosaic-compile --backend flutter --emit-project\` on Hello → 4 files; bare invocation → 1
- [x] security-review sub-agent — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)