### PR TITLE
feat(ruby-parser): Phase 6t — yield keyword with optional args

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | return_statement | break_statement | next_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -106,6 +106,30 @@ block_params = "|" NAME { COMMA NAME } "|" ;
 return_statement = "return" [ expression ] ;
 break_statement  = "break"  [ expression ] ;
 next_statement   = "next"   [ expression ] ;
+# Phase 6t — `yield` keyword.  Inside a method body, `yield` invokes
+# the block argument supplied by the caller (if any), forwarding the
+# given arguments to it.  All three surface forms supported:
+#
+#   yield                # bare — no args
+#   yield x              # parenless — one or more args
+#   yield x, y           # parenless — multiple args
+#   yield(x)             # parens — same
+#   yield(x, y)
+#   yield()              # parens, no args
+#
+# Placed in `statement` AFTER `next_statement` and BEFORE the catch-all
+# `multi_assignment` / `modifier_statement` / `assignment` /
+# `method_with_block` / `method_call` family so that `yield` (which the
+# lexer reclassifies as a KEYWORD token) doesn't accidentally fall
+# through to `method_call_no_paren` (which would treat it as a
+# keyword-led paren-less method call, losing the yield-specific
+# lowering).
+#
+# Args reuse `call_arg` (Phase 6s) so splat (`yield *arr`) and
+# double-splat (`yield **hsh`) work uniformly with method-call args.
+yield_statement = "yield" [ yield_args ] ;
+yield_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+           | call_arg { COMMA call_arg } ;
 # Phase 6s — splat (`*args`) and double-splat (`**kwargs`) parameters.
 #
 # `params` previously was `NAME { COMMA NAME }`.  We now wrap each

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.21.0] - 2026-05-25
+
+### Added (Phase 6t — `yield` keyword with optional args)
+
+New grammar rule:
+
+```
+statement       = ... | next_statement | yield_statement | multi_assignment | ... ;
+yield_statement = "yield" [ yield_args ] ;
+yield_args      = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+                | call_arg { COMMA call_arg } ;
+```
+
+All three surface forms supported:
+
+| Source | AST |
+|---|---|
+| `yield` | yield_statement with no `yield_args` wrapper |
+| `yield(x, y)` | yield_statement → yield_args → LPAREN call_arg COMMA call_arg RPAREN |
+| `yield x, y` | yield_statement → yield_args → call_arg COMMA call_arg |
+| `yield(*arr)` | yield_statement → yield_args → LPAREN call_arg(*arr) RPAREN |
+
+Placed AFTER `next_statement` and BEFORE the catch-all `multi_assignment` / `modifier_statement` / `assignment` / `method_with_block` / `method_call` family so `yield` (which the lexer reclassifies as a KEYWORD token) doesn't fall through to `method_call_no_paren` (which would lose the yield-specific lowering).
+
+Args reuse Phase 6s's `call_arg`, so splat (`yield *arr`) and double-splat (`yield **hsh`) work uniformly with method-call args.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+`yield ...` → `Stmt::ExprStmt(Expr::BuiltinCall("yield", lowered_args, EffectSet::PURE))`.
+
+Effects are PURE — the block's effects bubble up through its construction site (via the `MakeClosure` effect set) rather than via the `yield` call.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 94 → **98** (+4):
+  - `test_parse_bare_yield` — `yield` alone.
+  - `test_parse_yield_with_paren_args` — `yield(x, y)`.
+  - `test_parse_yield_with_parenless_args` — `yield x, y`.
+  - `test_parse_yield_with_splat_arg` — `yield(*arr)`.
+
 ## [0.20.0] - 2026-05-25
 
 ### Added (Phase 6s — splat / double-splat in params and call args)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -28,6 +28,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"return_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
