### PR TITLE
feat(closurec): wire --compilation_level WHITESPACE_ONLY (CLOC11.06)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.5.0] - 2026-05-25
+
+### Added — CLOC11.06: `--compilation_level WHITESPACE_ONLY` wired
+
+First *behavioral* compilation-level slice of [CLOC11]. CLOC11.01–03 wired the I/O layer; CLOC11.06 starts actually transforming JavaScript. The closurec binary now honors `--compilation_level WHITESPACE_ONLY` end-to-end, matching Closure's documented behavior at this level.
+
+- **New `whitespace_only` module.** Token-level minifier: tokenize via `javascript-lexer::tokenize_javascript_typed`, drop trivia (comments / whitespace / newlines), re-stitch survivors with the minimum-necessary inter-token whitespace. Conservative space-insertion rule: a single space goes between two adjacent *word-like* tokens (identifier, number, keyword, regex, template, BigInt, private name); other adjacencies emit back-to-back.
+- **String-literal re-quoting.** The lexer's `Token.value` is *unescaped* content (escape sequences resolved), so emitting it raw would corrupt `var s = "a\"b"`. The minifier re-quotes string tokens with double quotes and re-escapes `"`, `\`, LF, CR, TAB. Matches CC's WHITESPACE_ONLY canonicalization.
+- **`transform_source(source, config)` dispatch added to `run.rs`.** New per-level matrix:
+  - `WhitespaceOnly` → call into `whitespace_only::whitespace_only_minify`.
+  - `Simple` / `Advanced` / `Bundle` / `TranspileOnly` → identity for now; CLOC11.07–10 land their real bodies.
+- **`map_language_in_to_es_version`** projects `LanguageVersion` enum → `EsVersion` for the lexer. `Stable` / `EcmascriptNext` / `Unstable` / `NoTranspile` shortcuts all resolve to `EsVersion::latest()` so modern JS isn't silently downgraded.
+- **`CompilerError::Minify(MinifyError)`** new variant; carries the underlying tokenizer error message with the offending source context.
+- **Two new crate dependencies**: `coding-adventures-javascript-lexer` (the `tokenize_javascript_typed` entry point) and `lexer` (the underlying `Token` / `TokenType` types from the grammar-driven lexer).
+- **Diff fixture `tests/diff/whitespace-only/`** per CLOC11 §3: a JS input with line comments, block comments, mixed whitespace, function bodies — `expected.stdout` is the canonical compact emission.
+- **New integration test `tests/diff_whitespace_only.rs`** drives the built binary against the fixture and asserts byte-equal stdout.
+- **11 new unit tests in `whitespace_only::tests`**: empty input, line-comment stripping, block-comment stripping, whitespace collapsing around punctuation, space-between-keywords (`return typeof x`), space-between-keyword-and-number (`return 1`, must not become `return1`), no-space-around-punctuation, string-literal content preservation through re-quoting, multiline-to-single-line, mixed-comments-and-whitespace, error display.
+
+### Behavior changes (user-visible)
+
+- **`closurec --compilation_level WHITESPACE_ONLY --js foo.js`** now actually minifies. Previously this invocation ran the identity pipeline.
+- All other levels still run identity (concatenation) — that changes in CLOC11.07+.
+
+### Implementation note — operating at the token level (not the AST)
+
+The CLOC09 typed AST (`javascript_ast::Program`) and the parser (which produces `GrammarASTNode`) don't yet have a bridge. WHITESPACE_ONLY doesn't need the AST — it operates on tokens — so this PR skips the bridge and uses the lexer directly. Building the AST bridge is on the critical path for CLOC11.07 (`--compilation_level SIMPLE`) and will land then.
+
+### Tests
+
+78 unit + 4 integration tests passing. Clippy clean.
+
+### Version
+
+Bumps closurec 0.4.0 → 0.5.0 (Cargo.toml + cli.spec.json kept in sync).
+
+[CLOC11]: ../../specs/CLOC11-drop-in-closure-compat.md
+
 ## [0.4.0] - 2026-05-25
 
 ### Added — CLOC11.03: `--js_output_file` write semantics

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 
@@ -14,7 +14,9 @@ cli-builder = { path = "../../../packages/rust/cli-builder" }
 
 # Front end
 coding-adventures-javascript-tokens = { path = "../../../packages/rust/javascript-tokens" }
