### PR TITLE
feat(ruby-parser): Phase 6s — splat / double-splat in params and call args

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -106,7 +106,21 @@ block_params = "|" NAME { COMMA NAME } "|" ;
 return_statement = "return" [ expression ] ;
 break_statement  = "break"  [ expression ] ;
 next_statement   = "next"   [ expression ] ;
-params       = NAME { COMMA NAME } ;
+# Phase 6s — splat (`*args`) and double-splat (`**kwargs`) parameters.
+#
+# `params` previously was `NAME { COMMA NAME }`.  We now wrap each
+# parameter in a `param` rule that admits an optional leading `*` /
+# `**` prefix.  The lexer emits `*` as a single Star token (value
+# "*"), and the 1.8-baseline state machine already coalesces `**` into
+# one Name-typed token with value "**".  Both forms match here by
+# literal value.
+#
+# Multiple splats or double-splats per signature are syntactically
+# accepted but semantically illegal in Ruby; the SIR lowerer accepts
+# the first of each and flags duplicates as a deferred limitation
+# (v0 keeps the grammar permissive and pushes shape validation up).
+params       = param { COMMA param } ;
+param        = [ "*" | "**" ] NAME ;
 if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
 elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;
 else_clause  = "else" { !"end" statement } ;
@@ -143,8 +157,15 @@ assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expre
 #
 # Setter calls (`foo.bar = 1`) and bracket access (`arr[0]`) are
 # deliberately out of scope for this chunk — they get their own phases.
-method_call  = ( NAME | KEYWORD ) LPAREN [ expression { COMMA expression } ] RPAREN { dot_call } ;
-dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ expression { COMMA expression } ] RPAREN ] ;
+method_call  = ( NAME | KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
+dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] ;
+# Phase 6s — splat call arguments.  `f(*arr)` and `f(**hsh)` (and the
+# mixed form `f(1, *arr, **hsh, named: x)`) flow through here.  The
+# optional `[ "*" | "**" ]` prefix sits inside a single call_arg slot,
+# so positional and splat args interleave naturally on the COMMA
+# separator.  Lowering wraps the prefixed forms in
+# `BuiltinCall("splat", …)` / `BuiltinCall("double_splat", …)`.
+call_arg     = [ "*" | "**" ] expression ;
 # Phase 6h — paren-less method call.  Idiomatic Ruby allows
 # `puts 1, 2` (no parens) when the call has at least one argument.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.20.0] - 2026-05-25
+
+### Added (Phase 6s — splat / double-splat in params and call args)
+
+Grammar additions:
+
+```
+params   = param { COMMA param } ;
+param    = [ "*" | "**" ] NAME ;
+method_call = ( NAME | KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
+dot_call    = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] ;
+call_arg = [ "*" | "**" ] expression ;
+```
+
+`params` previously bound bare `NAME` tokens; each parameter is now wrapped in a `param` rule that admits the optional splat / double-splat prefix.  Similarly, `method_call` and `dot_call` argument slots are wrapped in a `call_arg` rule.
+
+`method_call_no_paren` intentionally keeps bare `expression` args — wrapping it in `call_arg` would create a grammar ambiguity with binary `*` at expression-start position (`a * b` would parse as `a(splat b)`).  Paren-less splat (`puts *arr`) is therefore a v0 deferred limitation; users can always fall back to the parenned form `puts(*arr)`.
+
+The lexer already emits `**` as one Name-typed Op token (1.8-baseline state machine coalesces it); `*` is a Star token.  Both match by literal value in the grammar.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+- **Call args**: `f(*arr)` → `BuiltinCall("splat", [VarRef(arr)])`; `f(**hsh)` → `BuiltinCall("double_splat", [VarRef(hsh)])`.  Bare args are unchanged.
+- **Params**: v0 lossy — `*args` and `**kwargs` lower to regular `Param { name: "args" / "kwargs" }`.  SIR's `Param` has no variadic flag, so splat-ness is dropped at the SIR level.  Downstream emitters treat the parameter as positional; correctness for variadic call sites is a deferred limitation.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 88 → **94** (+6):
+  - `test_parse_splat_param` — `def f(*args) end`.
+  - `test_parse_double_splat_param` — `def f(**kwargs) end`.
+  - `test_parse_mixed_params_with_splats` — `def f(a, *rest, **opts) end`.
+  - `test_parse_splat_call_arg` — `f(*arr)`.
+  - `test_parse_mixed_call_args_with_splats` — `f(1, *arr, **hsh)`.
+  - `test_parse_binary_star_still_parses_as_expression` — regression: `a * b` stays binary.
+
+Also updates two pre-existing tests to walk the new `param` / `call_arg` wrappers (`test_parse_def_with_params`, `test_parse_dot_call_with_args`).
+
 ## [0.19.0] - 2026-05-25
 
 ### Added (Phase 6r — multiple assignment `a, b = 1, 2`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -213,13 +213,24 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"params"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"param"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 109,