@@ -211,6 +212,38 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 108,
         },
         GrammarRule {
+            name: r#"yield_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"yield"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
+            ] },
+            line_number: 130,
+        },
+        GrammarRule {
+            name: r#"yield_args"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                    GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                                ] }) },
+                        ] }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"call_arg"#.to_string() },
+                        ] }) },
+                ] },
+            ] },
+            line_number: 131,
+        },
+        GrammarRule {
             name: r#"params"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::RuleReference { name: r#"param"#.to_string() },
@@ -219,7 +252,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 122,
+            line_number: 146,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -230,7 +263,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 123,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -247,7 +280,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 124,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -261,7 +294,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 125,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -272,7 +305,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 126,
+            line_number: 150,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -287,7 +320,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 127,
+            line_number: 151,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -300,7 +333,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 128,
+            line_number: 152,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -313,7 +346,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 129,
+            line_number: 153,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -330,7 +363,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 149,
+            line_number: 173,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -350,7 +383,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 160,
+            line_number: 184,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -372,7 +405,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 161,
+            line_number: 185,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -383,7 +416,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 168,
+            line_number: 192,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -398,17 +431,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 182,
+            line_number: 206,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 183,
+            line_number: 207,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 269,
+            line_number: 293,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -421,7 +454,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 270,
+            line_number: 294,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -435,7 +468,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 271,
+            line_number: 295,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -449,7 +482,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 272,
+            line_number: 296,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -463,7 +496,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 273,
+            line_number: 297,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -474,7 +507,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 280,
+            line_number: 304,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -492,7 +525,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 281,
+            line_number: 305,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -506,7 +539,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 282,
+            line_number: 306,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -520,7 +553,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 283,
+            line_number: 307,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -543,7 +576,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 293,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -551,7 +584,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 294,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -563,7 +596,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 295,
+            line_number: 319,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -578,7 +611,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 296,
+            line_number: 320,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -593,7 +626,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 297,
+            line_number: 321,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -609,7 +642,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 298,
+            line_number: 322,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1597,5 +1597,79 @@ mod tests {
         let term = find_descendant(&ast, "term").expect("expected term node");
         assert!(tree_has_token_value(term, "*"), "expected binary `*` in term");
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6t — `yield` keyword with optional args
+    //
+    // Grammar:
+    //   yield_statement = "yield" [ yield_args ] ;
+    //   yield_args      = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+    //                   | call_arg { COMMA call_arg } ;
+    //
+    // Placed before the generic method_call_no_paren so `yield x`
+    // doesn't fall through to keyword-led no-paren call lowering.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_bare_yield() {
+        // `yield` alone — no args.
+        let ast = parse_ruby("yield");
+        let y = find_descendant(&ast, "yield_statement")
+            .expect("expected yield_statement node");
+        // Token "yield" present, no yield_args wrapper.
+        assert!(tree_has_token_value(y, "yield"), "expected `yield` keyword");
+        assert!(
+            find_descendant(y, "yield_args").is_none(),
+            "bare `yield` should not produce a yield_args wrapper"
+        );
+        assert!(
+            find_descendant(y, "call_arg").is_none(),
+            "bare `yield` should not produce a call_arg"
+        );
+    }
+
+    #[test]
+    fn test_parse_yield_with_paren_args() {
+        // `yield(x, y)` — parens-form with two args.
+        let ast = parse_ruby("yield(x, y)");
+        let y = find_descendant(&ast, "yield_statement")
+            .expect("expected yield_statement node");
+        let ya = find_descendant(y, "yield_args").expect("expected yield_args");
+        let arg_count = ya
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 2, "expected 2 call_args, got {arg_count}");
+    }
+
+    #[test]
+    fn test_parse_yield_with_parenless_args() {
+        // `yield x, y` — parenless form.
+        let ast = parse_ruby("yield x, y");
+        let y = find_descendant(&ast, "yield_statement")
+            .expect("expected yield_statement node for parenless yield");
+        let ya = find_descendant(y, "yield_args").expect("expected yield_args");
+        let arg_count = ya
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "call_arg"))
+            .count();
+        assert_eq!(arg_count, 2, "expected 2 call_args (parenless), got {arg_count}");
+        // Regression: NO LPAREN/RPAREN tokens in the args.
+        assert!(!tree_has_token_value(ya, "("),
+            "parenless form must not produce an LPAREN");
+    }
+
+    #[test]
+    fn test_parse_yield_with_splat_arg() {
+        // `yield *arr` — splat arg reuses Phase 6s's call_arg shape.
+        let ast = parse_ruby("yield(*arr)");
+        let y = find_descendant(&ast, "yield_statement")
+            .expect("expected yield_statement node");
+        let ca = find_descendant(y, "call_arg").expect("expected call_arg");
+        assert!(tree_has_token_value(ca, "*"), "expected `*` splat prefix in yield arg");
+        assert!(tree_has_token_value(ca, "arr"));
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.21.0] - 2026-05-25
+
+### Added (Phase 6t — `yield` lowering)
+
+`yield ...` → `Stmt::ExprStmt(Expr::BuiltinCall("yield", lowered_args, EffectSet::PURE))`.
+
+Lowering walks the optional `yield_args` wrapper (when present), extracts its `call_arg` children, and routes each through Phase 6s's `lower_call_arg` helper.  Bare `yield` (no `yield_args` wrapper) lowers to an empty-arg BuiltinCall.
+
+Effects are PURE — `yield` invokes the caller-supplied block, whose effects are tracked at the *block construction* site (via `Expr::MakeClosure`'s captured effect set), not at the yield call site.  Modelling `yield` as PURE keeps the effect lattice from double-counting block effects.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 96 → **100** (+4):
+  - `bare_yield_lowers_to_yield_builtin_no_args`
+  - `yield_with_one_arg_lowers_to_builtin_with_one_arg`
+  - `yield_with_paren_args_lowers_to_two_arg_builtin`
+  - `yield_with_splat_arg_lowers_with_splat_envelope` — exercises Phase 6t × Phase 6s composition.
+
 ## [0.20.0] - 2026-05-25
 
 ### Added (Phase 6s — splat / double-splat lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1889,4 +1889,76 @@ mod tests {
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 6t — `yield` keyword
+    // -----------------------------------------------------------------
+    //
+    // `yield ...` → ExprStmt(BuiltinCall("yield", lowered_args, PURE)).
+
+    #[test]
+    fn bare_yield_lowers_to_yield_builtin_no_args() {
+        let m = lower("yield\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "yield");
+                assert_eq!(args.len(), 0, "bare yield should have 0 args");
+            }
+            other => panic!("expected ExprStmt(BuiltinCall(yield, [])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn yield_with_one_arg_lowers_to_builtin_with_one_arg() {
+        let m = lower("yield 42\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "yield");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(&args[0], Expr::IntLit { value: 42, .. }));
+            }
+            other => panic!("expected yield builtin call, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn yield_with_paren_args_lowers_to_two_arg_builtin() {
+        let m = lower("yield(1, 2)\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "yield");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected yield builtin call with 2 args, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn yield_with_splat_arg_lowers_with_splat_envelope() {
+        // `yield(*arr)` — the splat reuses Phase 6s's BuiltinCall("splat", …)
+        // envelope, and yield itself sees that envelope as a single arg.
+        let m = lower("arr = [1]\nyield(*arr)\n");
+        let b = main_body(&m);
+        // Second stmt is the yield.
+        match &b.stmts[1] {
+            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                assert_eq!(name, "yield");
+                assert_eq!(args.len(), 1);
+                match &args[0] {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "splat");
+                        assert_eq!(args.len(), 1);
+                        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "arr"));
+                    }
+                    other => panic!("expected splat envelope, got {:?}", other),
+                }
+            }
+            other => panic!("expected yield builtin call, got {:?}", other),
+        }
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -406,6 +406,51 @@ impl Lowerer {
                 // `lhs until cond` → While(not cond, [lhs])
                 self.lower_modifier_statement(node)
             }
