### PR TITLE
feat(cas-summation): Phase 70 — Three-Sqrt × Two-Log × polynomial numerator (2.8.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.8.0 — 2026-05-25
+
+### Added
+
+- **Phase 70 — Three-Sqrt × Two-Log × polynomial numerator** (`_three_sqrt_two_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(h1(k)), Log(h2(k)), polynomial..., bounded...)`.
+  Exactly 3 Sqrt factors and exactly 2 Log factors required; log² sub-polynomial contributes 0
+  to effective degree; `effective_x2 = deg(P1) + deg(P2) + deg(P3) + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 5 new unit tests in `TestPhase70ThreeSqrtTwoLogPoly`.
+
 ## 2.7.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.7.0"
+version = "2.8.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -970,6 +970,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 70: ``Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(h1), Log(h2),
+    #           polynomial..., bounded...)`` numerator.
+    # Three Sqrt + two Log factors; log² sub-polynomial → contributes 0.
+    # effective_x2 = deg(P1) + deg(P2) + deg(P3) + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    ts3l2p_x2 = _three_sqrt_two_log_poly_effective_x2(num, k)
+    if ts3l2p_x2 is not None:
+        den_deg_ts3l2p = _polynomial_degree_in_k(den, k)
+        if den_deg_ts3l2p is not None:
+            if 2 * den_deg_ts3l2p > ts3l2p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2215,6 +2229,73 @@ def _one_sqrt_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | No
     if sqrt_deg_x2 is None or log_count != 3:
         return None
     return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _three_sqrt_two_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``deg(P1) + deg(P2) + deg(P3) + 2·poly_deg`` when ``node`` is a
+    ``Mul`` with **exactly three** ``Sqrt(positive-leading polynomial)`` factors,
+    **exactly two** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 70 — Three-Sqrt × Two-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^d1) · sqrt(k^d2) · sqrt(k^d3) · log²(k) · k^m``
+    ``≈ k^{(d1+d2+d3)/2} · log²(k) · k^m``.
+    ``log²(k)`` is sub-polynomial (``o(k^ε)``), so it contributes 0.
+    Using the ×2 integer trick:
+    ``effective_x2 = d1 + d2 + d3 + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +-------------------------------------------------------+-------------------+
+    | Input                                                 | Return            |
+    +=======================================================+===================+
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k), Log(k))``    | ``1+1+1 = 3``     |
+    | ``Mul(Sqrt(k³), Sqrt(k), Sqrt(k), Log(k), Log(k+1))`` | ``3+1+1 = 5``     |
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k), Log(k), k)`` | ``1+1+1+2 = 5``   |
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k))``            | None (1 Log)      |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k), Log(k))``             | None (2 Sqrts)    |
+    +-------------------------------------------------------+-------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 3.
+         - ``Log(diverging)`` → count; bail after 2.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 3 Sqrt AND exactly 2 Log factors.
+      4. Return ``sqrt_deg1_x2 + sqrt_deg2_x2 + sqrt_deg3_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            sqrt_degs.append(deg_x2)
+            if len(sqrt_degs) > 3:
+                return None
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 2:
+                # Three or more Log factors — not this phase.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs) != 3 or log_count != 2:
+        return None
+    return sqrt_degs[0] + sqrt_degs[1] + sqrt_degs[2] + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -3438,3 +3438,109 @@ class TestPhase69OneSqrtThreeLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase70ThreeSqrtTwoLogPoly:
+    """Phase 70 — g(k)=Sqrt(P1)·Sqrt(P2)·Sqrt(P3)·Log(h1)·Log(h2)·poly / den.
+
+    effective_x2 = deg_x2(P1)+deg_x2(P2)+deg_x2(P3) + 2·poly_deg.
+    Converges when 2·den_deg > effective_x2 (polynomial denominator) or
+    denominator diverges super-polynomially.
+    """
+
+    def test_sqrt_k_cubed_log2_k_over_k2_closes(self):
+        """√k·√k·√k·log(k)²/k²: effective_x2=1+1+1=3; 2·2=4 > 3 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_higher_log2_over_k3_closes(self):
+        """√(k³)·√k·√k·log(k)²/k³: eff_x2=3+1+1=5; 2·3=6 > 5 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3_arg = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3_arg,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        denom_k = IRApply(POW, (_k, IRInteger(3)))
+        denom_kp1 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, denom_k))
+        g_kp1 = IRApply(DIV, (num_kp1, denom_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_log2_poly_factor_closes(self):
+        """√k·√k·√k·log(k)²·k/k³: poly factor k → poly_deg=1; eff_x2=3+2=5; 2·3=6>5 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                kp1))
+        denom_k = IRApply(POW, (_k, IRInteger(3)))
+        denom_kp1 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, denom_k))
+        g_kp1 = IRApply(DIV, (num_kp1, denom_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_log2_over_exponential_closes(self):
+        """√k·√k·√k·log(k)²/2^k: exponential denominator → super-polynomial divergence → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        two_k = IRApply(POW, (IRInteger(2), _k))
+        two_kp1 = IRApply(POW, (IRInteger(2), kp1))
+        g_k = IRApply(DIV, (num_k, two_k))
+        g_kp1 = IRApply(DIV, (num_kp1, two_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_three_sqrt_log2_over_k_refused(self):
+        """√k·√k·√k·log(k)²/k: eff_x2=3; 2·1=2 not > 3 → refused (SUM)."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.8.0 — 2026-05-25
+
+### Added
+
+- **Phase 70 — Three-Sqrt × Two-Log × polynomial numerator** (`three_sqrt_two_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(h1(k)), Log(h2(k)), polynomial..., bounded...)`.
+  Exactly 3 Sqrt factors and exactly 2 Log factors required; log² sub-polynomial contributes 0
+  to effective degree; `effective_x2 = deg(P1) + deg(P2) + deg(P3) + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs`.
+
 ## 2.7.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1785,6 +1785,37 @@ fn one_sqrt_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64
     Some(sd + 2 * poly_deg)
 }
 
+/// Phase 70 — Three-Sqrt × Two-Log × polynomial numerator.
+///
+/// `log²(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to the effective
+/// degree.  `effective_x2 = d1 + d2 + d3 + 2·poly_deg` where di are the
+/// doubled inner degrees of the three Sqrt factors.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn three_sqrt_two_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            sqrt_degs.push(d);
+            if sqrt_degs.len() > 3 { return None; } // more than three Sqrts — refuse
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 2 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs.len() != 3 || log_count != 2 { return None; }
+    Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2038,6 +2069,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s1l3_x2) = one_sqrt_three_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s1l3) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s1l3 > s1l3_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 70: Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+    // Three Sqrt factors + two Log factors; log² sub-polynomial — effective_x2 = d1+d2+d3 + 2*poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(ts2l_x2) = three_sqrt_two_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_ts2l) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_ts2l > ts2l_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2268,3 +2268,66 @@ fn phase69_sqrt_k_log3_k_over_const_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// Phase 70 — Three-Sqrt × Two-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase70_sqrt_k_cubed_log2_k_over_k2_closes() {
+    // √k·√k·√k·log(k)²/k²: effective_x2=1+1+1=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k.clone(), sqrt_k.clone(), sqrt_k, log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1, log_kp1.clone(), log_kp1]);
+    let den_k = apply(sym(POW), vec![k.clone(), int(2)]);
+    let den_kp1 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let g_k = apply(sym(DIV), vec![num_k, den_k]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, den_kp1]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase70_sqrt_k3_sqrt_k_sqrt_k_log2_k_over_k3_closes() {
+    // √(k³)·√k·√k·log(k)²/k³: effective_x2=3+1+1=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3.clone()]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3.clone()]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k3, sqrt_k.clone(), sqrt_k, log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_3, sqrt_kp1.clone(), sqrt_kp1, log_kp1.clone(), log_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase70_sqrt_k_cubed_log2_k_over_k_refused() {
+    // √k·√k·√k·log(k)²/k: effective_x2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k.clone(), sqrt_k.clone(), sqrt_k, log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1, log_kp1.clone(), log_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.8.0 — 2026-05-25
+
+### Added
+
+- **Phase 70 — Three-Sqrt × Two-Log × polynomial numerator** (`threeSqrtTwoLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(h1(k)), Log(h2(k)), polynomial..., bounded...)`.
+  Exactly 3 Sqrt and exactly 2 Log factors; log² sub-polynomial contributes 0 to effective
+  degree. effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg.
+  Closes when `denDeg > threeSqrtTwoLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 4 new tests in the "Phase 70" describe block.
+
 ## 2.7.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1506,6 +1506,44 @@ function oneSqrtThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | unde
   return sqrtHalfDeg + polyDeg;
 }
 
+/**
+ * Phase 70 — Three-Sqrt × Two-Log × polynomial numerator.
+ *
+ * Returns `sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg` when
+ * `node` is a `Mul` with exactly three `Sqrt` factors, exactly two
+ * `Log(diverging)` factors, any polynomial factors, and any bounded
+ * factors; `undefined` otherwise.
+ *
+ * `log²(k)` is sub-polynomial (`o(k^ε)`), so it contributes 0 to effective
+ * degree. effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg.
+ * Caller checks `denDeg > threeSqrtTwoLogPolyEffectiveDeg(num, k)`.
+ */
+function threeSqrtTwoLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const halfDeg = sqrtEffectiveHalfDegree(arg, k);
+    if (halfDeg !== undefined) {
+      sqrtHalfDegs.push(halfDeg);
+      if (sqrtHalfDegs.length > 3) return undefined; // more than three Sqrts — refuse
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 2) return undefined; // more than two Logs — refuse
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 2) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1764,6 +1802,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS1l3 = polynomialDegreeInK(den, k);
     if (denDegS1l3 !== undefined) {
       if (denDegS1l3 > s1l3Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 70: Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(diverging), Log(diverging), polynomial..., bounded...) numerator.
+  // Three Sqrt factors + two Log factors; log² is sub-polynomial — contributes 0 to effective degree.
+  // effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg.
+  // Closes when denDeg > threeSqrtTwoLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const ts3l2Deg = threeSqrtTwoLogPolyEffectiveDeg(num, k);
+  if (ts3l2Deg !== undefined) {
+    const denDegTs3l2 = polynomialDegreeInK(den, k);
+    if (denDegTs3l2 !== undefined) {
+      if (denDegTs3l2 > ts3l2Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -2205,3 +2205,105 @@ describe("Phase 69 — One-Sqrt × Three-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 70 — Three-Sqrt × Two-Log × polynomial numerator", () => {
+  it("√k·√k·√k·log(k)²/k² closes (effective=1.5, denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√k·√k·log(k)²/k³ closes (effective=2.5, denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k3] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_3] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·√k·log(k)² / 2^k closes (exponential denominator)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·√k·log(k)² / k refused (effective=1.5, denDeg=1 not > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Extends the `_g_vanishes_at_infinity` / `gVanishesAtInfinity` / `g_vanishes_at_infinity` convergence recogniser with Phase 70 across all three language ports (Python 2.7.0 → 2.8.0, TypeScript 2.7.0 → 2.8.0, Rust 2.7.0 → 2.8.0)
- New pattern: `Sqrt(P1) · Sqrt(P2) · Sqrt(P3) · Log(h1) · Log(h2) · poly / den` — exactly 3 Sqrt + exactly 2 Log factors
- `log²(k)` is sub-polynomial, so `effective_x2 = inner_deg(P1) + inner_deg(P2) + inner_deg(P3) + 2·poly_deg`; closes when `2·den_deg > effective_x2` or denominator diverges super-polynomially

## Test plan

- [x] Python: 5 new unit tests in `TestPhase70ThreeSqrtTwoLogPoly` (167 total, 86% coverage)
- [x] TypeScript: 4 new tests in "Phase 70" describe block (125 total)
- [x] Rust: 3 new integration tests (111 total)
- [x] All three test suites green locally
- [x] Security review passed (pure symbolic math, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)