### PR TITLE
feat(ui32): UI32-K-qt — Qt6 + CMake desktop shell

### DIFF
--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -926,18 +926,51 @@ fn run_pipeline(
             )
             .map(|r| r.output),
         ),
-        "qt" => emit_single_file(
-            backend,
-            output_path,
-            &mosmodel_out.component.component,
-            "qml",
-            mosaic_emit_qt::pipeline::from_pipeline(
+        "qt" => {
+            // UI32-K-qt: route through `from_pipeline_with_options`
+            // so --emit-project activates the Qt6 + CMake shell.
+            // Bare invocation is byte-identical to pre-UI32.
+            let mut qt_opts = mosaic_emit_qt::pipeline::EmitOptions::default();
+            qt_opts.emit_project = emit_project;
+            let result = mosaic_emit_qt::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
                 &style_out.def,
+                &qt_opts,
             )
-            .map(|r| r.output),
-        ),
+            .unwrap_or_else(|e| {
+                eprintln!("mosaic-compile: qt pipeline emit error: {e}");
+                process::exit(1);
+            });
+            let out = output_path
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{}.qml", result.component_name));
+            write_file_or_die(&out, &result.output);
+            eprintln!("Written: {out}");
+
+            // UI32-K-qt: emit CMakeLists.txt + main.cpp + qmldir +
+            // README.md flat next to the .qml.
+            if let Some(proj) = &result.project {
+                let side_file_path = |relative: &str| -> String {
+                    match std::path::Path::new(&out).parent() {
+                        Some(p) if !p.as_os_str().is_empty() => {
+                            p.join(relative).to_string_lossy().into_owned()
+                        }
+                        _ => relative.to_string(),
+                    }
+                };
+                let flat: [(String, &str); 4] = [
+                    (side_file_path("CMakeLists.txt"), &proj.cmake_lists),
+                    (side_file_path("main.cpp"), &proj.main_cpp),
+                    (side_file_path("qmldir"), &proj.qmldir),
+                    (side_file_path("README.md"), &proj.readme),
+                ];
+                for (path, src) in &flat {
+                    write_file_or_die(path, src);
+                    eprintln!("Written: {path}");
+                }
+            }
+        }
         "flutter" => {
             // UI32-K-flutter: route through `from_pipeline_with_options`
             // so --emit-project activates the Flutter app shell.

--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added — UI32-K-qt — `--emit-project` Qt6 + CMake desktop shell
+
+L6 of UI32 ([spec PR #4286](https://github.com/adhithyan15/coding-adventures/pull/4286); L2 React #4297, L3 HTML #4309, L4 WebComponent #4315, L5 Flutter #4319). `mosaic-compile --backend qt --emit-project` now produces a Qt6 + CMake desktop scaffold:
+
+- `CMakeLists.txt` — pinned Qt6 `6.7` + CMake `3.21` + C++17 per UI32 §3.6.3. `qt_add_executable` + `qt_add_qml_module` embed the component into a `Mosaic.<Component>` QML module.
+- `main.cpp` — `QGuiApplication` + `QQmlApplicationEngine` loading `qrc:/qt/qml/Mosaic/<Component>/<Component>.qml` (the path `qt_add_qml_module` exposes).
+- `qmldir` — `module Mosaic.<Component>` + `<Component> 1.0 <Component>.qml`.
+- `README.md` — `cmake -B build && cmake --build build && ./build/<Component>` recipe + file map.
+
+New public API (matches L2-L5 pattern):
+
+- `pub struct EmitOptions` — `emit_project`, `pinned_qt_version`, `pinned_cmake_min`, `pinned_cxx_standard`.
+- `pub struct ProjectFiles` — `cmake_lists`, `main_cpp`, `qmldir`, `readme`.
+- `pub struct PipelineEmitResultWithProject`.
+- `pub fn from_pipeline_with_options(...)`. Existing `from_pipeline(...)` unchanged.
+
+UI32 §3.6.2 Qt row: no per-PR constraint beyond upstream — CMake target names exclude `-` (already excluded by `validate_component_name`). qmldir module names follow PascalCase (component name already PascalCase).
+
+9 new tests cover the spec §3 gates plus a qrc-path test that verifies main.cpp loads the component from the embedded QML module via the correct `qrc:/qt/qml/Mosaic/<Component>/<Component>.qml` resource path. Total tests: 90 (was 81, +9).
+
 ### Added — UI31-K-qt — `HostTable` RTL contract
 
 The Qt `HostTable` lowering (which produces a structural

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -143,6 +143,173 @@ impl std::fmt::Display for PipelineEmitError {
 
 impl std::error::Error for PipelineEmitError {}
 
+// =====================================================================
+// UI32-K-qt — `--emit-project` Qt6 + CMake app shell
+//
+// Mirrors L2 (React #4297), L3 (HTML #4309), L4 (WebComponent #4315),
+// L5 (Flutter #4319): EmitOptions / ProjectFiles /
+// from_pipeline_with_options.
+//
+// When `--emit-project` is on, emits a complete CMake-driven Qt6
+// project alongside the component .qml. Author runs `cmake -B build
+// && cmake --build build && ./build/<Component>` to see the
+// component on a desktop window.
+// =====================================================================
+
+/// Options controlling the Qt/QML emitter's behaviour.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmitOptions {
+    /// Also emit `CMakeLists.txt`, `main.cpp`, `qmldir`, `README.md`
+    /// alongside the component `.qml`. Default `false`.
+    pub emit_project: bool,
+
+    /// Pinned Qt6 version constraint to write into `CMakeLists.txt`'s
+    /// `find_package(Qt6 REQUIRED ...)`. UI32 spec §3.6.3 requires
+    /// exact pinning. Default `"6.7"` — a known-good 6.7 LTS.
+    /// CMake accepts `6.7` as a major.minor constraint that resolves
+    /// to any installed 6.7.x.
+    pub pinned_qt_version: String,
+
+    /// Pinned CMake minimum-required version. Default `"3.21"` — the
+    /// floor Qt6 + AUTOUIC support requires.
+    pub pinned_cmake_min: String,
+
+    /// CMake C++ standard. Default `"17"` — Qt6's documented minimum.
+    pub pinned_cxx_standard: String,
+}
+
+impl Default for EmitOptions {
+    fn default() -> Self {
+        Self {
+            emit_project: false,
+            pinned_qt_version: "6.7".to_string(),
+            pinned_cmake_min: "3.21".to_string(),
+            pinned_cxx_standard: "17".to_string(),
+        }
+    }
+}
+
+/// Project-shaped artifacts emitted when `EmitOptions::emit_project`
+/// is on. Four files — enough for `cmake -B build && cmake --build
+/// build && ./build/<Component>` to launch a Qt6 desktop window
+/// hosting the component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectFiles {
+    /// `CMakeLists.txt` — pinned Qt6 + CMake versions, `find_package(Qt6
+    /// REQUIRED COMPONENTS Quick QmlImportScanner)`, executable
+    /// target that links Qt6::Quick and embeds the QML via
+    /// `qt_add_qml_module`. The component `.qml` lands inside the
+    /// QML module.
+    pub cmake_lists: String,
+    /// `main.cpp` — `QGuiApplication` + `QQmlApplicationEngine`
+    /// loading the component QML as the root from the embedded
+    /// QML module. Falls through gracefully if the engine fails
+    /// to instantiate (returns -1).
+    pub main_cpp: String,
+    /// `qmldir` — Qt's QML module descriptor. Lists the component
+    /// as the module's export. The module name is `Mosaic.<Component>`
+    /// (derived inline; the single-component CLI path doesn't have
+    /// a mosaic-package.toml so we can't use the artifact-builder's
+    /// `qmldir_module_name` helper directly).
+    pub qmldir: String,
+    /// `README.md` — prereqs (Qt6 6.7+, CMake 3.21+, a C++17
+    /// compiler), build + run commands, file map.
+    pub readme: String,
+}
+
+/// Extended pipeline result — carries the optional `ProjectFiles`
+/// when `emit_project` is on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PipelineEmitResultWithProject {
+    pub output: String,
+    pub component_name: String,
+    pub project: Option<ProjectFiles>,
+}
+
+/// Compile a three-file Mosaic pipeline triple to QML with explicit
+/// emit options.
+pub fn from_pipeline_with_options(
+    interface: &MosmodelComponent,
+    layout: &LayoutDef,
+    style: &StyleDef,
+    options: &EmitOptions,
+) -> Result<PipelineEmitResultWithProject, PipelineEmitError> {
+    let component = from_pipeline(interface, layout, style)?;
+
+    let project = if options.emit_project {
+        Some(build_qt_project_files(&component.component_name, options))
+    } else {
+        None
+    };
+
+    Ok(PipelineEmitResultWithProject {
+        output: component.output,
+        component_name: component.component_name,
+        project,
+    })
+}
+
+/// Build the four Qt-shell side files for a single component.
+///
+/// UI32 spec §3.6.2 Qt row: no per-PR identifier shape constraint
+/// beyond upstream — CMake target names exclude `-` (validated by
+/// `validate_component_name` upstream as ASCII identifier shape).
+/// The qmldir module name follows the QML PascalCase convention,
+/// which the upstream-validated component name already satisfies.
+fn build_qt_project_files(name: &str, options: &EmitOptions) -> ProjectFiles {
+    // Single-component QML module name: `Mosaic.<Component>`.
+    // (The artifact-builder's `qmldir_module_name` derives from
+    // package name; the single-component CLI path has no package
+    // context, so we inline the convention here.)
+    let module_name = format!("Mosaic.{name}");
+    ProjectFiles {
+        cmake_lists: build_cmake_lists(name, &module_name, options),
+        main_cpp: build_main_cpp(name, &module_name),
+        qmldir: build_qmldir(name, &module_name),
+        readme: build_qt_readme(name, &module_name),
+    }
+}
+
+const BANNER_CMAKE: &str = "# AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit.\n# Fork the file (remove this banner) to customise.\n";
+const BANNER_CPP: &str = "// AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit.\n// Fork the file (remove this banner) to customise.\n";
+const BANNER_QMLDIR: &str = "# AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit.\n# Fork the file (remove this banner) to customise.\n";
+const BANNER_MD: &str = "<!-- AUTO-GENERATED by mosaic-compile --emit-project. Edits will be overwritten on next emit. -->\n<!-- Fork the file (remove this banner) to customise. -->\n";
+
+fn build_cmake_lists(name: &str, module_name: &str, options: &EmitOptions) -> String {
+    format!(
+        "{BANNER_CMAKE}cmake_minimum_required(VERSION {})\nproject({} VERSION 0.1.0 LANGUAGES CXX)\n\nset(CMAKE_CXX_STANDARD {})\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\nset(CMAKE_AUTOMOC ON)\n\nfind_package(Qt6 {} REQUIRED COMPONENTS Quick QmlImportScanner)\nqt_standard_project_setup(REQUIRES {})\n\nqt_add_executable({} main.cpp)\n\nqt_add_qml_module({}\n  URI {}\n  VERSION 1.0\n  QML_FILES {}.qml\n)\n\ntarget_link_libraries({} PRIVATE Qt6::Quick)\n",
+        options.pinned_cmake_min,
+        name,
+        options.pinned_cxx_standard,
+        options.pinned_qt_version,
+        options.pinned_qt_version,
+        name,
+        name,
+        module_name,
+        name,
+        name,
+    )
+}
+
+fn build_main_cpp(name: &str, module_name: &str) -> String {
+    format!(
+        "{BANNER_CPP}#include <QGuiApplication>\n#include <QQmlApplicationEngine>\n#include <QUrl>\n\nint main(int argc, char *argv[]) {{\n  QGuiApplication app(argc, argv);\n  QQmlApplicationEngine engine;\n\n  // Load the component as the root QML object from the embedded\n  // module. The qrc:// path is set up by qt_add_qml_module in\n  // CMakeLists.txt — the module URI is {module_name}, so the\n  // component resolves at qrc:/qt/qml/{module_name_slash}/{name}.qml.\n  const QUrl url(QStringLiteral(\"qrc:/qt/qml/{module_name_slash}/{name}.qml\"));\n  QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,\n                   &app, [](){{ qExit(-1); }}, Qt::QueuedConnection);\n  engine.load(url);\n  if (engine.rootObjects().isEmpty()) {{\n    return -1;\n  }}\n  return app.exec();\n}}\n",
+        module_name_slash = module_name.replace('.', "/"),
+    )
+}
+
+fn build_qmldir(name: &str, module_name: &str) -> String {
+    format!(
+        "{BANNER_QMLDIR}module {module_name}\n{name} 1.0 {name}.qml\n"
+    )
+}
+
+fn build_qt_readme(name: &str, module_name: &str) -> String {
+    format!(
+        "{BANNER_MD}# {name} — Qt6 + CMake desktop shell\n\nAuto-generated by `mosaic-compile --backend qt --emit-project`.\n\n## Prerequisites\n\n- Qt6 ≥ 6.7 (install via the official installer or your package manager).\n- CMake ≥ 3.21.\n- A C++17 compiler (GCC ≥ 9, Clang ≥ 10, MSVC 2019+).\n\n## Build + run\n\n```sh\ncmake -B build\ncmake --build build\n./build/{name}            # macOS / Linux\nbuild\\\\{name}.exe          # Windows\n```\n\n## What's in this directory\n\n| File | Purpose |\n|---|---|\n| `{name}.qml` | The Mosaic-compiled QML component. |\n| `CMakeLists.txt` | CMake build definition. Pinned Qt6 + CMake versions per UI32 spec §3.6.3. |\n| `main.cpp` | `QGuiApplication` + `QQmlApplicationEngine` loading the component as root QML. |\n| `qmldir` | QML module descriptor. Module URI: `{module_name}`. |\n| `README.md` | This file. |\n\n## Editing\n\nEvery file except `{name}.qml` carries an AUTO-GENERATED banner. Re-running `mosaic-compile --emit-project` will overwrite them. To customise the shell, remove the banner from a file and rename or relocate it; the next `--emit-project` run will recreate the original at its original name without touching your forked copy.\n"
+    )
+}
+
 /// Compile a three-file Mosaic pipeline triple to a QML source file.
 ///
 /// The `style` argument is accepted now (rather than added later) so that

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -5164,4 +5164,256 @@ mod tests {
             r.output
         );
     }
+
+    // =================================================================
+    // UI32-K-qt — `--emit-project` Qt6 + CMake shell tests
+    //
+    // Covers UI32 spec §3.1-§3.8 per-PR gates:
+    //   §3.4 Composable     : default options = no project shell.
+    //   §3.5 Banner          : every emitted file starts with banner.
+    //   §3.1 Reproducible    : two runs produce byte-identical output.
+    //   §3.6.2 Qt row        : CMake target + qmldir module name shape
+    //                          (PascalCase, no hyphen).
+    //   §3.6.3 Pinning       : CMakeLists.txt has pinned Qt6 + CMake +
+    //                          C++ standard.
+    //   §3.7 Output paths    : only the spec §2.2 enumeration.
+    //   §3.8 No env reads    : no /Users/, $HOME, etc. in output.
+    // =================================================================
+
+    /// Small helper for the UI32 tests: build a minimal HostScroll-
+    /// rooted layout (Qt's bare primitive set requires a root that
+    /// the emitter knows; Box is fine).
+    fn ui32_simple_layout(name: &str) -> LayoutDef {
+        LayoutDef {
+            component_name: name.to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: None,
+                props: Vec::new(),
+                children: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn ui32_emit_project_false_is_backward_compatible_with_from_pipeline() {
+        let m = component("X", vec![], vec![]);
+        let l = ui32_simple_layout("X");
+        let s = empty_style("X");
+
+        let legacy = from_pipeline(&m, &l, &s).unwrap();
+        let extended =
+            from_pipeline_with_options(&m, &l, &s, &EmitOptions::default()).unwrap();
+
+        assert_eq!(legacy.output, extended.output, ".qml bytes diverged");
+        assert_eq!(legacy.component_name, extended.component_name);
+        assert!(
+            extended.project.is_none(),
+            "default options must NOT emit a project shell"
+        );
+    }
+
+    #[test]
+    fn ui32_emit_project_true_returns_project_files() {
+        let m = component("Hello", vec![], vec![]);
+        let l = ui32_simple_layout("Hello");
+        let s = empty_style("Hello");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let r = from_pipeline_with_options(&m, &l, &s, &opts).unwrap();
+        assert!(r.project.is_some(), "emit_project: true must produce a shell");
+    }
+
+    #[test]
+    fn ui32_every_emitted_side_file_carries_auto_generated_banner() {
+        let m = component("Hello", vec![], vec![]);
+        let l = ui32_simple_layout("Hello");
+        let s = empty_style("Hello");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .expect("project shell expected");
+
+        // CMakeLists.txt uses `#` for comments.
+        assert!(
+            proj.cmake_lists.starts_with("# AUTO-GENERATED"),
+            "CMakeLists.txt must START with `# AUTO-GENERATED`"
+        );
+        // main.cpp uses `//` for comments.
+        assert!(
+            proj.main_cpp.starts_with("// AUTO-GENERATED"),
+            "main.cpp must START with `// AUTO-GENERATED`"
+        );
+        // qmldir uses `#` for comments.
+        assert!(
+            proj.qmldir.starts_with("# AUTO-GENERATED"),
+            "qmldir must START with `# AUTO-GENERATED`"
+        );
+        // README.md uses HTML-comment syntax.
+        assert!(
+            proj.readme.starts_with("<!-- AUTO-GENERATED"),
+            "README.md must START with banner"
+        );
+    }
+
+    #[test]
+    fn ui32_emit_project_is_byte_deterministic() {
+        let m = component("Deterministic", vec![], vec![]);
+        let l = ui32_simple_layout("Deterministic");
+        let s = empty_style("Deterministic");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+
+        let a = from_pipeline_with_options(&m, &l, &s, &opts).unwrap();
+        let b = from_pipeline_with_options(&m, &l, &s, &opts).unwrap();
+        assert_eq!(a.output, b.output, ".qml is not deterministic");
+        assert_eq!(a.project, b.project, "project shell is not deterministic");
+    }
+
+    /// §3.6.2 Qt row: the QML module URI is `Mosaic.<Component>`,
+    /// and the CMake target uses the bare component name. Both
+    /// flow from the upstream-validated ASCII identifier shape.
+    #[test]
+    fn ui32_qmldir_and_cmake_use_pascal_component_name() {
+        let m = component("ProfileCard", vec![], vec![]);
+        let l = ui32_simple_layout("ProfileCard");
+        let s = empty_style("ProfileCard");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        // qmldir carries the module URI + the component export.
+        assert!(
+            proj.qmldir.contains("module Mosaic.ProfileCard"),
+            "qmldir must declare module `Mosaic.ProfileCard`, got:\n{}",
+            proj.qmldir
+        );
+        assert!(
+            proj.qmldir.contains("ProfileCard 1.0 ProfileCard.qml"),
+            "qmldir must export ProfileCard at version 1.0, got:\n{}",
+            proj.qmldir
+        );
+        // CMake target uses the component name (no hyphen — the
+        // upstream validator excludes them, which keeps CMake happy).
+        assert!(
+            proj.cmake_lists.contains("project(ProfileCard"),
+            "CMakeLists.txt must declare `project(ProfileCard ...)`"
+        );
+        assert!(
+            proj.cmake_lists.contains("qt_add_executable(ProfileCard"),
+            "CMakeLists.txt must add executable `ProfileCard`"
+        );
+    }
+
+    /// §3.6.3 Pinning. CMakeLists.txt carries the default pinned
+    /// Qt + CMake + C++ versions.
+    #[test]
+    fn ui32_cmake_lists_carries_pinned_default_versions_exactly() {
+        let m = component("X", vec![], vec![]);
+        let l = ui32_simple_layout("X");
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        assert!(
+            proj.cmake_lists.contains("cmake_minimum_required(VERSION 3.21)"),
+            "expected CMake minimum 3.21"
+        );
+        assert!(
+            proj.cmake_lists.contains("find_package(Qt6 6.7 REQUIRED"),
+            "expected Qt6 6.7 pin"
+        );
+        assert!(
+            proj.cmake_lists.contains("set(CMAKE_CXX_STANDARD 17)"),
+            "expected C++17 standard"
+        );
+    }
+
+    /// §3.7 Output paths tripwire.
+    #[test]
+    fn ui32_project_files_struct_exposes_only_spec_22_qt_files() {
+        let m = component("X", vec![], vec![]);
+        let l = ui32_simple_layout("X");
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        let ProjectFiles {
+            cmake_lists,
+            main_cpp,
+            qmldir,
+            readme,
+        } = proj;
+        assert!(!cmake_lists.is_empty(), "CMakeLists.txt empty");
+        assert!(!main_cpp.is_empty(), "main.cpp empty");
+        assert!(!qmldir.is_empty(), "qmldir empty");
+        assert!(!readme.is_empty(), "README.md empty");
+    }
+
+    #[test]
+    fn ui32_emitted_files_contain_no_environment_specific_strings() {
+        let m = component("X", vec![], vec![]);
+        let l = ui32_simple_layout("X");
+        let s = empty_style("X");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        let all = format!(
+            "{}\n{}\n{}\n{}",
+            proj.cmake_lists, proj.main_cpp, proj.qmldir, proj.readme
+        );
+        for banned in ["/Users/", "/home/", "C:\\Users\\", "$HOME"] {
+            assert!(
+                !all.contains(banned),
+                "emitted shell contains environment-specific fragment `{banned}`"
+            );
+        }
+    }
+
+    /// main.cpp loads the component from the embedded QML module via
+    /// `qrc:/qt/qml/Mosaic/<Component>/<Component>.qml`. This is the
+    /// path `qt_add_qml_module` exposes when given URI `Mosaic.<X>`.
+    #[test]
+    fn ui32_main_cpp_loads_component_from_embedded_qml_module() {
+        let m = component("MyWidget", vec![], vec![]);
+        let l = ui32_simple_layout("MyWidget");
+        let s = empty_style("MyWidget");
+        let mut opts = EmitOptions::default();
+        opts.emit_project = true;
+        let proj = from_pipeline_with_options(&m, &l, &s, &opts)
+            .unwrap()
+            .project
+            .unwrap();
+        // The qrc path uses slashes (not dots) to navigate the
+        // embedded resource tree.
+        assert!(
+            proj.main_cpp
+                .contains("qrc:/qt/qml/Mosaic/MyWidget/MyWidget.qml"),
+            "main.cpp must reference qrc:/qt/qml/Mosaic/MyWidget/MyWidget.qml, got:\n{}",
+            proj.main_cpp
+        );
+        // Must use QGuiApplication + QQmlApplicationEngine (the
+        // bare-metal Qt6 GUI bootstrap).
+        assert!(
+            proj.main_cpp.contains("QGuiApplication"),
+            "main.cpp must use QGuiApplication"
+        );
+        assert!(
+            proj.main_cpp.contains("QQmlApplicationEngine"),
+            "main.cpp must use QQmlApplicationEngine"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

L6 of UI32 ([spec PR #4286](https://github.com/adhithyan15/coding-adventures/pull/4286); L2 #4297, L3 #4309, L4 #4315, L5 #4319). `mosaic-compile --backend qt --emit-project` now produces a Qt6 + CMake desktop scaffold:

```sh
$ mosaic-compile --backend qt --emit-project \
    --interface Hello.mil --layout Hello.mll --style Hello.msl \
    -o out/Hello.qml

Written: out/Hello.qml
Written: out/CMakeLists.txt
Written: out/main.cpp
Written: out/qmldir
Written: out/README.md

$ cd out && cmake -B build && cmake --build build && ./build/Hello
```

## Architecture

Mirrors L2/L3/L4/L5 pattern: `EmitOptions` / `ProjectFiles` / `from_pipeline_with_options`. Existing `from_pipeline(...)` unchanged.

## Emitted shell

| File | Purpose |
|---|---|
| `Hello.qml` | The Mosaic-compiled QML component. |
| `CMakeLists.txt` | Pinned Qt6 6.7 + CMake 3.21 + C++17. `qt_add_qml_module` embeds the component into a `Mosaic.<Component>` QML module. |
| `main.cpp` | `QGuiApplication` + `QQmlApplicationEngine` loading `qrc:/qt/qml/Mosaic/<Component>/<Component>.qml`. |
| `qmldir` | `module Mosaic.<Component>` + `<Component> 1.0 <Component>.qml`. |
| `README.md` | Build + run recipe + file map. |

## §3.6.2 Qt row contract

No per-PR constraint beyond upstream — CMake target names exclude `-` (already excluded by `validate_component_name`). qmldir module names follow PascalCase (component name already PascalCase per grammar). The upstream-validated ASCII-identifier shape `[A-Za-z][A-Za-z0-9_]*` keeps both contexts safe.

## Contracts verified (UI32 §3.1–§3.8)

- §3.1 Reproducible: byte-deterministic
- §3.4 Composable: bare invocation unchanged
- §3.5 Banner on every file (CMake `#`, C++ `//`, qmldir `#`, HTML-comment for README)
- §3.6.3 Pinning: exact Qt6 6.7 + CMake 3.21 + C++17
- §3.7 Output paths: fixed enumeration; component name never in path construction
- §3.8 No env reads: emitter is a pure function

## Tests

9 new (90 total, was 81):

- \`ui32_emit_project_false_is_backward_compatible_with_from_pipeline\`
- \`ui32_emit_project_true_returns_project_files\`
- \`ui32_every_emitted_side_file_carries_auto_generated_banner\`
- \`ui32_emit_project_is_byte_deterministic\`
- \`ui32_qmldir_and_cmake_use_pascal_component_name\` (ProfileCard fixture)
- \`ui32_cmake_lists_carries_pinned_default_versions_exactly\`
- \`ui32_project_files_struct_exposes_only_spec_22_qt_files\`
- \`ui32_emitted_files_contain_no_environment_specific_strings\`
- \`ui32_main_cpp_loads_component_from_embedded_qml_module\` (positive: qrc path + QGuiApplication + QQmlApplicationEngine)

Security review: PASSED. Every substitution position (CMake macros, C++ string literal, qmldir directive, README markdown) is safe — the upstream-validated ASCII-identifier shape excludes every metacharacter that could escape any of those contexts.

## Test plan

- [x] \`cargo build -p mosaic-emit-qt -p mosaic-compile\` — clean
- [x] \`cargo test -p mosaic-emit-qt\` — 90 pass
- [x] Manual: \`mosaic-compile --backend qt --emit-project\` on Hello → 5 files; bare invocation → 1
- [x] qmldir + CMakeLists.txt visually inspected; main.cpp qrc path matches qt_add_qml_module URI
- [x] security-review sub-agent — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)