### PR TITLE
feat(ruby-parser): Phase 6u — case/when/else/end

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -151,6 +151,30 @@ else_clause  = "else" { !"end" statement } ;
 unless_statement = "unless" expression { !"else" !"end" statement } [ else_clause ] "end" ;
 while_statement = "while" expression { !"end" statement } "end" ;
 until_statement = "until" expression { !"end" statement } "end" ;
+# Phase 6u — `case … when … else … end`.
+#
+# Shape:
+#   case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
+#   when_clause    = "when" expression { COMMA expression }
+#                          { !"when" !"else" !"end" statement } ;
+#
+# Reuses the existing `else_clause` rule (defined for if_statement)
+# so the else body parses the same way it does in `if … else … end`.
+#
+# Each `when_clause` may list multiple values (`when 1, 2, 3`); the
+# SIR lowerer expands them as an `||` chain inside the synthetic
+# `if` condition.  The result of a `case` expression is the value of
+# the matched `when` body (or `else` body, or NilLit) — matching
+# Ruby semantics.
+#
+# v0 deferred:
+#   - `when` doesn't accept ranges/regexes/class patterns (uses `==`
+#     instead of Ruby's `===`).  Phase 7d adds full `case/in`
+#     pattern matching with the proper match semantics.
+#   - `when *splat` argument splat in the value list — deferred
+#     (the grammar accepts only positional values via `expression`).
+case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
+when_clause    = "when" expression { COMMA expression } { !"when" !"else" !"end" statement } ;
 # Phase 6p — compound assignment (`x += 1`, `x ||= 1`, etc.).
 #
 # The lexer's `fuse_compound_assigns` post-pass folds `Op =` adjacent

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.22.0] - 2026-05-25
+
+### Added (Phase 6u — `case … when … else … end`)
+
+New grammar rules:
+
+```
+statement      = ... | until_statement | case_statement | return_statement | ... ;
+case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
+when_clause    = "when" expression { COMMA expression }
+                      { !"when" !"else" !"end" statement } ;
+```
+
+`else_clause` is reused from the existing `if_statement` definition — the else body parses identically to `if … else … end`.
+
+Multi-value `when` lists are supported (`when 1, 2, 3` parses with three expression children inside the clause).  Each when_clause's body uses the same negative-lookahead repetition (`{ !"when" !"else" !"end" statement }`) as if/else, so it stops cleanly at the next clause boundary.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+Chained `Expr::If` with `==` comparisons:
+
+```
+case x
+when v1, v2 then a
+when v3     then b
+else c
+end
+```
+
+becomes
+
+```
+if ((x == v1) || (x == v2)) then a
+else if (x == v3) then b
+else c
+```
+
+- Each when_clause becomes one nested `If` step.
+- Multi-value `when 1, 2, 3` lists OR-fold left-to-right using `BuiltinCall("or", ...)`.
+- The else_clause (or implicit `NilLit` block) caps the chain.
+
+### v0 deferred limitations
+
+- `when` uses `==` instead of Ruby's `===` (case-equality, class-aware).  Phase 7d will add full `case/in` pattern matching with proper match semantics.
+- Range/Regex/Class values in `when` lists parse syntactically but don't match Ruby's case-equality semantics under v0's `==` lowering.
+- Splat in `when` argument lists (`when *arr`) is not supported.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 98 → **101** (+3):
+  - `test_parse_case_single_when` — one when, no else.
+  - `test_parse_case_multiple_whens_and_else` — two whens + else.
+  - `test_parse_when_with_multiple_values` — `when 1, 2, 3`.
+
 ## [0.21.0] - 2026-05-25
 
 ### Added (Phase 6t — `yield` keyword with optional args)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -25,6 +25,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"unless_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"while_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"until_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"case_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"return_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
