### PR TITLE
spice: add noise text table output

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `format_noise_table` for stable tab-separated `.NOISE` total and
+  per-source PSD text output snapshots.
 - Add `diode_at_temperature` and `circuit_at_temperature` helpers, which adjust
   diode thermal voltage and saturation current for an operating temperature
   using a SPICE-style silicon energy-gap foothold.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -27,7 +27,7 @@ The initial slices implement:
 - Constrained RC and RLC low-pass/high-pass/band-pass/notch pole-zero helpers.
 - Stable text output tables for selected node voltages, branch currents, and
   AC phasors, Fourier harmonics, transfer-function results, pole-zero entries,
-  and distortion harmonics.
+  noise PSD contributions, and distortion harmonics.
 
 The package supports resistors, capacitors, inductors, diodes, BJTs,
 independent current sources, independent voltage sources, voltage-controlled

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3393,6 +3393,41 @@ pub fn format_tf_table(result: &TfResult) -> String {
     )
 }
 
+pub fn format_noise_table(result: &NoiseResult) -> String {
+    let mut rows = vec![
+        "Index\tFrequency\tOutputNode\tInputSource\tOutputPSD\tInputReferredPSD\tElement\tType\tSourcePSD\tContributionPSD"
+            .to_string(),
+    ];
+    for (index, point) in result.points.iter().enumerate() {
+        for entry in &point.entries {
+            rows.push(format!(
+                "{index}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                format_table_number(point.frequency_hz),
+                result.output_node,
+                result.input_source,
+                format_table_number(point.output_psd),
+                format_table_number(point.input_referred_psd),
+                entry.element_name,
+                format_noise_type(entry.noise_type),
+                format_table_number(entry.source_psd),
+                format_table_number(entry.output_psd)
+            ));
+        }
+        if point.entries.is_empty() {
+            rows.push(format!(
+                "{index}\t{}\t{}\t{}\t{}\t{}\t\t\t\t",
+                format_table_number(point.frequency_hz),
+                result.output_node,
+                result.input_source,
+                format_table_number(point.output_psd),
+                format_table_number(point.input_referred_psd)
+            ));
+        }
+    }
+    rows.push(String::new());
+    rows.join("\n")
+}
+
 pub fn format_pole_zero_table(result: &PoleZeroResult) -> String {
     let mut rows = vec!["Index\tKind\tReal\tImaginary\tFrequency\tDamping".to_string()];
     for (index, entry) in result.entries.iter().enumerate() {
@@ -3454,6 +3489,12 @@ pub fn format_fourier_table(result: &FourierResult) -> String {
     }
     rows.push(String::new());
     rows.join("\n")
+}
+
+fn format_noise_type(noise_type: NoiseType) -> &'static str {
+    match noise_type {
+        NoiseType::Thermal => "thermal",
+    }
 }
 
 fn default_output_probes(

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    noise_ac, noise_ac_default, Capacitor, Circuit, CurrentSource, Element, Mosfet,
-    MosfetLevel1Params, MosfetType, NoiseType, Resistor, SpiceError, VoltageSource,
+    format_noise_table, noise_ac, noise_ac_default, Capacitor, Circuit, CurrentSource, Element,
+    Mosfet, MosfetLevel1Params, MosfetType, NoiseType, Resistor, SpiceError, VoltageSource,
 };
 
 const BOLTZMANN: f64 = 1.380_649e-23;
@@ -75,6 +75,31 @@ fn noise_ac_sorts_resistor_contributions_by_output_noise() {
         1.0e-30,
     );
     assert!(point.input_referred_psd > point.output_psd);
+}
+
+#[test]
+fn noise_text_output_table_is_stable() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "in", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rsource", "in", "out", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 2_000.0,
+    )));
+
+    let result = noise_ac(&circuit, "out", "Vin", &[10.0, 1_000.0], 300.0).unwrap();
+
+    assert_eq!(
+        format_noise_table(&result),
+        "Index\tFrequency\tOutputNode\tInputSource\tOutputPSD\tInputReferredPSD\tElement\tType\tSourcePSD\tContributionPSD\n\
+0\t1.000000e+01\tout\tVin\t1.104519e-17\t2.485168e-17\tRsource\tthermal\t1.656779e-23\t7.363461e-18\n\
+0\t1.000000e+01\tout\tVin\t1.104519e-17\t2.485168e-17\tRload\tthermal\t8.283894e-24\t3.681731e-18\n\
+1\t1.000000e+03\tout\tVin\t1.104519e-17\t2.485168e-17\tRsource\tthermal\t1.656779e-23\t7.363461e-18\n\
+1\t1.000000e+03\tout\tVin\t1.104519e-17\t2.485168e-17\tRload\tthermal\t8.283894e-24\t3.681731e-18\n"
+    );
 }
 
 #[test]

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -311,6 +311,9 @@ Status:
 - `.TF` transfer-function results can now be rendered as stable tab-separated
   text tables across Python, TypeScript, and Rust, covering gain and
   input/output impedance rows.
+- `.NOISE` results can now be rendered as stable tab-separated text tables in
+  the live Rust SPICE package, covering total output noise, input-referred
+  noise, and per-source PSD contribution rows.
 - Selected `.options` keys are wired into engine-call helpers across Python,
   TypeScript, and Rust, covering DC solver tolerances/iteration limits and
   transient method/adaptive-step options.


### PR DESCRIPTION
## Summary

- add stable `.NOISE` text table rendering for Rust `NoiseResult` totals and per-source PSD rows
- cover output node, input source, total output/input-referred PSD, element type, source PSD, and contribution PSD columns
- update Rust docs/changelog and the Phase 7 SPICE compatibility status

## Validation

- `cargo fmt -p spice-engine --check` in `code/packages/rust`
- `cargo test -p spice-engine --test noise_tests` in `code/packages/rust`
- `git diff --check`

## Note

- The fresh `origin/main` worktree is sparse to the live Rust SPICE packages; Python and TypeScript SPICE package trees are not present on this revision.