+            line_number: 122,
+        },
+        GrammarRule {
+            name: r#"param"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"*"#.to_string() },
+                        GrammarElement::Literal { value: r#"**"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 123,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -236,7 +247,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 110,
+            line_number: 124,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -250,7 +261,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 111,
+            line_number: 125,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -261,7 +272,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 112,
+            line_number: 126,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -276,7 +287,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 113,
+            line_number: 127,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -289,7 +300,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 114,
+            line_number: 128,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -302,7 +313,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 115,
+            line_number: 129,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -319,7 +330,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 135,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -330,16 +341,16 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
                         GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                                 GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
                             ] }) },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 146,
+            line_number: 160,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -352,16 +363,27 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
                         GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
                                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                                         GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
-                                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                                        GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
                                     ] }) },
                             ] }) },
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 147,
+            line_number: 161,
+        },
+        GrammarRule {
+            name: r#"call_arg"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"*"#.to_string() },
+                        GrammarElement::Literal { value: r#"**"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+            ] },
+            line_number: 168,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -376,17 +398,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 161,
+            line_number: 182,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 162,
+            line_number: 183,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 248,
+            line_number: 269,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -399,7 +421,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 249,
+            line_number: 270,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -413,7 +435,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 250,
+            line_number: 271,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -427,7 +449,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 251,
+            line_number: 272,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -441,7 +463,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 252,
+            line_number: 273,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -452,7 +474,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 259,
+            line_number: 280,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -470,7 +492,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 260,
+            line_number: 281,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -484,7 +506,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 261,
+            line_number: 282,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -498,7 +520,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 262,
+            line_number: 283,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -521,7 +543,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 272,
+            line_number: 293,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -529,7 +551,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 273,
+            line_number: 294,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -541,7 +563,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 274,
+            line_number: 295,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -556,7 +578,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 275,
+            line_number: 296,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -571,7 +593,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 276,
+            line_number: 297,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -587,7 +609,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 277,
+            line_number: 298,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -179,19 +179,27 @@ mod tests {
                 _ => None,
             })
             .expect("expected params subnode");
-        let names: Vec<&str> = params_node
+        // Phase 6s: each parameter is now wrapped in a `param` subnode
+        // (to admit the optional `*`/`**` splat prefix), so we walk
+        // the param children to extract Name tokens.
+        let names: Vec<String> = params_node
             .children
             .iter()
             .filter_map(|c| match c {
-                ASTNodeOrToken::Token(t)
-                    if matches!(t.type_, lexer::token::TokenType::Name) =>
-                {
-                    Some(t.value.as_str())
+                ASTNodeOrToken::Node(n) if n.rule_name == "param" => {
+                    n.children.iter().find_map(|cc| match cc {
+                        ASTNodeOrToken::Token(t)
+                            if matches!(t.type_, lexer::token::TokenType::Name) =>
+                        {
+                            Some(t.value.clone())
+                        }
+                        _ => None,
+                    })
                 }
                 _ => None,
             })
             .collect();
-        assert_eq!(names, vec!["x", "y"]);
+        assert_eq!(names, vec!["x".to_string(), "y".to_string()]);
     }
 
     #[test]
@@ -896,11 +904,12 @@ mod tests {
         // `foo.bar(1, 2)` — dot_call's optional arg list is populated.
         let ast = parse_ruby("foo.bar(1, 2)");
         let dot = find_descendant(&ast, "dot_call").expect("dot_call expected");
-        // Count `expression` direct children of the dot_call.
+        // Phase 6s: each argument is now wrapped in a `call_arg` rule
+        // (to admit optional `*`/`**` splat prefixes).
         let arg_count = dot
             .children
             .iter()
-            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression"))
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
             .count();
         assert_eq!(arg_count, 2, "expected 2 dot_call args, got {arg_count}");
     }
@@ -1490,6 +1499,103 @@ mod tests {
             find_descendant(&ast, "multi_assignment").is_none(),
             "single-LHS must NOT parse as multi_assignment"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 6s — splat / double-splat in params and call args
+    //
+    // Grammar additions:
+    //   params   = param { COMMA param } ;
+    //   param    = [ "*" | "**" ] NAME ;
+    //   call_arg = [ "*" | "**" ] expression ;
+    //   method_call's argument slot now uses call_arg instead of bare expression.
+    //
+    // method_call_no_paren intentionally still uses bare `expression` to
+    // avoid ambiguity with binary `*` at expression-start position
+    // (`a * b` would otherwise parse as `a(splat b)`).  Paren-less splat
+    // is a v0 deferred limitation; users can always fall back to `f(*arr)`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_splat_param() {
+        // `def f(*args) end` — single splat param.
+        let ast = parse_ruby("def f(*args)\nend");
+        // The `param` subnode is present and carries the `*` token plus the name.
+        let param = find_descendant(&ast, "param").expect("expected param subnode");
+        assert!(tree_has_token_value(param, "*"), "expected `*` splat prefix");
+        assert!(tree_has_token_value(param, "args"), "expected `args` name");
+        // Regression: NO `**` prefix.
+        assert!(!tree_has_token_value(param, "**"),
+            "single splat must not produce a `**` token");
+    }
+
+    #[test]
+    fn test_parse_double_splat_param() {
+        // `def f(**kwargs) end` — single double-splat param.
+        let ast = parse_ruby("def f(**kwargs)\nend");
+        let param = find_descendant(&ast, "param").expect("expected param subnode");
+        assert!(tree_has_token_value(param, "**"), "expected `**` double-splat prefix");
+        assert!(tree_has_token_value(param, "kwargs"), "expected `kwargs` name");
+    }
+
+    #[test]
+    fn test_parse_mixed_params_with_splats() {
+        // `def f(a, *rest, **opts) end` — three params: positional, splat, double-splat.
+        let ast = parse_ruby("def f(a, *rest, **opts)\nend");
+        let params_node = find_descendant(&ast, "params").expect("expected params");
+        let param_count = params_node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "param"))
+            .count();
+        assert_eq!(param_count, 3, "expected 3 param subnodes, got {param_count}");
+        // The whole tree should contain `*`, `**`, and the bare NAMEs.
+        assert!(tree_has_token_value(params_node, "*"));
+        assert!(tree_has_token_value(params_node, "**"));
+        assert!(tree_has_token_value(params_node, "rest"));
+        assert!(tree_has_token_value(params_node, "opts"));
+    }
+
+    #[test]
+    fn test_parse_splat_call_arg() {
+        // `f(*arr)` — splat call argument.
+        let ast = parse_ruby("f(*arr)");
+        let call_arg = find_descendant(&ast, "call_arg")
+            .expect("expected call_arg subnode");
+        assert!(tree_has_token_value(call_arg, "*"), "expected `*` in call_arg");
+        assert!(tree_has_token_value(call_arg, "arr"), "expected `arr` in call_arg");
+    }
+
+    #[test]
+    fn test_parse_mixed_call_args_with_splats() {
+        // `f(1, *arr, **hsh)` — three call_args: positional, splat, double-splat.
+        let ast = parse_ruby("f(1, *arr, **hsh)");
+        let call = find_descendant(&ast, "method_call").expect("expected method_call");
+        let arg_count = call
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 3, "expected 3 call_args, got {arg_count}");
+        assert!(tree_has_token_value(call, "*"));
+        assert!(tree_has_token_value(call, "**"));
+    }
+
+    #[test]
+    fn test_parse_binary_star_still_parses_as_expression() {
+        // Regression: `a * b` as a statement must still parse as a
+        // bare expression-stmt with binary `*`, NOT as `a(splat b)`.
+        // method_call_no_paren intentionally keeps bare `expression`
+        // args to preserve this behaviour.
+        let ast = parse_ruby("a * b");
+        // No call_arg node should appear in the AST.
+        assert!(
+            find_descendant(&ast, "call_arg").is_none(),
+            "binary `a * b` must NOT produce a call_arg"
+        );
+        // A term node containing the `*` should exist.
+        let term = find_descendant(&ast, "term").expect("expected term node");
+        assert!(tree_has_token_value(term, "*"), "expected binary `*` in term");
     }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.20.0] - 2026-05-25
