### PR TITLE
spice: add sensitivity text table output

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `format_sens_table` for stable tab-separated `.SENS` nominal,
+  absolute-sensitivity, and relative-sensitivity text output snapshots.
 - Add `format_noise_table` for stable tab-separated `.NOISE` total and
   per-source PSD text output snapshots.
 - Add `diode_at_temperature` and `circuit_at_temperature` helpers, which adjust

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -26,8 +26,9 @@ The initial slices implement:
 - Transient-to-distortion projection through the Fourier extraction path.
 - Constrained RC and RLC low-pass/high-pass/band-pass/notch pole-zero helpers.
 - Stable text output tables for selected node voltages, branch currents, and
-  AC phasors, Fourier harmonics, transfer-function results, pole-zero entries,
-  noise PSD contributions, and distortion harmonics.
+  AC phasors, sensitivity entries, Fourier harmonics, transfer-function
+  results, pole-zero entries, noise PSD contributions, and distortion
+  harmonics.
 
 The package supports resistors, capacitors, inductors, diodes, BJTs,
 independent current sources, independent voltage sources, voltage-controlled

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3428,6 +3428,27 @@ pub fn format_noise_table(result: &NoiseResult) -> String {
     rows.join("\n")
 }
 
+pub fn format_sens_table(result: &SensResult) -> String {
+    let mut rows = vec![
+        "OutputNode\tNominalVoltage\tElement\tParameter\tNominalValue\tSensitivity\tRelativeSensitivity"
+            .to_string(),
+    ];
+    for entry in &result.entries {
+        rows.push(format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            result.output_node,
+            format_table_number(result.nominal_voltage),
+            entry.element_name,
+            entry.parameter,
+            format_table_number(entry.nominal_value),
+            format_table_number(entry.sensitivity),
+            format_table_number(entry.relative_sensitivity)
+        ));
+    }
+    rows.push(String::new());
+    rows.join("\n")
+}
+
 pub fn format_pole_zero_table(result: &PoleZeroResult) -> String {
     let mut rows = vec!["Index\tKind\tReal\tImaginary\tFrequency\tDamping".to_string()];
     for (index, entry) in result.entries.iter().enumerate() {

--- a/code/packages/rust/spice-engine/tests/sens_tests.rs
+++ b/code/packages/rust/spice-engine/tests/sens_tests.rs
@@ -1,6 +1,6 @@
 use spice_engine::{
-    sens_dc, Cccs, Ccvs, Circuit, CurrentSource, Element, Resistor, SensResult, SpiceError, Vccs,
-    Vcvs, VoltageSource,
+    format_sens_table, sens_dc, Cccs, Ccvs, Circuit, CurrentSource, Element, Resistor, SensResult,
+    SpiceError, Vccs, Vcvs, VoltageSource,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -55,6 +55,30 @@ fn sens_dc_reports_divider_source_and_resistor_sensitivities() {
     assert_close(
         entry(&result, "Rbot", "resistance_ohms").relative_sensitivity,
         0.5,
+    );
+}
+
+#[test]
+fn sens_text_output_table_is_stable() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vin", "vin", "0", 10.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rtop", "vin", "out", 1_000.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbot", "out", "0", 1_000.0,
+    )));
+
+    let result = sens_dc(&circuit, "out").unwrap();
+
+    assert_eq!(
+        format_sens_table(&result),
+        "OutputNode\tNominalVoltage\tElement\tParameter\tNominalValue\tSensitivity\tRelativeSensitivity\n\
+out\t5.000000e+00\tVin\tvoltage\t1.000000e+01\t5.000000e-01\t1.000000e+00\n\
+out\t5.000000e+00\tRbot\tresistance_ohms\t1.000000e+03\t2.499999e-03\t4.999998e-01\n\
+out\t5.000000e+00\tRtop\tresistance_ohms\t1.000000e+03\t-2.499999e-03\t-4.999998e-01\n"
     );
 }
 

--- a/code/specs/spice-1970s-compatibility.md
+++ b/code/specs/spice-1970s-compatibility.md
@@ -314,6 +314,9 @@ Status:
 - `.NOISE` results can now be rendered as stable tab-separated text tables in
   the live Rust SPICE package, covering total output noise, input-referred
   noise, and per-source PSD contribution rows.
+- `.SENS` results can now be rendered as stable tab-separated text tables in
+  the live Rust SPICE package, covering nominal values, absolute
+  sensitivities, and relative sensitivities.
 - Selected `.options` keys are wired into engine-call helpers across Python,
   TypeScript, and Rust, covering DC solver tolerances/iteration limits and
   transient method/adaptive-step options.


### PR DESCRIPTION
## Summary

- add stable `.SENS` text table rendering for Rust `SensResult` entries
- cover output node, nominal voltage, element parameter, nominal value, absolute sensitivity, and relative sensitivity columns
- update Rust docs/changelog and the Phase 7 SPICE compatibility status

## Validation

- `cargo fmt -p spice-engine --check` in `code/packages/rust`
- `cargo test -p spice-engine --test sens_tests` in `code/packages/rust`
- `git diff --check`

## Note

- The fresh `origin/main` worktree is sparse to the live Rust SPICE packages; Python and TypeScript SPICE package trees are not present on this revision.