+            "yield_statement" => {
+                // Phase 6t — `yield` keyword.
+                //
+                // Grammar shape:
+                //   yield_statement = "yield" [ yield_args ] ;
+                //   yield_args      = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+                //                   | call_arg { COMMA call_arg } ;
+                //
+                // Lowering: `BuiltinCall("yield", lowered_args)` wrapped
+                // in `Stmt::ExprStmt`.  The `yield_args` wrapper (when
+                // present) holds the call_arg subnodes directly; we walk
+                // either the statement node or the yield_args wrapper.
+                //
+                // Effects: PURE.  `yield` invokes the caller-supplied
+                // block, whose effects bubble up through the call site's
+                // effect set when the block is constructed.  Modelling
+                // `yield` itself as PURE keeps the effect lattice from
+                // double-counting block effects.
+                let yield_args_node = self
+                    .find_node_child(node, "yield_args");
+                let call_arg_nodes: Vec<&GrammarASTNode> = if let Some(ya) = yield_args_node {
+                    ya.children
+                        .iter()
+                        .filter_map(|c| match c {
+                            ASTNodeOrToken::Node(n) if n.rule_name == "call_arg" => Some(n),
+                            _ => None,
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+                let args: Vec<Expr> = call_arg_nodes
+                    .into_iter()
+                    .map(|n| self.lower_call_arg(n))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Stmt::ExprStmt {
+                    expr: Expr::BuiltinCall {
+                        name: "yield".to_string(),
+                        args,
+                        effects: EffectSet::PURE,
+                        span: self.span_of(node),
+                    },
+                    span: self.span_of(node),
+                })
+            }
             "return_statement" | "break_statement" | "next_statement" => {
                 // Phase 6j: control-flow keywords lower to BuiltinCall
                 // with Effect::Divergent.  Optional trailing expression


### PR DESCRIPTION
## Summary

Adds Ruby's `yield` statement for invoking the caller-supplied block.

## Grammar (`ruby-parser`)

```
statement       = ... | next_statement | yield_statement | multi_assignment | ... ;
yield_statement = "yield" [ yield_args ] ;
yield_args      = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
                | call_arg { COMMA call_arg } ;
```

| Source | Parses as |
|---|---|
| `yield` | yield_statement, no yield_args wrapper |
| `yield x, y` | yield_statement → yield_args → call_arg, call_arg (parenless) |
| `yield(x, y)` | yield_statement → yield_args → LPAREN call_arg, call_arg RPAREN |
| `yield(*arr)` | reuses Phase 6s call_arg with splat prefix |

Placed AFTER `next_statement` and BEFORE the catch-all statement family so `yield` (a KEYWORD token) doesn't fall through to `method_call_no_paren`.

## SIR (`ruby-to-semantic-ir`)

`yield ...` → `Stmt::ExprStmt(Expr::BuiltinCall("yield", lowered_args, EffectSet::PURE))`.

Effects are PURE — block effects bubble up at the `MakeClosure` construction site, not the yield call.

## Tests

- `coding-adventures-ruby-parser`: 94 → **98** (+4)
- `ruby-to-semantic-ir`: 96 → **100** (+4)
- `coding-adventures-ruby-lexer`: 169 unchanged

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (98/98 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (100/100 pass)
- [x] Self-reviewed (security agent overloaded; diff is the same pattern as prior phases — no unsafe, no unwraps on user input, pure AST transformation)
- [ ] CI green

Follows PR #4331 (Phase 6s — splat/double-splat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
