### PR TITLE
feat(cas-summation): Phase 64 — Two-Log × Sqrt × polynomial numerator (2.2.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.0 — 2026-05-25
+
+### Added
+
+- **Phase 64 — Two-Log × Sqrt × polynomial numerator** (`_two_log_sqrt_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Sqrt(P), polynomial..., bounded...)`.
+  `log²(k)` is sub-polynomial; `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 5 new unit tests in `TestEvaluateSumPhase64TwoLogSqrtPolyNumerator`.
+
 ## 2.1.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.1.0"
+version = "2.2.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -886,6 +886,21 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 64: ``Mul(Log(diverging), Log(diverging), Sqrt(positive-poly),
+    #           polynomial..., bounded...)`` numerator.
+    # Two Log factors plus one Sqrt; log² is sub-polynomial and does not
+    # change the effective degree.
+    # effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    tlsp_x2 = _two_log_sqrt_poly_effective_x2(num, k)
+    if tlsp_x2 is not None:
+        den_deg_tlsp = _polynomial_degree_in_k(den, k)
+        if den_deg_tlsp is not None:
+            if 2 * den_deg_tlsp > tlsp_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1737,6 +1752,70 @@ def _two_sqrt_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if len(sqrt_degs) != 2 or log_count != 1:
         return None
     return sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg_sum
+
+
+def _two_log_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_inner_deg + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly two** ``Log(diverging-in-k)`` factors, **exactly one**
+    ``Sqrt(positive-leading polynomial)`` factor, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 64 — Two-Log × Sqrt × polynomial numerator.
+
+    ``log²(k)`` is sub-polynomial and does not change the effective degree.
+    ``effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +--------------------------------------------------+-------------------+
+    | Input                                            | Return            |
+    +==================================================+===================+
+    | ``Mul(Log(k), Log(k), Sqrt(k))``                 | ``1 + 0 = 1``     |
+    | ``Mul(Log(k), Log(k+1), Sqrt(k³))``              | ``3 + 0 = 3``     |
+    | ``Mul(Sin(k), Log(k), Log(k), Sqrt(k), k)``      | ``1 + 2 = 3``     |
+    | ``Mul(Log(k), Sqrt(k))``                         | None (1 Log)      |
+    | ``Mul(Log(k), Log(k), Log(k), Sqrt(k))``         | None (3 Logs)     |
+    | ``Mul(Log(k), Log(k), Sqrt(k), Sqrt(k))``        | None (2 Sqrts)    |
+    +--------------------------------------------------+-------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → count; bail after 2.
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 1.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 2 Log and exactly 1 Sqrt.
+      4. Return ``sqrt_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    sqrt_deg_x2: int | None = None
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 2:
+                return None
+            continue
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                # Second Sqrt — refuse.
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 2 or sqrt_deg_x2 is None:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -1981,7 +1981,9 @@ class TestEvaluateSumPhase57BoundedLogSqrtNumerator:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
 
-    def test_two_log_factors_refused(self):
+    def test_two_log_factors_now_closed_by_phase64(self):
+        """sin(k) · log(k) · log(k+1) · √k / k²: Phase 57 conservatively refused two Logs,
+        but Phase 64 now correctly closes this — effective_x2=1; 2·2=4 > 1 → closes."""
         from symbolic_ir import POW, SIN, SQRT, SUB
 
         sin_k = IRApply(SIN, (_k,))
@@ -1999,7 +2001,7 @@ class TestEvaluateSumPhase57BoundedLogSqrtNumerator:
         g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (kp1, IRInteger(2)))))
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
-        assert isinstance(result, IRApply) and result.head == SUM
+        assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_no_sqrt_falls_through_to_phase55(self):
         from symbolic_ir import POW, SIN, SUB
@@ -2780,6 +2782,120 @@ class TestEvaluateSumPhase63TwoSqrtLogPolyNumerator:
         kp1_2b = IRApply(POW, (kp1, IRInteger(2)))
         g_k = IRApply(DIV, (num_k, k2))
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2b))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase64TwoLogSqrtPolyNumerator:
+    """Phase 64: Mul(Log(h1), Log(h2), Sqrt(P), polynomial..., bounded...) numerator.
+
+    effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    log² is sub-polynomial; same effective degree formula as Phase 53.
+    Vanishes when 2·den_deg > effective_x2 or non-polynomial diverging denom.
+    """
+
+    def test_log_k_sq_sqrt_k_over_k_sq_closes(self):
+        """log(k)² · √k / k²: effective_x2=1; 2·2=4 > 1 → closes."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (log_k1, log_k2, sqrt_k))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1_1, log_kp1_2, sqrt_kp1))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_k_sq_sqrt_k3_over_k3_closes(self):
+        """log(k)² · √(k³) / k³: effective_x2=3; 2·3=6 > 3 → closes."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        sqrt_k3 = IRApply(SQRT, (k3,))
+        num_k = IRApply(MUL, (log_k1, log_k2, sqrt_k3))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_kp1_3 = IRApply(SQRT, (kp1_3,))
+        num_kp1 = IRApply(MUL, (log_kp1_1, log_kp1_2, sqrt_kp1_3))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_log_k_sq_sqrt_k_over_k_sq_closes(self):
+        """sin(k) · log(k)² · √k / k²: bounded + two Logs + Sqrt; effective_x2=1; 2·2=4 > 1 → closes."""
+        from symbolic_ir import LOG, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (sin_k, log_k1, log_k2, sqrt_k))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, log_kp1_1, log_kp1_2, sqrt_kp1))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_k_sq_sqrt_k_over_exponential_closes(self):
+        """log(k)² · √k / 2^k: non-polynomial diverging denominator."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        num_k = IRApply(MUL, (log_k1, log_k2, sqrt_k))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        num_kp1 = IRApply(MUL, (log_kp1_1, log_kp1_2, sqrt_kp1))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log_k_sq_sqrt_k2_over_k_refused(self):
+        """log(k)² · √(k²) / k: effective_x2=2; 2·1=2 not > 2 → refused (equal)."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2 = IRApply(SQRT, (k2,))
+        num_k = IRApply(MUL, (log_k1, log_k2, sqrt_k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1_2,))
+        num_kp1 = IRApply(MUL, (log_kp1_1, log_kp1_2, sqrt_kp1_2))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.0 — 2026-05-25
+
+### Added
+
+- **Phase 64 — Two-Log × Sqrt × polynomial numerator** (`two_log_sqrt_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Sqrt(P), polynomial..., bounded...)`.
+  log² sub-polynomial; `effective_x2 = sqrt_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs`.
+
 ## 2.1.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1587,6 +1587,39 @@ fn two_sqrt_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg)
 }
 
+/// Phase 64 — Two-Log × Sqrt × polynomial numerator.
+///
+/// Returns `sqrt_inner_deg_x2 + 2 * poly_deg` when `node` is a `Mul` with
+/// **exactly two** Log(diverging) factors, **exactly one** Sqrt factor,
+/// any polynomial factors, and any bounded factors; `None` otherwise.
+///
+/// log² is sub-polynomial; effective_x2 = sqrt_deg_x2 + 2 * poly_deg.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn two_log_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 2 { return None; }
+            continue;
+        }
+        if let Some(deg_x2) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt → refuse
+            sqrt_deg_x2 = Some(deg_x2);
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 2 { return None; }
+    sqrt_deg_x2.map(|d| d + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1767,6 +1800,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(tslp_x2) = two_sqrt_log_poly_effective_x2(num, k) {
         if let Some(den_deg_tslp) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_tslp > tslp_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 64: Mul(Log(diverging), Log(diverging), Sqrt(P), polynomial..., bounded...) numerator.
+    // Two Logs + one Sqrt; log² sub-polynomial; effective_x2 = sqrt_deg_x2 + 2 * poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(tlsp_x2) = two_log_sqrt_poly_effective_x2(num, k) {
+        if let Some(den_deg_tlsp) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_tlsp > tlsp_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1878,3 +1878,71 @@ fn phase63_sqrt_k2_sq_log_k_over_k2_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 64: Mul(Log(diverging), Log(diverging), Sqrt(P), polynomial..., bounded...) ─
+
+#[test]
+fn phase64_log_k_sq_sqrt_k_over_k_sq_closes() {
+    // log(k)²·√k / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k1 = apply(sym(LOG), vec![k.clone()]);
+    let log_k2 = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let log_kp1_1 = apply(sym(LOG), vec![kp1.clone()]);
+    let log_kp1_2 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k1, log_k2, sqrt_k]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1_1, log_kp1_2, sqrt_kp1]);
+    let den_k = apply(sym(POW), vec![k.clone(), int(2)]);
+    let den_kp1 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let g_k = apply(sym(DIV), vec![num_k, den_k]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, den_kp1]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase64_log_k_sq_sqrt_k3_over_k3_closes() {
+    // log(k)²·√(k³) / k³: effective_x2=3; 2·3=6 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let log_k1 = apply(sym(LOG), vec![k.clone()]);
+    let log_k2 = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3.clone()]);
+    let log_kp1_1 = apply(sym(LOG), vec![kp1.clone()]);
+    let log_kp1_2 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k1, log_k2, sqrt_k3]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1_1, log_kp1_2, sqrt_kp1_3]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase64_log_k_sq_sqrt_k2_over_k_refused() {
+    // log(k)²·√(k²) / k: effective_x2=2; 2·1=2 not > 2 → refused (equal).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k1 = apply(sym(LOG), vec![k.clone()]);
+    let log_k2 = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2]);
+    let log_kp1_1 = apply(sym(LOG), vec![kp1.clone()]);
+    let log_kp1_2 = apply(sym(LOG), vec![kp1.clone()]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2]);
+    let num_k = apply(sym(MUL), vec![log_k1, log_k2, sqrt_k2]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1_1, log_kp1_2, sqrt_kp1_2]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.0 — 2026-05-25
+
+### Added
+
+- **Phase 64 — Two-Log × Sqrt × polynomial numerator** (`twoLogSqrtPolyEffectiveDeg`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Sqrt(P), polynomial..., bounded...)`.
+  log² sub-polynomial; effective degree = sqrtHalfDeg + polyDeg.
+  Closes when `denDeg > twoLogSqrtPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 4 new tests in the "Phase 64" describe block.
+
 ## 2.1.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1295,6 +1295,42 @@ function twoSqrtLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
 }
 
+/**
+ * Phase 64 — Two-Log × Sqrt × polynomial numerator.
+ *
+ * Returns the effective degree when `node` is a `Mul` with exactly two
+ * Log(diverging) factors, exactly one Sqrt factor, any polynomial factors,
+ * and any bounded factors; `undefined` otherwise.
+ *
+ * log² is sub-polynomial; effective degree = sqrtHalfDeg + polyDeg.
+ * Caller checks `denDeg > twoLogSqrtPolyEffectiveDeg(num, k)`.
+ */
+function twoLogSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let sqrtHalfDeg: number | undefined = undefined;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 2) return undefined;
+      continue;
+    }
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined; // second Sqrt → refuse
+      sqrtHalfDeg = halfDeg;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 2 || sqrtHalfDeg === undefined) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1481,6 +1517,17 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegTslp = polynomialDegreeInK(den, k);
     if (denDegTslp !== undefined) {
       if (denDegTslp > tslpDeg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 64: Mul(Log(diverging), Log(diverging), Sqrt(P), polynomial..., bounded...) numerator.
+  // Two Logs + one Sqrt; log² sub-polynomial; effective degree = sqrtHalfDeg + polyDeg.
+  const tlspDeg = twoLogSqrtPolyEffectiveDeg(num, k);
+  if (tlspDeg !== undefined) {
+    const denDegTlsp = polynomialDegreeInK(den, k);
+    if (denDegTlsp !== undefined) {
+      if (denDegTlsp > tlspDeg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -8,6 +8,7 @@ import {
   NEG,
   POW,
   PRODUCT,
+  SQRT,
   SUB,
   SUM,
   app,
@@ -1685,6 +1686,86 @@ describe("Phase 63 — Two-Sqrt × Log × polynomial numerator", () => {
     const sqrt_kp1_2 = { kind: "apply" as const, head: sym("Sqrt"), args: [kp1] };
     const log_kp1 = { kind: "apply" as const, head: LOG, args: [kp1] };
     const numKp1 = { kind: "apply" as const, head: MUL, args: [sqrt_kp1_1, sqrt_kp1_2, log_kp1] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 64 — Two-Log × Sqrt × polynomial numerator", () => {
+  it("log(k)²·√k / k² closes (effective=0.5, denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const sqrt_k = { kind: "apply" as const, head: SQRT, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [log_k1, log_k2, sqrt_k] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const sqrt_kp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [log_kp1_1, log_kp1_2, sqrt_kp1] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)²·√(k³) / k³ closes (effective=1.5, denDeg=3 > 1.5)", () => {
+    const k = sym("k");
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const sqrt_k3 = { kind: "apply" as const, head: SQRT, args: [k3] };
+    const numK = { kind: "apply" as const, head: MUL, args: [log_k1, log_k2, sqrt_k3] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const sqrt_kp1_3 = { kind: "apply" as const, head: SQRT, args: [kp1_3] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [log_kp1_1, log_kp1_2, sqrt_kp1_3] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k3] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_3] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)²·√(k²) / k refused (effective=1, denDeg=1 not > 1)", () => {
+    const k = sym("k");
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const sqrt_k2 = { kind: "apply" as const, head: SQRT, args: [k2] };
+    const numK = { kind: "apply" as const, head: MUL, args: [log_k1, log_k2, sqrt_k2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const sqrt_kp1_2 = { kind: "apply" as const, head: SQRT, args: [kp1_2] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [log_kp1_1, log_kp1_2, sqrt_kp1_2] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)²·√k / 2^k closes (exponential denominator)", () => {
+    const k = sym("k");
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const sqrt_k = { kind: "apply" as const, head: SQRT, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [log_k1, log_k2, sqrt_k] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const sqrt_kp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [log_kp1_1, log_kp1_2, sqrt_kp1] };
     const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
     const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
     const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };


### PR DESCRIPTION
## Summary

- Adds Phase 64 to `_g_vanishes_at_infinity` / `gVanishesAtInfinity` / `g_vanishes_at_infinity` across Python, TypeScript, and Rust
- Recognises `Mul(Log(h1(k)), Log(h2(k)), Sqrt(P), polynomial..., bounded...)` — exactly two Log(diverging) factors + exactly one Sqrt factor
- `log²(k)` is sub-polynomial; `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg` (same formula as Phase 53)
- Also fixes a pre-existing Phase 57 test that conservatively refused two-Log + Sqrt — Phase 64 now closes it correctly
- All packages bumped 2.1.0 → 2.2.0

## New helpers

| Language | Helper |
|---|---|
| Python | `_two_log_sqrt_poly_effective_x2` |
| TypeScript | `twoLogSqrtPolyEffectiveDeg` |
| Rust | `two_log_sqrt_poly_effective_x2` |

## Tests

- Python: 5 new tests + 1 assertion flip (137 total)
- TypeScript: 4 new tests (101 total)
- Rust: 3 new tests (93 total)

## Test plan

- [x] `mise exec -- uv run pytest` passes (137 tests)
- [x] `mise exec -- npm test` passes (101 tests)
- [x] `cargo test` passes (93 tests)
- [x] Security review passed — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)