+
+### Added (Phase 6s — splat / double-splat lowering)
+
+#### Call args (preserved through SIR)
+
+| Source | Lowered |
+|---|---|
+| `f(*arr)` | `DirectCall(f, [BuiltinCall("splat", [VarRef(arr)])])` |
+| `f(**hsh)` | `DirectCall(f, [BuiltinCall("double_splat", [VarRef(hsh)])])` |
+| `f(1, *arr, **hsh)` | three positional args: `IntLit(1)`, `splat(arr)`, `double_splat(hsh)` |
+
+New helper `lower_call_arg` dispatches on the leading `*` / `**` token (if any) and wraps the inner expression in a `BuiltinCall` envelope.  No prefix → return the bare expression.  Downstream emitters can pattern-match the builtin name to convert back to splat syntax in target source.
+
+Renamed `head_call_expression_children` → `head_call_args` (returns `call_arg` Nodes instead of `expression` Nodes).  `lower_method_call` dispatches on the rule name: `method_call` uses the new `call_arg` shape; `method_call_no_paren` keeps the legacy bare-`expression` shape (paren-less splat is a deferred limitation — see ruby-parser changelog).
+
+`fold_one_dot_call` likewise routes through `lower_call_arg`.
+
+#### Params (lossy at SIR level)
+
+`*args` / `**kwargs` lower to regular `Param { name: "args" / "kwargs" }` — SIR's `Param` has no variadic flag, so the splat-ness is dropped.  The parameter-name extractor in `lower_def_statement` skips the splat-prefix tokens (`*` and `**`) when locating the identifier.
+
+**Downstream impact**: target source emitted for variadic functions will treat the parameter as positional.  Calls passing splat args (via the `BuiltinCall("splat", ...)` envelope) still preserve the variadic shape — the asymmetry only matters for definitions of variadic functions.  Tracked as a deferred limitation for a future SIR phase that adds variadic-aware `Param`.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 91 → **96** (+5):
+  - `splat_call_arg_lowers_to_splat_builtin`
+  - `double_splat_call_arg_lowers_to_double_splat_builtin`
+  - `mixed_call_args_with_splats_lower_in_order`
+  - `splat_param_lowers_to_bare_name_param` (asserts lossy v0 lowering)
+  - `splat_call_arg_module_passes_sir_validator` — end-to-end validator smoke.
+
 ## [0.19.0] - 2026-05-25
 
 ### Added (Phase 6r — multiple assignment lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1774,4 +1774,119 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6s — splat / double-splat
