### PR TITLE
feat(ruby-parser): Phase 6v — begin/rescue/ensure/end

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -175,6 +175,38 @@ until_statement = "until" expression { !"end" statement } "end" ;
 #     (the grammar accepts only positional values via `expression`).
 case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
 when_clause    = "when" expression { COMMA expression } { !"when" !"else" !"end" statement } ;
+# Phase 6v — `begin … rescue … ensure … end`.
+#
+# Shape:
+#   begin_statement = "begin"
+#                     { !"rescue" !"ensure" !"end" statement }
+#                     { rescue_clause }
+#                     [ ensure_clause ]
+#                     "end" ;
+#   rescue_clause   = "rescue" [ exception_list ] [ "=>" NAME ]
+#                            { !"rescue" !"ensure" !"end" statement } ;
+#   exception_list  = NAME { COMMA NAME } ;
+#   ensure_clause   = "ensure" { !"end" statement } ;
+#
+# v0 deferred:
+#   - `else` clause inside begin (executes when no exception raised)
+#     is NOT supported — typical Ruby code uses ensure for cleanup.
+#   - retry / raise inside rescue body lowers like any other statement
+#     (the SIR validator may emit warnings for unrecognised `retry`).
+#   - Exception class hierarchy is NOT modelled — `rescue StandardError`
+#     and `rescue` (bare) lower identically.
+begin_statement = "begin" { !"rescue" !"ensure" !"end" statement } { rescue_clause } [ ensure_clause ] "end" ;
+# `rescue_clause` accepts either the bare form (`rescue`) or the
+# typed-with-binding form (`rescue ExceptionType[, OtherType] => var`).
+# The exception types and `=> var` MUST appear together — bare
+# `rescue ExceptionType` (no `=>`) would create grammar ambiguity with
+# the rescue body's first NAME-led statement (e.g. `rescue x = 2`
+# would parse `x` as an exception type, then fail at `=`).
+# v0 deferred: write `rescue ExceptionType => _` as a workaround for
+# bare exception-type rescue.
+rescue_clause   = "rescue" [ exception_list "=>" NAME ] { !"rescue" !"ensure" !"end" statement } ;
+exception_list  = NAME { COMMA NAME } ;
+ensure_clause   = "ensure" { !"end" statement } ;
 # Phase 6p — compound assignment (`x += 1`, `x ||= 1`, etc.).
 #
 # The lexer's `fuse_compound_assigns` post-pass folds `Op =` adjacent

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.23.0] - 2026-05-25
+
+### Added (Phase 6v — `begin … rescue … ensure … end`)
+
+New grammar rules:
+
+```
+statement       = ... | case_statement | begin_statement | return_statement | ... ;
+begin_statement = "begin"
+                  { !"rescue" !"ensure" !"end" statement }
+                  { rescue_clause }
+                  [ ensure_clause ]
+                  "end" ;
+rescue_clause   = "rescue" [ exception_list "=>" NAME ]
+                       { !"rescue" !"ensure" !"end" statement } ;
+exception_list  = NAME { COMMA NAME } ;
+ensure_clause   = "ensure" { !"end" statement } ;
+```
+
+#### Grammar design decision
+
+`rescue_clause` accepts the optional exception header ONLY when paired with `=>` binding (`rescue StandardError => e`).  Bare `rescue ExceptionType` (no `=>`) would create grammar ambiguity with the rescue body's first NAME-led statement — `rescue x = 2` would otherwise parse `x` as an exception type and fail at `=`.  Workaround for users wanting bare-type rescue: write `rescue ExceptionType => _`.
+
+#### Lowering (in `ruby-to-semantic-ir`)
+
+SIR has no try/catch primitive.  v0 lowering is lossy: body, rescue, and ensure stmts emit inline with synthetic marker `BuiltinCall`s:
+
+```
+begin body
+rescue StandardError, IOError => e rescue_body
+ensure ensure_body
+end
+```
+
+→
+
+```
+body_stmts...
+ExprStmt(BuiltinCall("__rescue_marker__", [StrLit("StandardError,IOError"), StrLit("e")]))
+rescue_stmts...
+ExprStmt(BuiltinCall("__ensure_marker__", []))
+ensure_stmts...
+```
+
+Markers carry the `Effect::MayThrow` tag.  Downstream emitters targeting languages with real exceptions can re-stitch the form via marker detection; for v0 the rescue body is unreachable in SIR's effect model.
+
+`lower_statement_inner_multi` (already routing `multi_assignment` to a Vec<Stmt> path from Phase 6r) is extended to dispatch `begin_statement` to a new `lower_begin_statement` helper.
+
+#### v0 deferred limitations
+
+- Bare `rescue ExceptionType` (no `=>`) — see grammar design note.
+- `else` clause inside begin (executes when no exception raised) — not supported.
+- Real try/catch propagation through SIR's effect lattice — markers only.
+- `retry` / `raise` inside rescue body lower like any other call.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 101 → **105** (+4):
+  - `test_parse_begin_with_rescue` — bare `rescue` body.
+  - `test_parse_begin_with_rescue_typed_and_var` — `rescue StandardError => e`.
+  - `test_parse_begin_with_ensure` — `begin … ensure … end`.
+  - `test_parse_begin_with_rescue_and_ensure` — full three-section form.
+
 ## [0.22.0] - 2026-05-25
 
 ### Added (Phase 6u — `case … when … else … end`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -26,6 +26,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"while_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"until_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"case_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"begin_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"return_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"break_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"next_statement"#.to_string() },
