### PR TITLE
feat(ruby-parser): Phase 6z — float / hex / bin / oct numeric literal parsing

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.27.0] - 2026-05-25
+
+### Added (Phase 6z — float / hex / bin / oct numeric literal parsing)
+
+The lexer's Phase-4k float fusion (`1.5`, `1e10`, `1.5e-3`) and Phase-4l radix-prefix fusion (`0x1F`, `0b1010`, `0o17`, `0d42`) emit each literal as a single `TokenType::Number` token whose value is the verbatim source text.  Phase 6z is therefore **grammar-zero**: the existing NUMBER token at factor position already accepts every shape.  This phase adds the SIR lowering dispatch + explicit test coverage on both sides of the pipeline.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+A new helper `lower_numeric_literal` dispatches on shape:
+
+| Source       | SIR shape                                |
+|--------------|------------------------------------------|
+| `42`         | `IntLit { value: 42 }`                   |
+| `1_000_000`  | `IntLit { value: 1000000 }`              |
+| `0x1F`       | `IntLit { value: 31 }` (radix 16)        |
+| `0xDEAD_BEEF`| `IntLit { value: 3735928559 }`           |
+| `0b1010`     | `IntLit { value: 10 }` (radix 2)         |
+| `0o17`       | `IntLit { value: 15 }` (radix 8)         |
+| `0d42`       | `IntLit { value: 42 }` (radix 10 explicit) |
+| `1.5`        | `FloatLit { value: 1.5 }` + Feature::Floats |
+| `1e10`       | `FloatLit { value: 1e10 }` + Feature::Floats |
+| `1.5e-3`     | `FloatLit { value: 0.0015 }` + Feature::Floats |
+
+Underscore separators (`_`) are stripped before parsing.  Radix detection checks `bytes[1] ∈ {x,X,b,B,o,O,d,D}` after a leading `0`.  Float detection is a single scan for `.` or `e`/`E` in the cleaned digit string; the two checks are mutually exclusive in the Ruby grammar.
+
+### v0 deferred limitations
+
+- Ruby's Rational (`r`) / Complex (`i`) numeric suffixes (lexed by Phase 4f) are rejected — a future phase will route those into `BuiltinCall("rational", ...)` / `BuiltinCall("complex", ...)` markers.
+- Negative literals are still handled by the unary-minus path (Phase 6k); this routine sees only the magnitude.
+- Ruby's legacy octal syntax (`017` without `0o` prefix) is not supported; use `0o17`.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 117 → **122** (+5 grammar tests):
+  - `test_parse_float_literal_assignment` — `x = 1.5`.
+  - `test_parse_float_literal_with_exponent` — `x = 1.5e-3`.
+  - `test_parse_hex_integer_literal` — `x = 0xDEAD_BEEF`.
+  - `test_parse_binary_integer_literal` — `x = 0b1010`.
+  - `test_parse_octal_integer_literal` — `x = 0o17`.
+
 ## [0.26.0] - 2026-05-25
 
 ### Added (Phase 6y — string interpolation expression parsing)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2027,5 +2027,72 @@ mod tests {
         assert!(find_descendant(&ast, "assignment").is_some());
         assert!(tree_has_token_value(&ast, "a=#{a}, b=#{b}"));
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6z — float / hex / bin / oct integer literal parsing
+    //
+    // The lexer's Phase-4k float fusion produces a single `Number` token for
+    // `1.5`, `1e10`, `1.5e-3`, etc., and Phase-4l's radix fusion produces a
+    // single `Number` token for `0x1F`, `0b1010`, `0o17`, `0d42`.  The
+    // parser sees them all uniformly at the factor position, so this phase
+    // is grammar-zero: these tests just confirm the existing NUMBER-at-
+    // factor handling accepts every shape and the SIR lowerer routes them.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_float_literal_assignment() {
+        // `x = 1.5` — float on RHS.  Lexer's float fusion collapses
+        // `1`/`.`/`5` into a single `Number("1.5")` token.
+        let ast = parse_ruby("x = 1.5");
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected assignment node for float RHS"
+        );
+        assert!(
+            tree_has_token_value(&ast, "1.5"),
+            "expected fused `1.5` NUMBER token in the tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_float_literal_with_exponent() {
+        // `x = 1.5e-3` — fractional + signed exponent.  Tests the
+        // full lexer fusion path through `Number`+`Name("e")`+`Op("-")`+`Int`.
+        let ast = parse_ruby("x = 1.5e-3");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        assert!(
+            tree_has_token_value(&ast, "1.5e-3"),
+            "expected fused `1.5e-3` NUMBER token"
+        );
+    }
+
+    #[test]
+    fn test_parse_hex_integer_literal() {
+        // `x = 0xDEAD_BEEF` — hex literal with underscore separator.
+        // Lexer Phase 4l fuses `Int("0")`+`Name("xDEAD_BEEF")` into a
+        // single `Number("0xDEAD_BEEF")` token.
+        let ast = parse_ruby("x = 0xDEAD_BEEF");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        assert!(
+            tree_has_token_value(&ast, "0xDEAD_BEEF"),
+            "expected fused hex literal in tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_binary_integer_literal() {
+        // `x = 0b1010` — binary literal.  Same fusion mechanism as hex.
+        let ast = parse_ruby("x = 0b1010");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        assert!(tree_has_token_value(&ast, "0b1010"));
+    }
+
+    #[test]
+    fn test_parse_octal_integer_literal() {
+        // `x = 0o17` — octal literal.  Decimal value 15.
+        let ast = parse_ruby("x = 0o17");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        assert!(tree_has_token_value(&ast, "0o17"));
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.27.0] - 2026-05-25
+
+### Added (Phase 6z — float / hex / bin / oct numeric literal lowering)
+
+`lower_factor_atom` now hands every `TokenType::Number` token to a new helper, `lower_numeric_literal`, which dispatches on shape (radix-prefix → IntLit with chosen radix; float-shape → FloatLit; otherwise → decimal IntLit).
+
+### Lowering
+
+| Source       | SIR shape                                |
+|--------------|------------------------------------------|
+| `42`         | `IntLit { value: 42 }`                   |
+| `1_000_000`  | `IntLit { value: 1000000 }`              |
+| `0x1F`       | `IntLit { value: 31 }` (radix 16)        |
+| `0xDEAD_BEEF`| `IntLit { value: 3735928559 }`           |
+| `0b1010`     | `IntLit { value: 10 }` (radix 2)         |
+| `0o17`       | `IntLit { value: 15 }` (radix 8)         |
+| `0d42`       | `IntLit { value: 42 }` (radix 10 explicit) |
+| `1.5`        | `FloatLit { value: 1.5 }`                |
+| `1e10`       | `FloatLit { value: 1e10 }`               |
+| `1.5e-3`     | `FloatLit { value: 0.0015 }`             |
+
+Float literals additionally trigger `Feature::Floats` in the module manifest.  The manifest aggregator now propagates `Feature::Floats` alongside the prior set (`Strings`, `Closures`, `Symbols`, etc.).
+
+Underscore separators are stripped before parsing.  Radix detection checks `bytes[1] ∈ {x,X,b,B,o,O,d,D}` after a leading `0`.  Float detection is a single scan for `.` or `e`/`E` — mutually exclusive with radix prefixes in the Ruby grammar.
+
+### v0 deferred limitations
+
+- Rational (`r`) / Complex (`i`) numeric suffixes (lexed by Phase 4f) are rejected by the integer-parse path — a future phase will route those into `BuiltinCall("rational", ...)` / `BuiltinCall("complex", ...)` markers.
+- Negative literals continue to flow through the Phase 6k unary-minus path; this routine sees only the magnitude.
+- Legacy octal (`017` without `0o` prefix) is not supported by either the lexer or this lowerer.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 121 → **127** (+6):
+  - `float_literal_lowers_to_floatlit_and_triggers_floats_feature` — `1.5`.
+  - `float_literal_with_signed_exponent_lowers_correctly` — `1.5e-3`.
+  - `hex_literal_lowers_to_intlit_with_correct_value` — `0xDEAD_BEEF` + asserts Floats feature NOT triggered.
+  - `binary_literal_lowers_to_intlit` — `0b1010`.
+  - `octal_literal_lowers_to_intlit` — `0o17`.
+  - `float_literal_module_passes_sir_validator` — end-to-end validator smoke.
+
 ## [0.26.0] - 2026-05-25
 
 ### Added (Phase 6y — string interpolation lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2503,4 +2503,125 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 6z — float / hex / bin / oct numeric literal lowering
+    //
+    // Shapes covered:
+    //   1.5          → FloatLit(1.5)   (+ Feature::Floats)
+    //   1e10         → FloatLit(1e10)
+    //   1.5e-3       → FloatLit(0.0015)
+    //   0x1F         → IntLit(31)
+    //   0xDEAD_BEEF  → IntLit(3735928559)
+    //   0b1010       → IntLit(10)
+    //   0o17         → IntLit(15)
+    //   42           → IntLit(42)      (regression — pre-Phase-6z path)
+    //   1_000_000    → IntLit(1000000) (underscore separator)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn float_literal_lowers_to_floatlit_and_triggers_floats_feature() {
+        // `x = 1.5` — fused single Number token by lexer Phase 4k.
+        let m = lower("x = 1.5");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding { value, name, .. } => {
+                assert_eq!(name, "x");
+                match value {
+                    Expr::FloatLit { value, .. } => {
+                        // Exact comparison is fine for 1.5 (representable
+                        // exactly in IEEE-754); we use `==` directly.
+                        assert_eq!(*value, 1.5_f64);
+                    }
+                    other => panic!("expected FloatLit, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+        // Feature::Floats must be tracked in the module's manifest.
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Floats),
+            "expected Floats feature in manifest"
+        );
+    }
+
+    #[test]
+    fn float_literal_with_signed_exponent_lowers_correctly() {
+        // `x = 1.5e-3` — fractional + signed exponent.  Value is
+        // 0.0015 (NOT exactly representable in IEEE-754, so we use a
+        // tight tolerance instead of `==`).
+        let m = lower("x = 1.5e-3");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding {
+                value: Expr::FloatLit { value, .. },
+                ..
+            } => {
+                assert!(
+                    (*value - 0.0015_f64).abs() < 1e-12,
+                    "expected 0.0015, got {}",
+                    value
+                );
+            }
+            other => panic!("expected LetBinding(FloatLit), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn hex_literal_lowers_to_intlit_with_correct_value() {
+        // `x = 0xDEAD_BEEF` — hex with underscore separator.  Decimal
+        // value is 3,735,928,559.  Triggers the radix-detection
+        // branch in `lower_numeric_literal`.
+        let m = lower("x = 0xDEAD_BEEF");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding {
+                value: Expr::IntLit { value, .. },
+                ..
+            } => {
+                assert_eq!(*value, 0xDEAD_BEEF_i64);
+            }
+            other => panic!("expected LetBinding(IntLit), got {:?}", other),
+        }
+        // Hex integers must NOT trigger Feature::Floats.
+        assert!(
+            !m.manifest.contains(semantic_ir::Feature::Floats),
+            "hex integer literal should not trigger Floats feature"
+        );
+    }
+
+    #[test]
+    fn binary_literal_lowers_to_intlit() {
+        // `x = 0b1010` → IntLit(10).
+        let m = lower("x = 0b1010");
+        let b = main_body(&m);
+        assert!(matches!(
+            &b.stmts[0],
+            Stmt::LetBinding { value: Expr::IntLit { value: 10, .. }, .. }
+        ));
+    }
+
+    #[test]
+    fn octal_literal_lowers_to_intlit() {
+        // `x = 0o17` → IntLit(15).
+        let m = lower("x = 0o17");
+        let b = main_body(&m);
+        assert!(matches!(
+            &b.stmts[0],
+            Stmt::LetBinding { value: Expr::IntLit { value: 15, .. }, .. }
+        ));
+    }
+
+    #[test]
+    fn float_literal_module_passes_sir_validator() {
+        // End-to-end smoke: a module that uses float literals and
+        // declares the Floats feature passes the validator.
+        let m = lower("x = 1.5\nputs(x)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected float-using module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -113,6 +113,9 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // method name when packing into the `__method__` envelope.
         // StrLit usage triggers the `Strings` feature.
         Feature::Strings,
+        // Phase 6z — float literals (`1.5`, `1e10`, `1.5e-3`) lower
+        // to `Expr::FloatLit` and trigger the `Floats` feature.
+        Feature::Floats,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -2932,6 +2935,124 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
+    // Phase 6z — numeric literal lowering (float / hex / bin / oct / dec)
+    // -------------------------------------------------------------------
+
+    /// Lower a Ruby numeric literal token (Phase 6z).
+    ///
+    /// The lexer's Phase-4k / Phase-4l post-passes fuse the source-level
+    /// shapes below into a single `TokenType::Number` token whose value
+    /// is the verbatim source text (with underscore separators preserved).
+    /// This routine dispatches on the shape:
+    ///
+    /// | Source       | SIR shape                                |
+    /// |--------------|------------------------------------------|
+    /// | `42`         | `IntLit { value: 42 }`                   |
+    /// | `1_000_000`  | `IntLit { value: 1000000 }`              |
+    /// | `0x1F`       | `IntLit { value: 31 }` (radix 16)        |
+    /// | `0xDEAD_BEEF`| `IntLit { value: 3735928559 }`           |
+    /// | `0b1010`     | `IntLit { value: 10 }` (radix 2)         |
+    /// | `0o17`       | `IntLit { value: 15 }` (radix 8)         |
+    /// | `0d42`       | `IntLit { value: 42 }` (radix 10 explicit) |
+    /// | `1.5`        | `FloatLit { value: 1.5 }`                |
+    /// | `1e10`       | `FloatLit { value: 1e10 }`               |
+    /// | `1.5e-3`     | `FloatLit { value: 0.0015 }`             |
+    ///
+    /// Float detection is a single pass over the cleaned (underscore-
+    /// stripped) value: if `.` or `e` / `E` is present **anywhere**,
+    /// the literal is a float; otherwise it's an integer.  Radix
+    /// detection requires both the leading `0` *and* a radix-prefix
+    /// letter as the second character.  These two checks are mutually
+    /// exclusive in the Ruby grammar (radix prefixes start with a
+    /// letter, floats start with a digit run + `.` / `e`), so the
+    /// dispatch order doesn't matter — we test radix first because
+    /// it's the cheaper check.
+    ///
+    /// ## v0 deferred
+    ///
+    /// - Ruby's `r` / `i` numeric suffixes (Rational / Complex, lexed
+    ///   by Phase 4f) are still kept on the token as a trailing letter;
+    ///   the lowerer currently rejects those, since SIR has no
+    ///   Rational / Complex types.  A future phase will route those
+    ///   into `BuiltinCall("rational", [...])` / `BuiltinCall("complex", [...])`
+    ///   markers.
+    /// - Negative literals are still handled by the unary-minus path
+    ///   (Phase 6k); this routine sees only the magnitude.
+    fn lower_numeric_literal(
+        &mut self,
+        raw: &str,
+        span: Span,
+        err_line: usize,
+        err_column: usize,
+    ) -> Result<Expr, RubyLowerError> {
+        // Step 1: strip Ruby's `_` digit separators.  They're purely
+        // cosmetic (Ruby allows `1_000_000` to mean `1000000`).  We
+        // do this *before* the shape dispatch so both the float-parse
+        // and the radix-parse see clean digit strings.
+        let cleaned: String = raw.chars().filter(|c| *c != '_').collect();
+
+        // Step 2: radix-prefix detection (Phase 4l).  A Ruby radix
+        // literal is `0` followed by a radix letter then the digits:
+        //   0x | 0X  -> base 16
+        //   0b | 0B  -> base  2
+        //   0o | 0O  -> base  8
+        //   0d | 0D  -> base 10 (explicit decimal)
+        // Anything else starting with `0` is plain decimal (e.g. `0`,
+        // `017` would be Ruby's legacy octal — not supported in v0).
+        let bytes = cleaned.as_bytes();
+        if bytes.len() >= 3 && bytes[0] == b'0' {
+            let (radix, body_start): (u32, usize) = match bytes[1] {
+                b'x' | b'X' => (16, 2),
+                b'b' | b'B' => (2, 2),
+                b'o' | b'O' => (8, 2),
+                b'd' | b'D' => (10, 2),
+                _ => (0, 0),
+            };
+            if radix != 0 {
+                let body = &cleaned[body_start..];
+                // `i64::from_str_radix` rejects empty strings and bad
+                // digits — both of which would already be lexer bugs
+                // here, so propagate the error rather than panicking.
+                let v = i64::from_str_radix(body, radix).map_err(|_| RubyLowerError {
+                    message: format!("invalid radix-{} integer literal `{}`", radix, raw),
+                    line: err_line,
+                    column: err_column,
+                })?;
+                return Ok(Expr::IntLit { value: v, span });
+            }
+        }
+
+        // Step 3: float detection (Phase 4k).  A Ruby float literal has
+        // either a fractional part (`.` followed by digit) OR an
+        // exponent (`e` / `E`).  Both can appear together (`1.5e-3`).
+        // We use `contains` rather than `starts_with` because the dot
+        // / exponent can appear anywhere in the body.
+        //
+        // Note we cannot use a bare `.` check because the lexer's
+        // float fusion already guarantees the dot is between digits;
+        // we don't need to re-validate that here.
+        let has_fraction = cleaned.contains('.');
+        let has_exponent = cleaned.contains(['e', 'E']);
+        if has_fraction || has_exponent {
+            self.features_used.insert(Feature::Floats);
+            let v: f64 = cleaned.parse().map_err(|_| RubyLowerError {
+                message: format!("invalid float literal `{}`", raw),
+                line: err_line,
+                column: err_column,
+            })?;
+            return Ok(Expr::FloatLit { value: v, span });
+        }
+
+        // Step 4: plain decimal integer (pre-Phase-6z behaviour).
+        let v: i64 = cleaned.parse().map_err(|_| RubyLowerError {
+            message: format!("invalid integer literal `{}`", raw),
+            line: err_line,
+            column: err_column,
+        })?;
+        Ok(Expr::IntLit { value: v, span })
+    }
+
+    // -------------------------------------------------------------------
     // Phase 6y — string interpolation lowering
     // -------------------------------------------------------------------
 
@@ -3168,14 +3289,18 @@ impl Lowerer {
                     let span = self.span_of_token(tok);
                     match tok.type_ {
                         TokenType::Number => {
-                            let cleaned: String =
-                                tok.value.chars().filter(|c| *c != '_').collect();
-                            let v: i64 = cleaned.parse().map_err(|_| RubyLowerError {
-                                message: format!("invalid integer literal `{}`", tok.value),
-                                line: tok.line,
-                                column: tok.column,
-                            })?;
-                            return Ok(Expr::IntLit { value: v, span });
+                            // Phase 6z — float / hex / bin / oct / decimal-explicit
+                            // integer literal parsing.  The lexer (Phase 4k / 4l)
+                            // fuses these into a single `Number` token whose
+                            // value carries the verbatim source text.  The
+                            // parser sees them all uniformly at the factor
+                            // atom position — no grammar changes needed.
+                            return self.lower_numeric_literal(
+                                &tok.value,
+                                span,
+                                tok.line,
+                                tok.column,
+                            );
                         }
                         TokenType::String => {
                             // Phase 6y — string interpolation expression


### PR DESCRIPTION
## Summary

The lexer's Phase-4k float fusion (`1.5`, `1e10`, `1.5e-3`) and Phase-4l radix-prefix fusion (`0x1F`, `0b1010`, `0o17`, `0d42`) emit each literal as a single `TokenType::Number` token whose value is the verbatim source text.  Phase 6z is therefore **grammar-zero**: the existing NUMBER token at factor position already accepts every shape.  This PR adds the SIR lowering dispatch + explicit test coverage on both sides of the pipeline.

## Lowering

A new helper `lower_numeric_literal` in `ruby-to-semantic-ir/src/lower.rs` dispatches on shape:

| Source       | SIR shape                                |
|--------------|------------------------------------------|
| `42`         | `IntLit { value: 42 }`                   |
| `1_000_000`  | `IntLit { value: 1000000 }`              |
| `0x1F`       | `IntLit { value: 31 }` (radix 16)        |
| `0xDEAD_BEEF`| `IntLit { value: 3735928559 }`           |
| `0b1010`     | `IntLit { value: 10 }` (radix 2)         |
| `0o17`       | `IntLit { value: 15 }` (radix 8)         |
| `0d42`       | `IntLit { value: 42 }` (radix 10 explicit) |
| `1.5`        | `FloatLit { value: 1.5 }` + `Feature::Floats` |
| `1e10`       | `FloatLit { value: 1e10 }` + `Feature::Floats` |
| `1.5e-3`     | `FloatLit { value: 0.0015 }` + `Feature::Floats` |

Underscore separators are stripped before parsing.  Radix detection checks `bytes[1] ∈ {x,X,b,B,o,O,d,D}` after a leading `0`.  Float detection is a single scan for `.` or `e`/`E` — the two checks are mutually exclusive in the Ruby grammar, so dispatch order doesn't matter.

The module-level manifest aggregator now propagates `Feature::Floats` alongside the prior set.

## v0 deferred limitations

- Ruby's Rational (`r`) / Complex (`i`) numeric suffixes (lexed by Phase 4f) are rejected by the integer-parse path — a future phase will route those into `BuiltinCall("rational", ...)` / `BuiltinCall("complex", ...)` markers (same pattern as Phase 6v rescue/ensure and Phase 6y interp).
- Negative literals are still handled by the unary-minus path (Phase 6k); this routine sees only the magnitude.
- Ruby's legacy octal syntax (`017` without `0o` prefix) is not supported by either the lexer or this lowerer.

## Tests

- `coding-adventures-ruby-parser`: 117 → **122** (+5 grammar tests).
- `ruby-to-semantic-ir`: 121 → **127** (+6 lowering tests, incl. `Feature::Floats` gating regression and validator end-to-end smoke).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (122/122 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (127/127 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — `i64::from_str_radix` and `f64::parse` return `Result` which we propagate as `RubyLowerError`; bounded loops over short token strings; same patterns as prior phases)
- [ ] CI green

Follows PR #4359 (Phase 6y — string interpolation expression parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
