### PR TITLE
feat(cas-summation): Phase 69 — One-Sqrt × Three-Log × polynomial numerator (2.7.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.7.0 — 2026-05-25
+
+### Added
+
+- **Phase 69 — One-Sqrt × Three-Log × polynomial numerator** (`_one_sqrt_three_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 3 Log factors required; log³ sub-polynomial contributes 0
+  to effective degree; `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 5 new unit tests in `TestPhase69OneSqrtThreeLogPoly`.
+
 ## 2.6.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.6.0"
+version = "2.7.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -956,6 +956,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 69: ``Mul(Sqrt(P), Log(diverging), Log(diverging), Log(diverging),
+    #           polynomial..., bounded...)`` numerator.
+    # One Sqrt factor + three Log factors; log³ is sub-polynomial → contributes 0.
+    # effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s1l3p_x2 = _one_sqrt_three_log_poly_effective_x2(num, k)
+    if s1l3p_x2 is not None:
+        den_deg_s1l3p = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l3p is not None:
+            if 2 * den_deg_s1l3p > s1l3p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2132,6 +2146,75 @@ def _three_sqrt_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if len(sqrt_degs) != 3 or log_count != 1:
         return None
     return sqrt_degs[0] + sqrt_degs[1] + sqrt_degs[2] + 2 * poly_deg_sum
+
+
+def _one_sqrt_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_inner_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly one** ``Sqrt(positive-leading polynomial)`` factor,
+    **exactly three** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 69 — One-Sqrt × Three-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^d) · log(k)³ · k^m ≈ k^{d/2} · log³(k) · k^m``.
+    ``log³(k)`` is sub-polynomial (``o(k^ε)``), so it contributes 0 to effective
+    degree.  Using the ×2 integer trick:
+    ``effective_x2 = d + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------+------------------+
+    | Input                                                    | Return           |
+    +==========================================================+==================+
+    | ``Mul(Sqrt(k), Log(k), Log(k), Log(k))``                 | ``1 + 0 = 1``    |
+    | ``Mul(Sqrt(k³), Log(k), Log(k+1), Log(k+2))``            | ``3 + 0 = 3``    |
+    | ``Mul(Sqrt(k), Log(k), Log(k), Log(k), k)``              | ``1 + 2 = 3``    |
+    | ``Mul(Sqrt(k), Log(k), Log(k))``                         | None (2 Logs)    |
+    | ``Mul(Sqrt(k), Log(k), Log(k), Log(k), Log(k))``         | None (4 Logs)    |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k), Log(k), Log(k))``        | None (2 Sqrts)   |
+    | ``Mul(Log(k), Log(k), Log(k))``                          | None (0 Sqrts)   |
+    +----------------------------------------------------------+------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 1.
+         - ``Log(diverging)`` → count; bail after 3.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 1 Sqrt AND exactly 3 Log factors.
+      4. Return ``sqrt_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                # Second Sqrt — not this phase.
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 3:
+                # Four or more Log factors — not this phase.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 3:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -3210,8 +3210,9 @@ class TestEvaluateSumPhase67ThreeLogPolyNumerator:
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert not (isinstance(result, IRApply) and result.head == SUM)
 
-    def test_sqrt_present_refused(self):
-        """log(k)³ · √k / k²: sqrt factor present → refused (returns SUM node)."""
+    def test_sqrt_present_refused_by_phase67_but_caught_by_phase69(self):
+        """log(k)³ · √k / k²: Phase 67 refuses (Sqrt present), but Phase 69 closes it.
+        effective_x2=1; 2·2=4 > 1 → Phase 69 recognises 1-Sqrt × 3-Log and closes."""
         from symbolic_ir import LOG, SQRT, SUB
 
         log_k1 = IRApply(LOG, (_k,))
@@ -3231,7 +3232,7 @@ class TestEvaluateSumPhase67ThreeLogPolyNumerator:
         g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
-        assert isinstance(result, IRApply) and result.head == SUM
+        assert not (isinstance(result, IRApply) and result.head == SUM)
 
     def test_log_k_cubed_over_k_refused_when_equal(self):
         """log(k)³ · k / k: effective_x2=2; 2·1=2 not > 2 → refused."""
