### PR TITLE
feat(cas-summation): Phase 65 — Two-Sqrt × Two-Log × polynomial numerator (2.3.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.3.0 — 2026-05-25
+
+### Added
+
+- **Phase 65 — Two-Sqrt × Two-Log × polynomial numerator** (`_two_sqrt_two_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), polynomial..., bounded...)`.
+  log² sub-polynomial; `effective_x2 = deg(P1) + deg(P2) + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 5 new unit tests in `TestEvaluateSumPhase65TwoSqrtTwoLogPolyNumerator`.
+
 ## 2.2.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.2.0"
+version = "2.3.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -901,6 +901,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 65: ``Mul(Sqrt(P1), Sqrt(P2), Log(diverging), Log(diverging),
+    #           polynomial..., bounded...)`` numerator.
+    # Two Sqrt + two Log; log² sub-polynomial; effective_x2 = deg(P1) + deg(P2) + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    ts2l_x2 = _two_sqrt_two_log_poly_effective_x2(num, k)
+    if ts2l_x2 is not None:
+        den_deg_ts2l = _polynomial_degree_in_k(den, k)
+        if den_deg_ts2l is not None:
+            if 2 * den_deg_ts2l > ts2l_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -1816,6 +1829,68 @@ def _two_log_sqrt_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 2 or sqrt_deg_x2 is None:
         return None
     return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_two_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``deg(P1) + deg(P2) + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly two** ``Sqrt(positive-leading polynomial)`` factors,
+    **exactly two** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 65 — Two-Sqrt × Two-Log × polynomial numerator.
+
+    ``log²(k)`` is sub-polynomial and does not change the effective degree.
+    ``effective_x2 = deg(P1) + deg(P2) + 2·poly_deg`` (same as Phase 61).
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +------------------------------------------------------+-------------------+
+    | Input                                                | Return            |
+    +======================================================+===================+
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k), Log(k))``            | ``1 + 1 = 2``     |
+    | ``Mul(Sqrt(k³), Sqrt(k), Log(k), Log(k+1))``         | ``3 + 1 = 4``     |
+    | ``Mul(Sin(k), Sqrt(k), Sqrt(k), Log(k), Log(k), k)`` | ``1+1+2 = 4``     |
+    | ``Mul(Sqrt(k), Log(k), Log(k))``                     | None (1 Sqrt)     |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k))``                    | None (1 Log)      |
+    +------------------------------------------------------+-------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 2.
+         - ``Log(diverging)`` → count; bail after 2.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 2 Sqrt and exactly 2 Log.
+      4. Return ``sqrt_deg1_x2 + sqrt_deg2_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            sqrt_degs.append(deg_x2)
+            if len(sqrt_degs) > 2:
+                return None
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 2:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs) != 2 or log_count != 2:
+        return None
+    return sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -2899,3 +2899,128 @@ class TestEvaluateSumPhase64TwoLogSqrtPolyNumerator:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestEvaluateSumPhase65TwoSqrtTwoLogPolyNumerator:
+    """Phase 65: Mul(Sqrt(P1), Sqrt(P2), Log(h1), Log(h2), polynomial..., bounded...) numerator.
+
+    effective_x2 = deg(P1) + deg(P2) + 2·poly_deg.
+    log² sub-polynomial; same effective degree as Phase 61.
+    Vanishes when 2·den_deg > effective_x2 or non-polynomial diverging denom.
+    """
+
+    def test_sqrt_k_sq_log_k_sq_over_k_sq_closes(self):
+        """√k · √k · log(k)² / k²: effective_x2=2; 2·2=4 > 2 → closes."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        sqrt_k1 = IRApply(SQRT, (_k,))
+        sqrt_k2 = IRApply(SQRT, (_k,))
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sqrt_k1, sqrt_k2, log_k1, log_k2))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_kp1_1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1,))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_1, sqrt_kp1_2, log_kp1_1, log_kp1_2))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_sqrt_k_log_k_sq_over_k3_closes(self):
+        """√(k³) · √k · log(k)² / k³: effective_x2=3+1=4; 2·3=6 > 4 → closes."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        sqrt_k3 = IRApply(SQRT, (k3,))
+        sqrt_k = IRApply(SQRT, (_k,))
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sqrt_k3, sqrt_k, log_k1, log_k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        sqrt_kp1_3 = IRApply(SQRT, (kp1_3,))
+        sqrt_kp1 = IRApply(SQRT, (kp1,))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_3, sqrt_kp1, log_kp1_1, log_kp1_2))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sin_sqrt_k_sq_log_k_sq_over_k_sq_closes(self):
+        """sin(k) · √k · √k · log(k)² / k²: bounded + two Sqrts + two Logs; effective_x2=2; closes."""
+        from symbolic_ir import LOG, SIN, SQRT, SUB
+
+        sin_k = IRApply(SIN, (_k,))
+        sqrt_k1 = IRApply(SQRT, (_k,))
+        sqrt_k2 = IRApply(SQRT, (_k,))
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sin_k, sqrt_k1, sqrt_k2, log_k1, log_k2))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sin_kp1 = IRApply(SIN, (kp1,))
+        sqrt_kp1_1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1,))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sin_kp1, sqrt_kp1_1, sqrt_kp1_2, log_kp1_1, log_kp1_2))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_sq_log_k_sq_over_exponential_closes(self):
+        """√k · √k · log(k)² / 2^k: non-polynomial diverging denominator."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        sqrt_k1 = IRApply(SQRT, (_k,))
+        sqrt_k2 = IRApply(SQRT, (_k,))
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sqrt_k1, sqrt_k2, log_k1, log_k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        sqrt_kp1_1 = IRApply(SQRT, (kp1,))
+        sqrt_kp1_2 = IRApply(SQRT, (kp1,))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_1, sqrt_kp1_2, log_kp1_1, log_kp1_2))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k2_sq_log_k_sq_over_k2_refused(self):
+        """√(k²) · √(k²) · log(k)² / k²: effective_x2=2+2=4; 2·2=4 not > 4 → refused."""
+        from symbolic_ir import LOG, SQRT, SUB
+
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        sqrt_k2_1 = IRApply(SQRT, (k2,))
+        sqrt_k2_2 = IRApply(SQRT, (k2,))
+        log_k1 = IRApply(LOG, (_k,))
+        log_k2 = IRApply(LOG, (_k,))
+        num_k = IRApply(MUL, (sqrt_k2_1, sqrt_k2_2, log_k1, log_k2))
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        sqrt_kp1_2_1 = IRApply(SQRT, (kp1_2,))
+        sqrt_kp1_2_2 = IRApply(SQRT, (kp1_2,))
+        log_kp1_1 = IRApply(LOG, (kp1,))
+        log_kp1_2 = IRApply(LOG, (kp1,))
+        num_kp1 = IRApply(MUL, (sqrt_kp1_2_1, sqrt_kp1_2_2, log_kp1_1, log_kp1_2))
+        kp1_2b = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2b))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.3.0 — 2026-05-25
+
+### Added
+
+- **Phase 65 — Two-Sqrt × Two-Log × polynomial numerator** (`two_sqrt_two_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), polynomial..., bounded...)`.
+  log² sub-polynomial; `effective_x2 = deg(P1) + deg(P2) + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs`.
+
 ## 2.2.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1620,6 +1620,39 @@ fn two_log_sqrt_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     sqrt_deg_x2.map(|d| d + 2 * poly_deg)
 }
 
+/// Phase 65 — Two-Sqrt × Two-Log × polynomial numerator.
+///
+/// Returns `deg(P1) + deg(P2) + 2 * poly_deg` when `node` is a `Mul` with
+/// exactly two Sqrt factors, exactly two Log(diverging) factors,
+/// any polynomial factors, and any bounded factors; `None` otherwise.
+///
+/// log² is sub-polynomial; effective_x2 = deg(P1) + deg(P2) + 2 * poly_deg.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn two_sqrt_two_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(deg_x2) = sqrt_effective_half_degree_x2(arg, k) {
+            sqrt_degs.push(deg_x2);
+            if sqrt_degs.len() > 2 { return None; }
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 2 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 2 || log_count != 2 { return None; }
+    Some(sqrt_degs[0] + sqrt_degs[1] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1812,6 +1845,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(tlsp_x2) = two_log_sqrt_poly_effective_x2(num, k) {
         if let Some(den_deg_tlsp) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_tlsp > tlsp_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 65: Mul(Sqrt(P1), Sqrt(P2), Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+    // Two Sqrts + two Logs; log² sub-polynomial; effective_x2 = deg(P1) + deg(P2) + 2 * poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(ts2l_x2) = two_sqrt_two_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_ts2l) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_ts2l > ts2l_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -1946,3 +1946,77 @@ fn phase64_log_k_sq_sqrt_k2_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 65: Two Sqrts × Two Logs × polynomial ──────────────────────────────
+
+#[test]
+fn phase65_sqrt_k_sq_log_k_sq_over_k_sq_closes() {
+    // √k·√k·log(k)²/k²: effective_x2=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k1 = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k.clone()]);
+    let log_k1 = apply(sym(LOG), vec![k.clone()]);
+    let log_k2 = apply(sym(LOG), vec![k.clone()]);
+    let sqrt_kp1_1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_kp1_1 = apply(sym(LOG), vec![kp1.clone()]);
+    let log_kp1_2 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k1, sqrt_k2, log_k1, log_k2]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_1, sqrt_kp1_2, log_kp1_1, log_kp1_2]);
+    let den_k = apply(sym(POW), vec![k.clone(), int(2)]);
+    let den_kp1 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let g_k = apply(sym(DIV), vec![num_k, den_k]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, den_kp1]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase65_sqrt_k3_sqrt_k_log_k_sq_over_k3_closes() {
+    // √(k³)·√k·log(k)²/k³: effective_x2=3+1=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k1 = apply(sym(LOG), vec![k.clone()]);
+    let log_k2 = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1_1 = apply(sym(LOG), vec![kp1.clone()]);
+    let log_kp1_2 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k3, sqrt_k, log_k1, log_k2]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_3, sqrt_kp1, log_kp1_1, log_kp1_2]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase65_sqrt_k2_sq_log_k_sq_over_k2_refused() {
+    // √(k²)·√(k²)·log(k)²/k²: effective_x2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k2_1 = apply(sym("Sqrt"), vec![k2.clone()]);
+    let sqrt_k2_2 = apply(sym("Sqrt"), vec![k2.clone()]);
+    let sqrt_kp1_2_1 = apply(sym("Sqrt"), vec![kp1_2.clone()]);
+    let sqrt_kp1_2_2 = apply(sym("Sqrt"), vec![kp1_2.clone()]);
+    let log_k1 = apply(sym(LOG), vec![k.clone()]);
+    let log_k2 = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1_1 = apply(sym(LOG), vec![kp1.clone()]);
+    let log_kp1_2 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k2_1, sqrt_k2_2, log_k1, log_k2]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_2_1, sqrt_kp1_2_2, log_kp1_1, log_kp1_2]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.3.0 — 2026-05-25
+
+### Added
+
+- **Phase 65 — Two-Sqrt × Two-Log × polynomial numerator** (`twoSqrtTwoLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), polynomial..., bounded...)`.
+  log² sub-polynomial; effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  Closes when `denDeg > twoSqrtTwoLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 4 new tests in the "Phase 65" describe block.
+
 ## 2.2.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1331,6 +1331,42 @@ function twoLogSqrtPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined
   return sqrtHalfDeg + polyDeg;
 }
 