+coding-adventures-javascript-lexer = { path = "../../../packages/rust/javascript-lexer" }
 coding-adventures-javascript-ast = { path = "../../../packages/rust/javascript-ast" }
+lexer = { path = "../../../packages/rust/lexer" }
 
 # Type checker
 coding-adventures-closure-typechecker = { path = "../../../packages/rust/closure-typechecker" }

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -64,9 +64,11 @@ use std::process::ExitCode;
 // CLOC11.01 added these three modules to give the previously-empty
 // CLI binary an actual body. See CLOC11 §5 for the architecture.
 // CLOC11.02 added `globs` for --js pattern expansion.
+// CLOC11.06 added `whitespace_only` for --compilation_level WHITESPACE_ONLY.
 pub mod config;
 pub mod globs;
 pub mod run;
+pub mod whitespace_only;
 pub mod wire;
 
 /// The cli-builder JSON spec, embedded at compile time. This is

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -19,8 +19,10 @@
 //! `read → lex → parse → typecheck → passes → emit → write`.
 //! The function signature doesn't change; only the body grows.
 
-use crate::config::CompilerConfig;
+use crate::config::{CompilationLevel, CompilerConfig};
 use crate::globs;
+use crate::whitespace_only;
+use coding_adventures_javascript_tokens::EsVersion;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -68,6 +70,9 @@ pub enum CompilerError {
     /// FS walk error). The inner [`globs::GlobError`] carries the
     /// specific reason and the offending pattern.
     GlobExpansion(globs::GlobError),
+    /// `--compilation_level WHITESPACE_ONLY` minification failed.
+    /// Carries the underlying [`whitespace_only::MinifyError`].
+    Minify(whitespace_only::MinifyError),
 }
 
 impl std::fmt::Display for CompilerError {
@@ -80,6 +85,7 @@ impl std::fmt::Display for CompilerError {
                 write!(f, "failed to write output {}: {message}", path.display())
             }
             CompilerError::GlobExpansion(e) => write!(f, "{e}"),
+            CompilerError::Minify(e) => write!(f, "{e}"),
         }
     }
 }
@@ -89,6 +95,65 @@ impl std::error::Error for CompilerError {}
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
+
+/// Transform a single input source string per the config's
+/// `--compilation_level`.
+///
+/// # Level matrix (CLOC11.06)
+///
+/// | Level             | Transform                                   |
+/// |-------------------|---------------------------------------------|
+/// | `WhitespaceOnly`  | strip comments + collapse whitespace        |
+/// | `Simple`          | identity (CLOC11.07 lands real passes)      |
+/// | `Advanced`        | identity (CLOC11.08)                        |
+/// | `Bundle`          | identity (CLOC11.09)                        |
+/// | `TranspileOnly`   | identity (CLOC11.10)                        |
+///
+/// Mapping `config.language.language_in` → `EsVersion`:
+/// - `Stable` / `EcmascriptNext` / `Unstable` / anything missing →
+///   `EsVersion::latest()`.
+/// - A specific year → that EsVersion.
+///
+/// This mapping lives here (not in `wire.rs`) because it's
+/// transform-policy, not flag-mapping.
+pub fn transform_source(
+    source: &str,
+    config: &CompilerConfig,
+) -> Result<String, CompilerError> {
+    let es_version = map_language_in_to_es_version(config);
+    match config.compilation.level {
+        CompilationLevel::WhitespaceOnly => {
+            whitespace_only::whitespace_only_minify(source, es_version)
+                .map_err(CompilerError::Minify)
+        }
+        // CLOC11.07+ will replace each of these with real passes.
+        CompilationLevel::Simple
+        | CompilationLevel::Advanced
+        | CompilationLevel::Bundle
+        | CompilationLevel::TranspileOnly => Ok(source.to_string()),
+    }
+}
+
+/// Project the typed `LanguageVersion` enum into the
+/// `EsVersion` the lexer understands. Defaults to the latest
+/// known version for the shortcuts (`Stable`, `EcmascriptNext`,
+/// `Unstable`) so user code targeting "modern JS" never gets
+/// silently restricted.
+fn map_language_in_to_es_version(config: &CompilerConfig) -> EsVersion {
+    use crate::config::LanguageVersion as L;
+    match config.language.language_in {
+        L::Ecmascript3 => EsVersion::Es5, // closest available
+        L::Ecmascript5 | L::Ecmascript5Strict => EsVersion::Es5,
+        L::Ecmascript2015 => EsVersion::Es2015,
+        L::Ecmascript2016 => EsVersion::Es2016,
+        L::Ecmascript2017 => EsVersion::Es2017,
+        L::Ecmascript2018 => EsVersion::Es2018,
+        L::Ecmascript2019 => EsVersion::Es2019,
+        L::Ecmascript2020 => EsVersion::Es2020,
+        L::Ecmascript2021 => EsVersion::Es2021,
+        L::Stable | L::EcmascriptNext | L::Unstable | L::NoTranspile => EsVersion::latest(),
+    }
+}
 
 /// Resolve the list of input files from a `CompilerConfig`.
 ///