+    // -----------------------------------------------------------------
+    //
+    // Splat in CALL ARGS:
+    //   `f(*arr)`  → DirectCall(f, [BuiltinCall("splat",        [VarRef(arr)])])
+    //   `f(**hsh)` → DirectCall(f, [BuiltinCall("double_splat", [VarRef(hsh)])])
+    //
+    // Splat in DEF PARAMS:
+    //   v0 limitation — Param has no variadic flag.  Splat-ness is
+    //   LOST at the SIR level; `*args` lowers to `Param { name: "args" }`,
+    //   indistinguishable from a positional parameter.  Documented for
+    //   downstream emitter follow-up.
+
+    #[test]
+    fn splat_call_arg_lowers_to_splat_builtin() {
+        // `arr` must be a local first so the validator accepts the VarRef.
+        let m = lower("arr = [1, 2, 3]\nf(*arr)\n");
+        let b = main_body(&m);
+        // Find the DirectCall(f, …) — it's either the tail value
+        // (promoted) or the second body stmt.
+        let call_expr: &Expr = match &b.value {
+            Expr::DirectCall { fn_name, .. } if fn_name == "f" => &b.value,
+            _ => panic!("expected tail DirectCall(f, ...), got value={:?}", b.value),
+        };
+        match call_expr {
+            Expr::DirectCall { args, .. } => {
+                assert_eq!(args.len(), 1);
+                match &args[0] {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "splat");
+                        assert_eq!(args.len(), 1);
+                        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "arr"));
+                    }
+                    other => panic!("expected BuiltinCall(splat, ...), got {:?}", other),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn double_splat_call_arg_lowers_to_double_splat_builtin() {
+        let m = lower("hsh = {a: 1}\nf(**hsh)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => args,
+            other => panic!("expected DirectCall(f, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 1);
+        match &args[0] {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "double_splat");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "hsh"));
+            }
+            other => panic!("expected BuiltinCall(double_splat, ...), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mixed_call_args_with_splats_lower_in_order() {
+        // `f(1, *arr, **hsh)` → three args:
+        //   IntLit(1), BuiltinCall(splat, [VarRef(arr)]),
+        //   BuiltinCall(double_splat, [VarRef(hsh)]).
+        let m = lower("arr = [1]\nhsh = {a: 1}\nf(1, *arr, **hsh)\n");
+        let b = main_body(&m);
+        let args = match &b.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => args,
+            other => panic!("expected tail DirectCall(f, ...), got {:?}", other),
+        };
+        assert_eq!(args.len(), 3, "expected 3 args, got {}", args.len());
+        assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+        assert!(matches!(
+            &args[1],
+            Expr::BuiltinCall { name, .. } if name == "splat"
+        ));
+        assert!(matches!(
+            &args[2],
+            Expr::BuiltinCall { name, .. } if name == "double_splat"
+        ));
+    }
+
+    #[test]
+    fn splat_param_lowers_to_bare_name_param() {
+        // v0 lossy lowering: `*args` and `**kwargs` become regular
+        // Params with the bare name.  Confirms the parse round-trip
+        // doesn't crash and that the parameter name comes through
+        // (without `*` / `**` prefix in `Param.name`).
+        // Body uses a parens-wrapped expression to dodge the
+        // bare-NAME-led def body ambiguity (see lessons.md).
+        let m = lower("def f(a, *rest, **opts)\n  (a)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f")
+            .expect("expected user-defined function `f`");
+        let names: Vec<&str> = f.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["a", "rest", "opts"],
+            "expected bare param names (v0 lossy splat lowering)"
+        );
+    }
+
+    #[test]
+    fn splat_call_arg_module_passes_sir_validator() {
+        // End-to-end smoke check: a module that uses splat call args
+        // validates cleanly.
+        let m = lower("arr = [1, 2, 3]\nputs(*arr)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected splat call-arg output: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -925,9 +925,22 @@ impl Lowerer {
         })?;
         let name = name_token.value.clone();
 
