### PR TITLE
feat(cas-summation): Phase 62 — Two-Log × polynomial numerator (2.0.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.0 — 2026-05-25
+
+### Added
+
+- **Phase 62 — Two-Log × polynomial numerator** (`_two_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), polynomial..., bounded...)` as a
+  numerator that vanishes at infinity.  `log²(k)` grows sub-polynomially
+  (`log²(k) = o(k^ε)` for any ε > 0), so the effective polynomial degree is
+  unchanged by the two log factors.  `effective_x2 = 2·poly_deg`; closes when
+  `2·den_deg > effective_x2` (polynomial denominator) or the denominator is
+  non-polynomial diverging.  Sqrt factors are refused (belong to two-Sqrt /
+  log-Sqrt family).
+  - 6 new unit tests in `TestEvaluateSumPhase62TwoLogPolyNumerator`.
+
 ## 1.9.0 — 2026-05-25
 
 **Phase 61 — Two-Sqrt × polynomial numerator (Python).**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "1.9.0"
+version = "2.0.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -858,6 +858,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 62: ``Mul(Log(diverging), Log(diverging), polynomial..., bounded...)``
+    # numerator.  Extends Phase 50 (single Log) to the case of two Log factors.
+    # log²(k) is still sub-polynomial: log²(k)·k^m = o(k^{m+ε}) for any ε>0.
+    # effective_x2 = 2·poly_deg (log² contributes nothing to effective degree).
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    tlp_x2 = _two_log_poly_effective_x2(num, k)
+    if tlp_x2 is not None:
+        den_deg_tlp = _polynomial_degree_in_k(den, k)
+        if den_deg_tlp is not None:
+            if 2 * den_deg_tlp > tlp_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1579,6 +1593,74 @@ def _two_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if len(sqrt_degs) != 2:
         return None
     return sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg_sum
+
+
+def _two_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly two**
+    ``Log(diverging-in-k)`` factors, any polynomial factors (total degree
+    ``m``), and any number of bounded factors; ``None`` otherwise.
+
+    Phase 62 — Two-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)² · k^m ≈ o(k^{m + ε})`` for any ε > 0 (log² is sub-polynomial).
+    Using the ×2 integer trick:
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    ``Sqrt`` factors are refused (belong to the two-Sqrt / log-Sqrt phases).
+
+    +-------------------------------------------+-----------+
+    | Input                                     | Return    |
+    +===========================================+===========+
+    | ``Mul(Log(k), Log(k))``                   | ``0``     |
+    | ``Mul(Log(k), Log(k+1), k)``              | ``2``     |
+    | ``Mul(Sin(k), Log(k), Log(k+1))``         | ``0``     |
+    | ``Mul(Log(k), Log(k), k²)``               | ``4``     |
+    | ``Mul(Log(k),)``                          | None (1 Log)|
+    | ``Mul(Log(k), Log(k), Log(k))``           | None (3 Log)|
+    | ``Mul(Log(k), Log(k), Sqrt(k))``          | None (Sqrt)|
+    +-------------------------------------------+-----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → count; bail after the second one.
+         - ``Sqrt(...)`` → bail immediately (log-Sqrt patterns are separate).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly two Log factors.
+      4. Return ``2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        # Log(diverging) factor?
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 2:
+                # Three or more Log factors — refuse (conservative).
+                return None
+            continue
+        # Sqrt factor — refuse (belongs to two-Sqrt / log-Sqrt phases).
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        # Polynomial factor?
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        # Bounded (non-polynomial, non-Log, non-Sqrt)?
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor — bail.
+        return None
+    if log_count != 2:
+        return None
+    return 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -2548,3 +2548,123 @@ class TestEvaluateSumPhase61TwoSqrtPolyNumerator:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase62TwoLogPolyNumerator:
+    """Phase 62: Mul(Log(h1), Log(h2), polynomial..., bounded...) numerator.
+
+    effective_x2 = 2·poly_deg.
+    Vanishes when 2·den_deg > effective_x2 or non-polynomial diverging denom.
+    """
+
+    def test_log_k_sq_over_k_sq_closes(self):
+        """log(k)·log(k) / k²: poly_deg=0, effective_x2=0; 2·2=4 > 0 → closes."""
+        from symbolic_ir import LOG, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (log_k, log_k2))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, log_kp1_2))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_k_sq_times_k_over_k_cubed_closes(self):
+        """log(k)² · k / k³: poly_deg=1, effective_x2=2; 2·3=6 > 2 → closes."""
+        from symbolic_ir import LOG, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (log_k, log_k2, _k))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, log_kp1_2, kp1))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_k_sq_over_k_sq_closes(self):
+        """sin(k) · log(k)² / k²: bounded + two logs, poly_deg=0; 2·2=4 > 0 → closes."""
+        from symbolic_ir import LOG, SIN, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k, log_k2))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1, log_kp1_2))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_k_sq_over_exponential_closes(self):
+        """log(k)² / 2^k: non-polynomial diverging denominator."""
+        from symbolic_ir import LOG, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (log_k, log_k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, log_kp1_2))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_k_sq_times_k_sq_over_k_sq_refused(self):
+        """log(k)² · k² / k²: poly_deg=2, effective_x2=4; 2·2=4 not > 4 → refused."""
+        from symbolic_ir import LOG, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        num_k = IRApply(MUL, (log_k, log_k2, k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_kp1 = IRApply(MUL, (log_kp1, log_kp1_2, kp1_2))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_log_k_sq_times_k_over_k_refused(self):
+        """log(k)² · k / k: poly_deg=1, effective_x2=2; 2·1=2 not > 2 → refused."""
+        from symbolic_ir import LOG, SUB
+
+        log_k = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (log_k, log_k2, _k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1, log_kp1_2, kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.0 — 2026-05-25
+
+### Added
+
+- **Phase 62 — Two-Log × polynomial numerator** (`two_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), polynomial..., bounded...)` as a
+  numerator that vanishes at infinity.  `effective_x2 = 2 * poly_deg` (log²
+  grows sub-polynomially).  Closes when `2 * den_deg > effective_x2` or
+  denominator is non-polynomial diverging.  Sqrt factors refused.
+  - 3 new integration tests in `tests/tests.rs`.
+
 ## 1.9.0 — 2026-05-25
 
 **Phase 61 — Two-Sqrt × polynomial numerator (Rust port).**

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "1.9.0"
+version = "2.0.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1523,6 +1523,37 @@ fn two_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg)
 }
 
+/// Phase 62 — Two-Log × polynomial numerator.
+///
+/// Returns `2 * poly_deg_sum` when `node` is a `Mul` with **exactly two**
+/// `Log(diverging-in-k)` factors, any polynomial factors (total degree `m`),
+/// and any bounded factors; `None` otherwise.
+///
+/// `log(k)² · k^m` grows sub-polynomially, so `effective_x2 = 2 * m`.
+/// Caller checks `2 * den_deg > effective_x2`.
+///
+/// Sqrt factors are refused (belong to the two-Sqrt / log-Sqrt family).
+fn two_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 2 { return None; }
+            continue;
+        }
+        // Sqrt factor → refuse
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 2 { return None; }
+    Some(2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1679,6 +1710,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(tsp_x2) = two_sqrt_poly_effective_x2(num, k) {
         if let Some(den_deg_tsp) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_tsp > tsp_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 62: Mul(Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+    // log²(k) is sub-polynomial; effective_x2 = 2 * poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(tlp_x2) = two_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_tlp) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_tlp > tlp_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1750,3 +1750,62 @@ fn phase61_sqrt_k2_times_sqrt_k2_over_k2_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 62: Mul(Log(diverging), Log(diverging), polynomial..., bounded...) ─
+// effective_x2 = 2 * poly_deg.  log²(k) grows sub-polynomially (o(k^ε) for
+// any ε > 0).  Vanishes when 2·den_deg > effective_x2 or non-polynomial
+// diverging denominator.  Sqrt factors are refused.
+
+#[test]
+fn phase62_log_k_sq_over_k_sq_closes() {
+    // log(k)·log(k) / k²: poly_deg=0, effective_x2=0; 2·2=4 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1.clone(), log_kp1]);
+    let den_k = apply(sym(POW), vec![k.clone(), int(2)]);
+    let den_kp1 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let g_k = apply(sym(DIV), vec![num_k, den_k]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, den_kp1]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase62_log_k_sq_times_k_over_k_cubed_closes() {
+    // log(k)²·k / k³: poly_deg=1, effective_x2=2; 2·3=6 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k.clone(), log_k, k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1.clone(), log_kp1, kp1.clone()]);
+    let den_k = apply(sym(POW), vec![k.clone(), int(3)]);
+    let den_kp1 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let g_k = apply(sym(DIV), vec![num_k, den_k]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, den_kp1]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase62_log_k_sq_times_k_sq_over_k_sq_refused() {
+    // log(k)²·k² / k²: poly_deg=2, effective_x2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![log_k.clone(), log_k, k2.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1.clone(), log_kp1, kp1_2.clone()]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.0 — 2026-05-25
+
+### Added
+
+- **Phase 62 — Two-Log × polynomial numerator** (`twoLogPolyEffectiveDeg`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), polynomial..., bounded...)` as a
+  numerator that vanishes at infinity.  Effective degree = `poly_deg` (log²
+  contributes nothing).  Closes when `denDeg > twoLogPolyEffectiveDeg` or
+  denominator is non-polynomial diverging.  Sqrt factors refused.
+  - 4 new tests in the "Phase 62" describe block.
+
 ## 1.9.0 — 2026-05-25
 
 **Phase 61 — Two-Sqrt × polynomial numerator (TypeScript port).**

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1227,6 +1227,38 @@ function twoSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
 }
 
+/**
+ * Phase 62 — Two-Log × polynomial numerator.
+ *
+ * Returns the effective polynomial degree when `node` is a `Mul` with
+ * **exactly two** `Log(diverging-in-k)` factors, any polynomial factors,
+ * and any bounded factors; `undefined` otherwise.
+ *
+ * `log(k)² · k^m` grows sub-polynomially, so the effective degree equals
+ * `poly_deg`. Caller checks `denDeg > twoLogPolyEffectiveDeg(num, k)`.
+ *
+ * Sqrt factors are refused (belong to the two-Sqrt / log-Sqrt family).
+ */
+function twoLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 2) return undefined;
+      continue;
+    }
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // Sqrt → refuse
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 2) return undefined;
+  return polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1390,6 +1422,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
       if (denDegTsp > tspDeg) {
         return true;
       }
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 62: Mul(Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+  // log²(k) is sub-polynomial; effective degree = poly_deg.
+  // Closes when denDeg > twoLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const tlpDeg = twoLogPolyEffectiveDeg(num, k);
+  if (tlpDeg !== undefined) {
+    const denDegTlp = polynomialDegreeInK(den, k);
+    if (denDegTlp !== undefined) {
+      if (denDegTlp > tlpDeg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1540,3 +1540,75 @@ describe("summation: Phase 61 two Sqrt × polynomial numerator", () => {
     expect(out.kind === "apply" ? out.head : undefined).toEqual(SUM);
   });
 });
+
+describe("Phase 62 — Two-Log × polynomial numerator", () => {
+  it("log(k)·log(k) / k² closes (poly_deg=0, denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const logK = { kind: "apply" as const, head: LOG, args: [k] };
+    const logK2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [logK, logK2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const logKp1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const logKp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [logKp1, logKp1_2] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)²·k / k³ closes (poly_deg=1, denDeg=3 > 1)", () => {
+    const k = sym("k");
+    const logK = { kind: "apply" as const, head: LOG, args: [k] };
+    const logK2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [logK, logK2, k] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const logKp1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const logKp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [logKp1, logKp1_2, kp1] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k3] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_3] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)²·k² / k² refused (poly_deg=2, denDeg=2 not > 2)", () => {
+    const k = sym("k");
+    const logK = { kind: "apply" as const, head: LOG, args: [k] };
+    const logK2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [logK, logK2, k2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const logKp1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const logKp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [logKp1, logKp1_2, kp1_2] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)² / 2^k closes (exponential denominator)", () => {
+    const k = sym("k");
+    const logK = { kind: "apply" as const, head: LOG, args: [k] };
+    const logK2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [logK, logK2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const logKp1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const logKp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [logKp1, logKp1_2] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Phase 62 to `_g_vanishes_at_infinity` / `gVanishesAtInfinity` / `g_vanishes_at_infinity` across Python, TypeScript, and Rust
- Recognises `Mul(Log(h1(k)), Log(h2(k)), polynomial..., bounded...)` as a vanishing numerator — exactly two `Log(diverging-in-k)` factors plus optional polynomial/bounded factors
- `log²(k)` is sub-polynomial (`log²(k) = o(k^ε)` for any ε > 0), so `effective_x2 = 2·poly_deg`; closes when `2·den_deg > effective_x2` or denominator is non-polynomial diverging
- Sqrt factors refused (belong to the two-Sqrt / log-Sqrt family)
- All packages bumped 1.9.0 → 2.0.0

## New helpers

| Language | Helper |
|---|---|
| Python | `_two_log_poly_effective_x2` in `summation.py` |
| TypeScript | `twoLogPolyEffectiveDeg` in `index.ts` |
| Rust | `two_log_poly_effective_x2` in `lib.rs` |

## Tests

- Python: 6 new tests in `TestEvaluateSumPhase62TwoLogPolyNumerator` (127 total)
- TypeScript: 4 new tests in Phase 62 describe block (93 total)
- Rust: 3 new tests (87 total)

## Test plan

- [x] `mise exec -- uv run pytest` passes (127 tests)
- [x] `mise exec -- npm test` passes (93 tests)
- [x] `cargo test` passes (87 tests)
- [x] Security review passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)