+/**
+ * Phase 65 — Two-Sqrt × Two-Log × polynomial numerator.
+ *
+ * Returns sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg when `node` is a `Mul`
+ * with exactly two Sqrt factors, exactly two Log(diverging) factors,
+ * any polynomial factors, and any bounded factors; `undefined` otherwise.
+ *
+ * log² is sub-polynomial; effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+ * Caller checks `denDeg > twoSqrtTwoLogPolyEffectiveDeg(num, k)`.
+ */
+function twoSqrtTwoLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      sqrtHalfDegs.push(halfDeg);
+      if (sqrtHalfDegs.length > 2) return undefined;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 2) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 2) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1528,6 +1564,17 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegTlsp = polynomialDegreeInK(den, k);
     if (denDegTlsp !== undefined) {
       if (denDegTlsp > tlspDeg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 65: Mul(Sqrt(P1), Sqrt(P2), Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+  // Two Sqrts + two Logs; log² sub-polynomial; effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  const ts2lDeg = twoSqrtTwoLogPolyEffectiveDeg(num, k);
+  if (ts2lDeg !== undefined) {
+    const denDegTs2l = polynomialDegreeInK(den, k);
+    if (denDegTs2l !== undefined) {
+      if (denDegTs2l > ts2lDeg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -1694,6 +1694,94 @@ describe("Phase 63 — Two-Sqrt × Log × polynomial numerator", () => {
   });
 });
 
+describe("Phase 65 — Two-Sqrt × Two-Log × polynomial numerator", () => {
+  it("√k·√k·log(k)² / k² closes (effective=1, denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const sqrt_k1 = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrt_k2 = { kind: "apply" as const, head: SQRT, args: [k] };
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [sqrt_k1, sqrt_k2, log_k1, log_k2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const sqrt_kp1_1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const sqrt_kp1_2 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [sqrt_kp1_1, sqrt_kp1_2, log_kp1_1, log_kp1_2] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√k·log(k)² / k³ closes (effective=2, denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const sqrt_k3 = { kind: "apply" as const, head: SQRT, args: [k3] };
+    const sqrt_k = { kind: "apply" as const, head: SQRT, args: [k] };
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [sqrt_k3, sqrt_k, log_k1, log_k2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const sqrt_kp1_3 = { kind: "apply" as const, head: SQRT, args: [kp1_3] };
+    const sqrt_kp1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [sqrt_kp1_3, sqrt_kp1, log_kp1_1, log_kp1_2] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k3] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_3] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k²)·√(k²)·log(k)² / k² refused (effective=2, denDeg=2 not > 2)", () => {
+    const k = sym("k");
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const sqrt_k2_1 = { kind: "apply" as const, head: SQRT, args: [k2] };
+    const sqrt_k2_2 = { kind: "apply" as const, head: SQRT, args: [k2] };
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [sqrt_k2_1, sqrt_k2_2, log_k1, log_k2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const sqrt_kp1_2_1 = { kind: "apply" as const, head: SQRT, args: [kp1_2] };
+    const sqrt_kp1_2_2 = { kind: "apply" as const, head: SQRT, args: [kp1_2] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [sqrt_kp1_2_1, sqrt_kp1_2_2, log_kp1_1, log_kp1_2] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·log(k)² / 2^k closes (exponential denominator)", () => {
+    const k = sym("k");
+    const sqrt_k1 = { kind: "apply" as const, head: SQRT, args: [k] };
+    const sqrt_k2 = { kind: "apply" as const, head: SQRT, args: [k] };
+    const log_k1 = { kind: "apply" as const, head: LOG, args: [k] };
+    const log_k2 = { kind: "apply" as const, head: LOG, args: [k] };
+    const numK = { kind: "apply" as const, head: MUL, args: [sqrt_k1, sqrt_k2, log_k1, log_k2] };
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const sqrt_kp1_1 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const sqrt_kp1_2 = { kind: "apply" as const, head: SQRT, args: [kp1] };
+    const log_kp1_1 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const log_kp1_2 = { kind: "apply" as const, head: LOG, args: [kp1] };
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [sqrt_kp1_1, sqrt_kp1_2, log_kp1_1, log_kp1_2] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
 describe("Phase 64 — Two-Log × Sqrt × polynomial numerator", () => {
   it("log(k)²·√k / k² closes (effective=0.5, denDeg=2 > 0.5)", () => {
     const k = sym("k");


### PR DESCRIPTION
## Summary

- Extends `_g_vanishes_at_infinity` / `gVanishesAtInfinity` / `g_vanishes_at_infinity` across all three `cas-summation` packages (Python, TypeScript, Rust) to recognise **Phase 65** numerator patterns: `Mul(Sqrt(P₁(k)), Sqrt(P₂(k)), Log(h₁(k)), Log(h₂(k)), polynomial..., bounded...)`
- Two sqrt factors + two log factors (log² is sub-polynomial); `effective_x2 = deg(P₁) + deg(P₂) + 2·poly_deg`; closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator
- Version bumps: Python 2.2.0 → 2.3.0, TypeScript 2.2.0 → 2.3.0, Rust 2.2.0 → 2.3.0

## Test plan

- [ ] Python: 5 new tests in `TestEvaluateSumPhase65TwoSqrtTwoLogPolyNumerator`; 142 total pass (`mise exec -- uv run pytest`)
- [ ] TypeScript: 4 new tests in "Phase 65" describe block; 105 total pass (`npm test`)
- [ ] Rust: 3 new tests (`phase65_*`); 96 total pass (`cargo test`)
- [ ] All three packages pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)