### PR TITLE
feat(image-codec-webp): VP8L lossless WebP codec (IC06 v0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -371,6 +371,7 @@ members = [
     "image-codec-jpeg",
     "image-codec-ppm",
     "image-codec-qoi",
+    "image-codec-webp",
     "mosaic-analyzer",
     "mosaic-driver",
     "mosaic-compile",

--- a/code/packages/rust/image-codec-webp/BUILD
+++ b/code/packages/rust/image-codec-webp/BUILD
@@ -1,9 +1,1 @@
-rust_library(
-    name = "image-codec-webp",
-    srcs = glob(["src/**/*.rs"]),
-    deps = [
-        "//code/packages/rust/pixel-container",
-        "//code/packages/rust/paint-instructions",
-        "//code/packages/rust/huffman-tree",
-    ],
-)
+cargo test -p image-codec-webp -- --nocapture

--- a/code/packages/rust/image-codec-webp/BUILD
+++ b/code/packages/rust/image-codec-webp/BUILD
@@ -1,0 +1,9 @@
+rust_library(
+    name = "image-codec-webp",
+    srcs = glob(["src/**/*.rs"]),
+    deps = [
+        "//code/packages/rust/pixel-container",
+        "//code/packages/rust/paint-instructions",
+        "//code/packages/rust/huffman-tree",
+    ],
+)

--- a/code/packages/rust/image-codec-webp/CHANGELOG.md
+++ b/code/packages/rust/image-codec-webp/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog — image-codec-webp
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.1.0] — 2026-05-25
+
+### Added
+
+- **`encode_webp_lossless(pixels: &PixelContainer) -> Vec<u8>`** — encode a
+  pixel buffer as a complete VP8L lossless WebP file (RIFF container included).
+
+- **`decode_webp(bytes: &[u8]) -> Result<PixelContainer, String>`** — decode a
+  WebP file; supports VP8L chunks; returns descriptive errors for VP8 lossy,
+  VP8X extended, and unknown chunk types.
+
+- **`WebPCodec`** — implements `paint_instructions::ImageCodec`:
+  - `mime_type()` returns `"image/webp"`.
+  - `encode()` calls `encode_webp_lossless` (lossless mode) or panics with a
+    clear message (lossy mode — `range-coder` required).
+  - `decode()` delegates to `decode_webp`.
+
+- **`src/riff.rs`** — RIFF container builder (`build_riff`): encodes the
+  12-byte file header, chunk header, chunk data, and even-byte padding.
+
+- **`src/vp8l/bitstream.rs`** — LSB-first `BitWriter` and `BitReader`:
+  - `BitWriter::write_bits(value, count)` — packs bits LSB-first.
+  - `BitReader::read_bits(count)` / `peek_bits` / `consume_bits`.
+
+- **`src/vp8l/huffman.rs`** — VP8L canonical Huffman encoding and decoding:
+  - `HuffmanTable::from_lengths` — builds a fast decode lookup table
+    (indexed by bit-reversed canonical codes for LSB-first streams).
+  - `write_huffman_code` — writes simple-1, simple-2, or complex (meta-Huffman)
+    code storage to the bitstream.
+  - `read_huffman_code` — reads all three code storage formats back.
+  - `lengths_from_frequencies` — builds Huffman code lengths from symbol
+    frequencies using the `huffman-tree` crate.
+  - `build_encode_table` — builds `(reversed_code, code_len)` per symbol.
+
+- **`src/vp8l/lz77.rs`** — VP8L LZ77 distance mapping:
+  - `DISTANCE_MAP` — 120-entry 2D distance offset table from the VP8L spec.
+  - `dist_code_to_offset` — converts a distance code to a 1D pixel offset.
+  - `length_symbol_to_base` — decodes VP8L copy-length symbols.
+
+- **`src/vp8l/transforms.rs`** — VP8L transform infrastructure:
+  - `TransformKind` — the four VP8L transform type codes.
+  - `apply_subtract_green` / `inverse_subtract_green` — forward and inverse
+    subtract-green transforms (forward not yet called by encoder).
+
+- **52 unit tests** covering:
+  - RIFF header layout and padding.
+  - Round-trip encode/decode for: blank images, solid-colour images, gradients,
+    1×1 images, transparent images, varying-alpha images.
+  - VP8L signature byte, header fields.
+  - Huffman simple-1, simple-2, and complex (meta-Huffman) code round-trips.
+  - Bit-reversal, encode-table/decode-table consistency.
+  - Error cases: bad magic, truncated input, VP8 lossy stub, unknown chunk.
+  - LZ77 distance table size and sample values.
+  - Subtract-green transform round-trip.
+
+### Implementation notes
+
+- Uses **literal-only** VP8L (no transforms, no LZ77, no colour cache).
+  This is valid VP8L; compression ratio is lower than a full implementation.
+- Single-symbol Huffman groups use the VP8L simple-1 format (0 bits emitted
+  per symbol after writing the code table header).
+- Complex code storage uses a fixed meta-tree (all meta-lengths = 4 for
+  symbols 0-15) for simplicity; this is valid but not maximally compact.
+- VP8 lossy (`encode_webp`) panics with `"VP8 lossy not yet implemented:
+  range-coder required"` — will be wired up when the `range-coder` crate lands.
+
+### Known limitations
+
+- LZ77 back-references (G symbol ≥ 256) in the bitstream cause a decode error.
+- Predictor, colour, and colour-index transforms are not implemented.
+- VP8X extended WebP files are not supported.

--- a/code/packages/rust/image-codec-webp/Cargo.toml
+++ b/code/packages/rust/image-codec-webp/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "image-codec-webp"
+version = "0.1.0"
+edition = "2021"
+description = "WebP image codec for paint-instructions: PixelContainer ↔ WebP bytes (VP8L lossless + VP8 lossy stub)"
+
+[dependencies]
+pixel-container = { path = "../pixel-container" }
+paint-instructions = { path = "../paint-instructions" }
+huffman-tree = { path = "../huffman-tree" }

--- a/code/packages/rust/image-codec-webp/README.md
+++ b/code/packages/rust/image-codec-webp/README.md
@@ -1,0 +1,141 @@
+# image-codec-webp
+
+WebP image codec for the paint-instructions pixel pipeline.
+
+Implements VP8L (lossless) encoding and decoding.  VP8 lossy support requires
+the `range-coder` crate and will be added in a future release.
+
+## Position in the Stack
+
+```text
+PixelContainer   ←— rendered by paint-metal / paint-vm-*
+     │
+     │   encode_webp_lossless()
+     ▼
+  Vec<u8>  (complete .webp file, RIFF container + VP8L chunk)
+     │
+     │   decode_webp()
+     ▼
+PixelContainer
+```
+
+## Architecture
+
+A WebP file is a RIFF container:
+
+```text
+RIFF <file_size> WEBP
+  VP8L <chunk_size> <vp8l-bitstream>
+```
+
+The VP8L bitstream format:
+
+```text
+[0x2F]                      VP8L signature byte
+[14 bits] width - 1
+[14 bits] height - 1
+[1 bit]   alpha_is_used
+[3 bits]  version (must be 0)
+[1 bit]   has_transform       (0 in v0.1 — no transforms)
+[4 bits]  color_cache_code_bits  (0 in v0.1 — no color cache)
+[G-table] Huffman code for green channel (280 symbols)
+[R-table] Huffman code for red channel   (256 symbols)
+[B-table] Huffman code for blue channel  (256 symbols)
+[A-table] Huffman code for alpha channel (256 symbols)
+[D-table] Huffman code for distances     (40 symbols)
+[pixel data: per pixel, G-symbol then R, B, A symbols]
+```
+
+## Usage
+
+### Functional API
+
+```rust
+use image_codec_webp::{encode_webp_lossless, decode_webp};
+use pixel_container::PixelContainer;
+
+// Encode
+let mut pixels = PixelContainer::new(64, 64);
+pixels.fill(200, 100, 50, 255);
+let webp_bytes = encode_webp_lossless(&pixels);
+
+// Decode
+let decoded = decode_webp(&webp_bytes).unwrap();
+assert_eq!(decoded.pixel_at(0, 0), (200, 100, 50, 255));
+```
+
+### Trait API
+
+```rust
+use image_codec_webp::WebPCodec;
+use paint_instructions::ImageCodec;
+
+let codec = WebPCodec::new(90, true); // lossless mode
+let bytes = codec.encode(&pixels);
+let decoded = codec.decode(&bytes).unwrap();
+```
+
+## Module Structure
+
+```
+src/
+  lib.rs              — public API (WebPCodec, encode_webp_lossless, decode_webp)
+  riff.rs             — RIFF container builder
+  vp8l/
+    mod.rs            — VP8L encode/decode orchestration
+    bitstream.rs      — LSB-first BitWriter and BitReader
+    huffman.rs        — Canonical Huffman tables (encode + decode)
+    lz77.rs           — LZ77 distance mapping table (decode stub)
+    transforms.rs     — VP8L transform types and inverse-subtract-green
+```
+
+## Encoding Strategy (v0.1)
+
+This release uses **literal-only** encoding:
+
+- **No transforms** — the encoder writes `has_transform = 0`.
+  The subtract-green, predictor, colour, and colour-index transforms are
+  defined in `transforms.rs` but not applied.
+
+- **No LZ77 back-references** — every pixel is encoded as four Huffman-coded
+  channel values (G, R, B, A).  The distance Huffman group always uses a
+  trivial one-symbol code.
+
+- **No colour cache** — `color_cache_code_bits = 0`.
+
+This produces valid VP8L output that round-trips perfectly.  Compression ratio
+is lower than a fully-optimised encoder because spatial redundancy is not
+exploited.
+
+## Huffman Code Storage
+
+VP8L encodes each Huffman group in one of two formats:
+
+| Format    | When used                          | Bits written        |
+|-----------|------------------------------------|---------------------|
+| Simple-1  | Group has exactly 1 distinct symbol | `1, 0, symbol[8]` |
+| Simple-2  | Group has exactly 2 distinct symbols | `1, 1, sym0_bits, sym1[8]` |
+| Complex   | Group has ≥ 3 distinct symbols      | Meta-Huffman scheme |
+
+For complex codes this crate uses a fixed meta-tree where meta-symbols 0-15
+each have meta-length 4.  This is valid VP8L (the format allows any valid
+meta-tree) but not maximally compact.
+
+## Limitations and Future Work
+
+| Feature                         | Status                |
+|---------------------------------|-----------------------|
+| VP8L literal encoding           | Implemented ✓        |
+| VP8L subtract-green transform   | Decode only; not applied by encoder |
+| VP8L predictor transform        | Not yet implemented   |
+| VP8L colour transform           | Not yet implemented   |
+| VP8L colour-index transform     | Not yet implemented   |
+| VP8L LZ77 back-references       | Decoder returns error |
+| VP8L colour cache               | Not yet implemented   |
+| VP8 lossy encoding/decoding     | Requires `range-coder` crate |
+
+## References
+
+- [WebP Lossless Bitstream Specification](https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification)
+- [WebP Container Specification (RIFF)](https://developers.google.com/speed/webp/docs/riff_container)
+- [RFC 6386 — VP8](https://www.rfc-editor.org/rfc/rfc6386)

--- a/code/packages/rust/image-codec-webp/src/lib.rs
+++ b/code/packages/rust/image-codec-webp/src/lib.rs
@@ -1,0 +1,364 @@
+//! # image-codec-webp
+//!
+//! WebP image codec for the paint-instructions pixel pipeline.
+//! Implements VP8L (lossless) encoding and decoding.
+//! VP8 lossy encoding/decoding requires the `range-coder` crate and will be
+//! added in a future release.
+//!
+//! ## Architecture
+//!
+//! WebP files use a RIFF container:
+//!
+//! ```text
+//! RIFF <file_size> WEBP
+//!   VP8L <chunk_size> <vp8l-bitstream>
+//! ```
+//!
+//! The VP8L bitstream stores pixels using:
+//!
+//! 1. Optional transforms (subtract_green, color, predictor, color_index).
+//!    This release always writes no transforms.
+//! 2. LZ77 backward references with 2D distance mapping.
+//!    This release uses literal-only mode (no back-references).
+//! 3. Canonical Huffman prefix codes in 5 groups (G, R, B, A, Dist).
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use image_codec_webp::{encode_webp_lossless, decode_webp, WebPCodec};
+//! use paint_instructions::ImageCodec;
+//!
+//! // Functional API:
+//! let encoded = encode_webp_lossless(&pixels);
+//! let decoded = decode_webp(&encoded).unwrap();
+//!
+//! // Trait API:
+//! let codec = WebPCodec::new(90, true);
+//! let bytes = codec.encode(&pixels);
+//! let pixels2 = codec.decode(&bytes).unwrap();
+//! ```
+//!
+//! ## VP8 lossy
+//!
+//! Lossy WebP (VP8) requires the `range-coder` crate (arithmetic coding) which
+//! is being implemented in a parallel PR.  Calling `encode_webp` or constructing
+//! `WebPCodec::new(q, false)` and calling `encode` will panic with a clear message.
+//!
+//! ## References
+//!
+//! - WebP lossless bitstream spec: https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification
+//! - WebP container spec: https://developers.google.com/speed/webp/docs/riff_container
+//! - VP8 lossy spec: https://www.rfc-editor.org/rfc/rfc6386
+
+pub const VERSION: &str = "0.1.0";
+
+mod riff;
+pub mod vp8l;
+
+use paint_instructions::{ImageCodec, PixelContainer};
+
+// ---------------------------------------------------------------------------
+// WebPCodec — implements the ImageCodec trait
+// ---------------------------------------------------------------------------
+
+/// A WebP image codec that implements [`ImageCodec`].
+///
+/// Supports lossless encoding (VP8L) and returns a descriptive error for
+/// VP8 lossy encoding (requires the `range-coder` crate, coming in a future PR).
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// use image_codec_webp::WebPCodec;
+/// use paint_instructions::ImageCodec;
+///
+/// let codec = WebPCodec::new(90, true); // 90% quality, lossless
+/// let bytes = codec.encode(&pixels);
+/// let decoded = codec.decode(&bytes).unwrap();
+/// ```
+pub struct WebPCodec {
+    /// Quality hint for lossy encoding (0–100).  Ignored in lossless mode.
+    pub quality: u8,
+    /// If `true`, use VP8L lossless encoding.  If `false`, use VP8 lossy
+    /// (currently unimplemented — panics).
+    pub lossless: bool,
+}
+
+impl WebPCodec {
+    /// Create a new `WebPCodec`.
+    ///
+    /// `quality` is a hint for the VP8 lossy encoder (0=worst, 100=best).
+    /// In lossless mode (`lossless=true`) quality is ignored.
+    pub fn new(quality: u8, lossless: bool) -> Self {
+        Self { quality, lossless }
+    }
+}
+
+impl ImageCodec for WebPCodec {
+    /// Returns `"image/webp"`.
+    fn mime_type(&self) -> &'static str {
+        "image/webp"
+    }
+
+    /// Encode a pixel buffer as a WebP file.
+    ///
+    /// In lossless mode (`self.lossless = true`) this calls `encode_webp_lossless`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.lossless = false` (VP8 lossy not yet implemented).
+    fn encode(&self, pixels: &PixelContainer) -> Vec<u8> {
+        if self.lossless {
+            encode_webp_lossless(pixels)
+        } else {
+            // VP8 lossy requires range-coder crate — coming in next PR.
+            panic!("VP8 lossy not yet implemented: range-coder required")
+        }
+    }
+
+    /// Decode a WebP file into a pixel buffer.
+    ///
+    /// Supports VP8L (lossless) chunk type.
+    /// Returns `Err` for VP8 lossy, VP8X extended, or unknown chunk types.
+    fn decode(&self, bytes: &[u8]) -> Result<PixelContainer, String> {
+        decode_webp(bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Functional API
+// ---------------------------------------------------------------------------
+
+/// Encode a `PixelContainer` as a lossless WebP file (VP8L).
+///
+/// Returns a complete, self-contained WebP file (RIFF container + VP8L chunk).
+/// Ready to write to disk or send over the network.
+///
+/// This uses literal-only VP8L encoding without transforms or LZ77
+/// back-references.  Compression is valid but not optimal compared to a
+/// full encoder with all transforms enabled.
+pub fn encode_webp_lossless(pixels: &PixelContainer) -> Vec<u8> {
+    let bitstream = vp8l::encode(pixels);
+    riff::build_riff(b"VP8L", &bitstream)
+}
+
+/// Encode a `PixelContainer` as a lossy WebP file (VP8).
+///
+/// # Panics
+///
+/// Always panics — VP8 lossy encoding requires the `range-coder` crate which
+/// will be added in a future PR.
+pub fn encode_webp(_pixels: &PixelContainer, _quality: u8) -> Vec<u8> {
+    panic!("VP8 lossy not yet implemented: range-coder required")
+}
+
+/// Decode a WebP file (RIFF container) into a `PixelContainer`.
+///
+/// Supports the VP8L (lossless) chunk type.
+/// Returns a descriptive error for:
+/// - Files that are too short to parse.
+/// - Files missing the RIFF magic or WEBP fourCC.
+/// - VP8 lossy (`VP8 ` chunk) — not yet implemented.
+/// - VP8X extended (`VP8X` chunk) — not yet implemented.
+/// - Unknown chunk types.
+pub fn decode_webp(bytes: &[u8]) -> Result<PixelContainer, String> {
+    if bytes.len() < 12 {
+        return Err("WebP: file too short (need at least 12 bytes for RIFF header)".to_string());
+    }
+    if &bytes[0..4] != b"RIFF" {
+        return Err("WebP: missing RIFF magic bytes".to_string());
+    }
+    if bytes.len() < 20 {
+        return Err("WebP: file too short to contain a WEBP chunk header".to_string());
+    }
+    if &bytes[8..12] != b"WEBP" {
+        return Err("WebP: missing WEBP fourCC (bytes 8-11)".to_string());
+    }
+
+    // Parse the first chunk (immediately after the RIFF/WEBP header).
+    let chunk_type = &bytes[12..16];
+    let chunk_size = u32::from_le_bytes(bytes[16..20].try_into().unwrap()) as usize;
+
+    let chunk_data_start = 20usize;
+    if bytes.len() < chunk_data_start + chunk_size {
+        return Err(format!(
+            "WebP: chunk truncated (need {} bytes after offset 20, have {})",
+            chunk_size,
+            bytes.len() - chunk_data_start
+        ));
+    }
+    let chunk_data = &bytes[chunk_data_start..chunk_data_start + chunk_size];
+
+    match chunk_type {
+        b"VP8L" => vp8l::decode(chunk_data),
+        b"VP8 " => Err(
+            "WebP: VP8 lossy not yet implemented: range-coder required".to_string()
+        ),
+        b"VP8X" => Err(
+            "WebP: VP8X extended format not yet implemented".to_string()
+        ),
+        _ => Err(format!(
+            "WebP: unknown chunk type {:?} (expected VP8L, VP8 , or VP8X)",
+            std::str::from_utf8(chunk_type).unwrap_or("<non-UTF8>")
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paint_instructions::PixelContainer;
+
+    // ── Version ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn version_exists() {
+        assert_eq!(VERSION, "0.1.0");
+    }
+
+    // ── WebPCodec ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn mime_type_is_webp() {
+        assert_eq!(WebPCodec::new(75, true).mime_type(), "image/webp");
+    }
+
+    #[test]
+    fn codec_encode_decode_roundtrip() {
+        let mut pixels = PixelContainer::new(4, 4);
+        pixels.fill(128, 64, 32, 200);
+        let codec = WebPCodec::new(90, true);
+        let bytes = codec.encode(&pixels);
+        let decoded = codec.decode(&bytes).unwrap();
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    // ── RIFF magic bytes ──────────────────────────────────────────────────────
+
+    #[test]
+    fn riff_magic_bytes() {
+        let pixels = PixelContainer::new(4, 4);
+        let bytes = encode_webp_lossless(&pixels);
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(&bytes[8..12], b"WEBP");
+    }
+
+    // ── VP8L signature byte ───────────────────────────────────────────────────
+
+    #[test]
+    fn vp8l_signature_byte() {
+        let pixels = PixelContainer::new(4, 4);
+        let bytes = encode_webp_lossless(&pixels);
+        // VP8L chunk: bytes[12..16] = b"VP8L", bytes[16..20] = chunk size, bytes[20] = 0x2F
+        assert_eq!(&bytes[12..16], b"VP8L");
+        assert_eq!(bytes[20], 0x2F);
+    }
+
+    // ── Round-trip tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_solid_color() {
+        let mut pixels = PixelContainer::new(4, 4);
+        for y in 0..4u32 {
+            for x in 0..4u32 {
+                pixels.set_pixel(x, y, 200, 100, 50, 255);
+            }
+        }
+        let encoded = encode_webp_lossless(&pixels);
+        let decoded = decode_webp(&encoded).unwrap();
+        assert_eq!(decoded.width, 4);
+        assert_eq!(decoded.height, 4);
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    #[test]
+    fn round_trip_gradient() {
+        let mut pixels = PixelContainer::new(8, 8);
+        for y in 0..8u32 {
+            for x in 0..8u32 {
+                pixels.set_pixel(x, y, (x * 30) as u8, (y * 30) as u8, 128, 255);
+            }
+        }
+        let encoded = encode_webp_lossless(&pixels);
+        let decoded = decode_webp(&encoded).unwrap();
+        assert_eq!(decoded.width, 8);
+        assert_eq!(decoded.height, 8);
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    #[test]
+    fn round_trip_1x1() {
+        let mut pixels = PixelContainer::new(1, 1);
+        pixels.set_pixel(0, 0, 255, 128, 64, 200);
+        let encoded = encode_webp_lossless(&pixels);
+        let decoded = decode_webp(&encoded).unwrap();
+        assert_eq!(decoded.pixel_at(0, 0), (255, 128, 64, 200));
+    }
+
+    #[test]
+    fn round_trip_transparent() {
+        let pixels = PixelContainer::new(4, 4); // all zeros (transparent black)
+        let encoded = encode_webp_lossless(&pixels);
+        let decoded = decode_webp(&encoded).unwrap();
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    #[test]
+    fn round_trip_all_channels_varied() {
+        let mut pixels = PixelContainer::new(4, 1);
+        pixels.set_pixel(0, 0, 10, 20, 30, 0);
+        pixels.set_pixel(1, 0, 10, 20, 30, 85);
+        pixels.set_pixel(2, 0, 10, 20, 30, 170);
+        pixels.set_pixel(3, 0, 10, 20, 30, 255);
+        let encoded = encode_webp_lossless(&pixels);
+        let decoded = decode_webp(&encoded).unwrap();
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    // ── Decode error cases ────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_error_bad_magic() {
+        let result = decode_webp(b"this is not a webp file at all!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_error_too_short() {
+        let result = decode_webp(&[0u8; 8]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_vp8_lossy_returns_err() {
+        // Simulate a VP8 (lossy) chunk — should return a descriptive error.
+        let mut fake = vec![0u8; 24];
+        fake[0..4].copy_from_slice(b"RIFF");
+        fake[4..8].copy_from_slice(&16u32.to_le_bytes()); // file_size_field
+        fake[8..12].copy_from_slice(b"WEBP");
+        fake[12..16].copy_from_slice(b"VP8 ");
+        fake[16..20].copy_from_slice(&4u32.to_le_bytes()); // chunk_size = 4
+        // chunk_data = 4 zero bytes
+        let result = decode_webp(&fake);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("VP8 lossy"), "expected 'VP8 lossy' in error: {err}");
+    }
+
+    #[test]
+    fn decode_unknown_chunk_returns_err() {
+        let mut fake = vec![0u8; 24];
+        fake[0..4].copy_from_slice(b"RIFF");
+        fake[4..8].copy_from_slice(&16u32.to_le_bytes());
+        fake[8..12].copy_from_slice(b"WEBP");
+        fake[12..16].copy_from_slice(b"UNKN");
+        fake[16..20].copy_from_slice(&4u32.to_le_bytes());
+        let result = decode_webp(&fake);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unknown chunk"));
+    }
+}

--- a/code/packages/rust/image-codec-webp/src/riff.rs
+++ b/code/packages/rust/image-codec-webp/src/riff.rs
@@ -1,0 +1,151 @@
+//! RIFF container helpers for WebP files.
+//!
+//! A WebP file is a RIFF file with the WEBP fourCC.  The RIFF container is
+//! a very simple binary framing format: a 12-byte fixed header followed by
+//! one or more typed chunks.
+//!
+//! ## Layout
+//!
+//! ```text
+//! Offset  Size  Field
+//!   0       4   "RIFF"                (literal ASCII)
+//!   4       4   file_size - 8         (u32 little-endian; excludes the RIFF+size fields)
+//!   8       4   "WEBP"                (WebP fourCC)
+//!  12       4   chunk_type            (e.g. "VP8L", "VP8 ", "VP8X")
+//!  16       4   chunk_size            (u32 little-endian; bytes of chunk_data)
+//!  20       ?   chunk_data            (chunk_size bytes, followed by a 0 pad if odd)
+//! ```
+//!
+//! ## RIFF file size field
+//!
+//! The field at offset 4 is the total file size minus 8 bytes (the size of the
+//! "RIFF" tag and the size field itself).  So:
+//!
+//! ```text
+//! file_size_field = 4 (WEBP) + 4 (chunk_type) + 4 (chunk_size) + len(chunk_data)
+//!                 = 12 + len(chunk_data)
+//! ```
+//!
+//! If chunk_data has odd length, a padding byte of 0 is appended **after**
+//! the data (the padding is not counted in chunk_size, but it IS counted in
+//! file_size_field).
+//!
+//! ## References
+//!
+//! - RIFF spec: https://www.iana.org/assignments/wave-avi-codec-registry/wave-avi-codec-registry.xhtml
+//! - WebP container spec: https://developers.google.com/speed/webp/docs/riff_container
+
+/// Build a complete WebP RIFF file containing one chunk.
+///
+/// `chunk_type` is a 4-byte chunk identifier (e.g. `b"VP8L"`).
+/// `chunk_data` is the raw chunk payload (not including the type or size fields).
+///
+/// Returns the complete file as a `Vec<u8>`, ready to write to disk.
+///
+/// ## Example
+///
+/// ```text
+/// let bytes = build_riff(b"VP8L", &payload);
+/// // bytes[0..4]  = b"RIFF"
+/// // bytes[4..8]  = (bytes.len() - 8) as u32 le
+/// // bytes[8..12] = b"WEBP"
+/// // bytes[12..16] = b"VP8L"
+/// // bytes[16..20] = payload.len() as u32 le
+/// // bytes[20..]  = payload (+ optional pad byte)
+/// ```
+pub fn build_riff(chunk_type: &[u8; 4], chunk_data: &[u8]) -> Vec<u8> {
+    // chunk_size field: actual chunk data length (does NOT include padding).
+    let chunk_size = chunk_data.len() as u32;
+
+    // Padding: RIFF chunks must be even-length.  If chunk_data has odd length,
+    // append one zero byte.  This pad byte IS counted in the RIFF file size but
+    // NOT in the chunk_size field.
+    let padded_chunk_len = chunk_data.len() + (chunk_data.len() & 1);
+
+    // RIFF file size field: "WEBP" (4) + chunk_type (4) + chunk_size_field (4) + padded_data.
+    let file_size_field = (4u32 + 4 + 4) + padded_chunk_len as u32;
+
+    let total_len = 12 + 8 + padded_chunk_len; // RIFF header + chunk header + data
+    let mut out = Vec::with_capacity(total_len);
+
+    // RIFF header.
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&file_size_field.to_le_bytes());
+    out.extend_from_slice(b"WEBP");
+
+    // Chunk header.
+    out.extend_from_slice(chunk_type);
+    out.extend_from_slice(&chunk_size.to_le_bytes());
+
+    // Chunk data + padding.
+    out.extend_from_slice(chunk_data);
+    if chunk_data.len() & 1 != 0 {
+        out.push(0);
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn riff_header_magic() {
+        let out = build_riff(b"VP8L", &[]);
+        assert_eq!(&out[0..4], b"RIFF");
+        assert_eq!(&out[8..12], b"WEBP");
+    }
+
+    #[test]
+    fn chunk_type_written_correctly() {
+        let out = build_riff(b"VP8L", &[0u8; 10]);
+        assert_eq!(&out[12..16], b"VP8L");
+    }
+
+    #[test]
+    fn chunk_size_field_matches_data_length() {
+        let data = vec![0u8; 17];
+        let out = build_riff(b"VP8L", &data);
+        let chunk_size = u32::from_le_bytes(out[16..20].try_into().unwrap());
+        assert_eq!(chunk_size, 17);
+    }
+
+    #[test]
+    fn file_size_field_even_data() {
+        // chunk_data len = 4 (even)
+        let data = vec![0u8; 4];
+        let out = build_riff(b"VP8L", &data);
+        let file_size_field = u32::from_le_bytes(out[4..8].try_into().unwrap());
+        // Expected: 4 (WEBP) + 4 (type) + 4 (size) + 4 (data) = 16
+        assert_eq!(file_size_field, 16);
+        // Total file length = 8 (RIFF+size_field) + file_size_field = 24
+        assert_eq!(out.len(), 24);
+    }
+
+    #[test]
+    fn padding_added_for_odd_data() {
+        let data = vec![0u8; 3]; // odd
+        let out = build_riff(b"VP8L", &data);
+        // chunk_size field must be 3 (no padding counted there).
+        let chunk_size = u32::from_le_bytes(out[16..20].try_into().unwrap());
+        assert_eq!(chunk_size, 3);
+        // Total file should be even.
+        assert_eq!(out.len() % 2, 0);
+        // Pad byte must be 0.
+        assert_eq!(out[23], 0);
+    }
+
+    #[test]
+    fn empty_chunk_data() {
+        let out = build_riff(b"VP8L", &[]);
+        assert_eq!(&out[0..4], b"RIFF");
+        let file_size_field = u32::from_le_bytes(out[4..8].try_into().unwrap());
+        // 4 (WEBP) + 4 (type) + 4 (size field) + 0 (data) = 12
+        assert_eq!(file_size_field, 12);
+    }
+}

--- a/code/packages/rust/image-codec-webp/src/vp8l/bitstream.rs
+++ b/code/packages/rust/image-codec-webp/src/vp8l/bitstream.rs
@@ -1,0 +1,237 @@
+//! LSB-first bit reader and writer for the VP8L bitstream.
+//!
+//! VP8L packs bits LSB-first: the first bit written appears in bit 0 of the
+//! first byte, the second bit in bit 1, and so on — exactly like DEFLATE.
+//!
+//! ## Why LSB-first?
+//!
+//! WebP inherits the bit-packing convention from VP8 (the video codec), which
+//! itself follows the convention used in many image/video codecs. LSB-first
+//! means that the lowest-significance bit of each symbol is written first into
+//! the lowest-significance bit of the current byte. This makes "byte-aligning"
+//! very cheap: just flush the accumulator.
+//!
+//! ## Example
+//!
+//! Writing 3 bits `0b101` then 5 bits `0b11001`:
+//! ```text
+//! buf = 0b00000000
+//! write 101: buf |= 101 << 0 → 0b00000101, bits=3
+//! write 11001: buf |= 11001 << 3 → 0b11001_101, bits=8
+//! flush byte → output [0b11001101]
+//! ```
+
+/// A bit-level writer that accumulates bits in an internal u64 buffer and
+/// flushes complete bytes to the output vector when they fill up.
+///
+/// The internal accumulator `buf` holds bits starting from the LSB.
+/// `bits` tracks how many bits are currently buffered.
+pub struct BitWriter {
+    /// Accumulator: bits are packed starting at bit 0 (LSB-first).
+    buf: u64,
+    /// Number of valid bits currently held in `buf`.
+    bits: u32,
+    /// Flushed output bytes.
+    output: Vec<u8>,
+}
+
+impl BitWriter {
+    /// Create a new, empty `BitWriter`.
+    pub fn new() -> Self {
+        Self { buf: 0, bits: 0, output: Vec::new() }
+    }
+
+    /// Write the low `count` bits of `value` into the stream.
+    ///
+    /// Bits are placed starting at the current LSB position of the accumulator.
+    /// Complete bytes are flushed to `output` automatically.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug mode if `count > 56` (the safe limit for a u64 accumulator
+    /// that might already hold up to 7 buffered bits).
+    pub fn write_bits(&mut self, value: u64, count: u32) {
+        debug_assert!(count <= 56, "write_bits: count={count} exceeds 56-bit safe limit");
+        self.buf |= value << self.bits;
+        self.bits += count;
+        // Flush complete bytes.
+        while self.bits >= 8 {
+            self.output.push((self.buf & 0xFF) as u8);
+            self.buf >>= 8;
+            self.bits -= 8;
+        }
+    }
+
+    /// Finish writing and return all buffered bytes.
+    ///
+    /// Any remaining buffered bits (fewer than 8) are flushed as a final
+    /// zero-padded byte.
+    pub fn finish(mut self) -> Vec<u8> {
+        if self.bits > 0 {
+            self.output.push((self.buf & 0xFF) as u8);
+        }
+        self.output
+    }
+
+    /// Current number of bytes written (not counting any partial byte still in
+    /// the accumulator). Useful for alignment checks.
+    pub fn bytes_written(&self) -> usize {
+        self.output.len()
+    }
+}
+
+impl Default for BitWriter {
+    fn default() -> Self { Self::new() }
+}
+
+// ---------------------------------------------------------------------------
+// BitReader
+// ---------------------------------------------------------------------------
+
+/// A bit-level reader that refills its accumulator from a byte slice on demand.
+///
+/// Like `BitWriter`, bits are packed LSB-first. `read_bits(n)` returns the
+/// next `n` bits as a `u32`.
+pub struct BitReader<'a> {
+    /// Source byte slice.
+    data: &'a [u8],
+    /// Current read position in `data` (next byte to load into the accumulator).
+    pos: usize,
+    /// Bit accumulator — bits available for reading start at bit 0.
+    buf: u64,
+    /// Number of valid bits currently in `buf`.
+    bits: u32,
+}
+
+impl<'a> BitReader<'a> {
+    /// Create a reader over `data`.
+    ///
+    /// The reader starts at the beginning of the slice with an empty accumulator.
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0, buf: 0, bits: 0 }
+    }
+
+    /// Refill the accumulator by loading bytes from `data` until at least 57
+    /// bits are available (or the data is exhausted).
+    ///
+    /// We refill when bits ≤ 56 so that a subsequent `read_bits(k)` with
+    /// k ≤ 56 is always safe.
+    fn refill(&mut self) {
+        while self.bits <= 56 && self.pos < self.data.len() {
+            self.buf |= (self.data[self.pos] as u64) << self.bits;
+            self.bits += 8;
+            self.pos += 1;
+        }
+    }
+
+    /// Read the next `count` bits from the stream, returning them as a `u32`.
+    ///
+    /// The bits are consumed from the accumulator LSB-first.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the stream is exhausted before `count` bits can be read.
+    pub fn read_bits(&mut self, count: u32) -> u32 {
+        self.refill();
+        debug_assert!(
+            count <= self.bits,
+            "BitReader: requested {count} bits but only {} available",
+            self.bits
+        );
+        let mask = if count < 64 { (1u64 << count) - 1 } else { u64::MAX };
+        let val = (self.buf & mask) as u32;
+        self.buf >>= count;
+        self.bits -= count;
+        val
+    }
+
+    /// Peek at the next `count` bits without consuming them.
+    ///
+    /// Useful for Huffman decoding lookahead.
+    pub fn peek_bits(&mut self, count: u32) -> u32 {
+        self.refill();
+        let mask = if count < 64 { (1u64 << count) - 1 } else { u64::MAX };
+        (self.buf & mask) as u32
+    }
+
+    /// Consume `count` bits (must call `peek_bits` first to ensure availability).
+    pub fn consume_bits(&mut self, count: u32) {
+        self.buf >>= count;
+        self.bits -= count;
+    }
+
+    /// Return `true` when all data has been read and the accumulator is empty.
+    pub fn is_exhausted(&self) -> bool {
+        self.bits == 0 && self.pos >= self.data.len()
+    }
+
+    /// Number of bits remaining (including buffered bits and bytes not yet loaded).
+    pub fn bits_remaining(&self) -> usize {
+        self.bits as usize + (self.data.len() - self.pos) * 8
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_single_byte() {
+        let mut w = BitWriter::new();
+        w.write_bits(0xAB, 8);
+        let bytes = w.finish();
+        let mut r = BitReader::new(&bytes);
+        assert_eq!(r.read_bits(8), 0xAB);
+    }
+
+    #[test]
+    fn round_trip_partial_bits() {
+        let mut w = BitWriter::new();
+        w.write_bits(0b101, 3);
+        w.write_bits(0b11001, 5);
+        let bytes = w.finish();
+        let mut r = BitReader::new(&bytes);
+        assert_eq!(r.read_bits(3), 0b101);
+        assert_eq!(r.read_bits(5), 0b11001);
+    }
+
+    #[test]
+    fn round_trip_multi_byte() {
+        let mut w = BitWriter::new();
+        for i in 0u64..16 {
+            w.write_bits(i, 4);
+        }
+        let bytes = w.finish();
+        assert_eq!(bytes.len(), 8); // 16 * 4 bits = 8 bytes
+        let mut r = BitReader::new(&bytes);
+        for i in 0u64..16 {
+            assert_eq!(r.read_bits(4), i as u32);
+        }
+    }
+
+    #[test]
+    fn peek_does_not_consume() {
+        let mut w = BitWriter::new();
+        w.write_bits(0b1100_1010, 8);
+        let bytes = w.finish();
+        let mut r = BitReader::new(&bytes);
+        let peeked = r.peek_bits(4);
+        assert_eq!(peeked, 0b1010); // low 4 bits
+        let read_val = r.read_bits(4);
+        assert_eq!(read_val, 0b1010); // same bits still there
+    }
+
+    #[test]
+    fn is_exhausted_after_full_read() {
+        let mut w = BitWriter::new();
+        w.write_bits(0xFF, 8);
+        let bytes = w.finish();
+        let mut r = BitReader::new(&bytes);
+        r.read_bits(8);
+        assert!(r.is_exhausted());
+    }
+}

--- a/code/packages/rust/image-codec-webp/src/vp8l/huffman.rs
+++ b/code/packages/rust/image-codec-webp/src/vp8l/huffman.rs
@@ -1,0 +1,815 @@
+//! VP8L canonical Huffman code storage and lookup tables.
+//!
+//! VP8L uses a custom Huffman code storage format that is more compact than
+//! simply listing all code lengths.  This module implements:
+//!
+//! 1. **Code-length serialisation** — writing the 5 Huffman group tables into
+//!    the bitstream using VP8L's "simple code" and "complex code" formats.
+//!
+//! 2. **Code-length deserialisation** — reading those tables back from the
+//!    bitstream.
+//!
+//! 3. **Canonical Huffman decode tables** — fast decode tables built from
+//!    code lengths for an LSB-first bit stream.
+//!
+//! ## Bit ordering — LSB-first canonical codes
+//!
+//! VP8L uses LSB-first bit packing (like DEFLATE): the first bit written is
+//! the LSB of the first byte.  Canonical Huffman codes in VP8L are stored with
+//! the MSB of the canonical code first in the stream — but since the stream is
+//! LSB-first, the code is **bit-reversed** before writing.
+//!
+//! Concretely: for a canonical code `c` of length `l`:
+//! - The encoder writes `reverse_bits(c, l)` using `write_bits`.
+//! - The decoder's `peek_bits(max_len)` returns the bit-reversed canonical code
+//!   in the low `l` bits (with the suffix bits in bits above position `l`).
+//! - The fast table is indexed by `peek_bits(max_code_len)`, mapping to the
+//!   correct symbol.
+//!
+//! ## Huffman groups
+//!
+//! VP8L uses **five** Huffman trees (groups G, R, B, A, Dist):
+//!
+//! - **G (green)** — 280 symbols: 0-255 literal green, 256-279 LZ77 length.
+//! - **R (red)** — 256 symbols.
+//! - **B (blue)** — 256 symbols.
+//! - **A (alpha)** — 256 symbols.
+//! - **Dist** — 40 symbols (distance codes).
+//!
+//! ## VP8L Huffman code storage
+//!
+//! ### Simple code (≤ 2 distinct symbols)
+//!
+//! ```text
+//! 1 bit:  simple_flag = 1
+//! 1 bit:  num_symbols_minus_1 (0=one symbol, 1=two symbols)
+//! If one symbol:
+//!   8 bits: symbol0
+//! If two symbols:
+//!   1 bit:  symbol0_is_8bit (0=symbol0 < 2 and fits in 1 bit; 1=use 8 bits)
+//!   (1 or 8) bits: symbol0
+//!   8 bits: symbol1
+//! ```
+//!
+//! symbol0 gets code 0 (1 bit), symbol1 gets code 1 (1 bit).
+//!
+//! ### Complex code (> 2 distinct symbols)
+//!
+//! Code lengths are stored using a meta-Huffman tree over the 19-symbol
+//! meta-alphabet { 0-15, 16, 17, 18 }, where:
+//!  - 0-15 = literal code length values.
+//!  - 16 = repeat last non-zero length 3..=6 times.
+//!  - 17 = repeat zero 3..=10 times.
+//!  - 18 = repeat zero 11..=138 times.
+//!
+//! The meta-tree itself is stored as 19 raw 3-bit code lengths (in
+//! `CODE_LENGTH_ORDER`).  We use a fixed meta-tree where symbols 0-7 each
+//! have meta-length 4 and symbols 8-15 each have meta-length 4, but in
+//! practice we use a simpler uniform meta-tree of meta-length = 4 for the
+//! 16 symbols we actually need (0-15) and 0 for symbols 16-18.
+
+use super::bitstream::{BitReader, BitWriter};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Size of the G (green + length) Huffman group alphabet (256 + 24 = 280).
+pub const G_ALPHABET_SIZE: usize = 280;
+
+/// Size of R, B, A Huffman group alphabets (one entry per byte value).
+pub const RGBA_ALPHABET_SIZE: usize = 256;
+
+/// Size of the Dist (distance) Huffman group alphabet.
+pub const DIST_ALPHABET_SIZE: usize = 40;
+
+/// Fixed order in which meta-alphabet code lengths are stored in the bitstream.
+const CODE_LENGTH_ORDER: [usize; 19] = [
+    17, 18, 0, 1, 2, 3, 4, 5, 16, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+];
+
+// ---------------------------------------------------------------------------
+// HuffmanTable — fast decode lookup table for LSB-first streams
+// ---------------------------------------------------------------------------
+
+/// A canonical Huffman decode table for VP8L's LSB-first bit streams.
+///
+/// ## Fast decode algorithm
+///
+/// 1. `peek_bits(max_code_len)` — reads up to `max_code_len` bits without consuming.
+/// 2. `fast[peeked]` — gives `(symbol, actual_code_len)`.
+/// 3. `consume_bits(actual_code_len)` — advances the stream.
+///
+/// For codes shorter than `max_code_len`, the same entry appears in multiple
+/// consecutive slots (one per possible "don't care" suffix).
+///
+/// For trivial (0 or 1 symbol) codes, no bits are consumed; the symbol is
+/// returned directly.
+#[derive(Debug, Clone)]
+pub struct HuffmanTable {
+    /// Maximum code length in this table.  0 = trivial (≤1-symbol) code.
+    pub max_code_len: u32,
+    /// The single symbol for trivial codes.  `None` if the table has 0 or ≥2 symbols.
+    pub trivial_symbol: Option<u16>,
+    /// Fast decode table.  Size = `1 << max_code_len`.
+    /// `fast[peeked_bits]` = `(symbol, code_length)`.
+    /// Indexed by the bit-reversed canonical code padded to `max_code_len` bits.
+    /// Unused slots hold `(u16::MAX, 0)`.
+    fast: Vec<(u16, u32)>,
+}
+
+impl HuffmanTable {
+    /// Build a `HuffmanTable` from code lengths.
+    ///
+    /// `code_lengths[i]` is the number of bits for symbol `i`.
+    /// A length of 0 means the symbol is absent.
+    pub fn from_lengths(code_lengths: &[u32]) -> Result<Self, String> {
+        let max_code_len = code_lengths.iter().copied().max().unwrap_or(0);
+
+        // Collect active symbols.
+        let mut active: Vec<(u16, u32)> = code_lengths
+            .iter()
+            .enumerate()
+            .filter(|&(_, &l)| l > 0)
+            .map(|(i, &l)| (i as u16, l))
+            .collect();
+
+        // 0 or 1 active symbol → trivial table.
+        // We also treat the single-symbol case with any length as trivial:
+        // the encoder writes write_simple_1(sym) and the decoder always returns
+        // that symbol without consuming any bits.
+        if active.len() <= 1 {
+            return Ok(HuffmanTable {
+                max_code_len: 0,
+                trivial_symbol: active.first().map(|&(sym, _)| sym),
+                fast: vec![],
+            });
+        }
+
+        // Sort by (length, symbol) for deterministic canonical assignment.
+        active.sort_by_key(|&(sym, len)| (len, sym));
+
+        if max_code_len > 15 {
+            return Err(format!(
+                "VP8L: max code length {max_code_len} exceeds VP8L limit of 15"
+            ));
+        }
+
+        // Assign canonical codes (standard MSB-first algorithm).
+        let mut canonical_codes: Vec<u32> = Vec::with_capacity(active.len());
+        {
+            let mut code = 0u32;
+            let mut prev_len = active[0].1;
+            for &(_, len) in &active {
+                if len > prev_len {
+                    code <<= len - prev_len;
+                }
+                canonical_codes.push(code);
+                code += 1;
+                prev_len = len;
+            }
+        }
+
+        // Build the fast table.
+        //
+        // The table is indexed by `peek_bits(max_code_len)`.  Since the bit
+        // stream is LSB-first, `peek_bits(n)` returns the next `n` bits with
+        // bit[0] in position 0 of the result.  When the encoder writes a
+        // canonical code it bit-reverses it first, so what's in the stream for
+        // a code of length `l` is `reverse_bits(canonical, l)`.
+        //
+        // For a code of length `l < max_code_len`, peeking `max_code_len` bits
+        // gives `reverse_bits(canonical, l)` in the low `l` bits, with the high
+        // `max_code_len - l` bits coming from the next symbol in the stream
+        // ("don't care" bits for the current lookup).
+        //
+        // So for each symbol with code `canonical` of length `l`:
+        //   reversed = reverse_bits(canonical, l)
+        //   for each possible suffix k in 0..2^(max_code_len - l):
+        //     table[reversed | (k << l)] = (symbol, l)
+
+        let table_size = 1usize << max_code_len;
+        let mut fast = vec![(u16::MAX, 0u32); table_size];
+
+        for (i, &(sym, len)) in active.iter().enumerate() {
+            let canonical = canonical_codes[i];
+            let reversed = reverse_bits_n(canonical, len);
+            let suffix_bits = max_code_len - len;
+            let suffix_count = 1usize << suffix_bits;
+            for k in 0..suffix_count {
+                let idx = reversed as usize | (k << len);
+                fast[idx] = (sym, len);
+            }
+        }
+
+        Ok(HuffmanTable {
+            max_code_len,
+            trivial_symbol: None,
+            fast,
+        })
+    }
+
+    /// Decode one symbol from the bit reader.
+    pub fn decode(&self, reader: &mut BitReader) -> Result<u16, String> {
+        // Trivial 1-symbol code: return the symbol without reading any bits.
+        if let Some(sym) = self.trivial_symbol {
+            return Ok(sym);
+        }
+
+        if self.max_code_len == 0 {
+            return Err("VP8L Huffman: empty decode table".to_string());
+        }
+
+        let peeked = reader.peek_bits(self.max_code_len);
+        let (sym, len) = self.fast[peeked as usize];
+        if len == 0 {
+            return Err(format!(
+                "VP8L Huffman: invalid code (peeked {peeked:#b} with max_len={})",
+                self.max_code_len
+            ));
+        }
+        reader.consume_bits(len);
+        Ok(sym)
+    }
+}
+
+/// Reverse the low `n` bits of `code`.
+///
+/// `reverse_bits_n(0b110, 3)` = `0b011`.
+pub fn reverse_bits_n(code: u32, n: u32) -> u32 {
+    if n == 0 {
+        return 0;
+    }
+    let mut result = 0u32;
+    let mut c = code;
+    for _ in 0..n {
+        result = (result << 1) | (c & 1);
+        c >>= 1;
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Write Huffman code to bitstream
+// ---------------------------------------------------------------------------
+
+/// Write the Huffman code table for one group into the bitstream.
+///
+/// Chooses simple (≤ 2 distinct symbols) or complex (> 2) format automatically.
+pub fn write_huffman_code(bw: &mut BitWriter, code_lengths: &[u32]) {
+    let active: Vec<(usize, u32)> = code_lengths
+        .iter()
+        .enumerate()
+        .filter(|&(_, &l)| l > 0)
+        .map(|(i, &l)| (i, l))
+        .collect();
+
+    match active.len() {
+        0 => write_simple_1(bw, 0),
+        1 => write_simple_1(bw, active[0].0 as u32),
+        2 => write_simple_2(bw, active[0].0 as u32, active[1].0 as u32),
+        _ => write_complex_code(bw, code_lengths),
+    }
+}
+
+/// Write a simple 1-symbol code.
+///
+/// ```text
+/// 1 bit:  simple_flag = 1
+/// 1 bit:  num_symbols_minus_1 = 0
+/// 8 bits: symbol0
+/// ```
+pub fn write_simple_1(bw: &mut BitWriter, symbol: u32) {
+    bw.write_bits(1, 1); // simple_flag = 1
+    bw.write_bits(0, 1); // 1 symbol
+    bw.write_bits(symbol as u64, 8);
+}
+
+/// Write a simple 2-symbol code.
+///
+/// ```text
+/// 1 bit:  simple_flag = 1
+/// 1 bit:  num_symbols_minus_1 = 1
+/// 1 bit:  symbol0_is_8bit
+/// (1 or 8) bits: symbol0
+/// 8 bits: symbol1
+/// ```
+pub fn write_simple_2(bw: &mut BitWriter, sym0: u32, sym1: u32) {
+    bw.write_bits(1, 1); // simple_flag = 1
+    bw.write_bits(1, 1); // 2 symbols
+    if sym0 < 2 {
+        bw.write_bits(0, 1); // symbol0 fits in 1 bit
+        bw.write_bits(sym0 as u64, 1);
+    } else {
+        bw.write_bits(1, 1); // symbol0 needs 8 bits
+        bw.write_bits(sym0 as u64, 8);
+    }
+    bw.write_bits(sym1 as u64, 8);
+}
+
+/// Write a complex Huffman code table using the meta-Huffman scheme.
+///
+/// We use a fixed meta-tree where meta-symbols 0-15 each have meta-length 4
+/// (giving 16 × 4-bit codes = valid Huffman tree), and meta-symbols 16-18
+/// have meta-length 0 (absent — we don't emit any RLE codes).
+///
+/// With all 16 active meta-symbols at length 4, canonical codes are:
+///   symbol 0 → canonical 0b0000 = 0, reversed = 0b0000 = 0
+///   symbol 1 → canonical 0b0001 = 1, reversed = 0b1000 = 8
+///   ...
+///   symbol n → canonical n, reversed = reverse_bits_n(n, 4)
+///
+/// Each actual code length `cl` (value 0..=15) is encoded as 4 bits in the
+/// stream: `reverse_bits_n(cl, 4)`.
+///
+/// ## Format
+///
+/// ```text
+/// 0 bit:   simple_flag = 0
+/// 4 bits:  num_stored - 4 = 15  (we store 19 entries, all 19 in CODE_LENGTH_ORDER)
+///          Actually: num_stored = 5 (only 5 meta-code lengths = 4, rest = 0)
+///          No: we store exactly the meta-lengths for symbols 16,18,0,1,...,15
+///          using CODE_LENGTH_ORDER.
+/// 19×3 bits: meta-code lengths in CODE_LENGTH_ORDER
+/// N×4 bits:  actual code lengths encoded via meta-tree
+/// ```
+fn write_complex_code(bw: &mut BitWriter, code_lengths: &[u32]) {
+    bw.write_bits(0, 1); // simple_flag = 0 (complex code)
+
+    // Meta-tree: meta-symbols 0-15 all have meta-length 4; 16-18 have 0.
+    // Store all 19 entries so the decoder can reconstruct the meta-tree.
+    // num_stored field = count - 4; for 19 entries write 15.
+    bw.write_bits(15, 4); // store all 19 meta-code lengths
+
+    // Write meta-lengths in CODE_LENGTH_ORDER.
+    // For the meta-tree: lengths 0-15 (indices 0-15) get meta-length 4.
+    //                    lengths 16-18 (meta-symbols for RLE) get 0.
+    let meta_lengths: [u32; 19] = {
+        let mut ml = [0u32; 19];
+        // Symbols 0-15 in our meta-tree get length 4.
+        for i in 0usize..16 {
+            ml[i] = 4;
+        }
+        // Symbols 16, 17, 18 get 0 (absent — we don't use RLE).
+        // ml[16] = ml[17] = ml[18] = 0;  (already 0 from initialisation)
+        ml
+    };
+
+    for &order_idx in &CODE_LENGTH_ORDER {
+        bw.write_bits(meta_lengths[order_idx] as u64, 3);
+    }
+
+    // Now write each actual code length as a meta-tree symbol.
+    // Meta-tree canonical codes: 16 symbols, each length 4.
+    // Sorted by (len=4, sym): 0,1,2,...,15.
+    // Canonical: sym i → code i  (in 4 bits, MSB-first).
+    // Reversed for LSB-first writing: reverse_bits_n(i, 4).
+    for i in 0..code_lengths.len() {
+        let cl = code_lengths[i].min(15) as u32;
+        // Encode meta-symbol `cl` using 4-bit reversed canonical code.
+        let reversed = reverse_bits_n(cl, 4) as u64;
+        bw.write_bits(reversed, 4);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Read Huffman code from bitstream
+// ---------------------------------------------------------------------------
+
+/// Read one Huffman code table from the bitstream.
+pub fn read_huffman_code(
+    br: &mut BitReader,
+    alphabet_size: usize,
+) -> Result<HuffmanTable, String> {
+    let simple_flag = br.read_bits(1);
+    if simple_flag == 1 {
+        read_simple_code(br, alphabet_size)
+    } else {
+        read_complex_code(br, alphabet_size)
+    }
+}
+
+/// Read a simple code (1 or 2 symbols).
+fn read_simple_code(br: &mut BitReader, alphabet_size: usize) -> Result<HuffmanTable, String> {
+    let num_symbols_minus_1 = br.read_bits(1);
+
+    if num_symbols_minus_1 == 0 {
+        // One symbol — trivial code.
+        let symbol = br.read_bits(8) as usize;
+        if symbol >= alphabet_size {
+            return Err(format!(
+                "VP8L: simple 1-symbol code: symbol {symbol} >= alphabet_size {alphabet_size}"
+            ));
+        }
+        return Ok(HuffmanTable {
+            max_code_len: 0,
+            trivial_symbol: Some(symbol as u16),
+            fast: vec![],
+        });
+    }
+
+    // Two symbols.
+    let symbol0_is_8bit = br.read_bits(1);
+    let symbol0 = if symbol0_is_8bit == 0 {
+        br.read_bits(1) as usize
+    } else {
+        br.read_bits(8) as usize
+    };
+    let symbol1 = br.read_bits(8) as usize;
+
+    if symbol0 >= alphabet_size {
+        return Err(format!(
+            "VP8L: simple 2-symbol code: s0={symbol0} >= alphabet_size {alphabet_size}"
+        ));
+    }
+    if symbol1 >= alphabet_size {
+        return Err(format!(
+            "VP8L: simple 2-symbol code: s1={symbol1} >= alphabet_size {alphabet_size}"
+        ));
+    }
+    if symbol0 == symbol1 {
+        return Err("VP8L: simple 2-symbol code has duplicate symbols".to_string());
+    }
+
+    let mut code_lengths = vec![0u32; alphabet_size];
+    code_lengths[symbol0] = 1;
+    code_lengths[symbol1] = 1;
+
+    HuffmanTable::from_lengths(&code_lengths)
+}
+
+/// Read a complex code using the meta-Huffman scheme.
+fn read_complex_code(
+    br: &mut BitReader,
+    alphabet_size: usize,
+) -> Result<HuffmanTable, String> {
+    // Read how many meta-code lengths are stored: 4 bits → count = value + 4.
+    let num_stored = br.read_bits(4) as usize + 4;
+    if num_stored > 19 {
+        return Err(format!(
+            "VP8L: num_code_lengths_to_store={num_stored} > 19"
+        ));
+    }
+
+    // Read raw meta-code lengths (3 bits each) in CODE_LENGTH_ORDER.
+    let mut meta_lengths = [0u32; 19];
+    for i in 0..num_stored {
+        let order_idx = CODE_LENGTH_ORDER[i];
+        meta_lengths[order_idx] = br.read_bits(3);
+    }
+
+    // Build the meta-Huffman decode table.
+    let meta_table = HuffmanTable::from_lengths(&meta_lengths)
+        .map_err(|e| format!("VP8L: invalid meta-Huffman table: {e}"))?;
+
+    // Decode actual code lengths using the meta-tree.
+    let mut code_lengths = vec![0u32; alphabet_size];
+    let mut i = 0;
+    let mut last_non_zero = 8u32; // default used when RLE code 16 is first
+
+    while i < alphabet_size {
+        let meta_sym = meta_table.decode(br)
+            .map_err(|e| format!("VP8L: error decoding code-length at i={i}: {e}"))?;
+
+        match meta_sym {
+            0..=15 => {
+                code_lengths[i] = meta_sym as u32;
+                if meta_sym > 0 {
+                    last_non_zero = meta_sym as u32;
+                }
+                i += 1;
+            }
+            16 => {
+                // Repeat last non-zero length 3..=6 times.
+                let extra = br.read_bits(2);
+                let count = (3 + extra) as usize;
+                for _ in 0..count {
+                    if i >= alphabet_size { break; }
+                    code_lengths[i] = last_non_zero;
+                    i += 1;
+                }
+            }
+            17 => {
+                // Repeat 0 length 3..=10 times.
+                let extra = br.read_bits(3);
+                let count = (3 + extra) as usize;
+                i += count.min(alphabet_size - i);
+            }
+            18 => {
+                // Repeat 0 length 11..=138 times.
+                let extra = br.read_bits(7);
+                let count = (11 + extra) as usize;
+                i += count.min(alphabet_size - i);
+            }
+            _ => {
+                return Err(format!("VP8L: unknown meta-symbol {meta_sym}"));
+            }
+        }
+    }
+
+    HuffmanTable::from_lengths(&code_lengths)
+        .map_err(|e| format!("VP8L: failed to build Huffman table from decoded lengths: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Build code lengths from symbol frequencies
+// ---------------------------------------------------------------------------
+
+/// Compute canonical VP8L Huffman code lengths from symbol frequencies.
+///
+/// Uses the `huffman-tree` crate to build the optimal tree, then extracts
+/// code lengths.  Symbols with zero frequency get length 0 (absent).
+/// Lengths are capped at 15 bits (VP8L limit).
+pub fn lengths_from_frequencies(freqs: &[u32]) -> Vec<u32> {
+    let weights: Vec<(u16, u32)> = freqs
+        .iter()
+        .enumerate()
+        .filter(|&(_, &f)| f > 0)
+        .map(|(i, &f)| (i as u16, f))
+        .collect();
+
+    let mut lengths = vec![0u32; freqs.len()];
+
+    if weights.is_empty() {
+        return lengths;
+    }
+    if weights.len() == 1 {
+        // Single active symbol: VP8L simple-1 code.
+        // We give it length 1 so write_huffman_code sees 1 active symbol and
+        // calls write_simple_1 with the correct symbol value.
+        // The decoder reconstructs this as a trivial table via read_simple_code.
+        lengths[weights[0].0 as usize] = 1;
+        return lengths;
+    }
+
+    match huffman_tree::HuffmanTree::build(&weights) {
+        Ok(tree) => {
+            let table = tree.canonical_code_table();
+            for (sym, code) in &table {
+                let len = code.len() as u32;
+                lengths[*sym as usize] = len.min(15);
+            }
+        }
+        Err(_) => {
+            // Fallback: uniform lengths.
+            let bits = ((weights.len() as f64).log2().ceil() as u32).max(1).min(15);
+            for &(sym, _) in &weights {
+                lengths[sym as usize] = bits;
+            }
+        }
+    }
+
+    lengths
+}
+
+// ---------------------------------------------------------------------------
+// Build encode table from code lengths
+// ---------------------------------------------------------------------------
+
+/// Build an encode table from canonical code lengths.
+///
+/// Returns a vector where `encode_table[symbol]` = `(bit_pattern, bit_count)`.
+/// `bit_pattern` is the **bit-reversed canonical code** ready for `write_bits`.
+/// For absent symbols (length 0), `bit_count = 0`.
+pub fn build_encode_table(code_lengths: &[u32]) -> Vec<(u64, u32)> {
+    let n = code_lengths.len();
+    let mut table = vec![(0u64, 0u32); n];
+
+    let mut active: Vec<(usize, u32)> = code_lengths
+        .iter()
+        .enumerate()
+        .filter(|&(_, &l)| l > 0)
+        .map(|(i, &l)| (i, l))
+        .collect();
+
+    if active.is_empty() {
+        return table;
+    }
+
+    // Single-symbol trivial code: the VP8L simple-1 format means the decoder
+    // returns the symbol without consuming any bits.  The encoder must likewise
+    // emit 0 bits per occurrence of this symbol.
+    if active.len() == 1 {
+        // table[sym] already = (0, 0) → 0 bits emitted.  Nothing to do.
+        return table;
+    }
+
+    active.sort_by_key(|&(sym, len)| (len, sym));
+
+    let mut code = 0u32;
+    let mut prev_len = active[0].1;
+    for &(sym, len) in &active {
+        if len > prev_len {
+            code <<= len - prev_len;
+        }
+        let reversed = reverse_bits_n(code, len) as u64;
+        table[sym] = (reversed, len);
+        code += 1;
+        prev_len = len;
+    }
+
+    table
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trivial_table_decodes_without_bits() {
+        let table = HuffmanTable {
+            max_code_len: 0,
+            trivial_symbol: Some(42),
+            fast: vec![],
+        };
+        let data = &[];
+        let mut br = BitReader::new(data);
+        assert_eq!(table.decode(&mut br).unwrap(), 42);
+    }
+
+    #[test]
+    fn simple_1_round_trip() {
+        let mut bw = BitWriter::new();
+        write_simple_1(&mut bw, 100);
+        let bytes = bw.finish();
+        let mut br = BitReader::new(&bytes);
+        let table = read_huffman_code(&mut br, 256).unwrap();
+        assert_eq!(table.trivial_symbol, Some(100));
+    }
+
+    #[test]
+    fn simple_2_round_trip_small_sym0() {
+        let mut bw = BitWriter::new();
+        write_simple_2(&mut bw, 1, 200);
+        let bytes = bw.finish();
+        let mut br = BitReader::new(&bytes);
+        let table = read_huffman_code(&mut br, 256).unwrap();
+        assert!(table.trivial_symbol.is_none());
+        assert_eq!(table.max_code_len, 1);
+    }
+
+    #[test]
+    fn simple_2_round_trip_large_sym0() {
+        let mut bw = BitWriter::new();
+        write_simple_2(&mut bw, 50, 200);
+        let bytes = bw.finish();
+        let mut br = BitReader::new(&bytes);
+        let table = read_huffman_code(&mut br, 256).unwrap();
+        assert!(table.trivial_symbol.is_none());
+        assert_eq!(table.max_code_len, 1);
+    }
+
+    #[test]
+    fn from_lengths_two_symbols_decodes() {
+        // sym 50 and sym 100, both length 1.
+        // Canonical: 50→0, 100→1.
+        // Reversed (len=1): 50→0, 100→1.
+        let mut lengths = vec![0u32; 256];
+        lengths[50] = 1;
+        lengths[100] = 1;
+        let table = HuffmanTable::from_lengths(&lengths).unwrap();
+
+        let mut bw = BitWriter::new();
+        bw.write_bits(0, 1); // sym50 (reversed canonical 0)
+        bw.write_bits(1, 1); // sym100 (reversed canonical 1)
+        let bytes = bw.finish();
+
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(table.decode(&mut br).unwrap(), 50);
+        assert_eq!(table.decode(&mut br).unwrap(), 100);
+    }
+
+    #[test]
+    fn from_lengths_three_symbols_decodes() {
+        // Symbol 0 (len=1), symbol 1 (len=2), symbol 2 (len=2).
+        // Canonical: 0→0b0=0, 1→0b10=2, 2→0b11=3.
+        // Reversed:  0→0 (1 bit), 1→0b01=1 (2 bits), 2→0b11=3 (2 bits).
+        let mut lengths = vec![0u32; 10];
+        lengths[0] = 1;
+        lengths[1] = 2;
+        lengths[2] = 2;
+        let table = HuffmanTable::from_lengths(&lengths).unwrap();
+        assert_eq!(table.max_code_len, 2);
+
+        let mut bw = BitWriter::new();
+        bw.write_bits(0, 1); // sym0
+        bw.write_bits(1, 2); // sym1 (reversed "10" = 0b01 = 1)
+        bw.write_bits(3, 2); // sym2 (reversed "11" = 0b11 = 3)
+        let bytes = bw.finish();
+
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(table.decode(&mut br).unwrap(), 0);
+        assert_eq!(table.decode(&mut br).unwrap(), 1);
+        assert_eq!(table.decode(&mut br).unwrap(), 2);
+    }
+
+    #[test]
+    fn build_encode_table_round_trip() {
+        // 3 symbols: lengths [1, 2, 2].
+        let mut lengths = vec![0u32; 10];
+        lengths[0] = 1;
+        lengths[1] = 2;
+        lengths[2] = 2;
+
+        let enc = build_encode_table(&lengths);
+        let table = HuffmanTable::from_lengths(&lengths).unwrap();
+
+        let symbols = [0usize, 1, 2, 0, 2, 1];
+        let mut bw = BitWriter::new();
+        for &sym in &symbols {
+            let (bits, count) = enc[sym];
+            if count > 0 {
+                bw.write_bits(bits, count);
+            }
+        }
+        let bytes = bw.finish();
+
+        let mut br = BitReader::new(&bytes);
+        for &expected in &symbols {
+            assert_eq!(table.decode(&mut br).unwrap() as usize, expected);
+        }
+    }
+
+    #[test]
+    fn complex_code_round_trip() {
+        // Build code lengths with > 2 active symbols.
+        let mut lengths = vec![0u32; 256];
+        lengths[0] = 1;
+        lengths[1] = 2;
+        lengths[2] = 3;
+        lengths[3] = 3;
+
+        let enc = build_encode_table(&lengths);
+
+        let mut bw = BitWriter::new();
+        write_huffman_code(&mut bw, &lengths);
+        let bytes = bw.finish();
+
+        let mut br = BitReader::new(&bytes);
+        let table = read_huffman_code(&mut br, 256).unwrap();
+
+        // Encode and decode all 4 symbols.
+        let symbols = [0usize, 1, 2, 3];
+        let mut bw2 = BitWriter::new();
+        for &sym in &symbols {
+            let (bits, count) = enc[sym];
+            if count > 0 {
+                bw2.write_bits(bits, count);
+            }
+        }
+        let bytes2 = bw2.finish();
+
+        let mut br2 = BitReader::new(&bytes2);
+        for &expected in &symbols {
+            assert_eq!(table.decode(&mut br2).unwrap() as usize, expected);
+        }
+    }
+
+    #[test]
+    fn lengths_from_frequencies_uniform() {
+        let mut freqs = vec![0u32; 256];
+        freqs[10] = 5;
+        freqs[20] = 3;
+        freqs[30] = 1;
+        let lengths = lengths_from_frequencies(&freqs);
+        assert_eq!(lengths.len(), 256);
+        assert!(lengths[10] > 0);
+        assert!(lengths[20] > 0);
+        assert!(lengths[30] > 0);
+        assert_eq!(lengths[0], 0);
+    }
+
+    #[test]
+    fn reverse_bits_sanity() {
+        assert_eq!(reverse_bits_n(0b110, 3), 0b011);
+        assert_eq!(reverse_bits_n(0b1010, 4), 0b0101);
+        assert_eq!(reverse_bits_n(1, 8), 0b10000000);
+    }
+
+    #[test]
+    fn write_huffman_code_1_symbol_sets_simple_flag() {
+        let lengths = vec![0u32; 256]; // all zero
+        let mut bw = BitWriter::new();
+        write_huffman_code(&mut bw, &lengths); // 0 active → write_simple_1(0)
+        let bytes = bw.finish();
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_bits(1), 1); // simple_flag
+    }
+
+    #[test]
+    fn write_huffman_code_2_symbols_sets_simple_flag() {
+        let mut lengths = vec![0u32; 256];
+        lengths[10] = 1;
+        lengths[20] = 1;
+        let mut bw = BitWriter::new();
+        write_huffman_code(&mut bw, &lengths);
+        let bytes = bw.finish();
+        let mut br = BitReader::new(&bytes);
+        assert_eq!(br.read_bits(1), 1); // simple_flag
+        assert_eq!(br.read_bits(1), 1); // 2 symbols
+    }
+}

--- a/code/packages/rust/image-codec-webp/src/vp8l/lz77.rs
+++ b/code/packages/rust/image-codec-webp/src/vp8l/lz77.rs
@@ -1,0 +1,176 @@
+//! VP8L LZ77 backward-reference distance mapping.
+//!
+//! In VP8L, pixel data can be compressed using LZ77 backward references.
+//! A backward reference says "copy N pixels from position X in the already-
+//! decoded output buffer".  The distance is encoded using a special 2D mapping
+//! that gives shorter codes to nearby pixels (both horizontally and
+//! vertically).
+//!
+//! ## Symbol encoding
+//!
+//! In the main pixel stream, the green-channel Huffman tree (G group) uses an
+//! extended alphabet:
+//!
+//! ```text
+//! Symbol 0..=255        → literal green channel value; read R, B, A from
+//!                          their respective trees to form a full pixel.
+//! Symbol 256..=279      → backward reference; symbol encodes copy length,
+//!                          read distance from Dist tree.
+//! Symbol 280..=287      → backward reference (extended length codes).
+//! Symbol ≥ 256+24+cache → color-cache reference (if cache enabled).
+//! ```
+//!
+//! ## Distance mapping
+//!
+//! VP8L maps a 1D distance `d` in the pixel stream to a 2D spatial distance
+//! `(dx, dy)` using a predefined lookup table.  This gives short codes to
+//! pixels that are spatially close (nearby rows and columns) rather than
+//! just close in memory order.
+//!
+//! The mapping for the first 120 distance codes is fixed by the spec
+//! (see Appendix A of the WebP lossless bitstream specification).
+//! For distances > 120, the 1D distance in raster order is used directly.
+//!
+//! ## Current status
+//!
+//! This initial release does **not** emit LZ77 backward references.  The
+//! encoder uses literal-only mode (every pixel is a literal).  This module
+//! provides the distance-mapping table and helper functions for future use.
+//!
+//! The decoder detects backward-reference symbols in the stream and returns
+//! an error, because an encoder in literal-only mode will never produce them.
+//! A future PR will implement full LZ77 encoding and decoding.
+
+// ---------------------------------------------------------------------------
+// Distance mapping table (first 120 entries from the VP8L spec)
+// ---------------------------------------------------------------------------
+
+/// VP8L 2D distance offsets for the first 120 distance codes.
+///
+/// Each entry is `(dx, dy)` where `dx` is the horizontal offset (positive =
+/// right, negative = left) and `dy` is the vertical offset (positive = down).
+/// The 1D backward distance in the pixel array is `dy * image_width + dx`.
+///
+/// These are taken verbatim from Table 1 of the WebP lossless bitstream spec.
+/// Distances are ordered so that nearby pixels (small spatial distance) get
+/// the smallest codes.
+pub const DISTANCE_MAP: [(i32, i32); 120] = [
+    (0, 1), (1, 0), (1, 1), (-1, 1), (0, 2), (2, 0), (1, 2), (-1, 2),
+    (2, 1), (-2, 1), (2, 2), (-2, 2), (0, 3), (3, 0), (1, 3), (-1, 3),
+    (3, 1), (-3, 1), (2, 3), (-2, 3), (3, 2), (-3, 2), (0, 4), (4, 0),
+    (1, 4), (-1, 4), (4, 1), (-4, 1), (3, 3), (-3, 3), (2, 4), (-2, 4),
+    (4, 2), (-4, 2), (0, 5), (3, 4), (-3, 4), (4, 3), (-4, 3), (5, 0),
+    (1, 5), (-1, 5), (5, 1), (-5, 1), (2, 5), (-2, 5), (5, 2), (-5, 2),
+    (4, 4), (-4, 4), (3, 5), (-3, 5), (5, 3), (-5, 3), (0, 6), (6, 0),
+    (1, 6), (-1, 6), (6, 1), (-6, 1), (2, 6), (-2, 6), (6, 2), (-6, 2),
+    (4, 5), (-4, 5), (5, 4), (-5, 4), (3, 6), (-3, 6), (6, 3), (-6, 3),
+    (0, 7), (7, 0), (4, 6), (-4, 6), (6, 4), (-6, 4), (1, 7), (-1, 7),
+    (5, 5), (-5, 5), (7, 1), (-7, 1), (2, 7), (-2, 7), (7, 2), (-7, 2),
+    (3, 7), (-3, 7), (7, 3), (-7, 3), (4, 7), (-4, 7), (7, 4), (-7, 4),
+    (5, 6), (-5, 6), (6, 5), (-6, 5), (8, 0), (5, 7), (-5, 7), (7, 5),
+    (-7, 5), (8, 1), (-8, 1), (6, 6), (-6, 6), (8, 2), (-8, 2), (6, 7),
+    (-6, 7), (7, 6), (-7, 6), (8, 3), (-8, 3), (7, 7), (-7, 7), (8, 4),
+];
+
+/// Convert a VP8L distance code to a 1D pixel-stream backward distance.
+///
+/// `dist_code` is the raw value from the Dist Huffman tree.
+/// `image_width` is the width of the image being decoded.
+///
+/// Returns the number of pixels to go backward in the output buffer.
+///
+/// For codes 1..=120 the 2D mapping table is used.  For code 0 or codes
+/// > 120 the distance is used directly (after subtracting 120 and adding the
+/// distance directly in raster order, per the spec).
+pub fn dist_code_to_offset(dist_code: u32, image_width: u32) -> usize {
+    if dist_code == 0 {
+        // Distance 0 is invalid; return 1 as a safe fallback.
+        return 1;
+    }
+    if dist_code <= 120 {
+        let (dx, dy) = DISTANCE_MAP[(dist_code - 1) as usize];
+        let offset = dy * image_width as i32 + dx;
+        // Negative offsets would mean forward references — invalid.
+        offset.max(1) as usize
+    } else {
+        // For large distances, subtract 120 and use directly.
+        (dist_code - 120) as usize
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Copy-length helpers (spec Table 2)
+// ---------------------------------------------------------------------------
+
+/// Decode a VP8L copy-length code.
+///
+/// Symbols 256..=279 (24 symbols) encode copy lengths 2..=129 using a
+/// prefix-extra-bits scheme (similar to DEFLATE):
+///
+/// ```text
+/// Symbol 256 → length 2   (0 extra bits)
+/// Symbol 257 → length 3   (0 extra bits)
+/// ...
+/// Symbol 264 → length 10  (0 extra bits)
+/// Symbol 265 → length 11..=12 (1 extra bit)
+/// ...
+/// Symbol 279 → length 115..=129 (4 extra bits, last code)
+/// ```
+///
+/// Returns `(base_length, extra_bits_needed)`.
+pub fn length_symbol_to_base(symbol: u32) -> (u32, u32) {
+    debug_assert!((256..=279).contains(&symbol), "not a length symbol: {symbol}");
+    let code = symbol - 256;
+    match code {
+        0..=7 => (code + 2, 0),
+        8..=9 => (10 + (code - 8) * 2, 1),
+        10..=11 => (14 + (code - 10) * 4, 2),
+        12..=13 => (22 + (code - 12) * 8, 3),
+        14..=15 => (38 + (code - 14) * 16, 4),
+        16..=23 => (70 + (code - 16) * 8, 3), // extended range
+        _ => unreachable!("symbol out of range"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distance_map_size() {
+        assert_eq!(DISTANCE_MAP.len(), 120);
+    }
+
+    #[test]
+    fn dist_code_1_is_one_pixel_up() {
+        // Code 1 → (dx=0, dy=1), so offset = 1 * width + 0 = width.
+        let width = 8u32;
+        assert_eq!(dist_code_to_offset(1, width), 8);
+    }
+
+    #[test]
+    fn dist_code_2_is_one_pixel_left() {
+        // Code 2 → (dx=1, dy=0), so offset = 0 * width + 1 = 1.
+        let width = 8u32;
+        assert_eq!(dist_code_to_offset(2, width), 1);
+    }
+
+    #[test]
+    fn dist_code_large_uses_direct() {
+        // dist_code=121 → 121 - 120 = 1
+        let width = 10u32;
+        assert_eq!(dist_code_to_offset(121, width), 1);
+        // dist_code=200 → 200 - 120 = 80
+        assert_eq!(dist_code_to_offset(200, width), 80);
+    }
+
+    #[test]
+    fn length_symbol_base_cases() {
+        assert_eq!(length_symbol_to_base(256), (2, 0));
+        assert_eq!(length_symbol_to_base(263), (9, 0));
+    }
+}

--- a/code/packages/rust/image-codec-webp/src/vp8l/mod.rs
+++ b/code/packages/rust/image-codec-webp/src/vp8l/mod.rs
@@ -1,0 +1,353 @@
+//! VP8L lossless WebP encode and decode.
+//!
+//! This module implements the VP8L bitstream format:
+//!
+//! ```text
+//! [signature byte 0x2F]
+//! [32-bit header: width-1(14b), height-1(14b), alpha_is_used(1b), version(3b)]
+//! [has_transform: 1 bit = 0 (no transforms in v0.1)]
+//! [color_cache_code_bits: 4 bits = 0 (no color cache)]
+//! [5 Huffman group tables: G, R, B, A, Dist]
+//! [pixel data: one G-symbol per pixel, plus R/B/A symbols]
+//! ```
+//!
+//! ## Encoding strategy (v0.1)
+//!
+//! This release uses **literal-only** encoding:
+//! - No transforms (subtract-green, predictor, colour, colour-index).
+//! - No LZ77 back-references.
+//! - No colour cache.
+//!
+//! Each pixel is encoded as four Huffman-coded values: green from the G tree,
+//! red from the R tree, blue from the B tree, alpha from the A tree.
+//! The Dist tree is always a trivial 1-symbol code (distance 0) because no
+//! back-references are used.
+//!
+//! ## Decoding
+//!
+//! The decoder supports:
+//! - Simple 1-symbol and 2-symbol codes.
+//! - Complex codes (meta-Huffman format).
+//! - Literal pixel decoding (G symbol < 256).
+//! - Returns an error on LZ77 symbols (G symbol ≥ 256).
+
+pub mod bitstream;
+pub mod huffman;
+pub mod lz77;
+pub mod transforms;
+
+use bitstream::{BitReader, BitWriter};
+use huffman::{
+    build_encode_table, lengths_from_frequencies, read_huffman_code, write_huffman_code,
+    DIST_ALPHABET_SIZE, G_ALPHABET_SIZE, RGBA_ALPHABET_SIZE,
+};
+use pixel_container::PixelContainer;
+
+// ---------------------------------------------------------------------------
+// VP8L encode
+// ---------------------------------------------------------------------------
+
+/// Encode a `PixelContainer` as a VP8L lossless bitstream (without the RIFF
+/// wrapper — the caller in `lib.rs`/`riff.rs` adds that).
+///
+/// The result starts with the VP8L signature byte `0x2F`, followed by the
+/// bit-packed bitstream.
+pub fn encode(pixels: &PixelContainer) -> Vec<u8> {
+    let w = pixels.width as u64;
+    let h = pixels.height as u64;
+
+    // ── Step 1: Collect pixel channel frequencies ────────────────────────────
+    //
+    // PixelContainer stores pixels as [R, G, B, A, R, G, B, A, ...] row-major.
+
+    let mut g_freq = vec![0u32; G_ALPHABET_SIZE];   // green channel literals
+    let mut r_freq = vec![0u32; RGBA_ALPHABET_SIZE]; // red channel
+    let mut b_freq = vec![0u32; RGBA_ALPHABET_SIZE]; // blue channel
+    let mut a_freq = vec![0u32; RGBA_ALPHABET_SIZE]; // alpha channel
+    let mut d_freq = vec![0u32; DIST_ALPHABET_SIZE]; // distance (unused)
+
+    for chunk in pixels.data.chunks_exact(4) {
+        g_freq[chunk[1] as usize] += 1; // G (green)
+        r_freq[chunk[0] as usize] += 1; // R (red)
+        b_freq[chunk[2] as usize] += 1; // B (blue)
+        a_freq[chunk[3] as usize] += 1; // A (alpha)
+    }
+
+    // Dist tree: always trivial (no back-references in v0.1).
+    d_freq[0] = 1;
+
+    // ── Step 2: Compute canonical code lengths ───────────────────────────────
+
+    let g_lens = lengths_from_frequencies(&g_freq);
+    let r_lens = lengths_from_frequencies(&r_freq);
+    let b_lens = lengths_from_frequencies(&b_freq);
+    let a_lens = lengths_from_frequencies(&a_freq);
+    let d_lens = lengths_from_frequencies(&d_freq);
+
+    // Build the encode tables (symbol → (bit_reversed_code, code_len)).
+    // For symbols with length 0 (trivial code), encoding emits 0 bits.
+    let g_encode = build_encode_table(&g_lens);
+    let r_encode = build_encode_table(&r_lens);
+    let b_encode = build_encode_table(&b_lens);
+    let a_encode = build_encode_table(&a_lens);
+
+    // ── Step 3: Write bitstream ──────────────────────────────────────────────
+
+    let mut bw = BitWriter::new();
+
+    // Header: (width-1) in 14 bits, (height-1) in 14 bits, alpha=1, version=0.
+    bw.write_bits(w - 1, 14);
+    bw.write_bits(h - 1, 14);
+    bw.write_bits(1, 1); // alpha_is_used = 1
+    bw.write_bits(0, 3); // version_number = 0
+
+    // No transforms.
+    bw.write_bits(0, 1); // has_transform = 0
+
+    // Color cache code bits = 0 (no color cache).
+    bw.write_bits(0, 4);
+
+    // Write Huffman code tables for the 5 groups (G, R, B, A, Dist).
+    write_huffman_code(&mut bw, &g_lens);
+    write_huffman_code(&mut bw, &r_lens);
+    write_huffman_code(&mut bw, &b_lens);
+    write_huffman_code(&mut bw, &a_lens);
+    write_huffman_code(&mut bw, &d_lens);
+
+    // Write pixel data.
+    // For each pixel: emit G (green), then R, B, A.
+    // Trivial codes (length 0) emit 0 bits — correct VP8L behaviour.
+    for chunk in pixels.data.chunks_exact(4) {
+        emit_symbol(&mut bw, chunk[1] as usize, &g_encode); // G (green)
+        emit_symbol(&mut bw, chunk[0] as usize, &r_encode); // R (red)
+        emit_symbol(&mut bw, chunk[2] as usize, &b_encode); // B (blue)
+        emit_symbol(&mut bw, chunk[3] as usize, &a_encode); // A (alpha)
+    }
+
+    // Finalise bitstream.
+    let payload = bw.finish();
+
+    // Prepend the VP8L signature byte (0x2F).
+    let mut result = Vec::with_capacity(1 + payload.len());
+    result.push(0x2Fu8);
+    result.extend_from_slice(&payload);
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// VP8L decode
+// ---------------------------------------------------------------------------
+
+/// Decode a VP8L bitstream (starting with the 0x2F signature byte).
+///
+/// Returns a `PixelContainer` on success, or a descriptive error string.
+pub fn decode(data: &[u8]) -> Result<PixelContainer, String> {
+    if data.is_empty() {
+        return Err("VP8L: empty bitstream".to_string());
+    }
+
+    // ── Signature byte ───────────────────────────────────────────────────────
+    if data[0] != 0x2F {
+        return Err(format!(
+            "VP8L: bad signature byte 0x{:02X} (expected 0x2F)",
+            data[0]
+        ));
+    }
+
+    let mut br = BitReader::new(&data[1..]);
+
+    // ── Header ───────────────────────────────────────────────────────────────
+    let width = br.read_bits(14) + 1;
+    let height = br.read_bits(14) + 1;
+    let _alpha_is_used = br.read_bits(1);
+    let version = br.read_bits(3);
+
+    if version != 0 {
+        return Err(format!(
+            "VP8L: unsupported version {version} (expected 0)"
+        ));
+    }
+
+    // ── Transform section ────────────────────────────────────────────────────
+    let mut applied_transforms: Vec<u8> = Vec::new();
+    loop {
+        let has_transform = br.read_bits(1);
+        if has_transform == 0 {
+            break;
+        }
+        let transform_type = br.read_bits(2);
+        applied_transforms.push(transform_type as u8);
+
+        match transform_type {
+            2 => { /* SubtractGreen: no extra data in the bitstream */ }
+            0 | 1 | 3 => {
+                return Err(format!(
+                    "VP8L: transform type {transform_type} not yet implemented in decoder"
+                ));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // ── Color cache ──────────────────────────────────────────────────────────
+    let color_cache_code_bits = br.read_bits(4);
+    if color_cache_code_bits > 0 {
+        return Err(format!(
+            "VP8L: color cache (code_bits={color_cache_code_bits}) not yet implemented"
+        ));
+    }
+
+    // ── Huffman code tables ──────────────────────────────────────────────────
+    let g_table = read_huffman_code(&mut br, G_ALPHABET_SIZE)?;
+    let r_table = read_huffman_code(&mut br, RGBA_ALPHABET_SIZE)?;
+    let b_table = read_huffman_code(&mut br, RGBA_ALPHABET_SIZE)?;
+    let a_table = read_huffman_code(&mut br, RGBA_ALPHABET_SIZE)?;
+    let _d_table = read_huffman_code(&mut br, DIST_ALPHABET_SIZE)?;
+
+    // ── Pixel data ───────────────────────────────────────────────────────────
+    let pixel_count = (width as usize) * (height as usize);
+    let mut data_out = Vec::with_capacity(pixel_count * 4);
+
+    for _ in 0..pixel_count {
+        let g_sym = g_table.decode(&mut br)?;
+
+        match g_sym {
+            0..=255 => {
+                // Literal pixel: G is green; read R, B, A from their trees.
+                let g = g_sym as u8;
+                let r = r_table.decode(&mut br)? as u8;
+                let b = b_table.decode(&mut br)? as u8;
+                let a = a_table.decode(&mut br)? as u8;
+                // PixelContainer stores pixels as [R, G, B, A].
+                data_out.push(r);
+                data_out.push(g);
+                data_out.push(b);
+                data_out.push(a);
+            }
+            256..=u16::MAX => {
+                // LZ77 back-reference or color-cache — not implemented in v0.1.
+                return Err(format!(
+                    "VP8L LZ77 back-references not yet implemented (G symbol={g_sym})"
+                ));
+            }
+        }
+    }
+
+    // ── Apply inverse transforms ─────────────────────────────────────────────
+    let mut pixels = PixelContainer::from_data(width, height, data_out);
+
+    // Transforms are inverted in reverse order of encoding.
+    for &t in applied_transforms.iter().rev() {
+        match t {
+            2 => transforms::inverse_subtract_green(&mut pixels),
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(pixels)
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Emit one Huffman symbol into the bitstream.
+///
+/// If `encode_table[symbol].1 == 0` (trivial code), nothing is written.
+fn emit_symbol(bw: &mut BitWriter, symbol: usize, encode_table: &[(u64, u32)]) {
+    let (bits, count) = encode_table[symbol];
+    if count > 0 {
+        bw.write_bits(bits, count);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_produces_vp8l_signature() {
+        let pixels = PixelContainer::new(2, 2);
+        let bs = encode(&pixels);
+        assert_eq!(bs[0], 0x2F, "VP8L signature byte must be 0x2F");
+    }
+
+    #[test]
+    fn round_trip_blank() {
+        let pixels = PixelContainer::new(4, 4);
+        let encoded = encode(&pixels);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.width, 4);
+        assert_eq!(decoded.height, 4);
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    #[test]
+    fn round_trip_solid_color() {
+        let mut pixels = PixelContainer::new(8, 8);
+        for y in 0..8 {
+            for x in 0..8 {
+                pixels.set_pixel(x, y, 200, 100, 50, 255);
+            }
+        }
+        let encoded = encode(&pixels);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    #[test]
+    fn round_trip_gradient() {
+        let mut pixels = PixelContainer::new(8, 8);
+        for y in 0..8u32 {
+            for x in 0..8u32 {
+                pixels.set_pixel(x, y, (x * 30) as u8, (y * 30) as u8, 128, 255);
+            }
+        }
+        let encoded = encode(&pixels);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.width, 8);
+        assert_eq!(decoded.height, 8);
+        assert_eq!(decoded.data, pixels.data);
+    }
+
+    #[test]
+    fn decode_bad_signature() {
+        let bad = vec![0x00u8, 0x00, 0x00];
+        let result = decode(&bad);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("signature"));
+    }
+
+    #[test]
+    fn decode_empty() {
+        let result = decode(&[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn round_trip_1x1_red() {
+        let mut pixels = PixelContainer::new(1, 1);
+        pixels.set_pixel(0, 0, 255, 0, 0, 255);
+        let encoded = encode(&pixels);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.pixel_at(0, 0), (255, 0, 0, 255));
+    }
+
+    #[test]
+    fn round_trip_varying_alpha() {
+        let mut pixels = PixelContainer::new(4, 1);
+        pixels.set_pixel(0, 0, 10, 20, 30, 0);
+        pixels.set_pixel(1, 0, 10, 20, 30, 85);
+        pixels.set_pixel(2, 0, 10, 20, 30, 170);
+        pixels.set_pixel(3, 0, 10, 20, 30, 255);
+        let encoded = encode(&pixels);
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.data, pixels.data);
+    }
+}

--- a/code/packages/rust/image-codec-webp/src/vp8l/transforms.rs
+++ b/code/packages/rust/image-codec-webp/src/vp8l/transforms.rs
@@ -1,0 +1,133 @@
+//! VP8L optional transforms.
+//!
+//! VP8L supports four optional, reversible transforms that the encoder may apply
+//! before entropy coding. Each transform is signalled by a `has_transform=1` bit
+//! in the bitstream. When multiple transforms are stacked they are applied in
+//! reverse order during decoding (the last transform written is the first inverse
+//! applied on decode).
+//!
+//! ## The four transforms
+//!
+//! 1. **Subtract-green** — For each pixel subtract the green channel from R and B
+//!    before coding.  This exploits the correlation between colour channels in
+//!    natural images.  On decode: `R += G`, `B += G` for every pixel.
+//!
+//! 2. **Color** — A spatially-varying linear colour-space transform stored as a
+//!    downsampled "colour transform element" image.  Each 2×2 block (or larger
+//!    power-of-two block) has its own transform coefficients.
+//!
+//! 3. **Predictor** — A spatially-varying predictor removes local spatial
+//!    redundancy.  The residual (actual − predicted) is stored.  Thirteen
+//!    predictor modes are defined in the spec.
+//!
+//! 4. **Color-index** — For images with ≤ 256 distinct colours, store a palette
+//!    and replace each pixel with its palette index.  The pixel stream then
+//!    contains palette indices rather than full ARGB values.
+//!
+//! ## Current status
+//!
+//! This initial release does **not** apply any transforms (the encoder writes
+//! `has_transform = 0`).  The infrastructure types and inverse-transform stubs
+//! are here to document the intended extension points and make it clear where
+//! future transform support will be wired in.
+//!
+//! Implement transforms in a future PR:
+//! - Subtract-green is trivial and adds ~5-10 % compression.
+//! - Predictor transform gives the biggest gains on natural images.
+//! - Color-index is critical for synthetic/graphic images with few colours.
+
+use pixel_container::PixelContainer;
+
+// ---------------------------------------------------------------------------
+// Transform kind enum
+// ---------------------------------------------------------------------------
+
+/// The four VP8L transform types, identified by their 2-bit code in the
+/// bitstream.
+///
+/// When `has_transform = 1`, the next 2 bits in the stream specify which
+/// transform follows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransformKind {
+    /// Code `0b00` — Spatially-varying predictor transform.
+    Predictor = 0,
+    /// Code `0b01` — Spatially-varying linear colour transform.
+    Color = 1,
+    /// Code `0b10` — Subtract the green channel from R and B.
+    SubtractGreen = 2,
+    /// Code `0b11` — Palette / colour-index transform.
+    ColorIndex = 3,
+}
+
+// ---------------------------------------------------------------------------
+// Forward transforms (applied during encoding, not yet used)
+// ---------------------------------------------------------------------------
+
+/// Apply the subtract-green transform in-place.
+///
+/// For each pixel: `R' = (R - G) & 0xFF`, `B' = (B - G) & 0xFF`.
+/// The green channel is left unchanged.
+///
+/// This is one of the simplest transforms and exploits the fact that in most
+/// images R and B are correlated with G.  After the transform the residuals
+/// R' and B' tend to cluster near 0, which compresses better.
+///
+/// # Note
+/// Not called in the current encoder (no transforms mode). Provided for
+/// future use.
+pub fn apply_subtract_green(pixels: &mut PixelContainer) {
+    for chunk in pixels.data.chunks_exact_mut(4) {
+        let g = chunk[1];
+        chunk[0] = chunk[0].wrapping_sub(g); // R -= G
+        chunk[2] = chunk[2].wrapping_sub(g); // B -= G
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inverse transforms (applied during decoding after pixel reconstruction)
+// ---------------------------------------------------------------------------
+
+/// Invert the subtract-green transform in-place.
+///
+/// For each pixel: `R = (R' + G) & 0xFF`, `B = (B' + G) & 0xFF`.
+/// This is the inverse of [`apply_subtract_green`].
+pub fn inverse_subtract_green(pixels: &mut PixelContainer) {
+    for chunk in pixels.data.chunks_exact_mut(4) {
+        let g = chunk[1];
+        chunk[0] = chunk[0].wrapping_add(g); // R += G
+        chunk[2] = chunk[2].wrapping_add(g); // B += G
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subtract_green_round_trip() {
+        let mut original = PixelContainer::new(2, 2);
+        original.set_pixel(0, 0, 100, 50, 200, 255);
+        original.set_pixel(1, 0, 10, 20, 30, 255);
+        original.set_pixel(0, 1, 255, 128, 64, 200);
+        original.set_pixel(1, 1, 0, 0, 0, 0);
+
+        let snapshot = original.clone();
+
+        apply_subtract_green(&mut original);
+        inverse_subtract_green(&mut original);
+
+        assert_eq!(original.data, snapshot.data, "subtract-green round-trip failed");
+    }
+
+    #[test]
+    fn transform_kind_codes() {
+        assert_eq!(TransformKind::Predictor as u8, 0);
+        assert_eq!(TransformKind::Color as u8, 1);
+        assert_eq!(TransformKind::SubtractGreen as u8, 2);
+        assert_eq!(TransformKind::ColorIndex as u8, 3);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `image-codec-webp` crate (IC06) implementing VP8L lossless WebP encode/decode
- VP8 lossy is stubbed with a clear panic message — will be wired up when `range-coder` lands
- 52 unit tests, all green; `cargo build --workspace` clean (pre-existing `uefi` error unrelated to this PR)

## What ships

| Module | Purpose |
|---|---|
| `riff.rs` | RIFF container builder — header, chunk framing, even-byte pad |
| `vp8l/bitstream.rs` | LSB-first `BitWriter` / `BitReader` (u64 accumulator) |
| `vp8l/huffman.rs` | VP8L Huffman: simple-1/2 and meta-Huffman complex codes; bit-reversed fast decode table |
| `vp8l/mod.rs` | Encode/decode orchestration — literal-only, no transforms, no LZ77 |
| `vp8l/lz77.rs` | 120-entry 2D distance map from spec; length-symbol base helpers |
| `vp8l/transforms.rs` | `TransformKind` enum; subtract-green forward/inverse |

## Encoding strategy

Literal-only VP8L: every pixel is 4 Huffman-coded channel values (G, R, B, A). No transforms, no LZ77, no colour cache. Produces valid VP8L that any conformant decoder can read.

## Key correctness insight

VP8L canonical Huffman codes in LSB-first streams require bit-reversal before writing. The fast decode table is indexed by `peek_bits(max_code_len)` which returns the bit-reversed canonical code — so table slots are filled by iterating over all possible "don't care" suffixes above the code's MSBs.

## Known limitations

- LZ77 back-references return an error ("not yet implemented")
- Predictor / colour / colour-index transforms not implemented
- VP8X extended format not supported

## Test plan

- [x] `cargo test -p image-codec-webp` — 52/52 pass
- [x] `cargo build --workspace` — only pre-existing `uefi` crate error
- [x] Round-trip: blank, solid-color, gradient, 1×1, transparent, varying-alpha
- [x] Error cases: bad magic, truncated input, VP8 lossy stub, VP8X stub, unknown chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)