@@ -121,7 +186,16 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // produces zero matches.
     let inputs = resolve_inputs(config)?;
 
-    // Step 2: read every resolved input.
+    // Step 2: read every resolved input, then transform per
+    // --compilation_level (CLOC11.06+).
+    //
+    // Today's level dispatch:
+    //   - WHITESPACE_ONLY → strip comments + collapse whitespace
+    //     via the token-level minifier (whitespace_only.rs).
+    //   - All other levels → identity (concatenate verbatim).
+    //
+    // CLOC11.07+ replace the SIMPLE/ADVANCED arms with real
+    // lex/parse/typecheck/passes/emit pipelines.
     let mut combined = String::new();
     for path in &inputs {
         let contents = fs::read_to_string(path).map_err(|e| CompilerError::InputReadError {
@@ -129,10 +203,11 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
             kind: e.kind(),
             message: e.to_string(),
         })?;
-        combined.push_str(&contents);
+        let transformed = transform_source(&contents, config)?;
+        combined.push_str(&transformed);
         // Closure separates concatenated inputs with a newline so
         // back-to-back files don't end up syntactically merged.
-        if !contents.ends_with('\n') {
+        if !transformed.ends_with('\n') {
             combined.push('\n');
         }
     }

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1,0 +1,380 @@
+//! `whitespace_only` — the body of `--compilation_level WHITESPACE_ONLY`.
+//!
+//! # What WHITESPACE_ONLY means
+//!
+//! Per the upstream Java Closure Compiler (`CompilationLevel.java`,
+//! `WHITESPACE_ONLY` enum value), this level:
+//!
+//! - **removes comments** (line and block);
+//! - **collapses runs of whitespace** to nothing where token
+//!   boundaries don't need a separator, or to a single space
+//!   where they do (e.g. between two adjacent identifier-like
+//!   tokens such as `return` `x`);
+//! - **does NOT rename identifiers, fold constants, dead-code
+//!   eliminate, or reorder**.
+//!
+//! It's the cheapest, most conservative optimisation Closure
+//! offers — its output is byte-equivalent semantically and
+//! visually recognisable to a human who knows the source.
+//!
+//! # Why we operate at the token level (and not the AST level)
+//!
+//! Today the parser produces a `GrammarASTNode` (from
+//! `grammar-tools`), but the emitter from CLOC07 only knows
+//! `javascript_ast::Program`. There is no bridge between the two
+//! yet. Building that bridge is a substantial separate piece of
+//! work and isn't on the CLOC11 critical path.
+//!
+//! Token-level whitespace removal sidesteps the AST entirely:
+//! tokenize the source, drop the trivia tokens, re-join the
+//! survivors with the minimum-necessary inter-token whitespace.
+//! This matches what `WHITESPACE_ONLY` actually does inside
+//! Closure (its `RenameVars` / `InlineVariables` passes are all
+//! disabled at this level).
+//!
+//! Later compilation levels (SIMPLE, ADVANCED) will need real
+//! AST processing and will route through the bridge when it
+//! exists.
+//!
+//! # Inter-token spacing rule
+//!
+//! Two consecutive non-trivia tokens need a space between them
+//! iff *omitting* the space would alter the lexer's tokenization
+//! of the joined string. The safe conservative rule:
+//!
+//! > Insert a single space between two adjacent tokens if BOTH
+//! > are "word-like" (identifier, number, keyword, regex,
+//! > template). Otherwise emit them back-to-back.
+//!
+//! Examples:
+//!
+//! | Token A   | Token B   | Joined        |
+//! |-----------|-----------|---------------|
+//! | `return`  | `x`       | `return x`    | (both word-like)
+//! | `x`       | `+`       | `x+`          | (B is punctuation)
+//! | `+`       | `x`       | `+x`          | (A is punctuation)
+//! | `(`       | `1`       | `(1`          |
+//! | `1`       | `+`       | `1+`          |
+//! | `++`      | `x`       | `++x`         | (operator + word: safe)
+//! | `x`       | `++`      | `x++`         |
+//!
+//! This is a *conservative* under-removal — we never produce
+//! incorrect output, but a more aggressive minifier could remove
+//! the space in some edge cases. CC's WHITESPACE_ONLY is
+//! similarly conservative.
+
+use coding_adventures_javascript_lexer::tokenize_javascript_typed;
+use coding_adventures_javascript_tokens::EsVersion;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Reasons whitespace-only minification can fail. Currently the
+/// only failure path is the underlying tokenizer rejecting the
+/// source — every other operation is infallible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MinifyError {
+    /// The tokenizer rejected the source. Inner string is the
+    /// tokenizer's own error message.
+    LexError(String),
+}
+
+impl std::fmt::Display for MinifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MinifyError::LexError(s) => write!(f, "whitespace-only: tokenizer failed: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for MinifyError {}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Apply WHITESPACE_ONLY to a single source string.
+///
+/// Returns the comment-stripped, whitespace-collapsed equivalent.
+/// `version` selects the JS spec the tokenizer should use.
+pub fn whitespace_only_minify(
+    source: &str,
+    version: EsVersion,
+) -> Result<String, MinifyError> {
+    let tokens = tokenize_javascript_typed(source, version)
+        .map_err(MinifyError::LexError)?;
+
+    // Filter out trivia tokens (comments, whitespace, newlines)
+    // and the EOF sentinel. The lexer marks trivia via the
+    // `type_name` string (set by the grammar's named rules);
+    // we accept multiple common spellings since different
+    // grammars label them differently.
+    let kept: Vec<_> = tokens
+        .iter()
+        .filter(|t| !is_trivia(t))
+        .filter(|t| !is_eof(t))
+        .collect();
+
+    // Re-stitch: insert a single space between two adjacent
+    // word-like tokens; otherwise concatenate directly. String
+    // literals get re-quoted because the lexer's `value` field
+    // is the *unescaped* content (per the `lexer::token::Token`
+    // docstring); emitting it raw would corrupt the program.
+    let mut out = String::with_capacity(source.len());
+    for (i, tok) in kept.iter().enumerate() {
+        if i > 0 {
+            let prev = kept[i - 1];
+            if needs_separator(prev, tok) {
+                out.push(' ');
+            }
+        }
+        if is_string_literal(tok) {
+            out.push('"');
+            push_quoted_string_content(&mut out, &tok.value);
+            out.push('"');
+        } else {
+            out.push_str(&tok.value);
+        }
+    }
+    Ok(out)
+}
+
+/// True iff this token came from a string-literal rule. The
+/// canonical names in JS grammars are `STRING` and `STRING_LITERAL`;
+/// we accept both.
+fn is_string_literal(tok: &lexer::token::Token) -> bool {
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        if upper == "STRING" || upper == "STRING_LITERAL" {
+            return true;
+        }
+    }
+    matches!(tok.type_, lexer::token::TokenType::String)
+}
+
+/// Push the JS-escaped form of `content` into `out`. Closure's
+/// WHITESPACE_ONLY canonicalizes to double-quoted strings; we
+/// follow. We escape:
+///
+/// - `"`  → `\"`
+/// - `\`  → `\\`
+/// - LF   → `\n`
+/// - CR   → `\r`
+/// - TAB  → `\t`
+///
+/// Other control characters and non-ASCII pass through
+/// unchanged. (CC has a more elaborate escape table; we'll
+/// expand to match in a follow-up if needed.)
+fn push_quoted_string_content(out: &mut String, content: &str) {
+    for c in content.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Token classification helpers
+// ---------------------------------------------------------------------------
+
+/// True iff this token is trivia (comment / whitespace / newline)
+/// that WHITESPACE_ONLY discards.
+///
+/// We check both the grammar-supplied `type_name` (an `Option<String>`)
+/// and the structural `TokenType`'s `is_trivia()`. The two should
+/// agree but we accept either: defensive against grammar evolution.
+fn is_trivia(tok: &lexer::token::Token) -> bool {
+    // Match grammar-supplied type names *exactly* — substring
+    // matching against "COMMENT" would misclassify hypothetical
+    // tokens like "NON_COMMENT_LITERAL". The set below is the
+    // closed list of trivia rule names the JS grammar (and its
+    // peers) use today.
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        return matches!(
+            upper.as_str(),
+            "COMMENT"
+                | "LINE_COMMENT"
+                | "BLOCK_COMMENT"
+                | "WHITESPACE"
+                | "WS"
+                | "NEWLINE"
+                | "LINE_TERMINATOR"
+                | "SKIP"
+        );
+    }
+    matches!(
+        tok.type_,
+        lexer::token::TokenType::Newline
+            | lexer::token::TokenType::Indent
+            | lexer::token::TokenType::Dedent
+    )
+}
+
+/// True iff this is the EOF sentinel emitted by the lexer.
+fn is_eof(tok: &lexer::token::Token) -> bool {
+    matches!(tok.type_, lexer::token::TokenType::Eof)
+}
+
+/// True iff two adjacent tokens need a space between them to
+/// preserve their separate identity when re-tokenized.
+fn needs_separator(a: &lexer::token::Token, b: &lexer::token::Token) -> bool {
+    // Conservative rule: both word-like → space; otherwise none.
+    is_word_like(a) && is_word_like(b)
+}
+
+/// True iff a token is "word-like" — its value would merge with
+/// an adjacent word-like value if no separator were inserted.
+///
+/// Word-like tokens: identifiers (NAME), numbers (NUMBER),
+/// keywords (KEYWORD), regexes (REGEX), template literals
+/// (TEMPLATE*), BigInts (BIGINT), private names (PRIVATE_NAME).
+///
+/// String literals are NOT word-like in this sense: `"a""b"`
+/// re-tokenizes correctly as two strings.
+fn is_word_like(tok: &lexer::token::Token) -> bool {
+    // Prefer the grammar's type_name when present; fall back to
+    // the structural TokenType for the basic categories.
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        return matches!(
+            upper.as_str(),
+            "NAME"
+                | "NUMBER"
+                | "KEYWORD"
+                | "REGEX"
+                | "BIGINT"
+                | "PRIVATE_NAME"
+                | "TEMPLATE"
+                | "TEMPLATE_NO_SUB"
+                | "TEMPLATE_HEAD"
+                | "TEMPLATE_MIDDLE"
+                | "TEMPLATE_TAIL"
+                | "IDENT"
+                | "IDENTIFIER"
+        );
+    }
+    matches!(
+        tok.type_,
+        lexer::token::TokenType::Name | lexer::token::TokenType::Number | lexer::token::TokenType::Keyword
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minify(src: &str) -> String {
+        whitespace_only_minify(src, EsVersion::Es2025).expect("ok")
+    }
+
+    #[test]
+    fn empty_source_yields_empty_output() {
+        assert_eq!(minify(""), "");
+    }
+
+    #[test]
+    fn strips_line_comment() {
+        let src = "// removed\nvar x = 1;";
+        let out = minify(src);
+        assert!(!out.contains("removed"), "comment leaked: {out:?}");
+        assert!(out.contains("var") && out.contains("x") && out.contains("1"));
+    }
+
+    #[test]
+    fn strips_block_comment() {
+        let src = "var/* removed */x=1;";
+        let out = minify(src);
+        assert!(!out.contains("removed"), "comment leaked: {out:?}");
+        // Must still have "var x" (space required between word tokens).
+        assert!(out.contains("var x"), "missing word-separator: {out:?}");
+    }
+
+    #[test]
+    fn collapses_whitespace_between_punctuation_and_word() {
+        let src = "x  =   1 ;";
+        let out = minify(src);
+        assert_eq!(out, "x=1;");
+    }
+
+    #[test]
+    fn keeps_space_between_two_keywords() {
+        let src = "return    typeof    x;";
+        let out = minify(src);
+        assert!(out.contains("return typeof"), "got: {out:?}");
+        assert!(out.contains("typeof x"), "got: {out:?}");
+    }
+
+    #[test]
+    fn keeps_space_between_keyword_and_number() {
+        // `return 1` is two word-like tokens; collapsing to
+        // `return1` would re-tokenize as an identifier.
+        let src = "return   1;";
+        let out = minify(src);
+        assert!(out.contains("return 1"), "got: {out:?}");
+    }
+
+    #[test]
+    fn no_space_around_punctuation() {
+        let src = "a + b ;";
+        let out = minify(src);
+        // Between identifier and `+` we have NO space (identifier
+        // is word-like, `+` is not — only one side is word-like).
+        // We accept either rendering as long as it round-trips
+        // through the lexer; the conservative emitter we built
+        // emits `a+b;`.
+        assert_eq!(out, "a+b;");
+    }
+
+    #[test]
+    fn preserves_string_literal_content() {
+        // String literal contents are kept verbatim including
+        // any whitespace inside them.
+        let src = "var s = \"hello  world\";";
+        let out = minify(src);
+        assert!(out.contains("\"hello  world\""), "got: {out:?}");
+    }
+
+    #[test]
+    fn multiline_input_becomes_single_line() {
+        let src = "var\n  x\n  =\n  1\n;";
+        let out = minify(src);
+        assert!(!out.contains('\n'), "newlines should be stripped: {out:?}");
+        assert!(out.contains("var x"));
+    }
+
+    #[test]
+    fn nested_comments_and_whitespace_all_removed() {
+        let src = r#"
+            // top comment
+            var /* inline */ x = 1; // trailing
+            /* block
+               with newline */
+            var y = 2;
+        "#;
+        let out = minify(src);
+        assert!(!out.contains("comment"));
+        assert!(!out.contains("inline"));
+        assert!(!out.contains("trailing"));
+        assert!(!out.contains("block"));
+        assert!(out.contains("var x"));
+        assert!(out.contains("var y"));
+    }
+
+    #[test]
+    fn error_display() {
+        let e = MinifyError::LexError("bad input".into());
+        assert!(e.to_string().contains("tokenizer failed"));
+        let _: &dyn std::error::Error = &e;
+    }
+}

