### PR TITLE
feat(ruby-parser): Phase 6w — arrow-lambda ->(params){body} and lambda/proc literals

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -370,7 +370,26 @@ term         = factor { ( STAR | SLASH ) factor } ;
 # leaving `(1).bar` unconsumed.  When no parens follow the name, the
 # method_call alternative fails (requires LPAREN) and we fall through to
 # the bare-NAME branch.
-factor       = ( method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call } ;
+factor       = ( lambda_literal | method_call | NUMBER | STRING | NAME | KEYWORD | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call } ;
+# Phase 6w — arrow-lambda literal `->(params){body}` / `->{body}`.
+#
+# Ruby 1.9+ shorthand for creating a `Proc`/`Lambda`.  The parameter
+# list is parenthesised and BEFORE the block; the body is a brace_block
+# or do_block.  v0 reuses the existing `params` rule (Phase 6s aware,
+# so splat is supported in arrow params) and the existing `block` rule
+# (which also admits a redundant `|...|` block_params header — we
+# ignore that case in lowering).
+#
+# Place in `factor` BEFORE the bare NAME / KEYWORD alternatives so that
+# the leading `->` literal wins (NAME alone can't start with `-`, but
+# the literal match is checked first regardless).
+#
+# `lambda { … }` and `proc { … }` are already handled by the existing
+# `method_with_block` rule (no new grammar needed — they're just NAME +
+# brace_block calls).  The SIR lowerer marks both as
+# `BuiltinCall("lambda", …)` via `ruby_builtin_effects` to give
+# downstream emitters a single closure-construction shape.
+lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
 unary_minus  = MINUS factor ;
 symbol_literal = COLON ( NAME | KEYWORD | STRING ) ;
 array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.24.0] - 2026-05-25