-        // Collect parameters.  The optional `params` rule node lists
-        // each parameter name as a sequence of Name tokens separated
-        // by COMMA tokens — we only care about the names.
+        // Collect parameters.  The optional `params` rule node holds
+        // a sequence of `param` subnodes (Phase 6s — each param is
+        // wrapped in its own rule so the optional `*` / `**` splat
+        // prefix can sit inside the param slot).  We walk each `param`,
+        // detect the splat prefix from its leading Token (`*` or `**`,
+        // both with `value` set), and extract the parameter Name.
+        //
+        // v0 limitation: the splat-ness of a param is LOST at the SIR
+        // level.  Param has no variadic flag, so a splat param lowers
+        // to a regular Param with the bare Name (no `*` prefix in
+        // `name`).  Downstream emitters therefore treat the parameter
+        // as positional rather than variadic — a deferred correctness
+        // limitation tracked for a future SIR phase.  The grammar +
+        // parse round-trip is correct; the lossy SIR shape only
+        // matters when generating target source for a Ruby program
+        // that actually relies on variadic semantics.
         let params_node = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
             _ => None,
@@ -936,13 +949,27 @@ impl Lowerer {
             pn.children
                 .iter()
                 .filter_map(|c| match c {
-                    ASTNodeOrToken::Token(t)
-                        if matches!(t.type_, TokenType::Name) =>
-                    {
-                        Some(Param {
-                            name: t.value.clone(),
-                            sir_type: None,
-                            span: self.span_of_token(t),
+                    ASTNodeOrToken::Node(param_node) if param_node.rule_name == "param" => {
+                        // Find the parameter Name token, skipping the
+                        // optional `*`/`**` splat prefix.  Both the
+                        // prefix and the identifier land on Name-typed
+                        // tokens (the 1.8-baseline state machine
+                        // coalesces `**` into one Name token with value
+                        // `"**"`, and `*` is technically a Star token
+                        // but defensive value-filter covers both).
+                        param_node.children.iter().find_map(|cc| match cc {
+                            ASTNodeOrToken::Token(t)
+                                if matches!(t.type_, TokenType::Name)
+                                    && t.value != "*"
+                                    && t.value != "**" =>
+                            {
+                                Some(Param {
+                                    name: t.value.clone(),
+                                    sir_type: None,
+                                    span: self.span_of_token(t),
+                                })
+                            }
+                            _ => None,
                         })
                     }
                     _ => None,
@@ -1306,24 +1333,45 @@ impl Lowerer {
     // -------------------------------------------------------------------
 
     fn lower_method_call(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
-        // Shape: (NAME | KEYWORD) LPAREN [expression (COMMA expression)*]
-        //          RPAREN { dot_call }
+        // Shapes (Phase 6s-aware):
+        //   method_call          = (NAME|KEYWORD) LPAREN [ call_arg
+        //                          (COMMA call_arg)* ] RPAREN { dot_call }
+        //   method_call_no_paren = (NAME|KEYWORD) expression
+        //                          (COMMA expression)*
+        //
+        // The two shapes use *different* arg encodings: parenned calls
+        // wrap each arg in a `call_arg` rule (which admits `*`/`**`
+        // splat prefixes — Phase 6s); paren-less calls keep bare
+        // `expression` children (the call_arg wrapper would create a
+        // grammar ambiguity with binary `*` at expression-start
+        // position — `a * b` as a statement would parse as `a(splat b)`,
+        // which is wrong).  Paren-less splat (`puts *arr`) is therefore
+        // a v0 deferred limitation; users who need it can fall back to
+        // the parenned form `puts(*arr)`.
         //
         // Phase 6l: trailing `dot_call` repetitions chain method calls
         // onto the result.  Args before the first dot_call belong to
         // the head call; args inside each dot_call belong to that step.
-        // We collect only the direct `expression` children (which are
-        // the head call's args) here, then fold dot_calls via
-        // `apply_dot_chain`.
         let (callee, _callee_span) = self.expect_first_name_token(node)?;
-        // Collect argument expressions belonging to the head call —
-        // these are `expression` nodes that come BEFORE any dot_call
-        // (the dot_call subtree owns its own `expression` children).
-        let args: Vec<Expr> = self
-            .head_call_expression_children(node)
-            .into_iter()
-            .map(|n| self.lower_expression(n))
-            .collect::<Result<Vec<_>, _>>()?;
+        let args: Vec<Expr> = if node.rule_name == "method_call_no_paren" {
+            // Legacy shape: bare `expression` children directly.
+            node.children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                    _ => None,
+                })
+                .map(|n| self.lower_expression(n))
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            // Phase 6s shape: `call_arg` wrappers (with optional splat
+            // prefix), collected only from the head call's prefix
+            // siblings.
+            self.head_call_args(node)
+                .into_iter()
+                .map(|n| self.lower_call_arg(n))
+                .collect::<Result<Vec<_>, _>>()?
+        };
 
         let span = self.span_of(node);
         let head: Expr = if let Some(effects) = ruby_builtin_effects(&callee) {
@@ -1348,16 +1396,17 @@ impl Lowerer {
         self.apply_dot_chain(head, node)
     }
 
-    /// Phase 6l helper — return the `expression` Node children of
+    /// Phase 6l+6s helper — return the `call_arg` Node children of
     /// `method_call` that belong to the *head* call (i.e. those that
     /// come before any `dot_call` child).  Without this guard, args
     /// nested inside `dot_call` subtrees would leak into the head call.
     ///
-    /// Because `find_node_child` etc. walk only direct children (not
-    /// the full subtree), filtering by parent identity is sufficient —
-    /// we just stop collecting `expression` nodes as soon as a
-    /// `dot_call` node appears in the sibling list.
-    fn head_call_expression_children<'a>(
+    /// Phase 6s renamed the prior `head_call_expression_children`:
+    /// `method_call`'s grammar now wraps each arg in a `call_arg` rule
+    /// (so splat/double-splat prefixes have a slot).  Callers route
+    /// each returned `call_arg` through [`lower_call_arg`] to unwrap
+    /// the `*` / `**` envelope.
+    fn head_call_args<'a>(
         &self,
         node: &'a GrammarASTNode,
     ) -> Vec<&'a GrammarASTNode> {
@@ -1367,12 +1416,75 @@ impl Lowerer {
                 if n.rule_name == "dot_call" {
                     break;
                 }
-                if n.rule_name == "expression" {
+                if n.rule_name == "call_arg" {
                     out.push(n);
                 }
             }
         }
         out
+    }
+
+    /// Phase 6s — lower a single `call_arg` node.
+    ///
+    /// Grammar shape: `call_arg = [ "*" | "**" ] expression ;`
+    ///
+    /// Lowering:
+    /// - No prefix → return the lowered `expression` as-is.
+    /// - `*` prefix → wrap in `BuiltinCall("splat", [inner])` — a
+    ///   semantic marker that downstream emitters can detect to expand
+    ///   into target-language variadic forwarding.
+    /// - `**` prefix → wrap in `BuiltinCall("double_splat", [inner])`
+    ///   — same pattern, for keyword-argument spread.
+    ///
+    /// The BuiltinCall envelope preserves splat semantics through SIR
+    /// (where the lossy v0 Param shape can't represent variadic
+    /// parameters directly).  Callers downstream can pattern-match the
+    /// builtin name to convert back to splat syntax in target source.
+    fn lower_call_arg(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        // Detect the leading `*` / `**` token (if present).  Both
+        // forms land on Token children with their value preserved
+        // (the 1.8-baseline state machine coalesces `**` into one
+        // Name-typed Op token; `*` is a Star token).
+        let prefix = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t)
+                if matches!(t.value.as_str(), "*" | "**") =>
+            {
+                Some(t.value.clone())
+            }
+            _ => None,
+        });
+        let expr_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "call_arg missing expression child".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let inner = self.lower_expression(expr_node)?;
+        let span = self.span_of(node);
+        Ok(match prefix.as_deref() {
+            Some("*") => Expr::BuiltinCall {
+                name: "splat".to_string(),
+                args: vec![inner],
+                effects: EffectSet::PURE,
+                span,
+            },
+            Some("**") => Expr::BuiltinCall {
+                name: "double_splat".to_string(),
+                args: vec![inner],
+                effects: EffectSet::PURE,
+                span,
+            },
+            _ => inner,
+        })
     }
 
     // -------------------------------------------------------------------
@@ -2321,9 +2433,9 @@ impl Lowerer {
         Ok(recv)
     }
 
-    /// Lower a single `dot_call` step.  Grammar shape:
-    ///     dot_call = "." ( NAME | KEYWORD ) [ LPAREN [ expression
-    ///                  { COMMA expression } ] RPAREN ] ;
+    /// Lower a single `dot_call` step.  Grammar shape (Phase 6s):
+    ///     dot_call = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg
+    ///                  { COMMA call_arg } ] RPAREN ] ;
     fn fold_one_dot_call(
         &mut self,
         receiver: Expr,
@@ -2331,15 +2443,16 @@ impl Lowerer {
     ) -> Result<Expr, RubyLowerError> {
         // First Name/Keyword token under dot_node is the method name.
         let (method_name, name_span) = self.expect_first_name_token(dot_node)?;
-        // Optional argument expressions (the inner LPAREN…RPAREN).
+        // Optional argument list — each arg is wrapped in `call_arg`
+        // (Phase 6s) so the optional splat prefix has a slot.
         let args: Vec<Expr> = dot_node
             .children
             .iter()
             .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                ASTNodeOrToken::Node(n) if n.rule_name == "call_arg" => Some(n),
                 _ => None,
             })
-            .map(|n| self.lower_expression(n))
+            .map(|n| self.lower_call_arg(n))
             .collect::<Result<Vec<_>, _>>()?;
 
         let span = self.span_of(dot_node);


### PR DESCRIPTION
## Summary

Adds Ruby's splat (`*args`) and double-splat (`**kwargs`) syntax to both parameter lists and call arguments.

## Grammar (`ruby-parser`)

```
params   = param { COMMA param } ;
param    = [ "*" | "**" ] NAME ;
method_call = ( NAME | KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
dot_call    = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] ;
call_arg = [ "*" | "**" ] expression ;
```

Each parameter is wrapped in a `param` rule that admits the optional splat / double-splat prefix.  Argument slots in `method_call` and `dot_call` are wrapped in `call_arg`.

`method_call_no_paren` intentionally keeps bare `expression` args — wrapping it in `call_arg` would create a grammar ambiguity with binary `*` (e.g. `a * b` would parse as `a(splat b)`).  Paren-less splat is a v0 deferred limitation; users can fall back to `f(*arr)`.

## SIR (`ruby-to-semantic-ir`)

### Call args (preserved through SIR)

| Source | Lowered |
|---|---|
| `f(*arr)` | `DirectCall(f, [BuiltinCall("splat", [VarRef(arr)])])` |
| `f(**hsh)` | `DirectCall(f, [BuiltinCall("double_splat", [VarRef(hsh)])])` |
| `f(1, *arr, **hsh)` | three positional args; splat-wrapped where appropriate |

New `lower_call_arg` helper dispatches on the leading `*` / `**` token and wraps the inner expression in a BuiltinCall envelope.  `lower_method_call` dispatches on rule name: `method_call` uses the new `call_arg` shape; `method_call_no_paren` keeps the legacy bare-`expression` shape.

### Params (lossy at SIR level)

`*args` / `**kwargs` lower to regular `Param { name: "args"/"kwargs" }`.  SIR's `Param` has no variadic flag — splat-ness is dropped.  Downstream emitters treat the parameter as positional.  Deferred limitation tracked for a future SIR phase.

## Tests

- `coding-adventures-ruby-parser`: 88 → **94** (+6 grammar tests, including a regression that `a * b` stays binary)
- `ruby-to-semantic-ir`: 91 → **96** (+5 lowering tests, including end-to-end validator smoke)
- `coding-adventures-ruby-lexer`: 169 unchanged

Two pre-existing parser tests updated to walk the new `param` / `call_arg` wrappers.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (94/94 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (96/96 pass)
- [x] Self-reviewed for security (agent tool was overloaded; diff has no new I/O, unsafe, or unwraps-on-user-input — same shape as prior phases that passed `/security-review`)
- [ ] CI green

Follows PR #4323 (Phase 6r — multiple assignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