@@ -379,6 +380,62 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 177,
         },
         GrammarRule {
+            name: r#"begin_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"begin"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"rescue"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"ensure"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"rescue_clause"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
+                GrammarElement::Literal { value: r#"end"#.to_string() },
+            ] },
+            line_number: 198,
+        },
+        GrammarRule {
+            name: r#"rescue_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rescue"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"exception_list"#.to_string() },
+                        GrammarElement::Literal { value: r#"=>"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"rescue"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"ensure"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 207,
+        },
+        GrammarRule {
+            name: r#"exception_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 208,
+        },
+        GrammarRule {
+            name: r#"ensure_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"ensure"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 209,
+        },
+        GrammarRule {
             name: r#"assignment"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
@@ -393,7 +450,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 197,
+            line_number: 229,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -413,7 +470,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 208,
+            line_number: 240,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -435,7 +492,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 209,
+            line_number: 241,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -446,7 +503,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 216,
+            line_number: 248,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -461,17 +518,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 230,
+            line_number: 262,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 231,
+            line_number: 263,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 317,
+            line_number: 349,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -484,7 +541,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 318,
+            line_number: 350,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -498,7 +555,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 319,
+            line_number: 351,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -512,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 320,
+            line_number: 352,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -526,7 +583,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 321,
+            line_number: 353,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -537,7 +594,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 328,
+            line_number: 360,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -555,7 +612,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 329,
+            line_number: 361,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -569,7 +626,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 330,
+            line_number: 362,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -583,7 +640,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 331,
+            line_number: 363,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -606,7 +663,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 341,
+            line_number: 373,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -614,7 +671,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 342,
+            line_number: 374,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -626,7 +683,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 343,
+            line_number: 375,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -641,7 +698,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 344,
+            line_number: 376,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -656,7 +713,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 345,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -672,7 +729,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 346,
+            line_number: 378,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1670,6 +1670,86 @@ mod tests {
     //                          { !"when" !"else" !"end" statement } ;
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // Phase 6v — `begin … rescue … ensure … end`
+    //
+    // Grammar:
+    //   begin_statement = "begin"
+    //                     { !"rescue" !"ensure" !"end" statement }
+    //                     { rescue_clause }
+    //                     [ ensure_clause ]
+    //                     "end" ;
+    //   rescue_clause   = "rescue" [ exception_list ] [ "=>" NAME ]
+    //                          { !"rescue" !"ensure" !"end" statement } ;
+    //   exception_list  = NAME { COMMA NAME } ;
+    //   ensure_clause   = "ensure" { !"end" statement } ;
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_begin_with_rescue() {
+        let ast = parse_ruby("begin\n  x = 1\nrescue\n  x = 2\nend");
+        let b = find_descendant(&ast, "begin_statement")
+            .expect("expected begin_statement node");
+        assert!(
+            find_descendant(b, "rescue_clause").is_some(),
+            "expected rescue_clause"
+        );
+        assert!(
+            find_descendant(b, "ensure_clause").is_none(),
+            "expected no ensure_clause"
+        );
+    }
+
+    #[test]
+    fn test_parse_begin_with_rescue_typed_and_var() {
+        // `rescue StandardError => e` — exception type and binding variable.
+        let ast = parse_ruby(
+            "begin\n  x = 1\nrescue StandardError => e\n  x = 2\nend",
+        );
+        let rc = find_descendant(&ast, "rescue_clause")
+            .expect("expected rescue_clause");
+        // Exception list present.
+        assert!(
+            find_descendant(rc, "exception_list").is_some(),
+            "expected exception_list under rescue_clause"
+        );
+        // Arrow token present.
+        assert!(tree_has_token_value(rc, "=>"), "expected `=>` token");
+        // The variable `e` is somewhere in the rescue subtree.
+        assert!(tree_has_token_value(rc, "e"), "expected `e` token");
+    }
+
+    #[test]
+    fn test_parse_begin_with_ensure() {
+        let ast = parse_ruby("begin\n  x = 1\nensure\n  cleanup = 1\nend");
+        let b = find_descendant(&ast, "begin_statement")
+            .expect("expected begin_statement node");
+        assert!(
+            find_descendant(b, "ensure_clause").is_some(),
+            "expected ensure_clause"
+        );
+    }
+
+    #[test]
+    fn test_parse_begin_with_rescue_and_ensure() {
+        // Full form: body + rescue + ensure.
+        let ast = parse_ruby(
+            "begin\n  x = 1\nrescue\n  x = 2\nensure\n  x = 3\nend",
+        );
+        let b = find_descendant(&ast, "begin_statement")
+            .expect("expected begin_statement node");
+        let rc_count = b
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "rescue_clause"))
+            .count();
+        assert_eq!(rc_count, 1, "expected 1 rescue_clause, got {rc_count}");
+        assert!(
+            find_descendant(b, "ensure_clause").is_some(),
+            "expected ensure_clause"
+        );
+    }
+
     #[test]
     fn test_parse_case_single_when() {
         // Smallest form: one when clause, no else.

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.23.0] - 2026-05-25
+
+### Added (Phase 6v — `begin … rescue … ensure … end` lowering)
+
+New `lower_begin_statement` helper fans the source `begin_statement` into multiple SIR statements (via the existing `lower_statement_inner_multi` Vec<Stmt> dispatch from Phase 6r):
+
+- Body stmts inline.
+- ExprStmt(BuiltinCall("__rescue_marker__", [StrLit(exc_types_csv), StrLit(var_name)])) per `rescue_clause`, followed by that clause's body stmts inline.
+- ExprStmt(BuiltinCall("__ensure_marker__", [])) before the ensure body stmts inline (if `ensure_clause` present).
+
+Markers carry the `Effect::MayThrow` tag.  Strings feature is auto-set (markers emit StrLits).
+
+### v0 deferred limitations
+
+- SIR has no try/catch primitive — markers only signal the form's presence to downstream emitters that target languages with real exceptions.
+- Rescue body is *unreachable* in SIR's effect model; the marker is informational.
+- `else` clause inside `begin` (Ruby's "no-exception" branch) is not supported by the grammar.
+- Exception class hierarchy is not modelled — `rescue StandardError` (with `=>`) and bare `rescue` lower identically apart from the marker payload.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 104 → **108** (+4):
+  - `begin_without_rescue_lowers_body_inline` — no marker for plain `begin … end`.
+  - `begin_with_rescue_emits_rescue_marker` — `__rescue_marker__("StandardError", "e")`.
+  - `begin_with_ensure_emits_ensure_marker` — `__ensure_marker__()`.
+  - `begin_with_rescue_and_ensure_emits_both_markers_in_order` — full sequence shape.
+
 ## [0.22.0] - 2026-05-25
 
 ### Added (Phase 6u — `case … when … else … end` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1891,6 +1891,101 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 6v — `begin … rescue … ensure … end`
+    // -----------------------------------------------------------------
+    //
+    // SIR has no try/catch primitive.  v0 lowering is lossy: body,
+    // rescue, and ensure stmts emit inline with marker BuiltinCalls
+    // (`__rescue_marker__`, `__ensure_marker__`) bracketing the
+    // rescue/ensure sections.
+
+    #[test]
+    fn begin_without_rescue_lowers_body_inline() {
+        // `begin x = 1 end` → just LetBinding(x, 1).  No markers.
+        let m = lower("begin\n  x = 1\nend\n");
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 1);
+        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "x"));
+    }
+
+    #[test]
+    fn begin_with_rescue_emits_rescue_marker() {
+        let m = lower(
+            "begin\n  x = 1\nrescue StandardError => e\n  y = 2\nend\n",
+        );
+        let b = main_body(&m);
+        // Stmts: LetBinding(x,1), ExprStmt(BuiltinCall(__rescue_marker__, ["StandardError", "e"])), LetBinding(y,2).
+        assert_eq!(b.stmts.len(), 3);
+        let marker = match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt(rescue marker), got {:?}", other),
+        };
+        match marker {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__rescue_marker__");
+                assert_eq!(args.len(), 2);
+                assert!(
+                    matches!(&args[0], Expr::StrLit { value, .. } if value == "StandardError")
+                );
+                assert!(
+                    matches!(&args[1], Expr::StrLit { value, .. } if value == "e")
+                );
+            }
+            other => panic!("expected __rescue_marker__ builtin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn begin_with_ensure_emits_ensure_marker() {
+        let m = lower("begin\n  x = 1\nensure\n  y = 2\nend\n");
+        let b = main_body(&m);
+        // Stmts: LetBinding(x,1), ExprStmt(BuiltinCall(__ensure_marker__, [])), LetBinding(y,2).
+        assert_eq!(b.stmts.len(), 3);
+        assert!(matches!(
+            &b.stmts[1],
+            Stmt::ExprStmt {
+                expr: Expr::BuiltinCall { name, args, .. },
+                ..
+            } if name == "__ensure_marker__" && args.is_empty()
+        ));
+    }
+
+    #[test]
+    fn begin_with_rescue_and_ensure_emits_both_markers_in_order() {
+        let m = lower(concat!(
+            "begin\n",
+            "  x = 1\n",
+            "rescue StandardError => e\n",
+            "  y = 2\n",
+            "ensure\n",
+            "  z = 3\n",
+            "end\n",
+        ));
+        let b = main_body(&m);
+        // Stmts in order:
+        //   0: LetBinding(x, 1)
+        //   1: ExprStmt(__rescue_marker__("StandardError", "e"))
+        //   2: LetBinding(y, 2)
+        //   3: ExprStmt(__ensure_marker__())
+        //   4: LetBinding(z, 3)
+        assert_eq!(b.stmts.len(), 5);
+        assert!(matches!(
+            &b.stmts[1],
+            Stmt::ExprStmt {
+                expr: Expr::BuiltinCall { name, .. },
+                ..
+            } if name == "__rescue_marker__"
+        ));
+        assert!(matches!(
+            &b.stmts[3],
+            Stmt::ExprStmt {
+                expr: Expr::BuiltinCall { name, .. },
+                ..
+            } if name == "__ensure_marker__"
+        ));
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6u — `case … when … else … end`
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -288,6 +288,7 @@ impl Lowerer {
     ) -> Result<Vec<Stmt>, RubyLowerError> {
         match node.rule_name.as_str() {
             "multi_assignment" => self.lower_multi_assignment(node),
+            "begin_statement" => self.lower_begin_statement(node),
             _ => Ok(vec![self.lower_statement_inner(node)?]),
         }
     }
@@ -1554,6 +1555,208 @@ impl Lowerer {
             };
             out.push(stmt);
         }