+
+### Added (Phase 6w — arrow-lambda literal `->(params){body}`)
+
+New grammar rule:
+
+```
+factor         = ( lambda_literal | method_call | NUMBER | ... ) { dot_call } ;
+lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
+```
+
+Placed BEFORE `method_call` in factor so the `->` literal wins.  Without this, `->` (a Name-typed Op token from the lexer) would be mis-matched by `method_call`'s `(NAME|KEYWORD) LPAREN` prefix when followed by parens.
+
+`lambda { … }` and `proc { … }` continue to lower via `method_with_block` (no new grammar — they're regular keyword-led calls).  The SIR lowerer now recognises `lambda` and `proc` as builtins so both shapes produce the same `BuiltinCall("lambda", …)` form.
+
+#### Parser default era bumped to "3.0"
+
+`create_ruby_parser` now invokes the lexer with `tokenize_ruby_for_version(source, "3.0")` so era-gated lexer fusions are visible to the parser by default.  Most importantly, `->` is now fused into a single Op token (1.9.1+ behaviour) so `lambda_literal` can match it.  Era-specific lexer tests still use the lower-level `tokenize_ruby_for_version` directly.
+
+New public constant: `DEFAULT_RUBY_ERA: &str = "3.0"`.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+Arrow lambda → `BuiltinCall("lambda", [MakeClosure { fn_name: "__block_<n>", captures: [] }])`.
+
+Body is hoisted to a top-level `Function` (named `__block_<n>`, reusing Phase 6g's counter).  Params are extracted from the parens-list (Phase 6s — splat supported) rather than from the block's `block_params` pipe header.
+
+### v0 deferred limitations
+
+- Block bodies that reference outer locals lose them — captures are NOT computed (same as Phase 6g).
+- If the user writes both `->(x) { |y| … }` (parens-params AND block_params), the latter is silently ignored.
+- `lambda { ... }` / `proc { ... }` works only at statement position, not as an expression RHS (because `method_with_block` is not in `factor`).  Arrow form (`->(...) { ... }`) is the recommended form for expression-position closures.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 105 → **109** (+4):
+  - `test_parse_arrow_lambda_no_params` — `-> { 1 }`.
+  - `test_parse_arrow_lambda_with_params` — `->(x, y) { x + y }`.
+  - `test_parse_arrow_lambda_inside_call` — `each(->(x) { x })`.
+  - `test_parse_lambda_keyword_with_brace_block` — `lambda { |x| x + 1 }` (regression: NOT a lambda_literal).
+
 ## [0.23.0] - 2026-05-25
 
 ### Added (Phase 6v — `begin … rescue … ensure … end`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -646,6 +646,7 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"factor"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"lambda_literal"#.to_string() },
                         GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
@@ -666,12 +667,25 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 373,
         },
         GrammarRule {
+            name: r#"lambda_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"->"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"params"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"block"#.to_string() },
+            ] },
+            line_number: 392,
+        },
+        GrammarRule {
             name: r#"unary_minus"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 374,
+            line_number: 393,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -683,7 +697,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 375,
+            line_number: 394,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -698,7 +712,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 376,
+            line_number: 395,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -713,7 +727,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 377,
+            line_number: 396,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -729,7 +743,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 378,
+            line_number: 397,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1,12 +1,27 @@
 //! Ruby parser backed by compiled parser grammar.
 
-use coding_adventures_ruby_lexer::tokenize_ruby;
+use coding_adventures_ruby_lexer::tokenize_ruby_for_version;
 use parser::grammar_parser::{GrammarASTNode, GrammarParser};
 
 mod _grammar;
 
+/// Default Ruby era for the parser.  Phase 6w bumped this from "1.8"
+/// (the lexer's default) to "3.0" so that era-gated lexer fusions
+/// — most importantly `->` (Op("->") fused via `fuse_lambda_arrow`,
+/// 1.9.1+) and the 2.x-era literal/operator fusions — are visible
+/// to the parser by default.  Without this bump, `->(x) { x }` would
+/// lex as `-`, `>`, ... and never match the `lambda_literal` rule.
+///
+/// "3.0" is chosen as the floor for "modern Ruby" — every 2.x and
+/// 3.0 lexer fusion is on; later 3.x eras add nothing the parser
+/// currently keys off.  Era-specific behaviour tests (e.g. lexer
+/// crate tests asserting 1.8 emits `-`+`>` separately) can still use
+/// the lower-level `tokenize_ruby_for_version` directly.
+pub const DEFAULT_RUBY_ERA: &str = "3.0";
+
 pub fn create_ruby_parser(source: &str) -> GrammarParser {
-    let tokens = tokenize_ruby(source);
+    let tokens = tokenize_ruby_for_version(source, DEFAULT_RUBY_ERA)
+        .expect("ruby lexer: DEFAULT_RUBY_ERA is a recognised era");
     let grammar = _grammar::parser_grammar();
     GrammarParser::new(tokens, grammar)
 }
@@ -1684,6 +1699,74 @@ mod tests {
     //   exception_list  = NAME { COMMA NAME } ;
     //   ensure_clause   = "ensure" { !"end" statement } ;
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Phase 6w — arrow-lambda literal `->(params){body}`
+    //
+    // Grammar:
+    //   lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
+    //
+    // Placed inside `factor` so lambdas are valid in any expression
+    // position.  `lambda { … }` / `proc { … }` still flow through
+    // `method_with_block` (no separate grammar).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_arrow_lambda_no_params() {
+        // `-> { 1 }` — no params, brace block.  We wrap in an
+        // assignment to dodge the bare-NAME-led statement ambiguity.
+        let ast = parse_ruby("f = -> { 1 }");
+        let ll = find_descendant(&ast, "lambda_literal")
+            .expect("expected lambda_literal node");
+        assert!(tree_has_token_value(ll, "->"), "expected `->` token");
+        // No params subnode.
+        assert!(
+            find_descendant(ll, "params").is_none(),
+            "expected no params subnode for bare arrow"
+        );
+        assert!(find_descendant(ll, "block").is_some());
+    }
+
+    #[test]
+    fn test_parse_arrow_lambda_with_params() {
+        // `->(x, y) { x + y }` — two parens-params, brace block.
+        let ast = parse_ruby("f = ->(x, y) { x + y }");
+        let ll = find_descendant(&ast, "lambda_literal")
+            .expect("expected lambda_literal node");
+        let p = find_descendant(ll, "params").expect("expected params subnode");
+        let param_count = p
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "param"))
+            .count();
+        assert_eq!(param_count, 2, "expected 2 params, got {param_count}");
+    }
+
+    #[test]
+    fn test_parse_arrow_lambda_inside_call() {
+        // `each(->(x) { x })` — arrow lambda as a call arg.
+        let ast = parse_ruby("each(->(x) { x })");
+        assert!(
+            find_descendant(&ast, "lambda_literal").is_some(),
+            "expected lambda_literal inside call args"
+        );
+    }
+
+    #[test]
+    fn test_parse_lambda_keyword_with_brace_block() {
+        // `lambda { |x| x + 1 }` — keyword form, uses method_with_block.
+        let ast = parse_ruby("lambda { |x| x + 1 }");
+        // Should NOT be a lambda_literal (that's the arrow form);
+        // it's a method_with_block instead.
+        assert!(
+            find_descendant(&ast, "lambda_literal").is_none(),
+            "lambda keyword form should NOT parse as lambda_literal"
+        );
+        assert!(
+            find_descendant(&ast, "method_with_block").is_some(),
+            "expected method_with_block for lambda keyword form"
+        );
+    }
 
     #[test]
     fn test_parse_begin_with_rescue() {

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.24.0] - 2026-05-25
+
+### Added (Phase 6w — arrow-lambda lowering)
+
+New `lower_lambda_literal` helper handles `->(params){body}`:
+
+- Extracts params from the leading parens-list (Phase 6s — splat names preserved bare).
+- Hoists the block body to a top-level `Function` named `__block_<n>` (reusing Phase 6g's counter) via new `hoist_lambda_body` helper.
+- Emits `Expr::BuiltinCall { name: "lambda", args: [MakeClosure { fn_name, captures: [] }], effects: PURE }`.
+- Auto-sets `Feature::Closures` (and `Feature::DynamicTyping` if any params present).
+
+`ruby_builtin_effects` extended to recognise `lambda` and `proc` so `lambda { ... }` and `proc { ... }` (keyword forms going through `method_with_block`) also emit `BuiltinCall("lambda"|"proc", ...)`.  Downstream emitters see a single closure-construction shape.
+
+### v0 deferred limitations
+
+- Captures from the enclosing scope are NOT computed for arrow lambda bodies (same limitation as Phase 6g blocks).
+- `lambda { … }` / `proc { … }` work at statement position only — they can't be used as an expression RHS because `method_with_block` is not part of `factor`.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 108 → **112** (+4):
+  - `arrow_lambda_no_params_lowers_to_lambda_builtin` — bare `-> { 1 }`.
+  - `arrow_lambda_with_params_hoists_body_with_params` — params propagate to hoisted Function.
+  - `lambda_keyword_form_lowers_via_method_with_block` — `lambda { |x| x + 1 }` keyword form.
+  - `arrow_lambda_module_passes_sir_validator` — end-to-end validator smoke.
+
 ## [0.23.0] - 2026-05-25
 
 ### Added (Phase 6v — `begin … rescue … ensure … end` lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -1891,6 +1891,88 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 6w — arrow-lambda literal `->(params){body}`
+    // -----------------------------------------------------------------
+    //
+    // Lowers to BuiltinCall("lambda", [MakeClosure { fn_name: "__block_<n>", captures: [] }]).
+    // Body is hoisted to a top-level Function with the parens-params.
+
+    #[test]
+    fn arrow_lambda_no_params_lowers_to_lambda_builtin() {
+        let m = lower("f = -> { 1 }\n");
+        // Outer body should have LetBinding(f, BuiltinCall("lambda", [MakeClosure])).
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { name, value, .. } if name == "f" => value,
+            other => panic!("expected LetBinding(f, ...), got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "lambda");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(&args[0], Expr::MakeClosure { .. }));
+            }
+            other => panic!("expected BuiltinCall(lambda, [MakeClosure]), got {:?}", other),
+        }
+        // The hoisted Function should have zero params.
+        let hoisted = m.functions.iter().find(|f| f.name.starts_with("__block_"));
+        assert!(hoisted.is_some(), "expected a __block_<n> hoisted Function");
+        assert_eq!(
+            hoisted.unwrap().params.len(),
+            0,
+            "expected zero params on bare arrow"
+        );
+    }
+
+    #[test]
+    fn arrow_lambda_with_params_hoists_body_with_params() {
+        let m = lower("f = ->(x, y) { x + y }\n");
+        // Locate the hoisted block function.
+        let hoisted = m
+            .functions
+            .iter()
+            .find(|f| f.name.starts_with("__block_"))
+            .expect("expected hoisted block function");
+        let names: Vec<&str> = hoisted.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn lambda_keyword_form_lowers_via_method_with_block() {
+        // `lambda { |x| x + 1 }` at top level uses method_with_block +
+        // the `lambda` builtin (Phase 6w added "lambda"/"proc" to the
+        // builtin map).  v0 limitation: `lambda { ... }` doesn't work
+        // as an expression RHS (e.g. `f = lambda { ... }`) because
+        // method_with_block isn't in `factor` — only at statement level.
+        let m = lower("lambda { |x| x + 1 }\n");
+        let b = main_body(&m);
+        // method_with_block lowers to an ExprStmt(BuiltinCall(lambda, [MakeClosure]))
+        // (not tail-promoted by `lower_program`).
+        assert_eq!(b.stmts.len(), 1);
+        let expr = match &b.stmts[0] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt, got {:?}", other),
+        };
+        match expr {
+            Expr::BuiltinCall { name, .. } => {
+                assert_eq!(name, "lambda", "expected `lambda` builtin");
+            }
+            other => panic!("expected BuiltinCall(lambda, ...), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn arrow_lambda_module_passes_sir_validator() {
+        let m = lower("f = ->(x) { x + 1 }\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected arrow-lambda output: {:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------
     // Phase 6v — `begin … rescue … ensure … end`
     // -----------------------------------------------------------------
     //

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2141,6 +2141,214 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
+    // Phase 6w — arrow-lambda literal `->(params){body}`
+    // -------------------------------------------------------------------
+
+    /// Lower a `lambda_literal` node (`->(params){body}`) into a
+    /// `BuiltinCall("lambda", [MakeClosure])` expression.
+    ///
+    /// Grammar shape (per `ruby.grammar`):
+    /// ```text
+    /// lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
+    /// ```
+    ///
+    /// The body is hoisted to a top-level `Function` (named `__block_<n>`,
+    /// reusing the same counter as `method_with_block` blocks).  Params
+    /// are extracted from the leading `params` subnode (Phase 6s — splat
+    /// supported) rather than from `block_params` (the `|x|` form inside
+    /// the block), because in `->` syntax the parens-list IS the
+    /// parameter list.
+    ///
+    /// **v0 deferred limitations**:
+    /// - Block bodies that reference outer locals lose them — captures
+    ///   are NOT computed for v0 (same limitation as Phase 6g blocks).
+    /// - If the user writes both `->(x) { |y| … }` (params in parens
+    ///   AND a block_params header), the latter is silently ignored;
+    ///   only the parens-list is honoured.
+    /// - `lambda { … }` and `proc { … }` continue to lower via
+    ///   `method_with_block` — they're regular keyword-led calls.
+    ///   The SIR builtin table tags both as `BuiltinCall("lambda", …)`
+    ///   so downstream emitters see a single closure-construction shape.
+    fn lower_lambda_literal(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, RubyLowerError> {
+        // 1. Find the `block` subnode (mandatory).
+        let block_node = self
+            .find_node_child(node, "block")
+            .ok_or_else(|| RubyLowerError {
+                message: "lambda_literal missing block subnode".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+
+        // 2. Extract arrow-lambda params from the optional `params`
+        //    subnode (Phase 6s: param = [ "*"|"**" ] NAME).
+        let params_node = self.find_node_child(node, "params");
+        let params: Vec<Param> = if let Some(pn) = params_node {
+            pn.children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(param_node)
+                        if param_node.rule_name == "param" =>
+                    {
+                        // Skip splat-prefix tokens; pick the bare NAME.
+                        param_node.children.iter().find_map(|cc| match cc {
+                            ASTNodeOrToken::Token(t)
+                                if matches!(t.type_, TokenType::Name)
+                                    && t.value != "*"
+                                    && t.value != "**" =>
+                            {
+                                Some(Param {
+                                    name: t.value.clone(),
+                                    sir_type: None,
+                                    span: self.span_of_token(t),
+                                })
+                            }
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+        if !params.is_empty() {
+            self.features_used.insert(Feature::DynamicTyping);
+        }
+
+        // 3. Hoist the block body to a Function with these params.
+        //    Reuse the same machinery as `hoist_block_to_function` but
+        //    using OUR `params` (from the parens-list), not the inner
+        //    block's `block_params` pipe form.
+        let fn_name = self.hoist_lambda_body(block_node, params)?;
+
+        // 4. Emit BuiltinCall("lambda", [MakeClosure]).  Closures
+        //    feature auto-set so the validator accepts MakeClosure.
+        self.features_used.insert(Feature::Closures);
+        let span = self.span_of(node);
+        Ok(Expr::BuiltinCall {
+            name: "lambda".to_string(),
+            args: vec![Expr::MakeClosure {
+                fn_name,
+                captures: Vec::new(),
+                span: span.clone(),
+            }],
+            effects: EffectSet::PURE,
+            span,
+        })
+    }
+
+    /// Phase 6w helper — hoist a `block` (do_block/brace_block) body
+    /// to a top-level Function, taking the params list from the caller
+    /// (the arrow lambda's parens-list) rather than from the block's
+    /// own `|...|` `block_params` header.
+    ///
+    /// This is structurally parallel to `hoist_block_to_function` but
+    /// with the params source swapped.  Returns the synthesised
+    /// function name.
+    fn hoist_lambda_body(
+        &mut self,
+        block_node: &GrammarASTNode,
+        params: Vec<Param>,
+    ) -> Result<String, RubyLowerError> {
+        let inner = self.first_node_child(block_node).ok_or_else(|| RubyLowerError {
+            message: "block missing do_block/brace_block child".to_string(),
+            line: block_node.start_line.unwrap_or(0),
+            column: block_node.start_column.unwrap_or(0),
+        })?;
+
+        // Lower body with fresh scope (params pre-declared as locals
+        // + tracked in current_params so VarRefs get Scope::Param).
+        let saved_locals = std::mem::take(&mut self.declared_locals);
+        let saved_params = std::mem::take(&mut self.current_params);
+        for p in &params {
+            self.declared_locals.insert(p.name.clone());
+            self.current_params.insert(p.name.clone());
+        }
+
+        // Body statements (same tail-expression promotion rule as the
+        // method_with_block hoister).
+        let body_stmts: Vec<&GrammarASTNode> = inner
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+        let mut stmts_out: Vec<Stmt> = Vec::new();
+        let mut value: Option<Expr> = None;
+        if body_stmts.is_empty() {
+            value = Some(Expr::NilLit {
+                span: self.span_of(inner),
+            });
+        } else {
+            let last_idx = body_stmts.len() - 1;
+            for (i, s) in body_stmts.iter().enumerate() {
+                let inner_stmt = self.first_node_child(s).ok_or_else(|| RubyLowerError {
+                    message: "statement node had no child rule".to_string(),
+                    line: s.start_line.unwrap_or(0),
+                    column: s.start_column.unwrap_or(0),
+                })?;
+                let is_tail = i == last_idx;
+                let kind = inner_stmt.rule_name.as_str();
+                if is_tail && matches!(kind, "expression_stmt" | "method_call") {
+                    let v = match kind {
+                        "expression_stmt" => {
+                            let en = self.first_node_child(inner_stmt).ok_or_else(|| {
+                                RubyLowerError {
+                                    message: "expression_stmt had no expression child"
+                                        .to_string(),
+                                    line: inner_stmt.start_line.unwrap_or(0),
+                                    column: inner_stmt.start_column.unwrap_or(0),
+                                }
+                            })?;
+                            self.lower_expression(en)?
+                        }
+                        "method_call" => self.lower_method_call(inner_stmt)?,
+                        _ => unreachable!(),
+                    };
+                    value = Some(v);
+                } else {
+                    stmts_out.extend(self.lower_statement_inner_multi(inner_stmt)?);
+                }
+            }
+        }
+        let value = value.unwrap_or(Expr::NilLit {
+            span: self.span_of(inner),
+        });
+
+        // Restore outer scope.
+        self.declared_locals = saved_locals;
+        self.current_params = saved_params;
+
+        // Mint a synthetic function name (shares the same counter as
+        // method_with_block-hoisted blocks).
+        let n = self.block_counter;
+        self.block_counter += 1;
+        let fn_name = format!("__block_{n}");
+
+        self.user_functions.push(Function {
+            name: fn_name.clone(),
+            params,
+            return_type: None,
+            captures: Vec::new(),
+            body: Block {
+                stmts: stmts_out,
+                value,
+                span: self.span_of(inner),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: self.span_of(block_node),
+        });
+
+        Ok(fn_name)
+    }
+
+    // -------------------------------------------------------------------
     // expression / term / factor
     // -------------------------------------------------------------------
 
@@ -2214,6 +2422,8 @@ impl Lowerer {
             // `factor`.  Reuse the statement-level lowerer; it handles
             // the trailing `{ dot_call }` chain transparently.
             "method_call" => self.lower_method_call(node),
+            // Phase 6w — arrow-lambda literal `->(params){body}`.
+            "lambda_literal" => self.lower_lambda_literal(node),
             // The parser sometimes wraps a bare token into an "expression_stmt"
             // when reached as the RHS of an assignment.  Recurse into it.
             "expression_stmt" => {
@@ -3017,6 +3227,12 @@ fn ruby_builtin_effects(name: &str) -> Option<EffectSet> {
         // we just declare PURE here.  Adding them to the builtin
         // table makes `each { … }` lower cleanly without forcing
         // every consumer to declare `each` as a user function.
+        // Phase 6w — explicit closure-construction builtins.  `lambda { ... }`
+        // and `proc { ... }` go through `method_with_block` and pass their
+        // hoisted closure as the trailing arg.  Tagging both as known
+        // builtins (PURE) gives downstream emitters a single
+        // closure-construction shape — same as Phase 6w's arrow-lambda.
+        "lambda" | "proc" => Some(EffectSet::PURE),
         "each" | "map" | "select" | "reject" | "filter"
         | "each_with_index" | "each_with_object" | "times"
         | "tap" | "then" | "yield_self" | "loop"


### PR DESCRIPTION
## Summary

Adds Ruby's arrow-lambda syntax `->(params){body}` and recognises `lambda { ... }` / `proc { ... }` as builtin closure-construction shapes.

## Grammar (`ruby-parser`)

```
factor         = ( lambda_literal | method_call | NUMBER | ... ) { dot_call } ;
lambda_literal = "->" [ LPAREN [ params ] RPAREN ] block ;
```

Placed BEFORE `method_call` in factor so the `->` literal wins (the lexer emits `->` as a single Name-typed token that would otherwise be mis-matched by `method_call`'s `(NAME|KEYWORD) LPAREN` prefix).

## Parser default era bumped to "3.0"

`create_ruby_parser` now uses `tokenize_ruby_for_version(source, "3.0")` so era-gated lexer fusions (most importantly `->`, fused at 1.9.1+) are visible to the parser by default.  New public `DEFAULT_RUBY_ERA: &str = "3.0"`.  Era-specific lexer tests still use the lower-level `tokenize_ruby_for_version` directly.

## SIR (`ruby-to-semantic-ir`)

New `lower_lambda_literal`:
- Extracts params from parens-list (Phase 6s — splat names preserved bare).
- Hoists body to top-level Function `__block_<n>` via new `hoist_lambda_body` helper.
- Emits `BuiltinCall("lambda", [MakeClosure {fn_name, captures: []}])`.
- Auto-sets `Feature::Closures`.

`ruby_builtin_effects` extended with `"lambda"` and `"proc"` so the keyword forms going through `method_with_block` also emit `BuiltinCall("lambda"|"proc", ...)`.  Downstream emitters see a single closure-construction shape.

## v0 deferred limitations

- Captures from enclosing scope NOT computed (same as Phase 6g blocks).
- `lambda { ... }` / `proc { ... }` work at statement position only, not as expression RHS — use arrow form for expression-position closures.

## Tests

- `coding-adventures-ruby-parser`: 105 → **109** (+4 grammar tests)
- `ruby-to-semantic-ir`: 108 → **112** (+4 lowering tests)
- `coding-adventures-ruby-lexer`: 169 unchanged

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (109/109 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (112/112 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — same shape as prior phases)
- [ ] CI green

Follows PR #4344 (Phase 6v — begin/rescue/ensure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
