### PR TITLE
feat(closurec): --define / -D value substitution (CLOC11.19)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.6.0] - 2026-05-25
+
+### Added — CLOC11.19: `--define / -D` value substitution
+
+Second behavioral slice of [CLOC11]. Users can now pass `--define NAME=value` (or `-D NAME=value`) and closurec will substitute every reference to `NAME` with `value` in the output.
+
+- **New `defines` module.** Token-level substitution: tokenize via `javascript-lexer`, walk tokens, replace any identifier-type token whose value matches a `--define` key with the typed value rendered as JS source. Keywords (`if`, `var`, etc.) are explicitly NOT eligible. String-literal content is NOT substituted — `"DEBUG"` stays a string even if `DEBUG` is defined.
+- **`DefineValue` rendering** for each variant of [`crate::config::DefineValue`]:
+  - `Bool(true)` → `true`
+  - `Bool(false)` → `false`
+  - `Null` → `null`
+  - `Number(42.0)` → `42` (integer-valued doubles emit without trailing `.0`, matching CC)
+  - `Number(3.14)` → `3.14`
+  - `Number(NaN)` → `NaN` sentinel
+  - `Number(Infinity)` → `Infinity` (or `-Infinity`)
+  - `String("hi")` → `"hi"` (re-quoted with JS escapes for `"`, `\`, LF, CR, TAB)
+- **`transform_source` now runs in two phases:**
+  1. **Level transform** — WHITESPACE_ONLY / identity per the compilation level (CLOC11.06 behavior).
+  2. **Define substitution** — applies `cfg.defines.defines` over the level's output.
+  This ordering means `--define DEBUG=false` composes naturally with `--compilation_level WHITESPACE_ONLY` (or with any future level transform).
+- **Fast path:** when `cfg.defines.defines` is empty, `apply_defines` is a string-copy no-op (skips tokenization entirely).
+- **New `CompilerError::Define(defines::DefineError)`** variant for substitution failures (currently only "tokenizer rejected the source").
+- **Diff fixture `tests/diff/define/`** per CLOC11 §3.
+- **New integration test `tests/diff_define.rs`** drives the actual binary against the fixture.
+- **17 new unit tests in `defines::tests`** covering: empty defines passthrough, every DefineValue variant (bool/integer/fractional/string/null), case-sensitive identifier matching (`DEBUG` doesn't match `debug`), string-literal content protection, word-boundary preservation (`return DEBUG` → `return false`, not `returnfalse`), no-space-around-punctuation, multiple defines, keyword non-substitution, NaN/Infinity sentinels, embedded-quote re-escape, error display.
+
+### Looseness vs. real CC
+
+This is v1: we substitute *every* reference to a `--define` name, not only references to `goog.define`-annotated variables. In practice this matches what users expect when they pass `--define FLAG_DEBUG=false` for a flag they own. The cases where CC would NOT substitute (e.g. a `var FLAG_DEBUG` shadowing the same name) are rare in real builds. CLOC11.21+ will tighten the rule once we have JSDoc `@define`-aware metadata.
+
+### Behavior changes (user-visible)
+
+- `closurec --define DEBUG=false --js app.js` now actually substitutes `DEBUG` references in the output. Previously the flag was parsed but ignored.
+- As a side-effect of routing through the tokenizer, the substitution output is already minified (single-space gap between word-like tokens, no spaces elsewhere). CC's WHITESPACE_ONLY does the same thing; we just get it for free.
+
+### Tests
+
+95 unit + 5 integration tests passing. Clippy clean.
+
+### Version
+
+Bumps closurec 0.5.0 → 0.6.0 (Cargo.toml + cli.spec.json kept in sync).
+
+[CLOC11]: ../../specs/CLOC11-drop-in-closure-compat.md
+
 ## [0.5.0] - 2026-05-25
 
 ### Added — CLOC11.06: `--compilation_level WHITESPACE_ONLY` wired

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/defines.rs
+++ b/code/programs/rust/closurec/src/defines.rs
@@ -1,0 +1,494 @@
+//! `defines` — `--define NAME=value` (and short `-D`) substitution.
+//!
+//! # What CC does
+//!
+//! The upstream Java Closure Compiler treats `--define NAME=value`
+//! as a *constant override*. When CC sees a `goog.define` call or
+//! a JSDoc `@define`-annotated variable named `NAME`, it replaces
+//! the right-hand side of the assignment with the supplied value.
+//! Subsequent passes (constant-fold, DCE, etc.) then act on that
+//! value, so `if (DEBUG) { … }` collapses to dead code when
+//! `--define DEBUG=false` is passed.
+//!
+//! # What we do today (CLOC11.19)
+//!
+//! We don't yet parse JSDoc `@define` annotations, and we don't
+//! yet have an AST to surgically modify the RHS of an assignment.
+//! What we *do* have is the lexer from CLOC11.06 and the typed
+//! [`DefineValue`](crate::config::DefineValue) from CLOC11.01.
+//!
+//! The simplest token-level slice that mimics CC's behavior:
+//!
+//! - Walk every token.
+//! - If the token is an identifier (`NAME`) whose value matches
+//!   a `--define` key exactly, replace it with a synthetic
+//!   token carrying the formatted value (number/string/bool/null).
+//! - Pass everything else through untouched.
+//!
+//! This is **looser than CC**: CC only substitutes references to
+//! variables tagged `@define`. We substitute *every* reference to
+//! the name. In practice this matches what users expect when they
+//! pass `--define FLAG_DEBUG=false` for a flag they own — they
+//! want that name replaced anywhere it appears. The few edge
+//! cases where CC would *not* substitute (e.g. an undeclared
+//! shadowing variable) are not common in real builds, and the
+//! CLOC11.21 follow-up that adds `@define`-aware substitution
+//! will tighten the rule.
+//!
+//! # Composition with WHITESPACE_ONLY
+//!
+//! `transform_source` calls `apply_defines` *after* the
+//! compilation-level dispatch. So:
+//!
+//! - `--compilation_level WHITESPACE_ONLY --define DEBUG=false`
+//!   first whitespace-minifies, then substitutes `DEBUG` →
+//!   `false` in the resulting compact source.
+//! - `--compilation_level SIMPLE --define DEBUG=false`
+//!   (still identity for the SIMPLE arm in CLOC11.19) substitutes
+//!   directly.
+//!
+//! Each call re-tokenizes — that's `O(n)` per pass, fine for our
+//! input sizes. CLOC11.07+ may consolidate the tokenize step
+//! when both WHITESPACE_ONLY-ish trimming and define substitution
+//! need to run; for now keeping them separate keeps each module
+//! testable in isolation.
+
+use crate::config::DefineValue;
+use coding_adventures_javascript_tokens::EsVersion;
+use std::collections::BTreeMap;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Reasons define substitution can fail. Like
+/// [`whitespace_only::MinifyError`](crate::whitespace_only::MinifyError),
+/// the only failure path today is the tokenizer rejecting the
+/// source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefineError {
+    /// The tokenizer rejected the source.
+    LexError(String),
+}
+
+impl std::fmt::Display for DefineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DefineError::LexError(s) => {
+                write!(f, "define substitution: tokenizer failed: {s}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DefineError {}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Apply `--define NAME=value` substitutions to `source`.
+///
+/// Returns the source with every identifier-token whose value
+/// matches a key in `defines` replaced by the formatted form of
+/// the corresponding [`DefineValue`].
+///
+/// If `defines` is empty, returns `source` unchanged (and skips
+/// tokenization entirely — cheap fast path for the common case).
+pub fn apply_defines(
+    source: &str,
+    defines: &BTreeMap<String, DefineValue>,
+    version: EsVersion,
+) -> Result<String, DefineError> {
+    // Fast path: no defines means no work.
+    if defines.is_empty() {
+        return Ok(source.to_string());
+    }
+
+    let tokens =
+        coding_adventures_javascript_lexer::tokenize_javascript_typed(source, version)
+            .map_err(DefineError::LexError)?;
+
+    // Walk tokens. For each one, decide whether to substitute.
+    // Output is rebuilt incrementally — we can't just rewrite
+    // bytes in `source` because the lexer's `value` is unescaped
+    // for some token kinds (strings) and the source-byte ranges
+    // aren't stable through escape handling. Reconstructing from
+    // tokens lets us be precise.
+    //
+    // We use the same "word-like" gap rule as `whitespace_only`
+    // so the output stays well-tokenized.
+    let mut out = String::with_capacity(source.len());
+    let mut last_emitted_was_word_like = false;
+    for tok in &tokens {
+        if is_eof(tok) {
+            continue;
+        }
+
+        if is_trivia(tok) {
+            // Pass trivia through verbatim — define substitution
+            // is supposed to be invisible to comments/whitespace.
+            out.push_str(&tok.value);
+            // Trivia doesn't count for adjacency; whatever was
+            // last emitted before the trivia still governs.
+            continue;
+        }
+
+        if is_identifier(tok) {
+            if let Some(value) = defines.get(&tok.value) {
+                // Substitution! Emit the formatted value, and
+                // book-keep the adjacency. Most replacements are
+                // word-like (numbers, bools, null) so we set the
+                // flag accordingly. Strings are not word-like
+                // (quoted) so they don't need the separator.
+                let (rendered, replacement_is_word_like) = render_define_value(value);
+                if last_emitted_was_word_like && replacement_is_word_like {
+                    out.push(' ');
+                }
+                out.push_str(&rendered);
+                last_emitted_was_word_like = replacement_is_word_like;
+                continue;
+            }
+        }
+
+        // Non-substituted token: emit as-is, with a separator
+        // when needed.
+        let word_like = is_word_like(tok);
+        if last_emitted_was_word_like && word_like {
+            out.push(' ');
+        }
+        if is_string_literal(tok) {
+            out.push('"');
+            push_quoted_string_content(&mut out, &tok.value);
+            out.push('"');
+            last_emitted_was_word_like = false;
+        } else {
+            out.push_str(&tok.value);
+            last_emitted_was_word_like = word_like;
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Value rendering
+// ---------------------------------------------------------------------------
+
+/// Render a [`DefineValue`] into JavaScript source plus a flag
+/// indicating whether the result is a word-like token (for
+/// adjacency-separator bookkeeping).
+fn render_define_value(value: &DefineValue) -> (String, bool) {
+    match value {
+        DefineValue::Bool(true) => ("true".to_string(), true),
+        DefineValue::Bool(false) => ("false".to_string(), true),
+        DefineValue::Null => ("null".to_string(), true),
+        DefineValue::Number(n) => {
+            // f64::to_string handles integer-valued doubles
+            // without a trailing `.0`, which matches CC's
+            // output. Special-case NaN/Inf to JS sentinels.
+            if n.is_nan() {
+                ("NaN".to_string(), true)
+            } else if n.is_infinite() {
+                if *n > 0.0 {
+                    ("Infinity".to_string(), true)
+                } else {
+                    ("-Infinity".to_string(), true)
+                }
+            } else {
+                (format_number(*n), true)
+            }
+        }
+        DefineValue::String(s) => {
+            let mut out = String::with_capacity(s.len() + 2);
+            out.push('"');
+            push_quoted_string_content(&mut out, s);
+            out.push('"');
+            // Quoted string is NOT word-like.
+            (out, false)
+        }
+    }
+}
+
+/// Format an `f64` for embedding in JS source. Integer-valued
+/// doubles render without `.0`, so `Number(42.0)` → `"42"`,
+/// matching CC.
+fn format_number(n: f64) -> String {
+    if n.fract() == 0.0 && n.is_finite() && n.abs() < 1e16 {
+        // Integer-valued in safe-integer range — emit as integer.
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Token classification helpers
+// ---------------------------------------------------------------------------
+//
+// These mirror the classifiers in `whitespace_only.rs`. We don't
+// share them because each module's needs are subtly different —
+// `whitespace_only` cares about "what to filter out"; `defines`
+// cares about "what to substitute" and "what's word-like for
+// adjacency tracking". Sharing would require passing around an
+// option set. v1: just duplicate.
+
+fn is_eof(tok: &lexer::token::Token) -> bool {
+    matches!(tok.type_, lexer::token::TokenType::Eof)
+}
+
+fn is_trivia(tok: &lexer::token::Token) -> bool {
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        return matches!(
+            upper.as_str(),
+            "COMMENT"
+                | "LINE_COMMENT"
+                | "BLOCK_COMMENT"
+                | "WHITESPACE"
+                | "WS"
+                | "NEWLINE"
+                | "LINE_TERMINATOR"
+                | "SKIP"
+        );
+    }
+    matches!(
+        tok.type_,
+        lexer::token::TokenType::Newline
+            | lexer::token::TokenType::Indent
+            | lexer::token::TokenType::Dedent
+    )
+}
+
+/// True iff this token is a plain identifier (eligible for
+/// `--define` substitution). Keywords are explicitly NOT
+/// eligible — CC won't substitute `--define if=foo`.
+fn is_identifier(tok: &lexer::token::Token) -> bool {
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        return matches!(upper.as_str(), "NAME" | "IDENT" | "IDENTIFIER");
+    }
+    matches!(tok.type_, lexer::token::TokenType::Name)
+}
+
+fn is_word_like(tok: &lexer::token::Token) -> bool {
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        return matches!(
+            upper.as_str(),
+            "NAME"
+                | "NUMBER"
+                | "KEYWORD"
+                | "REGEX"
+                | "BIGINT"
+                | "PRIVATE_NAME"
+                | "TEMPLATE"
+                | "TEMPLATE_NO_SUB"
+                | "TEMPLATE_HEAD"
+                | "TEMPLATE_MIDDLE"
+                | "TEMPLATE_TAIL"
+                | "IDENT"
+                | "IDENTIFIER"
+        );
+    }
+    matches!(
+        tok.type_,
+        lexer::token::TokenType::Name
+            | lexer::token::TokenType::Number
+            | lexer::token::TokenType::Keyword
+    )
+}
+
+fn is_string_literal(tok: &lexer::token::Token) -> bool {
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        if upper == "STRING" || upper == "STRING_LITERAL" {
+            return true;
+        }
+    }
+    matches!(tok.type_, lexer::token::TokenType::String)
+}
+
+fn push_quoted_string_content(out: &mut String, content: &str) {
+    for c in content.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defs(pairs: &[(&str, DefineValue)]) -> BTreeMap<String, DefineValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    fn run(source: &str, pairs: &[(&str, DefineValue)]) -> String {
+        apply_defines(source, &defs(pairs), EsVersion::Es2025).expect("ok")
+    }
+
+    #[test]
+    fn empty_defines_passes_through() {
+        let src = "var x = DEBUG;";
+        // No defines → exactly the source back.
+        let out = apply_defines(src, &BTreeMap::new(), EsVersion::Es2025).unwrap();
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn substitutes_bool_false() {
+        let out = run("var x = DEBUG;", &[("DEBUG", DefineValue::Bool(false))]);
+        assert!(out.contains("false"));
+        assert!(!out.contains("DEBUG"), "got: {out:?}");
+    }
+
+    #[test]
+    fn substitutes_bool_true() {
+        let out = run("if (FLAG) { a; }", &[("FLAG", DefineValue::Bool(true))]);
+        assert!(out.contains("true"));
+        assert!(!out.contains("FLAG"));
+    }
+
+    #[test]
+    fn substitutes_number_integer() {
+        // Integer-valued doubles render without trailing `.0`.
+        let out = run("var n = VERSION;", &[("VERSION", DefineValue::Number(42.0))]);
+        assert!(out.contains("42"), "got: {out:?}");
+        assert!(!out.contains("42.0"), "should not have trailing .0: {out:?}");
+    }
+
+    #[test]
+    fn substitutes_number_fractional() {
+        let out = run("var n = PI;", &[("PI", DefineValue::Number(3.14))]);
+        assert!(out.contains("3.14"), "got: {out:?}");
+    }
+
+    #[test]
+    fn substitutes_string() {
+        let out = run(
+            "var s = NAME;",
+            &[("NAME", DefineValue::String("hello".to_string()))],
+        );
+        assert!(out.contains("\"hello\""), "got: {out:?}");
+        assert!(!out.contains("NAME"));
+    }
+
+    #[test]
+    fn substitutes_null() {
+        let out = run("var x = EMPTY;", &[("EMPTY", DefineValue::Null)]);
+        assert!(out.contains("null"));
+    }
+
+    #[test]
+    fn does_not_substitute_unrelated_identifiers() {
+        // Only the exact name match should fire.
+        let out = run("var debug = DEBUG;", &[("DEBUG", DefineValue::Bool(false))]);
+        assert!(out.contains("debug"), "lowercase debug must remain: {out:?}");
+        assert!(out.contains("false"));
+    }
+
+    #[test]
+    fn does_not_substitute_inside_string_literal() {
+        // `"DEBUG"` is a string literal, not an identifier
+        // token, so it must survive untouched.
+        let out = run(
+            "var s = \"DEBUG\";",
+            &[("DEBUG", DefineValue::Bool(false))],
+        );
+        assert!(out.contains("\"DEBUG\""), "string content corrupted: {out:?}");
+        assert!(!out.contains("false"), "must not substitute inside string: {out:?}");
+    }
+
+    #[test]
+    fn keeps_space_between_keyword_and_substituted_value() {
+        // `return DEBUG;` with DEBUG → false must produce
+        // `return false;` (NOT `returnfalse;`).
+        let out = run("return DEBUG;", &[("DEBUG", DefineValue::Bool(false))]);
+        assert!(out.contains("return false"), "got: {out:?}");
+        // And not the concatenated form.
+        assert!(!out.contains("returnfalse"), "got: {out:?}");
+    }
+
+    #[test]
+    fn no_space_around_punctuation_after_substitution() {
+        // `x=DEBUG;` → `x=false;` (no extra space).
+        let out = run("x=DEBUG;", &[("DEBUG", DefineValue::Bool(false))]);
+        assert_eq!(out, "x=false;");
+    }
+
+    #[test]
+    fn multiple_defines_all_apply() {
+        let out = run(
+            "var a = X, b = Y;",
+            &[
+                ("X", DefineValue::Number(1.0)),
+                ("Y", DefineValue::String("hi".to_string())),
+            ],
+        );
+        assert!(out.contains("1"));
+        assert!(out.contains("\"hi\""));
+    }
+
+    #[test]
+    fn keyword_not_eligible_for_substitution() {
+        // CC won't substitute `--define if=...` because `if` is
+        // a keyword. Our `is_identifier` rules keywords out.
+        let out = run(
+            "if (x) {}",
+            &[("if", DefineValue::Bool(true))],
+        );
+        assert!(out.contains("if"), "keyword must survive: {out:?}");
+    }
+
+    #[test]
+    fn nan_renders_as_nan_sentinel() {
+        let out = run("var n = N;", &[("N", DefineValue::Number(f64::NAN))]);
+        assert!(out.contains("NaN"), "got: {out:?}");
+    }
+
+    #[test]
+    fn infinity_renders_as_infinity_sentinel() {
+        let out_pos = run("var n = P;", &[("P", DefineValue::Number(f64::INFINITY))]);
+        assert!(out_pos.contains("Infinity"));
+        let out_neg = run(
+            "var n = M;",
+            &[("M", DefineValue::Number(f64::NEG_INFINITY))],
+        );
+        assert!(out_neg.contains("-Infinity"));
+    }
+
+    #[test]
+    fn string_with_quotes_re_escapes_correctly() {
+        let out = run(
+            "var s = MSG;",
+            &[(
+                "MSG",
+                DefineValue::String("she said \"hi\"".to_string()),
+            )],
+        );
+        assert!(
+            out.contains("\"she said \\\"hi\\\"\""),
+            "got: {out:?}",
+        );
+    }
+
+    #[test]
+    fn error_display() {
+        let e = DefineError::LexError("bad".into());
+        assert!(e.to_string().contains("tokenizer failed"));
+        let _: &dyn std::error::Error = &e;
+    }
+}

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -65,7 +65,9 @@ use std::process::ExitCode;
 // CLI binary an actual body. See CLOC11 §5 for the architecture.
 // CLOC11.02 added `globs` for --js pattern expansion.
 // CLOC11.06 added `whitespace_only` for --compilation_level WHITESPACE_ONLY.
+// CLOC11.19 added `defines` for --define / -D value substitution.
 pub mod config;
+pub mod defines;
 pub mod globs;
 pub mod run;
 pub mod whitespace_only;

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -20,6 +20,7 @@
 //! The function signature doesn't change; only the body grows.
 
 use crate::config::{CompilationLevel, CompilerConfig};
+use crate::defines;
 use crate::globs;
 use crate::whitespace_only;
 use coding_adventures_javascript_tokens::EsVersion;
@@ -73,6 +74,9 @@ pub enum CompilerError {
     /// `--compilation_level WHITESPACE_ONLY` minification failed.
     /// Carries the underlying [`whitespace_only::MinifyError`].
     Minify(whitespace_only::MinifyError),
+    /// `--define / -D` substitution failed (tokenizer rejected the
+    /// source). Inner [`defines::DefineError`] carries the message.
+    Define(defines::DefineError),
 }
 
 impl std::fmt::Display for CompilerError {
@@ -86,6 +90,7 @@ impl std::fmt::Display for CompilerError {
             }
             CompilerError::GlobExpansion(e) => write!(f, "{e}"),
             CompilerError::Minify(e) => write!(f, "{e}"),
+            CompilerError::Define(e) => write!(f, "{e}"),
         }
     }
 }
@@ -121,17 +126,33 @@ pub fn transform_source(
     config: &CompilerConfig,
 ) -> Result<String, CompilerError> {
     let es_version = map_language_in_to_es_version(config);
-    match config.compilation.level {
+
+    // Step 1 — compilation-level transform.
+    let after_level = match config.compilation.level {
         CompilationLevel::WhitespaceOnly => {
             whitespace_only::whitespace_only_minify(source, es_version)
-                .map_err(CompilerError::Minify)
+                .map_err(CompilerError::Minify)?
         }
         // CLOC11.07+ will replace each of these with real passes.
         CompilationLevel::Simple
         | CompilationLevel::Advanced
         | CompilationLevel::Bundle
-        | CompilationLevel::TranspileOnly => Ok(source.to_string()),
-    }
+        | CompilationLevel::TranspileOnly => source.to_string(),
+    };
+
+    // Step 2 — `--define / -D` substitution (CLOC11.19). Runs
+    // *after* the compilation-level transform so that
+    // WHITESPACE_ONLY's output is the input to substitution. The
+    // ordering matches CC's: defines are applied during
+    // compilation, alongside the level's pass set. The
+    // composition matters because some `@define`-tagged names
+    // can survive comment-stripping (they shouldn't be in
+    // comments) but the *whitespace* changes don't affect
+    // identifier matching either way.
+    //
+    // Fast path: with no defines, this is a no-op string copy.
+    defines::apply_defines(&after_level, &config.defines.defines, es_version)
+        .map_err(CompilerError::Define)
 }
 
 /// Project the typed `LanguageVersion` enum into the

--- a/code/programs/rust/closurec/tests/diff/define/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/define/expected.stdout
@@ -1,0 +1,1 @@
+var DEBUG_FLAG=false;if(false){console.log("dev mode");}

--- a/code/programs/rust/closurec/tests/diff/define/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/define/flags.txt
@@ -1,0 +1,4 @@
+--define
+DEBUG=false
+--js
+tests/diff/define/input/app.js

--- a/code/programs/rust/closurec/tests/diff/define/input/app.js
+++ b/code/programs/rust/closurec/tests/diff/define/input/app.js
@@ -1,0 +1,4 @@
+var DEBUG_FLAG = DEBUG;
+if (DEBUG) {
+    console.log("dev mode");
+}

--- a/code/programs/rust/closurec/tests/diff_define.rs
+++ b/code/programs/rust/closurec/tests/diff_define.rs
@@ -1,0 +1,54 @@
+//! Integration test for the `tests/diff/define/` fixture.
+//!
+//! Exercises CLOC11.19 — `--define NAME=value` token-level
+//! substitution — end-to-end through the built binary. Drives
+//! `--define DEBUG=false` against a small input that references
+//! `DEBUG` in two places (initializer + `if` condition).
+//!
+//! Note this test does NOT pass `--compilation_level
+//! WHITESPACE_ONLY` explicitly. Because the define-substitution
+//! path re-tokenizes and re-emits with the same conservative
+//! spacing rule, the output is naturally minified. CC's behavior
+//! is similar — `--define` runs alongside whatever
+//! compilation-level passes are active. Per CLOC11 §3 this is
+//! "behavioral equality" not byte-equal to CC; the expected
+//! file is checked in from our own output and the diff target
+//! is the *meaning* of the substitution.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/define/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn define_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/define/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## Summary

Second behavioral slice of [CLOC11](code/specs/CLOC11-drop-in-closure-compat.md). Users can now pass \`--define NAME=value\` (or short \`-D NAME=value\`) and closurec will substitute every reference to NAME with the supplied value in the output.

### What lands

- **New \`defines\` module** — token-level substitution. Walks tokens, replaces any identifier matching a \`--define\` key with the typed value rendered as JS source. Keywords (\`if\`, \`var\`, etc.) NOT eligible. String-literal content NOT substituted.

- **DefineValue rendering** matches CC:
  - \`Bool\` → \`true\` / \`false\`
  - \`Null\` → \`null\`
  - \`Number(42.0)\` → \`42\` (integer-valued doubles no \`.0\`)
  - \`Number(NaN)\` → \`NaN\` sentinel; \`Inf\` → \`Infinity\` / \`-Infinity\`
  - \`String\` → re-quoted with JS escapes for \`"\`, \`\\\`, LF, CR, TAB

- **\`transform_source\` now two phases**:
  1. Compilation-level transform (CLOC11.06's WHITESPACE_ONLY / identity).
  2. \`apply_defines\` over the result.
  
  This ordering means \`--define\` composes naturally with \`--compilation_level WHITESPACE_ONLY\`. Empty defines → fast string-copy no-op.

- **New \`CompilerError::Define\`** variant.

- **Diff fixture** \`tests/diff/define/\` + integration test \`tests/diff_define.rs\`.

- **17 new unit tests** covering every DefineValue variant, identifier-matching semantics, string-literal protection, word-boundary preservation (\`return DEBUG\` → \`return false\` not \`returnfalse\`), keyword non-substitution, NaN/Infinity sentinels, embedded-quote re-escape, error display.

### Looseness vs. real CC (deliberate v1)

We substitute every reference to a \`--define\` name, not only \`goog.define\`-annotated variables. The rare cases where CC would NOT substitute (shadowing var with same name) are uncommon in real builds. CLOC11.21+ will tighten once we have JSDoc \`@define\`-aware metadata.

### Behavior changes

- \`closurec --define DEBUG=false --js app.js\` now actually substitutes. Previously the flag was parsed but ignored.
- Output is naturally minified (tokenizer round-trip applies the conservative spacing rule), same effect CC has when \`--define\` runs alongside its level passes.

### Tests

- **95 unit + 5 integration tests passing.**
- **Clippy clean.**
- **Manual security review** (sub-agent API overloaded again): no \`unsafe\`/FFI, no panic paths (\`f64 as i64\` cast is guarded by \`is_finite\` + bounded \`abs\` checks), no injection vector (\`--define DEBUG="alert(1)"\` emits the value as a string literal, not raw code).

### Version

Bumps closurec 0.5.0 → 0.6.0 (Cargo.toml + cli.spec.json in sync).

## Test plan

- [x] \`cargo test\` — 100/100 (95 unit + 5 integration)
- [x] \`cargo clippy --no-deps\` clean
- [x] Manual security review clean
- [x] CHANGELOG \`[0.6.0]\` entry documents the looseness-vs-CC trade and the planned tightening in CLOC11.21+
- [x] No new crate dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)