+        Ok(out)
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 6v — `begin … rescue … ensure … end`
+    // -------------------------------------------------------------------
+
+    /// Lower a `begin_statement` node to a sequence of SIR statements.
+    ///
+    /// Grammar shape (per `ruby.grammar`):
+    /// ```text
+    /// begin_statement = "begin"
+    ///                   { !"rescue" !"ensure" !"end" statement }
+    ///                   { rescue_clause }
+    ///                   [ ensure_clause ]
+    ///                   "end" ;
+    /// rescue_clause   = "rescue" [ exception_list ] [ "=>" NAME ]
+    ///                        { !"rescue" !"ensure" !"end" statement } ;
+    /// exception_list  = NAME { COMMA NAME } ;
+    /// ensure_clause   = "ensure" { !"end" statement } ;
+    /// ```
+    ///
+    /// **v0 lossy lowering** — SIR has no exception-handling primitive.
+    /// We lower body, rescue, and ensure blocks INLINE (concatenated)
+    /// with synthetic `BuiltinCall` markers bracketing each rescue and
+    /// ensure section so downstream emitters can detect the form:
+    ///
+    /// ```text
+    /// begin
+    ///   body_stmts
+    /// rescue StandardError, IOError => e
+    ///   rescue_stmts
+    /// ensure
+    ///   ensure_stmts
+    /// end
+    /// ```
+    ///
+    /// → SIR sequence:
+    ///
+    /// ```text
+    /// body_stmts...
+    /// ExprStmt(BuiltinCall("__rescue_marker__", [
+    ///     StrLit("StandardError,IOError"),
+    ///     StrLit("e"),
+    /// ]))
+    /// rescue_stmts...
+    /// ExprStmt(BuiltinCall("__ensure_marker__", []))
+    /// ensure_stmts...
+    /// ```
+    ///
+    /// Semantics: the body always runs.  Without a real try/catch
+    /// primitive, the rescue body is unreachable in the SIR model
+    /// (exceptions can't propagate through SIR's effect lattice in
+    /// v0).  The ensure body runs unconditionally after the rescue
+    /// section (same effect as a plain sequence under "no exception"
+    /// semantics).  Downstream emitters that target languages with
+    /// real exceptions can re-stitch the form via the marker
+    /// `BuiltinCall`s; this is documented as a deferred limitation.
+    ///
+    /// `__rescue_marker__` and `__ensure_marker__` carry the
+    /// `Effect::MayThrow` tag so the validator allows exception-aware
+    /// programs without forcing the user to declare extra features.
+    fn lower_begin_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Vec<Stmt>, RubyLowerError> {
+        let mut out: Vec<Stmt> = Vec::new();
+        let outer_span = self.span_of(node);
+
+        // 1. Lower the body statements (direct `statement` children of
+        //    `begin_statement`).  The grammar's negative-lookahead
+        //    repetition stops collection at the first rescue/ensure/end,
+        //    so direct `statement` children are exactly the body.
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                if n.rule_name == "statement" {
+                    if let Some(inner) = self.first_node_child(n) {
+                        out.extend(self.lower_statement_inner_multi(inner)?);
+                    }
+                }
+            }
+        }
+
+        // 2. Process each rescue_clause in order.
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                if n.rule_name == "rescue_clause" {
+                    // Collect the exception type list (if present).
+                    let exc_list = n
+                        .children
+                        .iter()
+                        .find_map(|c| match c {
+                            ASTNodeOrToken::Node(en)
+                                if en.rule_name == "exception_list" =>
+                            {
+                                Some(en)
+                            }
+                            _ => None,
+                        })
+                        .map(|en| {
+                            en.children
+                                .iter()
+                                .filter_map(|cc| match cc {
+                                    ASTNodeOrToken::Token(t)
+                                        if t.type_ == TokenType::Name =>
+                                    {
+                                        Some(t.value.as_str())
+                                    }
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        })
+                        .unwrap_or_default();
+                    // Find the exception variable name (after `=>`).
+                    // The grammar `[ "=>" NAME ]` puts both inside the
+                    // rescue_clause's direct token children.  Walk to
+                    // find the `=>` token, then take the next Name.
+                    let var_name: String = {
+                        let mut saw_arrow = false;
+                        let mut found: Option<String> = None;
+                        for cc in &n.children {
+                            if let ASTNodeOrToken::Token(t) = cc {
+                                if t.value == "=>" {
+                                    saw_arrow = true;
+                                } else if saw_arrow
+                                    && t.type_ == TokenType::Name
+                                {
+                                    found = Some(t.value.clone());
+                                    break;
+                                }
+                            }
+                        }
+                        found.unwrap_or_default()
+                    };
+                    // Emit the marker.
+                    out.push(Stmt::ExprStmt {
+                        expr: Expr::BuiltinCall {
+                            name: "__rescue_marker__".to_string(),
+                            args: vec![
+                                Expr::StrLit {
+                                    value: exc_list,
+                                    span: outer_span.clone(),
+                                },
+                                Expr::StrLit {
+                                    value: var_name,
+                                    span: outer_span.clone(),
+                                },
+                            ],
+                            effects: EffectSet::PURE.with(Effect::MayThrow),
+                            span: outer_span.clone(),
+                        },
+                        span: outer_span.clone(),
+                    });
+                    // Strings feature is required because we emit StrLits.
+                    self.features_used.insert(Feature::Strings);
+                    // Lower the rescue body's statements inline.
+                    for cc in &n.children {
+                        if let ASTNodeOrToken::Node(nn) = cc {
+                            if nn.rule_name == "statement" {
+                                if let Some(inner) = self.first_node_child(nn)
+                                {
+                                    out.extend(
+                                        self.lower_statement_inner_multi(inner)?,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 3. Process the optional ensure_clause.
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                if n.rule_name == "ensure_clause" {
+                    out.push(Stmt::ExprStmt {
+                        expr: Expr::BuiltinCall {
+                            name: "__ensure_marker__".to_string(),
+                            args: vec![],
+                            effects: EffectSet::PURE.with(Effect::MayThrow),
+                            span: outer_span.clone(),
+                        },
+                        span: outer_span.clone(),
+                    });
+                    for cc in &n.children {
+                        if let ASTNodeOrToken::Node(nn) = cc {
+                            if nn.rule_name == "statement" {
+                                if let Some(inner) = self.first_node_child(nn)
+                                {
+                                    out.extend(
+                                        self.lower_statement_inner_multi(inner)?,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(out)
     }
 


### PR DESCRIPTION
## Summary

Adds Ruby's `begin/rescue/ensure/end` exception-handling form, lowered to inline-stmt sequences with marker BuiltinCalls (SIR has no native try/catch primitive).

## Grammar (`ruby-parser`)

```
statement       = ... | case_statement | begin_statement | return_statement | ... ;
begin_statement = "begin"
                  { !"rescue" !"ensure" !"end" statement }
                  { rescue_clause }
                  [ ensure_clause ]
                  "end" ;
rescue_clause   = "rescue" [ exception_list "=>" NAME ]
                       { !"rescue" !"ensure" !"end" statement } ;
exception_list  = NAME { COMMA NAME } ;
ensure_clause   = "ensure" { !"end" statement } ;
```

### Grammar design note

`rescue_clause` requires the exception list to be paired with `=>` binding (`rescue StandardError => e`).  Bare `rescue ExceptionType` (no `=>`) would create grammar ambiguity with the rescue body's first NAME-led statement (`rescue x = 2` would parse `x` as exception type and fail at `=`).  Workaround: `rescue ExceptionType => _`.

## SIR (`ruby-to-semantic-ir`)

SIR has no try/catch primitive.  v0 lowering is lossy: body, rescue, and ensure stmts emit INLINE with marker `BuiltinCall`s:

```
body_stmts...
ExprStmt(__rescue_marker__([StrLit("StandardError,IOError"), StrLit("e")]))
rescue_stmts...
ExprStmt(__ensure_marker__())
ensure_stmts...
```

Markers carry `Effect::MayThrow`.  Downstream emitters targeting languages with real exceptions can re-stitch via marker detection.

`lower_statement_inner_multi` (already Vec<Stmt> from Phase 6r) dispatches `begin_statement` to a new `lower_begin_statement` helper.

## v0 deferred limitations

- Bare `rescue ExceptionType` (no `=>`) — see grammar design note.
- `else` clause inside begin (Ruby's no-exception branch) — not supported.
- Real try/catch propagation through SIR's effect lattice — markers only.
- Exception class hierarchy is not modelled.

## Tests

- `coding-adventures-ruby-parser`: 101 → **105** (+4 grammar tests)
- `ruby-to-semantic-ir`: 104 → **108** (+4 lowering tests, incl. marker shape and ordering)
- `coding-adventures-ruby-lexer`: 169 unchanged

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (105/105 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (108/108 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — same shape as prior phases)
- [ ] CI green

Follows PR #4338 (Phase 6u — case/when/else/end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
