### PR TITLE
Track browser document policy metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -285,6 +285,18 @@ def check_browser_document_metadata(
         require_optional_nullable_string(metadata_path, metadata, field, errors)
 
     require_optional_object_list(metadata_path, metadata, "theme_colors", errors)
+    require_optional_object_list(metadata_path, metadata, "viewport_directives", errors)
+    for index, directive in enumerate(object_list_items(metadata, "viewport_directives")):
+        directive_path = f"{metadata_path}.viewport_directives[{index}]"
+        require_string(directive_path, directive, "name", errors)
+        require_optional_nullable_string(directive_path, directive, "value", errors)
+    require_optional_string_list(metadata_path, metadata, "robots_directives", errors)
+    require_optional_object_list(metadata_path, metadata, "http_equiv_hints", errors)
+    for index, hint in enumerate(object_list_items(metadata, "http_equiv_hints")):
+        hint_path = f"{metadata_path}.http_equiv_hints[{index}]"
+        require_string(hint_path, hint, "name", errors)
+        require_string(hint_path, hint, "content", errors)
+
     for index, theme_color in enumerate(object_list_items(metadata, "theme_colors")):
         theme_color_path = f"{metadata_path}.theme_colors[{index}]"
         require_string(theme_color_path, theme_color, "color", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -847,17 +847,32 @@ pub struct BrowserDocument {
 pub struct BrowserDocumentMetadata {
     pub charset: Option<String>,
     pub viewport: Option<String>,
+    pub viewport_directives: Vec<BrowserMetadataDirective>,
     pub description: Option<String>,
     pub application_name: Option<String>,
     pub referrer_policy: Option<String>,
     pub robots: Option<String>,
+    pub robots_directives: Vec<String>,
     pub color_scheme: Option<String>,
+    pub http_equiv_hints: Vec<BrowserHttpEquivHint>,
     pub theme_colors: Vec<BrowserThemeColor>,
     pub refresh: Option<BrowserRefresh>,
     pub canonical_url: Option<String>,
     pub resolved_canonical_url: Option<String>,
     pub manifest_url: Option<String>,
     pub resolved_manifest_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMetadataDirective {
+    pub name: String,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserHttpEquivHint {
+    pub name: String,
+    pub content: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8881,8 +8896,18 @@ fn collect_meta_document_metadata(element: &Element, summary: &mut BrowserDocume
     }
 
     if let Some(content) = element.attribute("content") {
+        if let Some(name) = browser_meta_policy_http_equiv_name(element) {
+            summary
+                .metadata
+                .http_equiv_hints
+                .push(BrowserHttpEquivHint {
+                    name,
+                    content: content.to_string(),
+                });
+        }
         if browser_meta_name_is(element, "viewport") && summary.metadata.viewport.is_none() {
             summary.metadata.viewport = Some(content.to_string());
+            summary.metadata.viewport_directives = browser_metadata_directives(content);
         }
         if browser_meta_name_is(element, "description") && summary.metadata.description.is_none() {
             summary.metadata.description = Some(content.to_string());
@@ -8897,6 +8922,7 @@ fn collect_meta_document_metadata(element: &Element, summary: &mut BrowserDocume
         }
         if browser_meta_name_is(element, "robots") && summary.metadata.robots.is_none() {
             summary.metadata.robots = Some(content.to_string());
+            summary.metadata.robots_directives = browser_metadata_list(content);
         }
         if browser_meta_name_is(element, "color-scheme") && summary.metadata.color_scheme.is_none()
         {
@@ -8942,6 +8968,19 @@ fn browser_meta_http_equiv_is(element: &Element, expected: &str) -> bool {
     element
         .attribute("http-equiv")
         .is_some_and(|name| name.eq_ignore_ascii_case(expected))
+}
+
+fn browser_meta_http_equiv_name(element: &Element) -> Option<String> {
+    element
+        .attribute("http-equiv")
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_ascii_lowercase)
+}
+
+fn browser_meta_policy_http_equiv_name(element: &Element) -> Option<String> {
+    let name = browser_meta_http_equiv_name(element)?;
+    (!matches!(name.as_str(), "content-type" | "refresh")).then_some(name)
 }
 
 fn browser_meta_charset(element: &Element) -> Option<String> {
@@ -8991,6 +9030,38 @@ fn browser_refresh_url(part: &str) -> Option<String> {
     }
     let url = trim_browser_metadata_token(value);
     (!url.is_empty()).then_some(url)
+}
+
+fn browser_metadata_directives(content: &str) -> Vec<BrowserMetadataDirective> {
+    content
+        .split(',')
+        .filter_map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            let (name, value) = match part.split_once('=') {
+                Some((name, value)) => (
+                    name.trim(),
+                    Some(trim_browser_metadata_token(value)).filter(|value| !value.is_empty()),
+                ),
+                None => (part, None),
+            };
+            let name = name.trim();
+            (!name.is_empty()).then(|| BrowserMetadataDirective {
+                name: name.to_ascii_lowercase(),
+                value,
+            })
+        })
+        .collect()
+}
+
+fn browser_metadata_list(content: &str) -> Vec<String> {
+    content
+        .split(',')
+        .map(trim_browser_metadata_token)
+        .filter(|part| !part.is_empty())
+        .collect()
 }
 
 fn trim_browser_metadata_token(value: &str) -> String {
@@ -12035,12 +12106,17 @@ mod tests {
             "<base href=\"https://example.test/app/page.html\">\
              <meta http-equiv=content-type content=\"text/html; charset=windows-1252\">\
              <meta charset=utf-8>\
-             <meta name=viewport content=\"width=device-width, initial-scale=1\">\
+             <meta name=viewport content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\
              <meta name=description content=\"HTML parser workbench\">\
              <meta name=application-name content=Venture>\
              <meta name=referrer content=no-referrer>\
-             <meta name=robots content=\"index,follow\">\
+             <meta name=robots content=\"index, follow, max-image-preview:large\">\
              <meta name=color-scheme content=\"light dark\">\
+             <meta http-equiv=Content-Security-Policy content=\"default-src 'self'; img-src https:\">\
+             <meta http-equiv=Permissions-Policy content=\"geolocation=(), camera=()\">\
+             <meta http-equiv=Origin-Trial content=trial-token>\
+             <meta http-equiv=Accept-CH content=\"Sec-CH-UA-Platform, DPR\">\
+             <meta http-equiv=x-dns-prefetch-control content=off>\
              <meta name=theme-color content=\"#ffffff\" media=\"(prefers-color-scheme: light)\">\
              <meta name=theme-color content=\"#111111\" media=\"(prefers-color-scheme: dark)\">\
              <meta http-equiv=refresh content=\"5; url=next.html\">\
@@ -12053,7 +12129,24 @@ mod tests {
         assert_eq!(summary.metadata.charset.as_deref(), Some("windows-1252"));
         assert_eq!(
             summary.metadata.viewport.as_deref(),
-            Some("width=device-width, initial-scale=1")
+            Some("width=device-width, initial-scale=1, viewport-fit=cover")
+        );
+        assert_eq!(
+            summary.metadata.viewport_directives,
+            vec![
+                BrowserMetadataDirective {
+                    name: "width".to_string(),
+                    value: Some("device-width".to_string()),
+                },
+                BrowserMetadataDirective {
+                    name: "initial-scale".to_string(),
+                    value: Some("1".to_string()),
+                },
+                BrowserMetadataDirective {
+                    name: "viewport-fit".to_string(),
+                    value: Some("cover".to_string()),
+                },
+            ]
         );
         assert_eq!(
             summary.metadata.description.as_deref(),
@@ -12067,7 +12160,39 @@ mod tests {
             summary.metadata.referrer_policy.as_deref(),
             Some("no-referrer")
         );
-        assert_eq!(summary.metadata.robots.as_deref(), Some("index,follow"));
+        assert_eq!(
+            summary.metadata.robots.as_deref(),
+            Some("index, follow, max-image-preview:large")
+        );
+        assert_eq!(
+            summary.metadata.robots_directives,
+            vec!["index", "follow", "max-image-preview:large"]
+        );
+        assert_eq!(
+            summary.metadata.http_equiv_hints,
+            vec![
+                BrowserHttpEquivHint {
+                    name: "content-security-policy".to_string(),
+                    content: "default-src 'self'; img-src https:".to_string(),
+                },
+                BrowserHttpEquivHint {
+                    name: "permissions-policy".to_string(),
+                    content: "geolocation=(), camera=()".to_string(),
+                },
+                BrowserHttpEquivHint {
+                    name: "origin-trial".to_string(),
+                    content: "trial-token".to_string(),
+                },
+                BrowserHttpEquivHint {
+                    name: "accept-ch".to_string(),
+                    content: "Sec-CH-UA-Platform, DPR".to_string(),
+                },
+                BrowserHttpEquivHint {
+                    name: "x-dns-prefetch-control".to_string(),
+                    content: "off".to_string(),
+                },
+            ]
+        );
         assert_eq!(summary.metadata.color_scheme.as_deref(), Some("light dark"));
         assert_eq!(summary.metadata.theme_colors.len(), 2);
         assert_eq!(summary.metadata.theme_colors[0].color, "#ffffff");

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,9 +1,9 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata, BrowserForm,
-    BrowserFormControl, BrowserHeading, BrowserImage, BrowserImageSource, BrowserLink,
-    BrowserMedia, BrowserMeta, BrowserRefresh, BrowserResource, BrowserScript,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTemplate, BrowserThemeColor,
+    BrowserFormControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
+    BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh,
+    BrowserResource, BrowserScript, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -74,6 +74,8 @@ struct ExpectedDocumentMetadata {
     #[serde(default)]
     viewport: Option<String>,
     #[serde(default)]
+    viewport_directives: Vec<ExpectedMetadataDirective>,
+    #[serde(default)]
     description: Option<String>,
     #[serde(default)]
     application_name: Option<String>,
@@ -82,7 +84,11 @@ struct ExpectedDocumentMetadata {
     #[serde(default)]
     robots: Option<String>,
     #[serde(default)]
+    robots_directives: Vec<String>,
+    #[serde(default)]
     color_scheme: Option<String>,
+    #[serde(default)]
+    http_equiv_hints: Vec<ExpectedHttpEquivHint>,
     #[serde(default)]
     theme_colors: Vec<ExpectedThemeColor>,
     #[serde(default)]
@@ -95,6 +101,19 @@ struct ExpectedDocumentMetadata {
     manifest_url: Option<String>,
     #[serde(default)]
     resolved_manifest_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMetadataDirective {
+    name: String,
+    #[serde(default)]
+    value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedHttpEquivHint {
+    name: String,
+    content: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -622,11 +641,22 @@ impl ExpectedDocumentMetadata {
         BrowserDocumentMetadata {
             charset: self.charset,
             viewport: self.viewport,
+            viewport_directives: self
+                .viewport_directives
+                .into_iter()
+                .map(ExpectedMetadataDirective::into_browser_metadata_directive)
+                .collect(),
             description: self.description,
             application_name: self.application_name,
             referrer_policy: self.referrer_policy,
             robots: self.robots,
+            robots_directives: self.robots_directives,
             color_scheme: self.color_scheme,
+            http_equiv_hints: self
+                .http_equiv_hints
+                .into_iter()
+                .map(ExpectedHttpEquivHint::into_browser_http_equiv_hint)
+                .collect(),
             theme_colors: self
                 .theme_colors
                 .into_iter()
@@ -637,6 +667,24 @@ impl ExpectedDocumentMetadata {
             resolved_canonical_url: self.resolved_canonical_url,
             manifest_url: self.manifest_url,
             resolved_manifest_url: self.resolved_manifest_url,
+        }
+    }
+}
+
+impl ExpectedMetadataDirective {
+    fn into_browser_metadata_directive(self) -> BrowserMetadataDirective {
+        BrowserMetadataDirective {
+            name: self.name,
+            value: self.value,
+        }
+    }
+}
+
+impl ExpectedHttpEquivHint {
+    fn into_browser_http_equiv_hint(self) -> BrowserHttpEquivHint {
+        BrowserHttpEquivHint {
+            name: self.name,
+            content: self.content,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -191,19 +191,32 @@
     {
       "id": "document-metadata-policy-page",
       "description": "Browser document metadata extracts head policy hints from meta tags and canonical/manifest links.",
-      "input": "<base href=\"https://example.test/app/page.html\"><meta http-equiv=content-type content=\"text/html; charset=windows-1252\"><meta charset=utf-8><meta name=viewport content=\"width=device-width, initial-scale=1\"><meta name=description content=\"HTML parser workbench\"><meta name=application-name content=Venture><meta name=referrer content=no-referrer><meta name=robots content=\"index,follow\"><meta name=color-scheme content=\"light dark\"><meta name=theme-color content=\"#ffffff\" media=\"(prefers-color-scheme: light)\"><meta name=theme-color content=\"#111111\" media=\"(prefers-color-scheme: dark)\"><meta http-equiv=refresh content=\"5; url=next.html\"><link rel=canonical href=\"https://example.test/app/\"><link rel=manifest href=\"site.webmanifest\">",
+      "input": "<base href=\"https://example.test/app/page.html\"><meta http-equiv=content-type content=\"text/html; charset=windows-1252\"><meta charset=utf-8><meta name=viewport content=\"width=device-width, initial-scale=1, viewport-fit=cover\"><meta name=description content=\"HTML parser workbench\"><meta name=application-name content=Venture><meta name=referrer content=no-referrer><meta name=robots content=\"index, follow, max-image-preview:large\"><meta name=color-scheme content=\"light dark\"><meta http-equiv=Content-Security-Policy content=\"default-src 'self'; img-src https:\"><meta http-equiv=Permissions-Policy content=\"geolocation=(), camera=()\"><meta http-equiv=Origin-Trial content=trial-token><meta http-equiv=Accept-CH content=\"Sec-CH-UA-Platform, DPR\"><meta http-equiv=x-dns-prefetch-control content=off><meta name=theme-color content=\"#ffffff\" media=\"(prefers-color-scheme: light)\"><meta name=theme-color content=\"#111111\" media=\"(prefers-color-scheme: dark)\"><meta http-equiv=refresh content=\"5; url=next.html\"><link rel=canonical href=\"https://example.test/app/\"><link rel=manifest href=\"site.webmanifest\">",
       "expected": {
         "title": null,
         "base_href": "https://example.test/app/page.html",
         "base_target": null,
         "metadata": {
           "charset": "windows-1252",
-          "viewport": "width=device-width, initial-scale=1",
+          "viewport": "width=device-width, initial-scale=1, viewport-fit=cover",
+          "viewport_directives": [
+            { "name": "width", "value": "device-width" },
+            { "name": "initial-scale", "value": "1" },
+            { "name": "viewport-fit", "value": "cover" }
+          ],
           "description": "HTML parser workbench",
           "application_name": "Venture",
           "referrer_policy": "no-referrer",
-          "robots": "index,follow",
+          "robots": "index, follow, max-image-preview:large",
+          "robots_directives": ["index", "follow", "max-image-preview:large"],
           "color_scheme": "light dark",
+          "http_equiv_hints": [
+            { "name": "content-security-policy", "content": "default-src 'self'; img-src https:" },
+            { "name": "permissions-policy", "content": "geolocation=(), camera=()" },
+            { "name": "origin-trial", "content": "trial-token" },
+            { "name": "accept-ch", "content": "Sec-CH-UA-Platform, DPR" },
+            { "name": "x-dns-prefetch-control", "content": "off" }
+          ],
           "theme_colors": [
             { "color": "#ffffff", "media": "(prefers-color-scheme: light)" },
             { "color": "#111111", "media": "(prefers-color-scheme: dark)" }
@@ -218,12 +231,17 @@
         "metas": [
           { "name": null, "http_equiv": "content-type", "property": null, "charset": null, "content": "text/html; charset=windows-1252" },
           { "name": null, "http_equiv": null, "property": null, "charset": "utf-8", "content": null },
-          { "name": "viewport", "http_equiv": null, "property": null, "charset": null, "content": "width=device-width, initial-scale=1" },
+          { "name": "viewport", "http_equiv": null, "property": null, "charset": null, "content": "width=device-width, initial-scale=1, viewport-fit=cover" },
           { "name": "description", "http_equiv": null, "property": null, "charset": null, "content": "HTML parser workbench" },
           { "name": "application-name", "http_equiv": null, "property": null, "charset": null, "content": "Venture" },
           { "name": "referrer", "http_equiv": null, "property": null, "charset": null, "content": "no-referrer" },
-          { "name": "robots", "http_equiv": null, "property": null, "charset": null, "content": "index,follow" },
+          { "name": "robots", "http_equiv": null, "property": null, "charset": null, "content": "index, follow, max-image-preview:large" },
           { "name": "color-scheme", "http_equiv": null, "property": null, "charset": null, "content": "light dark" },
+          { "name": null, "http_equiv": "Content-Security-Policy", "property": null, "charset": null, "content": "default-src 'self'; img-src https:" },
+          { "name": null, "http_equiv": "Permissions-Policy", "property": null, "charset": null, "content": "geolocation=(), camera=()" },
+          { "name": null, "http_equiv": "Origin-Trial", "property": null, "charset": null, "content": "trial-token" },
+          { "name": null, "http_equiv": "Accept-CH", "property": null, "charset": null, "content": "Sec-CH-UA-Platform, DPR" },
+          { "name": null, "http_equiv": "x-dns-prefetch-control", "property": null, "charset": null, "content": "off" },
           { "name": "theme-color", "http_equiv": null, "property": null, "charset": null, "content": "#ffffff" },
           { "name": "theme-color", "http_equiv": null, "property": null, "charset": null, "content": "#111111" },
           { "name": null, "http_equiv": "refresh", "property": null, "charset": null, "content": "5; url=next.html" }


### PR DESCRIPTION
## Summary
- expose structured viewport and robots directives in browser document metadata
- surface policy/client-hint http-equiv metadata such as CSP, Permissions-Policy, Origin-Trial, Accept-CH, and DNS prefetch control
- extend browser readiness fixtures and schema governance for the new metadata fields

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- cargo test -p coding-adventures-html-parser browser_document_metadata_tracks_head_policy_hints
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