@@ -349,6 +350,35 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 153,
         },
         GrammarRule {
+            name: r#"case_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"case"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"when_clause"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 176,
+        },
+        GrammarRule {
+            name: r#"when_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"when"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"else"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 177,
+        },
+        GrammarRule {
             name: r#"assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
@@ -363,7 +393,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 173,
+            line_number: 197,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -383,7 +413,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 184,
+            line_number: 208,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -405,7 +435,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 185,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -416,7 +446,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 192,
+            line_number: 216,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -431,17 +461,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 206,
+            line_number: 230,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 207,
+            line_number: 231,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 293,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -454,7 +484,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 294,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -468,7 +498,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 295,
+            line_number: 319,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -482,7 +512,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 296,
+            line_number: 320,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -496,7 +526,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 297,
+            line_number: 321,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -507,7 +537,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 304,
+            line_number: 328,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -525,7 +555,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 305,
+            line_number: 329,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -539,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 306,
+            line_number: 330,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -553,7 +583,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 307,
+            line_number: 331,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -576,7 +606,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 317,
+            line_number: 341,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -584,7 +614,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 318,
+            line_number: 342,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -596,7 +626,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 319,
+            line_number: 343,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -611,7 +641,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 320,
+            line_number: 344,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -626,7 +656,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 321,
+            line_number: 345,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -642,7 +672,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 322,
+            line_number: 346,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1661,6 +1661,67 @@ mod tests {
             "parenless form must not produce an LPAREN");
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 6u — `case … when … else … end`
+    //
+    // Grammar:
+    //   case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
+    //   when_clause    = "when" expression { COMMA expression }
+    //                          { !"when" !"else" !"end" statement } ;
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_case_single_when() {
+        // Smallest form: one when clause, no else.
+        let ast = parse_ruby("case x\nwhen 1\n  y = 1\nend");
+        let cs = find_descendant(&ast, "case_statement")
+            .expect("expected case_statement node");
+        let when_count = cs
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "when_clause"))
+            .count();
+        assert_eq!(when_count, 1, "expected 1 when_clause, got {when_count}");
+        // No else_clause.
+        assert!(
+            find_descendant(cs, "else_clause").is_none(),
+            "expected no else_clause"
+        );
+    }
+
+    #[test]
+    fn test_parse_case_multiple_whens_and_else() {
+        let ast = parse_ruby(
+            "case x\nwhen 1\n  a = 1\nwhen 2\n  a = 2\nelse\n  a = 3\nend",
+        );
+        let cs = find_descendant(&ast, "case_statement")
+            .expect("expected case_statement node");
+        let when_count = cs
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "when_clause"))
+            .count();
+        assert_eq!(when_count, 2, "expected 2 when_clauses, got {when_count}");
+        assert!(
+            find_descendant(cs, "else_clause").is_some(),
+            "expected else_clause"
+        );
+    }
+
+    #[test]
+    fn test_parse_when_with_multiple_values() {
+        // `when 1, 2, 3` — comma-separated value list inside one clause.
+        let ast = parse_ruby("case x\nwhen 1, 2, 3\n  a = 1\nend");
+        let wc = find_descendant(&ast, "when_clause")
+            .expect("expected when_clause node");
+        let value_count = wc
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression"))
+            .count();
+        assert_eq!(value_count, 3, "expected 3 when values, got {value_count}");
+    }
+
     #[test]
     fn test_parse_yield_with_splat_arg() {
         // `yield *arr` — splat arg reuses Phase 6s's call_arg shape.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.22.0] - 2026-05-25
+
+### Added (Phase 6u — `case … when … else … end` lowering)
+
+New `lower_case_statement` helper folds the source `case_statement` into a chained `Expr::If`:
+
+```
+case x
+when v1, v2 then a
+when v3     then b
+else c
+end
+```
+
+→
+
+```
+if ((x == v1) || (x == v2)) then a
+else if (x == v3) then b
+else c
+```
+
+Each when_clause becomes one nested `If`; multi-value `when 1, 2, 3` lists OR-fold left-to-right using `BuiltinCall("or", ...)`.  The else clause (or implicit `NilLit` block) caps the chain.  Comparisons use `BuiltinCall("==", [scrutinee, value])` — see v0 deferred caveats below.
+
+The result is wrapped in `Stmt::ExprStmt`.
+
+### v0 deferred limitations
+
+- Comparisons use `==` not `===`.  Ruby's case-equality (class-aware: `Integer === 1`, range membership, regex match) is NOT modelled.  Phase 7d adds full `case/in` pattern matching.
+- Range/Regex/Class values in `when` lists work syntactically but don't behave as Ruby would.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 100 → **104** (+4):
+  - `case_single_when_lowers_to_if_with_eq` — basic shape check.
+  - `case_with_multi_value_when_lowers_to_or_chain` — `==` × 3 + `or` × 2.
+  - `case_with_else_terminates_chain` — else body lands in chain tail.
+  - `case_without_else_uses_nil_tail` — no else → NilLit tail.
+
 ## [0.21.0] - 2026-05-25
 
 ### Added (Phase 6t — `yield` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1891,6 +1891,125 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 6u — `case … when … else … end`
+    // -----------------------------------------------------------------
+    //
+    // case x
+    // when v1, v2 then a
+    // when v3     then b
+    // else c
+    // end
+    //
+    // lowers to a chained Expr::If with `==`-comparisons (joined by
+    // `or` for multi-value whens) and the else block as the chain's
+    // final tail.
+
+    #[test]
+    fn case_single_when_lowers_to_if_with_eq() {
+        // `case x; when 1; y = 1; end` — one when, no else.
+        let m = lower("x = 1\ncase x\nwhen 1\n  y = 1\nend\n");
+        let b = main_body(&m);
+        // Second stmt should be an ExprStmt(If) — the case lowering.
+        let if_expr = match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt(If) from case, got {:?}", other),
+        };
+        let cond = match if_expr {
+            Expr::If { cond, .. } => cond,
+            other => panic!("expected If from case, got {:?}", other),
+        };
+        // The condition is BuiltinCall("==", [VarRef(x), IntLit(1)]).
+        assert!(
+            matches!(cond.as_ref(), Expr::BuiltinCall { name, .. } if name == "=="),
+            "expected `==` builtin in when cond, got {:?}",
+            cond
+        );
+    }
+
+    #[test]
+    fn case_with_multi_value_when_lowers_to_or_chain() {
+        // `when 1, 2, 3` → cond is `(((x==1) || (x==2)) || (x==3))`.
+        let m = lower("x = 1\ncase x\nwhen 1, 2, 3\n  y = 1\nend\n");
+        let b = main_body(&m);
+        let if_expr = match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt(If), got {:?}", other),
+        };
+        let cond = match if_expr {
+            Expr::If { cond, .. } => cond,
+            other => panic!("expected If, got {:?}", other),
+        };
+        // Outermost should be `or`.  Count `==` and `or` nodes.
+        fn count_builtin(e: &Expr, target: &str) -> usize {
+            match e {
+                Expr::BuiltinCall { name, args, .. } => {
+                    let mine = if name == target { 1 } else { 0 };
+                    mine + args.iter().map(|a| count_builtin(a, target)).sum::<usize>()
+                }
+                _ => 0,
+            }
+        }
+        assert_eq!(
+            count_builtin(cond.as_ref(), "=="),
+            3,
+            "expected three `==` comparisons for three when values"
+        );
+        assert_eq!(
+            count_builtin(cond.as_ref(), "or"),
+            2,
+            "expected two `or` joins for three values (left-fold)"
+        );
+    }
+
+    #[test]
+    fn case_with_else_terminates_chain() {
+        // `case x; when 1; a=1; else a=2; end` — else body sits in the
+        // chain's outermost else-branch.
+        let m = lower("x = 1\ncase x\nwhen 1\n  a = 1\nelse\n  a = 2\nend\n");
+        let b = main_body(&m);
+        let if_expr = match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt(If), got {:?}", other),
+        };
+        let else_branch = match if_expr {
+            Expr::If { else_branch, .. } => else_branch,
+            other => panic!("expected If, got {:?}", other),
+        };
+        // Else branch's stmts should carry the `a = 2` assignment.
+        // (a was first defined in the if's then-branch as a LetBinding;
+        // the else-branch sees it as already declared via the shared
+        // outer scope snapshot.)
+        assert!(
+            !else_branch.stmts.is_empty(),
+            "expected else block to carry the `a = 2` stmt, got empty"
+        );
+    }
+
+    #[test]
+    fn case_without_else_uses_nil_tail() {
+        // No else clause → else-branch is `Block{stmts: [], value: NilLit}`.
+        let m = lower("x = 1\ncase x\nwhen 1\n  a = 1\nend\n");
+        let b = main_body(&m);
+        let if_expr = match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt(If), got {:?}", other),
+        };
+        let else_branch = match if_expr {
+            Expr::If { else_branch, .. } => else_branch,
+            other => panic!("expected If, got {:?}", other),
+        };
+        assert!(
+            else_branch.stmts.is_empty(),
+            "expected empty else block when no else clause"
+        );
+        assert!(
+            matches!(&else_branch.value, Expr::NilLit { .. }),
+            "expected NilLit tail when no else clause, got {:?}",
+            else_branch.value
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6t — `yield` keyword
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -384,6 +384,32 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
+            "case_statement" => {
+                // Phase 6u — `case x; when v1[,v2,...] then body; else end`.
+                //
+                // Lower to a chained `Expr::If`:
+                //
+                //   case x
+                //   when 1, 2 then a
+                //   when 3    then b
+                //   else c
+                //   end
+                //
+                // becomes
+                //
+                //   if (x == 1 || x == 2) then a
+                //   else if x == 3 then b
+                //   else c
+                //
+                // wrapped in `Stmt::ExprStmt`.  Each `when_clause`
+                // becomes a single `If` step; the else_clause (or
+                // implicit `NilLit` block) terminates the chain.
+                let expr = self.lower_case_statement(node)?;
+                Ok(Stmt::ExprStmt {
+                    expr,
+                    span: self.span_of(node),
+                })
+            }
             "while_statement" | "until_statement" => {
                 // Phase 6c: SIR's `Stmt::While` is the canonical
                 // top-level loop — `until cond` lowers to
@@ -695,6 +721,164 @@ impl Lowerer {
             body,
             span: self.span_of(node),
         })
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6u — `case … when … else … end`
+    // -------------------------------------------------------------------
+
+    /// Lower a `case_statement` node to a chained `Expr::If`.
+    ///
+    /// Grammar shape (per `ruby.grammar`):
+    /// ```text
+    /// case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
+    /// when_clause    = "when" expression { COMMA expression }
+    ///                       { !"when" !"else" !"end" statement } ;
+    /// ```
+    ///
+    /// Lowering rule:
+    ///
+    /// ```text
+    /// case x
+    /// when v1, v2 then body_a
+    /// when v3     then body_b
+    /// else body_c
+    /// end
+    /// ```
+    ///
+    /// becomes
+    ///
+    /// ```text
+    /// if ((x == v1) || (x == v2)) then body_a
+    /// else if (x == v3) then body_b
+    /// else body_c
+    /// ```
+    ///
+    /// Each `when_clause` produces one nested `If` step.  Multiple values
+    /// in a single `when` (`when 1, 2, 3`) chain through `BuiltinCall("or", ...)`
+    /// inside that step's condition.  The else terminator (or an empty
+    /// `NilLit` block when absent) caps the chain.
+    ///
+    /// v0 caveats (deferred):
+    /// - Ruby's `when` uses `===` (case-equality, class-aware) — this
+    ///   v0 lowers to `==`.  Phase 7d adds full `case/in` pattern
+    ///   matching with proper match semantics.
+    /// - Range/Regex/Class values in `when` lists work syntactically
+    ///   (they parse as expressions) but the `==` comparison won't
+    ///   match Ruby's case-equality semantics.
+    fn lower_case_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        // 1. Scrutinee — the first `expression` direct child of the
+        //    case_statement.  (subsequent `expression` children belong
+        //    to when_clause descendants, but they're inside subnodes,
+        //    not direct children.)
+        let scrutinee_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
+                message: "case_statement missing scrutinee expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let scrutinee = self.lower_expression(scrutinee_node)?;
+
+        // 2. Collect every when_clause subnode.
+        let when_clauses: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "when_clause" => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        // 3. Find the optional else_clause (reused from if_statement).
+        let else_clause = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "else_clause" => Some(n),
+            _ => None,
+        });
+
+        // 4. Build the tail: the else block, or an empty NilLit block
+        //    if no else clause was provided.
+        let mut tail: Block = if let Some(ec) = else_clause {
+            self.lower_clause_statements(ec)?
+        } else {
+            Block {
+                stmts: Vec::new(),
+                value: Expr::NilLit { span: self.span_of(node) },
+                span: self.span_of(node),
+            }
+        };
+
+        // 5. Unwind when_clauses in reverse, each wrapping the
+        //    accumulated tail as its else-branch.
+        for wc in when_clauses.iter().rev() {
+            // Collect this clause's value expressions (all `expression`
+            // Node children in order).
+            let value_nodes: Vec<&GrammarASTNode> = wc
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                    _ => None,
+                })
+                .collect();
+            if value_nodes.is_empty() {
+                return Err(RubyLowerError {
+                    message: "when_clause missing value expression(s)".to_string(),
+                    line: wc.start_line.unwrap_or(0),
+                    column: wc.start_column.unwrap_or(0),
+                });
+            }
+
+            // Build the condition: `(scrutinee == v1) || (scrutinee == v2) || ...`.
+            // Lower each value, build an `==` BuiltinCall, then OR-fold
+            // left-to-right (matches Ruby's left-to-right when evaluation).
+            let span = self.span_of(wc);
+            let mut cond: Option<Expr> = None;
+            for vn in &value_nodes {
+                let val = self.lower_expression(vn)?;
+                // Clone the scrutinee fresh for every comparison —
+                // SIR is tree-shaped, no shared subexpressions.
+                let cmp = Expr::BuiltinCall {
+                    name: "==".to_string(),
+                    args: vec![scrutinee.clone(), val],
+                    effects: EffectSet::PURE,
+                    span: span.clone(),
+                };
+                cond = Some(match cond {
+                    None => cmp,
+                    Some(prev) => Expr::BuiltinCall {
+                        name: "or".to_string(),
+                        args: vec![prev, cmp],
+                        effects: EffectSet::PURE,
+                        span: span.clone(),
+                    },
+                });
+            }
+            let cond = cond.expect("at least one when value");
+
+            // Lower the when body — same shape as `lower_clause_statements`
+            // handles for if/elsif/else.
+            let then_block = self.lower_clause_statements(wc)?;
+
+            // Wrap into an If and let `tail` become the else.
+            tail = Block {
+                stmts: Vec::new(),
+                value: Expr::If {
+                    cond: Box::new(cond),
+                    then_branch: Box::new(then_block),
+                    else_branch: Box::new(tail),
+                    span: span.clone(),
+                },
+                span,
+            };
+        }
+
+        // The case expression is the chain's outermost If — which
+        // currently sits as the `tail` Block's `value`.  Peel it out.
+        Ok(tail.value)
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds Ruby's `case`/`when`/`else` statement, lowered to a chained `If` in SIR.