--- a/code/programs/rust/closurec/tests/diff/whitespace-only/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/whitespace-only/expected.stdout
@@ -1,0 +1,1 @@
+var x=1;var y=2;function add(a,b){return a+b;}

--- a/code/programs/rust/closurec/tests/diff/whitespace-only/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/whitespace-only/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+WHITESPACE_ONLY
+--js
+tests/diff/whitespace-only/input/a.js

--- a/code/programs/rust/closurec/tests/diff/whitespace-only/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/whitespace-only/input/a.js
@@ -1,0 +1,8 @@
+// header comment
+var  x  =  1 ;   // tail comment
+/* block
+   comment */
+var   y   =   2;
+function   add(a, b) {
+    return   a   +   b;
+}

--- a/code/programs/rust/closurec/tests/diff_whitespace_only.rs
+++ b/code/programs/rust/closurec/tests/diff_whitespace_only.rs
@@ -1,0 +1,48 @@
+//! Integration test for the `tests/diff/whitespace-only/` fixture.
+//!
+//! Exercises the CLOC11.06 \--compilation_level WHITESPACE_ONLY path
+//! end-to-end: spawn the built binary against an input file that
+//! contains comments + lots of inter-token whitespace, assert the
+//! emitted output is byte-equal to the canned `expected.stdout`.
+//!
+//! Per [CLOC11 §3], the fixture is a behavioral oracle — when we
+//! verify against real `closure-compiler.jar` later, this expected
+//! file is the diff target.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/whitespace-only/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn whitespace_only_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/whitespace-only/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

