### PR TITLE
feat(ruby-parser): Phase 7a — backtick command literals in parser

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.28.0] - 2026-05-25
+
+### Added (Phase 7a — backtick command literals in parser)
+
+The lexer's Phase-4m `backtick_body` state emits `` `cmd args` `` as a single `TokenType::String` token whose value is the verbatim source **including the surrounding backticks** (`` `cmd args` ``) — the same lexeme-prefix sentinel trick used by percent literals and heredocs.  Phase 7a is therefore **grammar-zero**: the existing STRING token at factor / call-arg / assignment-RHS positions already accepts backtick literals.  This phase adds the SIR lowering dispatch + explicit test coverage on both sides of the pipeline.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+A new helper `lower_backtick_command_literal` strips the wrapping backticks and emits:
+
+```
+BuiltinCall {
+    name: "backtick",
+    args: [StrLit(body)],
+    effects: MayBlock | MayPrint | MayThrow,
+}
+```
+
+The triple-effect set reflects that command execution may **block** on the child process, **print** stdout/stderr, and **throw** if the command can't be invoked (`Errno::ENOENT` and friends).
+
+The `String` case of `lower_factor_atom` dispatches by lexeme prefix:
+- starts with `` ` `` → backtick command literal (Phase 7a)
+- otherwise → string interpolation lowering (Phase 6y)
+
+### v0 deferred limitations
+
+- Interpolation inside the body (`` `echo #{name}` ``) is NOT split — the body lowers as a single `StrLit` with `#{...}` markers preserved verbatim.  A future phase will reuse the Phase 6y interpolation splitter inside the body.
+- Escape sequences inside the body (`` \` ``, `\n`, `\t`) are already resolved by the lexer (Phase 4m's body state).
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 122 → **125** (+3 grammar tests):
+  - `test_parse_backtick_command_literal_assignment` — `` x = `ls -la` ``.
+  - `test_parse_backtick_command_literal_in_call_arg` — `` puts(`pwd`) ``.
+  - `test_parse_empty_backtick_command_literal` — `` x = `` ``.
+
 ## [0.27.0] - 2026-05-25
 
 ### Added (Phase 6z — float / hex / bin / oct numeric literal parsing)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2094,5 +2094,53 @@ mod tests {
         assert!(find_descendant(&ast, "assignment").is_some());
         assert!(tree_has_token_value(&ast, "0o17"));
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7a — backtick command literals in parser
+    //
+    // The lexer's Phase-4m backtick_body state emits the whole `` `cmd` ``
+    // literal as a single `TokenType::String` token whose value is the
+    // body wrapped back in backticks (`` `body` ``).  The parser sees
+    // this as a regular STRING token at the factor position — no grammar
+    // changes needed.  These tests confirm the grammar accepts every
+    // statement context (assignment RHS, call arg, bare expression).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_backtick_command_literal_assignment() {
+        // `x = `ls -la`` — backtick on RHS of an assignment.
+        let ast = parse_ruby("x = `ls -la`");
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected assignment node for backtick RHS"
+        );
+        assert!(
+            tree_has_token_value(&ast, "`ls -la`"),
+            "expected backtick-wrapped lexeme `\\`ls -la\\`` in tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_backtick_command_literal_in_call_arg() {
+        // `puts(`pwd`)` — backtick as a method-call argument.
+        let ast = parse_ruby("puts(`pwd`)");
+        assert!(
+            find_descendant(&ast, "method_call").is_some(),
+            "expected method_call node"
+        );
+        assert!(tree_has_token_value(&ast, "`pwd`"));
+    }
+
+    #[test]
+    fn test_parse_empty_backtick_command_literal() {
+        // `x = ``` — empty body.  Lexer's backtick_body fuses both
+        // backticks into a single Token whose value is "``".
+        let ast = parse_ruby("x = ``");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        assert!(
+            tree_has_token_value(&ast, "``"),
+            "expected empty-body backtick lexeme"
+        );
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.28.0] - 2026-05-25
+
+### Added (Phase 7a — backtick command literal lowering)
+
+`lower_factor_atom`'s `String` case now dispatches by lexeme prefix:
+- starts with `` ` `` → new `lower_backtick_command_literal` helper (Phase 7a).
+- otherwise → existing `lower_string_literal_with_interp` (Phase 6y).
+
+### Lowering
+
+| Source       | SIR shape                                                       |
+|--------------|-----------------------------------------------------------------|
+| `` `ls` ``   | `BuiltinCall("backtick", [StrLit("ls")])` + MayBlock\|MayPrint\|MayThrow |
+| `` `` ``     | `BuiltinCall("backtick", [StrLit("")])` + same effects          |
+
+The triple-effect set reflects that command execution may **block** on the child process, **print** stdout/stderr, and **throw** if the command can't be invoked.  Marker-builtin pattern reused from Phase 6v (`__rescue_marker__`), Phase 6w (`lambda`/`proc`), and Phase 6y (`__interp__`).
+
+The synthetic `StrLit` body triggers `Feature::Strings`.
+
+### v0 deferred limitations
+
+- Interpolation inside the body (`` `echo #{name}` ``) is NOT split — the body lowers as a single `StrLit` with any `#{...}` markers preserved verbatim.  Follow-up will reuse the Phase 6y splitter.
+- Escape sequences are already resolved by the lexer's `backtick_body` state.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 127 → **132** (+5):
+  - `backtick_command_literal_lowers_to_backtick_builtin_call` — happy path.
+  - `backtick_command_literal_carries_effect_set` — asserts MayBlock + MayPrint + MayThrow.
+  - `empty_backtick_command_literal_lowers_with_empty_body` — `` `` ``.
+  - `backtick_command_literal_triggers_strings_feature` — manifest gating.
+  - `backtick_command_literal_module_passes_sir_validator` — end-to-end smoke.
+
 ## [0.27.0] - 2026-05-25
 
 ### Added (Phase 6z — float / hex / bin / oct numeric literal lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2624,4 +2624,100 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7a — backtick command literal lowering
+    //
+    // Lexer Phase 4m emits `` `ls -la` `` as a `TokenType::String` whose
+    // value is the verbatim source including the surrounding backticks
+    // (`` `ls -la` ``).  The lowerer detects the leading backtick and
+    // emits a marker `BuiltinCall("backtick", [StrLit(body)])` with
+    // effects = MayBlock | MayPrint | MayThrow.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn backtick_command_literal_lowers_to_backtick_builtin_call() {
+        // `x = `ls -la`` → BuiltinCall("backtick", [StrLit("ls -la")]).
+        let m = lower("x = `ls -la`");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding { value, name, .. } => {
+                assert_eq!(name, "x");
+                match value {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "backtick");
+                        assert_eq!(args.len(), 1);
+                        match &args[0] {
+                            Expr::StrLit { value, .. } => {
+                                assert_eq!(value, "ls -la");
+                            }
+                            other => panic!("expected StrLit body, got {:?}", other),
+                        }
+                    }
+                    other => panic!("expected backtick BuiltinCall, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn backtick_command_literal_carries_effect_set() {
+        // Backtick spawns a child process — must carry MayBlock,
+        // MayPrint, MayThrow.  Verify all three are set on the marker.
+        let m = lower("x = `pwd`");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding {
+                value: Expr::BuiltinCall { effects, .. },
+                ..
+            } => {
+                assert!(effects.contains(Effect::MayBlock), "expected MayBlock");
+                assert!(effects.contains(Effect::MayPrint), "expected MayPrint");
+                assert!(effects.contains(Effect::MayThrow), "expected MayThrow");
+            }
+            other => panic!("expected backtick BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn empty_backtick_command_literal_lowers_with_empty_body() {
+        // `x = ``` (empty body).  The marker still emits a StrLit, with
+        // an empty body string.
+        let m = lower("x = ``");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding {
+                value: Expr::BuiltinCall { name, args, .. },
+                ..
+            } => {
+                assert_eq!(name, "backtick");
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value.is_empty()));
+            }
+            other => panic!("expected backtick BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn backtick_command_literal_triggers_strings_feature() {
+        // The synthetic StrLit body triggers `Feature::Strings`.
+        let m = lower("x = `whoami`");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Strings),
+            "expected Strings feature in manifest"
+        );
+    }
+
+    #[test]
+    fn backtick_command_literal_module_passes_sir_validator() {
+        // End-to-end smoke: a module that uses a backtick literal
+        // passes the SIR validator.
+        let m = lower("x = `echo hi`\nputs(x)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected backtick-using module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2935,6 +2935,73 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
+    // Phase 7a — backtick command literal lowering
+    // -------------------------------------------------------------------
+
+    /// Lower a Ruby backtick command literal `` `cmd args` `` (Phase 7a).
+    ///
+    /// The lexer's Phase-4m `backtick_body` state emits the entire
+    /// literal — including the surrounding backticks — as a single
+    /// `TokenType::String` token whose `value` is `` `<body>` `` (the
+    /// inner body wrapped back up).  This sentinel-by-prefix trick
+    /// lets the parser route both plain strings and backtick literals
+    /// through the same NUMBER/STRING/NAME factor alternation while
+    /// preserving the distinction for the lowerer.
+    ///
+    /// ## SIR shape
+    ///
+    /// `BuiltinCall { name: "backtick", args: [StrLit(body)] }` — the
+    /// inner body (backticks stripped) is carried as a `StrLit` arg.
+    /// Effects are `MayBlock | MayPrint | MayThrow`: command execution
+    /// can block (waiting for the child process), print (stdout/stderr
+    /// from the child), and throw (`Errno::ENOENT` and friends).  Same
+    /// marker-builtin pattern as Phase 6v's `__rescue_marker__`,
+    /// Phase 6w's lambda construction, and Phase 6y's `__interp__`.
+    ///
+    /// ## v0 deferred limitations
+    ///
+    /// - Interpolation inside the body (`` `echo #{name}` ``) is NOT
+    ///   split.  The body is emitted as a single `StrLit` with any
+    ///   `#{...}` markers preserved verbatim.  A future phase will
+    ///   reuse the Phase 6y interpolation splitter inside the body.
+    /// - Escape sequences inside the body (`` \` ``, `\n`, etc.) are
+    ///   resolved by the lexer (Phase 4m's body state) before reaching
+    ///   us — we don't re-process them here.
+    /// - Triggers `Feature::Strings` because we emit a `StrLit`.
+    fn lower_backtick_command_literal(&mut self, raw: &str, span: Span) -> Expr {
+        // Strip the surrounding backticks.  The lexer guarantees the
+        // value is `` `<body>` ``, so the first and last bytes are
+        // always ASCII `` ` `` (single-byte) — we can slice on bytes.
+        // Defensive fallback: if either delimiter is missing (which
+        // would be a lexer bug), treat the whole value as the body so
+        // we don't panic on a malformed input.
+        let body = if raw.len() >= 2
+            && raw.starts_with('`')
+            && raw.ends_with('`')
+        {
+            &raw[1..raw.len() - 1]
+        } else {
+            raw
+        };
+        self.features_used.insert(Feature::Strings);
+        Expr::BuiltinCall {
+            name: "backtick".to_string(),
+            args: vec![Expr::StrLit {
+                value: body.to_string(),
+                span: span.clone(),
+            }],
+            // Backtick execution can block on the child process, print
+            // its output, and throw if the command can't be invoked
+            // (`Errno::ENOENT`, etc).
+            effects: EffectSet::PURE
+                .with(Effect::MayBlock)
+                .with(Effect::MayPrint)
+                .with(Effect::MayThrow),
+            span,
+        }
+    }
+
+    // -------------------------------------------------------------------
     // Phase 6z — numeric literal lowering (float / hex / bin / oct / dec)
     // -------------------------------------------------------------------
 
@@ -3303,6 +3370,19 @@ impl Lowerer {
                             );
                         }
                         TokenType::String => {
+                            // Phase 7a — backtick command literal dispatch.
+                            // The lexer (Phase 4m) emits `` `cmd args` `` as
+                            // a `String` token whose value is the verbatim
+                            // source *including* the surrounding backticks
+                            // — same lexeme-prefix sentinel trick the
+                            // percent literals and heredocs use.  Detect by
+                            // checking the leading byte.
+                            if tok.value.starts_with('`') {
+                                return Ok(self.lower_backtick_command_literal(
+                                    &tok.value,
+                                    span,
+                                ));
+                            }
                             // Phase 6y — string interpolation expression
                             // lowering.  The lexer (Phase 3b) emits the
                             // entire `"foo#{x}bar"` literal as a single


### PR DESCRIPTION
## Summary

The lexer's Phase-4m `backtick_body` state emits `` `cmd args` `` as a single `TokenType::String` token whose value is the verbatim source **including the surrounding backticks** (`` `cmd args` ``) — the same lexeme-prefix sentinel trick used by percent literals and heredocs.  Phase 7a is therefore **grammar-zero**: the existing STRING token at factor / call-arg / assignment-RHS positions already accepts backtick literals.  This PR adds the SIR lowering dispatch + explicit test coverage.

## Lowering

A new helper `lower_backtick_command_literal` in `ruby-to-semantic-ir/src/lower.rs` strips the wrapping backticks and emits:

```
BuiltinCall {
    name: "backtick",
    args: [StrLit(body)],
    effects: MayBlock | MayPrint | MayThrow,
}
```

The triple-effect set reflects that command execution may **block** on the child process, **print** stdout/stderr, and **throw** if the command can't be invoked (`Errno::ENOENT` and friends).  Marker-builtin pattern reused from Phase 6v (`__rescue_marker__`), Phase 6w (`lambda`/`proc`), and Phase 6y (`__interp__`).

The `String` case of `lower_factor_atom` dispatches by lexeme prefix:
- starts with `` ` `` → backtick command literal (Phase 7a)
- otherwise → string interpolation lowering (Phase 6y)

The synthetic `StrLit` body triggers `Feature::Strings`.

## v0 deferred limitations

- Interpolation inside the body (`` `echo #{name}` ``) is NOT split — the body lowers as a single `StrLit` with `#{...}` markers preserved verbatim.  A future phase will reuse the Phase 6y interpolation splitter inside the body.
- Escape sequences inside the body (`` \` ``, `\n`, `\t`) are already resolved by the lexer (Phase 4m's body state) before reaching the lowerer.

## Tests

- `coding-adventures-ruby-parser`: 122 → **125** (+3 grammar tests).
- `ruby-to-semantic-ir`: 127 → **132** (+5 lowering tests, incl. effect-set assertion and validator end-to-end smoke).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (125/125 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (132/132 pass)
- [x] Self-reviewed (no I/O, no unsafe — the `BuiltinCall("backtick",...)` is a *marker* in the SIR; backend emitters decide how to dispatch.  The lowerer itself does not execute shell commands.  Defensive slice-bounds check before stripping the backtick wrapper; effects encode the runtime surface for downstream consumers; same patterns as prior phases)
- [ ] CI green

Follows PR #4363 (Phase 6z — float / hex / bin / oct numeric literal parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