## Grammar (`ruby-parser`)

```
statement      = ... | until_statement | case_statement | return_statement | ... ;
case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
when_clause    = "when" expression { COMMA expression }
                      { !"when" !"else" !"end" statement } ;
```

`else_clause` is reused from `if_statement`.  Multi-value `when 1, 2, 3` lists work natively via the comma-repetition.

## SIR (`ruby-to-semantic-ir`)

```
case x
when v1, v2 then a
when v3     then b
else c
end
```

becomes

```
if ((x == v1) || (x == v2)) then a
else if (x == v3) then b
else c
```

- Each when_clause → one nested `If`.
- Multi-value lists OR-fold left-to-right via `BuiltinCall("or", ...)`.
- The else_clause (or implicit `NilLit`) caps the chain.

Wrapped in `Stmt::ExprStmt`.

## v0 deferred limitations

- Comparisons use `==` not `===`. Phase 7d will add full `case/in` pattern matching with proper case-equality semantics.
- Range/Regex/Class values in `when` lists parse but don't get Ruby's case-equality behaviour.
- Splat in `when` argument lists is not supported.

## Tests

- `coding-adventures-ruby-parser`: 98 → **101** (+3 grammar tests)
- `ruby-to-semantic-ir`: 100 → **104** (+4 lowering tests, incl. multi-value OR-chain and else-tail checks)
- `coding-adventures-ruby-lexer`: 169 unchanged

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (101/101 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (104/104 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — same shape as prior phases)
- [ ] CI green

Follows PR #4332 (Phase 6t — `yield`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