@@ -3339,6 +3340,101 @@ class TestPhase68ThreeSqrtLogPoly:
                                 IRApply(SQRT, (kp1,)), IRApply(LOG, (kp1,))))
         g_k = IRApply(DIV, (num_k, _k))
         g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase69OneSqrtThreeLogPoly:
+    """Phase 69: Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)),
+    polynomial..., bounded...) numerator.
+
+    effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    log³ is sub-polynomial — contributes 0 to effective degree.
+    Vanishes when 2·den_deg > effective_x2 or non-polynomial diverging denom.
+    """
+
+    def test_sqrt_k_log3_k_over_k2_closes(self):
+        """√k·log(k)·log(k)·log(k) / k²: effective_x2=1; 2·2=4 > 1 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_log3_k_over_k3_closes(self):
+        """√(k³)·log(k)³ / k³: effective_x2=3; 2·3=6 > 3 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log3_k_poly_factor_closes(self):
+        """√k·log(k)³·k / k³: effective_x2=3; 2·3=6 > 3 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), kp1))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log3_k_over_exponential_closes(self):
+        """√k·log(k)³ / 2^k: non-polynomial diverging denom → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, IRApply(POW, (IRInteger(2), _k))))
+        g_kp1 = IRApply(DIV, (num_kp1, IRApply(POW, (IRInteger(2), kp1))))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log3_k_over_k_refused(self):
+        """√k·log(k)³ / k: effective_x2=1; 2·1=2 not > 1 is False — wait, 2>1 is True.
+        So effective_x2=1, 2·1=2 > 1 → closes. Let's check boundary with smaller denom.
+        Actually: √k·log(k)³ / √k = log(k)³ which converges. But den=√k is not polynomial.
+        Use den=1 (poly deg 0): 2·0=0 not > 1 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        # Denominator = 1 (polynomial degree 0): 2·0=0 not > 1 → refused.
+        g_k = IRApply(DIV, (num_k, IRInteger(1)))
+        g_kp1 = IRApply(DIV, (num_kp1, IRInteger(1)))
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.7.0 — 2026-05-25
+
+### Added
+
+- **Phase 69 — One-Sqrt × Three-Log × polynomial numerator** (`one_sqrt_three_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 3 Log factors required; log³ sub-polynomial contributes 0
+  to effective degree; `effective_x2 = sqrt_deg + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs`.
+
 ## 2.6.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1749,6 +1749,42 @@ fn three_sqrt_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(sqrt_degs[0] + sqrt_degs[1] + sqrt_degs[2] + 2 * poly_deg)
 }
 
+/// Return `sqrt_deg + 2 * poly_deg` when `node` is a `Mul` with **exactly one**
+/// `Sqrt(positive-leading polynomial)` factor, **exactly three**
+/// `Log(diverging-in-k)` factors, any polynomial factors, and any bounded
+/// factors; `None` otherwise.
+///
+/// Phase 69 — One-Sqrt × Three-Log × polynomial numerator.
+///
+/// `log³(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to the effective
+/// degree.  `effective_x2 = sqrt_deg + 2·poly_deg`.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn one_sqrt_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 3 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let sd = sqrt_deg?;
+    if log_count != 3 { return None; }
+    Some(sd + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -1990,6 +2026,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(ts3l_x2) = three_sqrt_log_poly_effective_x2(num, k) {
         if let Some(den_deg_ts3l) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_ts3l > ts3l_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 69: Mul(Sqrt(P), Log(diverging), Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+    // One Sqrt factor + three Log factors; log³ sub-polynomial — effective_x2 = sqrt_deg + 2*poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s1l3_x2) = one_sqrt_three_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l3) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l3 > s1l3_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2206,3 +2206,65 @@ fn phase68_three_sqrt_log_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 69 — One-Sqrt × Three-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase69_sqrt_k_log3_k_over_k2_closes() {
+    // √k·log(k)·log(k)·log(k) / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k, log_k.clone(), log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1, log_kp1.clone(), log_kp1.clone(), log_kp1]);
+    let den_k = apply(sym(POW), vec![k.clone(), int(2)]);
+    let den_kp1 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let g_k = apply(sym(DIV), vec![num_k, den_k]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, den_kp1]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase69_sqrt_k3_log3_k_over_k3_closes() {
+    // √(k³)·log(k)³ / k³: effective_x2=3; 2·3=6 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k3, log_k.clone(), log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_3, log_kp1.clone(), log_kp1.clone(), log_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase69_sqrt_k_log3_k_over_const_refused() {
+    // √k·log(k)³ / 1: effective_x2=1; 2·0=0 not > 1 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k, log_k.clone(), log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1, log_kp1.clone(), log_kp1.clone(), log_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, int(1)]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, int(1)]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.7.0 — 2026-05-25
+
+### Added
+
+- **Phase 69 — One-Sqrt × Three-Log × polynomial numerator** (`oneSqrtThreeLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt and exactly 3 Log factors; log³ sub-polynomial contributes 0 to effective
+  degree. effective degree = sqrtHalfDeg + polyDeg.
+  Closes when `denDeg > oneSqrtThreeLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 4 new tests in the "Phase 69" describe block.
+
 ## 2.6.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1469,6 +1469,43 @@ function threeSqrtLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefin
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
 }
 
+/**
+ * Phase 69 — One-Sqrt × Three-Log × polynomial numerator.
+ *
+ * Returns `sqrtHalfDeg + polyDeg` when `node` is a `Mul` with exactly one
+ * `Sqrt` factor, exactly three `Log(diverging)` factors, any polynomial
+ * factors, and any bounded factors; `undefined` otherwise.
+ *
+ * `log³(k)` is sub-polynomial (`o(k^ε)`), so it contributes 0 to effective
+ * degree. effective degree = sqrtHalfDeg + polyDeg.
+ * Caller checks `denDeg > oneSqrtThreeLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined = undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined; // second Sqrt — refuse
+      sqrtHalfDeg = halfDeg;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 3) return undefined; // more than three Logs — refuse
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 3) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1714,6 +1751,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegTs3l = polynomialDegreeInK(den, k);
     if (denDegTs3l !== undefined) {
       if (denDegTs3l > ts3lDeg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 69: Mul(Sqrt(P), Log(diverging), Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+  // One Sqrt factor + three Log factors; log³ is sub-polynomial — contributes 0 to effective degree.
+  // effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtThreeLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l3Deg = oneSqrtThreeLogPolyEffectiveDeg(num, k);
+  if (s1l3Deg !== undefined) {
+    const denDegS1l3 = polynomialDegreeInK(den, k);
+    if (denDegS1l3 !== undefined) {
+      if (denDegS1l3 > s1l3Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -2111,3 +2111,97 @@ describe("Phase 68 — Three-Sqrt × Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 69 — One-Sqrt × Three-Log × polynomial numerator", () => {
+  it("√k·log(k)³ / k² closes (effective=0.5, denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·log(k)³ / k³ closes (effective=1.5, denDeg=3 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k3] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_3] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)³ / 2^k closes (exponential denominator)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)³ / 1 refused (effective=0.5, denDeg=0 not > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, int(1)] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, int(1)] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Phase 69 convergence recogniser: handles `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), polynomial..., bounded...)` numerators
- Exactly 1 Sqrt factor + exactly 3 Log factors; log³ is sub-polynomial (o(k^ε)), contributing 0 to effective degree
- `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`; closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator
- Natural counterpart to Phase 68 (Three-Sqrt × One-Log); Phase 67 (Three-Log) intentionally refuses Sqrt factors — Phase 69 picks those cases up
- All three language packages bumped 2.6.0 → 2.7.0 (Python, TypeScript, Rust)
- New helpers: `_one_sqrt_three_log_poly_effective_x2` (Python), `oneSqrtThreeLogPolyEffectiveDeg` (TypeScript), `one_sqrt_three_log_poly_effective_x2` (Rust)
- Regression: updated Phase 67 `test_sqrt_present_refused` — `log(k)³·√k/k²` now correctly closes via Phase 69 (previously misclassified as refused)
- 12 new tests total: 5 (Python) + 4 (TypeScript) + 3 (Rust)

## Test plan

- [ ] Python: 204 tests pass (5 new Phase 69 tests + 1 updated Phase 67 test)
- [ ] TypeScript: 121 tests pass (4 new Phase 69 tests)
- [ ] Rust: 108 tests pass (3 new Phase 69 tests)
- [ ] Boundary/refusal: `√k·log(k)³/1` → SUM (effective_x2=1 but 2·0=0 not > 1)
- [ ] Exponential denominator: `√k·log(k)³/2^k` → closes via non-polynomial diverging path

🤖 Generated with [Claude Code](https://claude.com/claude-code)