### PR TITLE
feat(ruby-parser): Phase 6y — string interpolation expression parsing

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.26.0] - 2026-05-25
+
+### Added (Phase 6y — string interpolation expression parsing)
+
+The lexer's Phase-3b state machine captures `"foo#{x}bar"` as a single `TokenType::String` token whose value carries the `#{...}` markers verbatim, with `{`/`}` already brace-balanced by the lexer's `interp_brace_depth` tracking.  Phase 6y is therefore **grammar-zero**: the existing STRING token at factor / call-arg / assignment-RHS positions already accepts interpolated forms.  This phase adds explicit test coverage for the parser side and the SIR lowering for the interpolation split.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+The SIR lowerer's String case now scans the raw content for `#{...}` segments and emits:
+
+| Source              | SIR shape                                                                                       |
+|---------------------|-------------------------------------------------------------------------------------------------|
+| `"plain"`           | `StrLit("plain")` (zero-cost fast path — unchanged)                                             |
+| `"#{x}"`            | `VarRef("x")` (single non-literal segment, no wrapper)                                          |
+| `"hi #{name}"`      | `BuiltinCall("string_concat", [StrLit("hi "), VarRef("name")])`                                 |
+| `"sum=#{1+2}"`      | `BuiltinCall("string_concat", [StrLit("sum="), BuiltinCall("__interp__", [StrLit("1+2")])])`    |
+
+Bare-identifier interp bodies lower to a `VarRef` with the same `Scope::Param` / `Scope::Local` dispatch as the regular factor-atom Name case.  More complex interp bodies (arithmetic, calls, nested strings) emit a marker `BuiltinCall("__interp__", [StrLit(raw_body)])`, matching the marker pattern used by Phase 6v rescue/ensure — downstream Ruby emitters can re-emit the marker verbatim as `#{<raw>}`.
+
+### v0 deferred limitations
+
+- Complex interp bodies are carried as the raw `__interp__` marker rather than being recursively parsed — a future phase will invoke the parser/lowerer on the body so the SIR carries semantic info.
+- Escape sequences inside the string literal pass through unchanged (the lexer hasn't unescaped them yet).
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 113 → **117** (+4):
+  - `test_parse_interpolated_string_assignment` — `x = "hello #{name}"`.
+  - `test_parse_interpolated_string_in_call_arg` — `puts("sum=#{1+2}")`.
+  - `test_parse_interpolated_string_only_interp` — `x = "#{name}"`.
+  - `test_parse_interpolated_string_multiple_segments` — `x = "a=#{a}, b=#{b}"`.
+
 ## [0.25.0] - 2026-05-25
 
 ### Added (Phase 6x — instance var `@x`, class var `@@x`, global var `$x` refs)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -1955,5 +1955,77 @@ mod tests {
         assert!(tree_has_token_value(ca, "*"), "expected `*` splat prefix in yield arg");
         assert!(tree_has_token_value(ca, "arr"));
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6y — string interpolation expression parsing
+    //
+    // The lexer's Phase-3b state machine emits `"hello #{name}"` as a single
+    // `TokenType::String` token whose value carries the `#{...}` markers
+    // verbatim.  These tests merely confirm that the existing grammar
+    // (STRING token at factor position) accepts interpolated forms in every
+    // statement / expression context the lowerer will touch: assignment
+    // RHS, argument position, and bare expression.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_interpolated_string_assignment() {
+        // `x = "hello #{name}"` — interpolation on the RHS of an
+        // assignment.  The whole literal is one STRING token, so the
+        // grammar treats it identically to a plain string.
+        let ast = parse_ruby(r##"x = "hello #{name}""##);
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected an assignment node for `x = \"...#{{name}}\"`"
+        );
+        // The raw token value (with `#{...}` preserved) must be present
+        // in the tree.
+        assert!(
+            tree_has_token_value(&ast, "hello #{name}"),
+            "expected the verbatim interpolated string token in the parse tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_interpolated_string_in_call_arg() {
+        // `puts("sum=#{1+2}")` — interpolation body is an arbitrary
+        // expression; lexer brace-tracking keeps the `{...}` balanced.
+        let ast = parse_ruby(r##"puts("sum=#{1+2}")"##);
+        assert!(
+            find_descendant(&ast, "method_call").is_some(),
+            "expected a method_call node wrapping puts(...)"
+        );
+        assert!(
+            tree_has_token_value(&ast, "sum=#{1+2}"),
+            "expected the verbatim interpolation-bearing string token"
+        );
+    }
+
+    #[test]
+    fn test_parse_interpolated_string_only_interp() {
+        // `x = "#{name}"` — the entire string is a single `#{...}`.
+        // Lowering should emit only the interp expression with no
+        // surrounding literal text; here we only verify the grammar
+        // accepts it.
+        let ast = parse_ruby(r##"x = "#{name}""##);
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected an assignment node"
+        );
+        assert!(
+            tree_has_token_value(&ast, "#{name}"),
+            "expected `#{{name}}` token value preserved verbatim"
+        );
+    }
+
+    #[test]
+    fn test_parse_interpolated_string_multiple_segments() {
+        // `x = "a=#{a}, b=#{b}"` — multiple `#{...}` interp markers
+        // with literal text bridging them.  Verifies the lexer's
+        // brace tracking handles back-to-back interps and the grammar
+        // accepts the resulting single token.
+        let ast = parse_ruby(r##"x = "a=#{a}, b=#{b}""##);
+        assert!(find_descendant(&ast, "assignment").is_some());
+        assert!(tree_has_token_value(&ast, "a=#{a}, b=#{b}"));
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.26.0] - 2026-05-25
+
+### Added (Phase 6y — string interpolation lowering)
+
+`lower_factor_atom` now hands every `TokenType::String` token to a new helper, `lower_string_literal_with_interp`, which scans the raw content for `#{...}` interpolation markers and emits the appropriate SIR shape.
+
+### Lowering
+
+| Source              | SIR shape                                                                                       |
+|---------------------|-------------------------------------------------------------------------------------------------|
+| `"plain"`           | `StrLit("plain")` — zero-cost fast path                                                         |
+| `"#{x}"`            | `VarRef("x")` — single non-literal segment, no wrapper                                          |
+| `"hi #{name}"`      | `BuiltinCall("string_concat", [StrLit("hi "), VarRef("name")])`                                 |
+| `"#{a}#{b}"`        | `BuiltinCall("string_concat", [VarRef("a"), VarRef("b")])`                                      |
+| `"sum=#{1+2}"`      | `BuiltinCall("string_concat", [StrLit("sum="), BuiltinCall("__interp__", [StrLit("1+2")])])`    |
+
+Bare-identifier interp bodies route to `VarRef` with the same `Scope::Param` / `Scope::Local` dispatch as the regular factor-atom Name case.  Complex bodies emit a marker `BuiltinCall("__interp__", [StrLit(raw)])` — same marker pattern as Phase 6v's `__rescue_marker__` / `__ensure_marker__`.
+
+Brace depth is tracked while scanning the interp body so nested `{...}` (inline hash, block) is balanced correctly, matching the lexer's `interp_brace_depth` state.
+
+### v0 deferred limitations
+
+- Complex interp bodies (arithmetic, method calls, nested strings, sigil vars) are kept as a `__interp__` marker rather than being recursively parsed.  A future phase will invoke the Ruby parser/lowerer on the body so the SIR carries proper semantic info.
+- Escape sequences inside the string literal (`\n`, `\t`, `\\`, `\"`) pass through unchanged — the lexer hasn't unescaped them yet.
+- Sigil-prefixed vars (`@x`, `$x`, `@@x`) inside an interp body intentionally fall through to the `__interp__` marker; Phase 6x's sigil routing only fires at lex time, not at interp-split time.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 116 → **121** (+5):
+  - `plain_string_with_no_interp_remains_a_strlit` — regression for the zero-cost path.
+  - `interpolated_string_with_bare_name_lowers_to_string_concat` — happy path.
+  - `interpolated_string_that_is_only_interp_unwraps_to_a_single_segment` — `"#{name}"`.
+  - `interpolated_string_with_expression_uses_interp_marker` — `"sum=#{1+2}"`.
+  - `interpolated_string_module_passes_sir_validator` — end-to-end validator smoke.
+
 ## [0.25.0] - 2026-05-25
 
 ### Added (Phase 6x — sigil variable refs `@x`, `@@x`, `$x`)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2376,4 +2376,131 @@ mod tests {
             other => panic!("expected yield builtin call, got {:?}", other),
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6y — string interpolation lowering
+    //
+    // Output shapes covered:
+    //   "plain"              → StrLit("plain")
+    //   "#{x}"               → VarRef("x")
+    //   "hi #{name}"         → BuiltinCall("string_concat",
+    //                            [StrLit("hi "), VarRef("name")])
+    //   "sum=#{1+2}"         → BuiltinCall("string_concat",
+    //                            [StrLit("sum="),
+    //                             BuiltinCall("__interp__", [StrLit("1+2")])])
+    //
+    // Plus an end-to-end smoke test that an interpolated module passes
+    // the SIR validator (proves the BuiltinCall + StrLit shape is
+    // well-formed semantic IR).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn plain_string_with_no_interp_remains_a_strlit() {
+        // Regression: zero-cost path — no interpolation markers means
+        // we emit a plain `StrLit`, exactly as we did pre-Phase-6y.
+        let m = lower(r#"x = "hello""#);
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => match value {
+                Expr::StrLit { value, .. } => assert_eq!(value, "hello"),
+                other => panic!("expected plain StrLit, got {:?}", other),
+            },
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_string_with_bare_name_lowers_to_string_concat() {
+        // `"hi #{name}"` → string_concat(StrLit("hi "), VarRef("name"))
+        //
+        // The interpolated literal is in *trailing-value* position so
+        // it sees the prior LetBinding (the validator's parallel-let
+        // rule would otherwise reject the cross-binding reference).
+        let m = lower(r##"name = "world"
+"hi #{name}"
+"##);
+        let b = main_body(&m);
+        // Single LetBinding for `name`; the interpolated string is the
+        // block's trailing value expression.
+        assert_eq!(b.stmts.len(), 1);
+        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "name"));
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "string_concat");
+                assert_eq!(args.len(), 2, "expected 2 concat segments");
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "hi "));
+                assert!(matches!(&args[1], Expr::VarRef { name, .. } if name == "name"));
+            }
+            other => panic!("expected string_concat BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_string_that_is_only_interp_unwraps_to_a_single_segment() {
+        // `"#{name}"` has no literal text — the lowerer should hand back
+        // the single segment directly (no `string_concat` wrapper).
+        // Trailing-value position so the VarRef sees the LetBinding.
+        let m = lower(r##"name = "world"
+"#{name}"
+"##);
+        let b = main_body(&m);
+        assert_eq!(b.stmts.len(), 1);
+        assert!(matches!(&b.stmts[0], Stmt::LetBinding { name, .. } if name == "name"));
+        assert!(
+            matches!(&b.value, Expr::VarRef { name, .. } if name == "name"),
+            "expected bare VarRef without concat wrapper, got {:?}",
+            b.value
+        );
+    }
+
+    #[test]
+    fn interpolated_string_with_expression_uses_interp_marker() {
+        // `"sum=#{1+2}"` — the interp body `1+2` is not a bare name, so
+        // it must lower as the v0 `__interp__` marker carrying the raw
+        // body text.  Same marker pattern as Phase 6v rescue/ensure.
+        let m = lower(r##"x = "sum=#{1+2}""##);
+        let b = main_body(&m);
+        let value = match &b.stmts[0] {
+            Stmt::LetBinding { value, .. } => value,
+            other => panic!("expected LetBinding, got {:?}", other),
+        };
+        match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "string_concat");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "sum="));
+                match &args[1] {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "__interp__");
+                        assert_eq!(args.len(), 1);
+                        assert!(
+                            matches!(&args[0], Expr::StrLit { value, .. } if value == "1+2"),
+                            "expected the raw interp body preserved in the marker"
+                        );
+                    }
+                    other => panic!("expected __interp__ marker, got {:?}", other),
+                }
+            }
+            other => panic!("expected string_concat, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn interpolated_string_module_passes_sir_validator() {
+        // End-to-end smoke: the module produced from an interpolated
+        // string round-trips through the SIR validator.  This catches
+        // shape regressions (missing effects, wrong arg ordering,
+        // unbound names) that the unit assertions above might miss.
+        // Trailing-value placement so the interpolation's VarRef sees
+        // the prior LetBinding under the validator's parallel-let rule.
+        let m = lower(r##"name = "world"
+puts("hi #{name}")
+"##);
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected interpolated-string module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2931,6 +2931,218 @@ impl Lowerer {
         Ok(semantic_ir::nodes::MapEntry { key, value })
     }
 
+    // -------------------------------------------------------------------
+    // Phase 6y — string interpolation lowering
+    // -------------------------------------------------------------------
+
+    /// Lower a Ruby string literal whose raw content may contain
+    /// `#{...}` interpolation markers (Phase 6y).
+    ///
+    /// The lexer's Phase-3b state machine captures `"foo#{x}bar"` as a
+    /// single `TokenType::String` token whose `value` is the inner
+    /// content with the `#{...}` markers preserved verbatim and any
+    /// `{` / `}` inside the interpolation already brace-balanced by
+    /// the lexer's `interp_brace_depth` tracking.
+    ///
+    /// ## Split strategy
+    ///
+    /// Walk the content char-by-char.  When we hit `#{`, flush the
+    /// accumulated literal text as a `StrLit` segment, then scan the
+    /// interpolation body up to the matching `}` (tracking brace depth
+    /// so `#{ {a: 1} }` works).  Each interpolation body lowers via
+    /// [`lower_interp_expression`] — bare identifiers route to
+    /// `VarRef`, anything else lowers as a `BuiltinCall("__interp__",
+    /// [StrLit(raw)])` marker.  This matches the marker pattern used
+    /// by Phase 6v rescue/ensure.
+    ///
+    /// ## Output shapes
+    ///
+    /// | Source              | Lowered SIR shape                                                              |
+    /// |---------------------|--------------------------------------------------------------------------------|
+    /// | `"plain"`           | `StrLit("plain")`                                                              |
+    /// | `"#{x}"`            | `VarRef("x")` — single non-literal segment, no wrapper                         |
+    /// | `"hi #{name}"`      | `BuiltinCall("string_concat", [StrLit("hi "), VarRef("name")])`                |
+    /// | `"#{a}#{b}"`        | `BuiltinCall("string_concat", [VarRef("a"), VarRef("b")])`                     |
+    /// | `"sum is #{1+2}"`   | `BuiltinCall("string_concat", [StrLit("sum is "), BuiltinCall("__interp__", [StrLit("1+2")])])` |
+    ///
+    /// ## v0 deferred
+    ///
+    /// - Complex interpolation expressions are kept as the `__interp__`
+    ///   marker carrying the raw source text rather than being recursively
+    ///   parsed; downstream Ruby emitters can still reconstruct the
+    ///   original literal verbatim from the marker.  A future phase
+    ///   will recursively invoke the Ruby parser/lowerer on the body so
+    ///   the SIR carries proper semantic info.
+    /// - Escape sequences inside the literal (`\n`, `\t`, `\\`, `\"`)
+    ///   pass through unchanged — the lexer hasn't unescaped them yet.
+    fn lower_string_literal_with_interp(
+        &mut self,
+        raw: &str,
+        span: Span,
+        err_line: usize,
+        err_column: usize,
+    ) -> Result<Expr, RubyLowerError> {
+        let mut segments: Vec<Expr> = Vec::new();
+        let mut text_buf = String::new();
+        let mut chars = raw.char_indices().peekable();
+
+        while let Some((_, ch)) = chars.next() {
+            // Detect the `#{` interpolation opener — only when `#` is
+            // immediately followed by `{`.  Bare `#` inside a string
+            // (e.g. `"a#b"`) is just a literal character.
+            if ch == '#' {
+                if let Some(&(_, '{')) = chars.peek() {
+                    // Consume the `{`.
+                    chars.next();
+                    // Flush whatever literal text we've accumulated so
+                    // far as its own `StrLit` segment.  We do not push
+                    // empty segments (saves allocations and keeps the
+                    // emitted SIR clean for `"#{a}"`-style strings).
+                    if !text_buf.is_empty() {
+                        segments.push(Expr::StrLit {
+                            value: std::mem::take(&mut text_buf),
+                            span: span.clone(),
+                        });
+                    }
+                    // Scan up to the matching closing `}`, tracking
+                    // brace depth so nested `{...}` (e.g. inline hash
+                    // or block in the interp) is balanced correctly.
+                    let mut depth: usize = 1;
+                    let mut interp = String::new();
+                    let mut terminated = false;
+                    for (_, c) in chars.by_ref() {
+                        match c {
+                            '{' => {
+                                depth += 1;
+                                interp.push(c);
+                            }
+                            '}' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    terminated = true;
+                                    break;
+                                }
+                                interp.push(c);
+                            }
+                            other => interp.push(other),
+                        }
+                    }
+                    if !terminated {
+                        // Defensive: the lexer's Phase-3b state machine
+                        // would have rejected an unterminated `#{...`,
+                        // but propagate as a lower-error rather than
+                        // panicking if it ever slips through.
+                        return Err(RubyLowerError {
+                            message: format!(
+                                "unterminated `#{{...` interpolation in string literal `\"{}\"`",
+                                raw
+                            ),
+                            line: err_line,
+                            column: err_column,
+                        });
+                    }
+                    segments.push(self.lower_interp_expression(&interp, span.clone()));
+                    continue;
+                }
+            }
+            // Ordinary literal character.  push() copies one full
+            // UTF-8 char (not a byte) so multi-byte content stays
+            // intact.
+            text_buf.push(ch);
+        }
+        // Flush any trailing literal text after the last interp.
+        if !text_buf.is_empty() {
+            segments.push(Expr::StrLit {
+                value: text_buf,
+                span: span.clone(),
+            });
+        }
+
+        // Result-shape selection:
+        // - Empty string literal (`""`): emit a single empty `StrLit`.
+        // - Exactly one segment: hand it back directly (no concat
+        //   wrapper needed — keeps `"plain"` and `"#{x}"` lean).
+        // - Two or more segments: wrap in a `string_concat` builtin.
+        //
+        // Any path that emits one or more segments needs the `Strings`
+        // feature flag because we're producing `StrLit` data.
+        if segments.is_empty() {
+            return Ok(Expr::StrLit {
+                value: String::new(),
+                span,
+            });
+        }
+        self.features_used.insert(Feature::Strings);
+        if segments.len() == 1 {
+            return Ok(segments.into_iter().next().unwrap());
+        }
+        Ok(Expr::BuiltinCall {
+            name: "string_concat".to_string(),
+            args: segments,
+            effects: EffectSet::PURE,
+            span,
+        })
+    }
+
+    /// Lower the body of a single `#{...}` interpolation segment
+    /// (Phase 6y).
+    ///
+    /// v0 fast path: a bare identifier (no whitespace, no operators,
+    /// no sigils) routes to `VarRef` with the same `Scope::Param` /
+    /// `Scope::Local` dispatch as the regular factor-atom Name case.
+    /// This covers the overwhelmingly common shape `"hello #{name}"`.
+    ///
+    /// v0 fallback: anything else — arithmetic, method calls, nested
+    /// strings, sigil vars, etc. — lowers as a single marker
+    /// `BuiltinCall("__interp__", [StrLit(raw_body)])`.  Downstream
+    /// emitters that target Ruby can re-emit the marker as `#{<raw>}`
+    /// verbatim; emitters that target other languages can flag the
+    /// marker as a TODO for a future phase that re-parses the body.
+    ///
+    /// Same marker pattern as Phase 6v's `__rescue_marker__` /
+    /// `__ensure_marker__` — a known-name `BuiltinCall` whose arg
+    /// list carries the verbatim source text.
+    fn lower_interp_expression(&mut self, raw: &str, span: Span) -> Expr {
+        let trimmed = raw.trim();
+        // Bare-identifier check: starts with `_` or ASCII letter,
+        // and every following char is `_`/letter/digit.  We
+        // intentionally reject sigil vars (`@x`, `$x`, `@@x`) here
+        // because the Phase 6x routing happens at lex time, not at
+        // interp-split time — those would need their own special
+        // handling in a follow-up phase.
+        let mut chars_iter = trimmed.chars();
+        let is_bare_name = match chars_iter.next() {
+            Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+                chars_iter.all(|c| c.is_ascii_alphanumeric() || c == '_')
+            }
+            _ => false,
+        };
+        if is_bare_name {
+            let scope = if self.current_params.contains(&trimmed.to_string()) {
+                Scope::Param
+            } else {
+                Scope::Local
+            };
+            return Expr::VarRef {
+                name: trimmed.to_string(),
+                scope,
+                span,
+            };
+        }
+        // Fallback marker.  Triggers `Strings` because we embed the
+        // raw text as a `StrLit`.
+        self.features_used.insert(Feature::Strings);
+        Expr::BuiltinCall {
+            name: "__interp__".to_string(),
+            args: vec![Expr::StrLit {
+                value: raw.to_string(),
+                span: span.clone(),
+            }],
+            effects: EffectSet::PURE,
+            span,
+        }
+    }
+
     fn lower_factor(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // factor ::= ( atom ) { dot_call }
         //
@@ -2966,10 +3178,21 @@ impl Lowerer {
                             return Ok(Expr::IntLit { value: v, span });
                         }
                         TokenType::String => {
-                            return Ok(Expr::StrLit {
-                                value: tok.value.clone(),
+                            // Phase 6y — string interpolation expression
+                            // lowering.  The lexer (Phase 3b) emits the
+                            // entire `"foo#{x}bar"` literal as a single
+                            // `String` token whose `value` holds the inner
+                            // content with `#{...}` markers preserved
+                            // verbatim.  When markers are present we split
+                            // into segments and emit a concat builtin;
+                            // when absent we fall through to a plain
+                            // `StrLit` (zero-cost fast path).
+                            return self.lower_string_literal_with_interp(
+                                &tok.value,
                                 span,
-                            });
+                                tok.line,
+                                tok.column,
+                            );
                         }
                         TokenType::Name => {
                             // Inside a function body, parameter


### PR DESCRIPTION
## Summary

The lexer's Phase-3b state machine captures `"foo#{x}bar"` as a single `TokenType::String` token whose value carries the `#{...}` markers verbatim, with `{`/`}` already brace-balanced by `interp_brace_depth`.  Phase 6y is therefore **grammar-zero**: the existing STRING token at factor / call-arg / assignment-RHS positions already accepts interpolated forms.  This PR adds the SIR lowering split + explicit test coverage on both sides of the pipeline.

## Lowering

| Source              | SIR shape                                                                                       |
|---------------------|-------------------------------------------------------------------------------------------------|
| `"plain"`           | `StrLit("plain")` — zero-cost fast path (unchanged)                                             |
| `"#{x}"`            | `VarRef("x")` — single non-literal segment, no wrapper                                          |
| `"hi #{name}"`      | `BuiltinCall("string_concat", [StrLit("hi "), VarRef("name")])`                                 |
| `"#{a}#{b}"`        | `BuiltinCall("string_concat", [VarRef("a"), VarRef("b")])`                                      |
| `"sum=#{1+2}"`      | `BuiltinCall("string_concat", [StrLit("sum="), BuiltinCall("__interp__", [StrLit("1+2")])])`    |

Bare-identifier interp bodies route to `VarRef` with the same `Scope::Param` / `Scope::Local` dispatch as the regular factor-atom Name case.  Complex bodies emit a marker `BuiltinCall("__interp__", [StrLit(raw)])` — same marker pattern as Phase 6v's `__rescue_marker__` / `__ensure_marker__`.

Brace depth is tracked while scanning the interp body so nested `{...}` (inline hash, block) is balanced correctly, matching the lexer's brace tracking.

## v0 deferred limitations

- Complex interp bodies (arithmetic, method calls, nested strings, sigil vars) are kept as a `__interp__` marker rather than being recursively parsed.  A future phase will invoke the Ruby parser/lowerer on the body so the SIR carries proper semantic info.
- Escape sequences inside the string literal (`\n`, `\t`, `\\`, `\"`) pass through unchanged — the lexer hasn't unescaped them yet.
- Sigil-prefixed vars (`@x`, `$x`, `@@x`) inside an interp body intentionally fall through to the `__interp__` marker; Phase 6x's sigil routing only fires at lex time, not at interp-split time.

## Tests

- `coding-adventures-ruby-parser`: 113 → **117** (+4 grammar tests).
- `ruby-to-semantic-ir`: 116 → **121** (+5 lowering tests, incl. end-to-end validator smoke).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (117/117 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (121/121 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — the lowerer change is a pure scan over the already-tokenised string value with bounded loops and a brace-depth counter; unterminated `#{` propagates as `RubyLowerError` rather than panicking; same patterns as prior phases)
- [ ] CI green

Follows PR #4352 (Phase 6x — sigil var refs `@x`, `@@x`, `$x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