First **behavioral** compilation-level slice of [CLOC11](code/specs/CLOC11-drop-in-closure-compat.md). CLOC11.01–03 wired the I/O layer; CLOC11.06 starts actually transforming JavaScript. \`closurec\` now honors \`--compilation_level WHITESPACE_ONLY\` end-to-end, matching CC's documented behavior.

### What lands

- **New \`whitespace_only\` module** — token-level minifier:
  - Tokenize via \`javascript-lexer::tokenize_javascript_typed\`.
  - Drop trivia tokens (comments, whitespace, newlines) — exact-match on grammar-supplied type_name, no substring matching (defensive against grammar evolution).
  - Re-stitch survivors with the minimum-necessary inter-token whitespace. Conservative: single space between two adjacent word-like tokens; back-to-back otherwise.
  - String literals get re-quoted with double quotes + JS-escapes for \`"\`, \`\\\`, LF, CR, TAB — because the lexer's \`Token.value\` is unescaped content.

- **\`run.rs\` adds \`transform_source\` dispatch**:
  - \`WhitespaceOnly\` → \`whitespace_only_minify\`
  - \`Simple\` / \`Advanced\` / \`Bundle\` / \`TranspileOnly\` → identity (lands in CLOC11.07–10)

- **\`map_language_in_to_es_version\`** projects \`LanguageVersion\` enum → \`EsVersion\`.

- **New \`CompilerError::Minify\` variant** wrapping \`whitespace_only::MinifyError\`.

- **Two new crate deps**: \`coding-adventures-javascript-lexer\` (the typed tokenize entry) and \`lexer\` (Token/TokenType).

- **Diff fixture** \`tests/diff/whitespace-only/\` per CLOC11 §3 (input with mixed comments + whitespace + function bodies).

- **New integration test** \`tests/diff_whitespace_only.rs\`.

- **11 new unit tests** covering empty input, line/block comment stripping, whitespace collapsing, space-between-keywords (\`return typeof x\`), space-between-keyword-and-number (must not become \`return1\`), no-space-around-punctuation, string-literal preservation, multiline→single-line, mixed comments+whitespace, error display.

### Why token-level (not AST-level)

The CLOC09 typed AST (\`javascript_ast::Program\`) and the parser (which produces \`GrammarASTNode\`) don't yet have a bridge. WHITESPACE_ONLY doesn't need the AST — it operates on tokens — so this PR skips the bridge and uses the lexer directly. The bridge is on the critical path for CLOC11.07 (SIMPLE) and lands then.

### Security review

Sub-agent API was overloaded; did manual review inline. Tightened \`is_trivia\` from substring (\`contains("COMMENT")\`) to exact-match against the closed list of trivia rule names — defensive against future grammar tokens like \`NON_COMMENT_LITERAL\` being misclassified. No \`unsafe\`/FFI, no panics in production code, no resource exhaustion (\`String::with_capacity(source.len())\` bounded by input).

### Tests

- 78 unit + 4 integration tests passing.
- Clippy clean on closurec.

### Behavior change

\`closurec --compilation_level WHITESPACE_ONLY --js foo.js\` now actually minifies. Previously identity.

### Version

Bumps closurec 0.4.0 → 0.5.0 (Cargo.toml + cli.spec.json in sync).

## Test plan

- [x] \`cargo test\` — 82/82
- [x] \`cargo clippy --no-deps\` clean
- [x] Manual security review — clean after tightening trivia classifier
- [x] CHANGELOG \`[0.5.0]\` entry documents token-level approach + escape table + deferred AST bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)