### PR TITLE
feat(ruby-parser): Phase 7b — heredocs in parser

### DIFF
--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.29.0] - 2026-05-25
+
+### Added (Phase 7b — heredocs in parser)
+
+The lexer's Phase-3c body capture + Phase-4o opener-variant handling (`<<EOF`, `<<-EOF`, `<<~EOF`) finalise every heredoc into a single `TokenType::String` token whose value is the verbatim canonical form `<<TAG\n<body>TAG` (with `<<~TAG`'s common-indent stripping pre-applied).  Phase 7b is therefore **grammar-zero**: the existing STRING token at factor / assignment-RHS positions already accepts heredocs.  This PR adds the SIR lowering dispatch + explicit test coverage.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+A new helper `lower_heredoc_literal` strips the opener prefix and the closing tag, emitting:
+
+```
+StrLit(body)
+```
+
+The `String` case of `lower_factor_atom` now dispatches in lexeme-prefix priority order:
+- starts with `` ` `` → backtick command literal (Phase 7a)
+- starts with `<<` → heredoc (Phase 7b)
+- otherwise → string interpolation lowering (Phase 6y)
+
+The synthetic `StrLit` triggers `Feature::Strings`.
+
+### v0 deferred limitations
+
+- Interpolation inside the body (`#{name}`) is NOT split — the body lowers as a single `StrLit` with `#{...}` markers preserved verbatim.  Follow-up will reuse the Phase 6y splitter.
+- Non-interpolating heredocs (`<<'TAG'`) and the `<<"TAG"` form are not yet distinguished — the lexer doesn't carry the quote state, so every heredoc is treated the same.
+- Escape sequences inside the body are kept literal (the lexer's heredoc capture does not unescape; same v0 stance as backticks).
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 125 → **128** (+3 grammar tests):
+  - `test_parse_plain_heredoc_assignment` — `<<EOF`.
+  - `test_parse_dash_indent_heredoc_assignment` — `<<-EOF` with indented closer.
+  - `test_parse_tilde_indent_heredoc_assignment` — `<<~EOF` with indent stripping.
+
 ## [0.28.0] - 2026-05-25
 
 ### Added (Phase 7a — backtick command literals in parser)

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2142,5 +2142,60 @@ mod tests {
             "expected empty-body backtick lexeme"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7b — heredocs in parser
+    //
+    // The lexer's Phase-3c heredoc body capture + Phase-4o opener-variant
+    // handling finalise every heredoc (`<<EOF`, `<<-EOF`, `<<~EOF`) into
+    // a single `TokenType::String` token whose value is the verbatim
+    // canonical form (`<<TAG\n<body>TAG`).  The parser sees the heredoc
+    // as a regular STRING token at the factor position — no grammar
+    // changes needed.  These tests confirm the grammar accepts every
+    // variant in assignment-RHS context.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_plain_heredoc_assignment() {
+        // `x = <<EOF\nhello\nEOF\n` — plain heredoc on RHS.
+        let ast = parse_ruby("x = <<EOF\nhello\nEOF\n");
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected assignment node"
+        );
+        assert!(
+            tree_has_token_value(&ast, "<<EOF\nhello\nEOF"),
+            "expected canonical heredoc lexeme in tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_dash_indent_heredoc_assignment() {
+        // `x = <<-EOF\nhello\n  EOF` — `<<-` indent-tolerant heredoc:
+        // closing tag may be indented (lexer Phase 4o).
+        let ast = parse_ruby("x = <<-EOF\nhello\n  EOF\n");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        // The lexer's canonicalisation strips the indentation from the
+        // closing tag in the *value*, so the in-tree lexeme is the
+        // canonical form.
+        assert!(
+            tree_has_token_value(&ast, "<<-EOF\nhello\nEOF"),
+            "expected canonical <<- heredoc lexeme in tree"
+        );
+    }
+
+    #[test]
+    fn test_parse_tilde_indent_heredoc_assignment() {
+        // `x = <<~EOF\n  hello\n  EOF` — `<<~` indent-stripping heredoc.
+        // The lexer strips common leading indent from each body line
+        // before re-wrapping into the canonical token form.
+        let ast = parse_ruby("x = <<~EOF\n  hello\n  EOF\n");
+        assert!(find_descendant(&ast, "assignment").is_some());
+        // Lexer stripped the common 2-space indent from `  hello`.
+        assert!(
+            tree_has_token_value(&ast, "<<~EOF\nhello\nEOF"),
+            "expected canonical <<~ heredoc with indent stripped"
+        );
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.29.0] - 2026-05-25
+
+### Added (Phase 7b — heredoc literal lowering)
+
+`lower_factor_atom`'s `String` case now dispatches in lexeme-prefix priority order:
+- starts with `` ` `` → backtick command literal (Phase 7a)
+- starts with `<<` → heredoc (Phase 7b — this phase)
+- otherwise → string interpolation lowering (Phase 6y)
+
+### Lowering
+
+| Source                            | SIR shape                            |
+|-----------------------------------|--------------------------------------|
+| `` `<<EOF\nhello\nEOF` ``         | `StrLit("hello\n")`                  |
+| `` `<<-EOF\nhello\n  EOF` ``      | `StrLit("hello\n")`                  |
+| `` `<<~EOF\n  hello\n  EOF` ``    | `StrLit("hello\n")` (lexer pre-strips indent) |
+
+The `<<~TAG` common-indent stripping is performed by the lexer's `finalize_heredoc` before the token reaches the lowerer; this routine just removes the opener prefix (`<<`, `<<-`, `<<~`) and the trailing closing-tag suffix.
+
+The synthetic `StrLit` triggers `Feature::Strings`.
+
+### v0 deferred limitations
+
+- Interpolation inside the body (`#{name}`) is NOT split — the body lowers as a single `StrLit` with `#{...}` markers preserved verbatim.  Follow-up will reuse the Phase 6y interpolation splitter.
+- Non-interpolating heredocs (`<<'TAG'`) and the `<<"TAG"` form are not yet distinguished from the unquoted form — the lexer doesn't carry the quote state through.
+- Escape sequences inside the body are kept literal.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 132 → **137** (+5):
+  - `plain_heredoc_lowers_to_strlit_body_only` — happy path.
+  - `dash_indent_heredoc_lowers_to_strlit_body_only` — `<<-EOF`.
+  - `tilde_indent_heredoc_strips_common_leading_whitespace` — `<<~EOF`.
+  - `heredoc_triggers_strings_feature` — manifest gating.
+  - `heredoc_module_passes_sir_validator` — end-to-end smoke.
+
 ## [0.28.0] - 2026-05-25
 
 ### Added (Phase 7a — backtick command literal lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2720,4 +2720,94 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7b — heredoc literal lowering
+    //
+    // Lexer Phase 3c/4o emits every heredoc as a `TokenType::String` whose
+    // value is the canonical `<<TAG\n<body>TAG` form (with `<<~TAG`
+    // indent-stripping pre-applied).  The lowerer detects the `<<` prefix
+    // and emits `StrLit(body)` — the inner body, tag suffix stripped.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn plain_heredoc_lowers_to_strlit_body_only() {
+        // `x = <<EOF\nhello\nEOF\n` → StrLit("hello\n").
+        let m = lower("x = <<EOF\nhello\nEOF\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding { value, name, .. } => {
+                assert_eq!(name, "x");
+                match value {
+                    Expr::StrLit { value, .. } => {
+                        // Body retains the trailing newline that was
+                        // part of the source between `hello` and `EOF`.
+                        assert_eq!(value, "hello\n");
+                    }
+                    other => panic!("expected StrLit, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dash_indent_heredoc_lowers_to_strlit_body_only() {
+        // `<<-EOF` strips opener prefix `<<-` and closing tag, leaves
+        // body intact.  Closing-tag indentation is already stripped by
+        // the lexer's canonicalisation.
+        let m = lower("x = <<-EOF\nhello\n  EOF\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding {
+                value: Expr::StrLit { value, .. },
+                ..
+            } => {
+                assert_eq!(value, "hello\n");
+            }
+            other => panic!("expected StrLit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn tilde_indent_heredoc_strips_common_leading_whitespace() {
+        // `<<~EOF` — common leading whitespace pre-stripped by the
+        // lexer.  Our lowerer just emits the body as a StrLit.
+        let m = lower("x = <<~EOF\n  hello\n  world\n  EOF\n");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding {
+                value: Expr::StrLit { value, .. },
+                ..
+            } => {
+                // Lexer stripped the 2-space common indent from each
+                // non-empty body line.
+                assert_eq!(value, "hello\nworld\n");
+            }
+            other => panic!("expected StrLit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn heredoc_triggers_strings_feature() {
+        // The synthetic StrLit body triggers `Feature::Strings`.
+        let m = lower("x = <<EOF\nhi\nEOF\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::Strings),
+            "expected Strings feature in manifest"
+        );
+    }
+
+    #[test]
+    fn heredoc_module_passes_sir_validator() {
+        // End-to-end smoke: a module that uses a heredoc literal
+        // passes the SIR validator.
+        let m = lower("x = <<EOF\nhello\nEOF\nputs(x)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected heredoc-using module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -2935,6 +2935,78 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
+    // Phase 7b — heredoc literal lowering
+    // -------------------------------------------------------------------
+
+    /// Lower a Ruby heredoc literal (Phase 7b).
+    ///
+    /// The lexer's Phase-3c body capture and Phase-4o opener-variant
+    /// handling finalise every heredoc into a single `TokenType::String`
+    /// token whose value is the verbatim canonical form:
+    ///
+    /// ```text
+    /// <<TAG\n<body>TAG     (Plain)
+    /// <<-TAG\n<body>TAG    (DashIndent — closing tag may be indented)
+    /// <<~TAG\n<body>TAG    (TildeIndent — common indent already stripped)
+    /// ```
+    ///
+    /// Note: the `<<~TAG` indent-stripping is already applied by the
+    /// lexer before we see the token, so we don't repeat it here.
+    ///
+    /// ## SIR shape
+    ///
+    /// `StrLit(body)` — the inner body (opener line + tag suffix
+    /// stripped) is emitted as a plain string literal.  This matches
+    /// Ruby's surface semantics: a heredoc *is* a string literal, just
+    /// with a different on-source representation.  Triggers
+    /// `Feature::Strings`.
+    ///
+    /// ## v0 deferred limitations
+    ///
+    /// - Interpolation inside the body (`#{name}`) is NOT split.  The
+    ///   body is emitted as a single `StrLit` with any `#{...}` markers
+    ///   preserved verbatim.  Follow-up will reuse the Phase 6y
+    ///   interpolation splitter.
+    /// - Non-interpolating heredocs (`<<'TAG'`) and the `<<"TAG"` form
+    ///   are not yet distinguished — the lexer doesn't carry the quote
+    ///   state, so we treat every heredoc the same.
+    /// - Escape sequences inside the body are kept literal (the lexer's
+    ///   heredoc capture does not unescape; same v0 stance as backticks).
+    fn lower_heredoc_literal(&mut self, raw: &str, span: Span) -> Expr {
+        // Step 1: strip the opener prefix.  Order matters — `<<~` and
+        // `<<-` must be tried *before* `<<`, because `<<~`/`<<-` both
+        // start with `<<`.
+        let after_prefix = raw
+            .strip_prefix("<<~")
+            .or_else(|| raw.strip_prefix("<<-"))
+            .or_else(|| raw.strip_prefix("<<"))
+            .unwrap_or(raw);
+
+        // Step 2: split off the tag (everything up to the first `\n`).
+        // The remainder is `<body><tag>` (the trailing tag was appended
+        // by the lexer's `finalize_heredoc`).
+        let body: String = if let Some(nl_idx) = after_prefix.find('\n') {
+            let tag = &after_prefix[..nl_idx];
+            let body_plus_tag = &after_prefix[nl_idx + 1..];
+            // Strip the closing tag from the end.  Defensive `or`:
+            // if the suffix isn't present (a lexer bug), keep the
+            // body intact rather than panicking.
+            body_plus_tag
+                .strip_suffix(tag)
+                .unwrap_or(body_plus_tag)
+                .to_string()
+        } else {
+            // Pathological: opener with no newline.  Shouldn't be
+            // possible given the lexer's finalise path, but handle it
+            // by treating the whole thing as the body.
+            after_prefix.to_string()
+        };
+
+        self.features_used.insert(Feature::Strings);
+        Expr::StrLit { value: body, span }
+    }
+
+    // -------------------------------------------------------------------
     // Phase 7a — backtick command literal lowering
     // -------------------------------------------------------------------
 
@@ -3379,6 +3451,18 @@ impl Lowerer {
                             // checking the leading byte.
                             if tok.value.starts_with('`') {
                                 return Ok(self.lower_backtick_command_literal(
+                                    &tok.value,
+                                    span,
+                                ));
+                            }
+                            // Phase 7b — heredoc dispatch.  The lexer (Phase
+                            // 3c / 4o) finalises every heredoc into a single
+                            // `String` token whose value is the verbatim
+                            // source: opener line (`<<TAG`, `<<-TAG`, or
+                            // `<<~TAG`), a `\n`, the body, then the closing
+                            // tag.  We detect by the `<<` prefix.
+                            if tok.value.starts_with("<<") {
+                                return Ok(self.lower_heredoc_literal(
                                     &tok.value,
                                     span,
                                 ));


### PR DESCRIPTION
## Summary

The lexer's Phase-3c body capture + Phase-4o opener-variant handling (`<<EOF`, `<<-EOF`, `<<~EOF`) finalise every heredoc into a single `TokenType::String` token whose value is the canonical form `<<TAG\n<body>TAG` (with `<<~TAG`'s common-indent stripping pre-applied).  Phase 7b is therefore **grammar-zero**: the existing STRING token at factor / assignment-RHS positions already accepts heredocs.  This PR adds the SIR lowering dispatch + explicit test coverage.

## Lowering

A new helper `lower_heredoc_literal` in `ruby-to-semantic-ir/src/lower.rs` strips the opener prefix and the trailing closing-tag, emitting `StrLit(body)`.

| Source                          | SIR shape           |
|---------------------------------|---------------------|
| `<<EOF\nhello\nEOF`             | `StrLit("hello\n")` |
| `<<-EOF\nhello\n  EOF`          | `StrLit("hello\n")` |
| `<<~EOF\n  hello\n  EOF`        | `StrLit("hello\n")` (lexer pre-strips indent) |

The `String` case of `lower_factor_atom` now dispatches in lexeme-prefix priority order:
- starts with `` ` `` → backtick command literal (Phase 7a)
- starts with `<<` → heredoc (Phase 7b — this PR)
- otherwise → string interpolation lowering (Phase 6y)

The synthetic `StrLit` triggers `Feature::Strings`.

## v0 deferred limitations

- Interpolation inside the body (`#{name}`) is NOT split — the body lowers as a single `StrLit` with `#{...}` markers preserved verbatim.  Follow-up will reuse the Phase 6y splitter.
- Non-interpolating heredocs (`<<'TAG'`) and the `<<"TAG"` form are not yet distinguished — the lexer doesn't carry the quote state through.
- Escape sequences inside the body are kept literal (same v0 stance as Phase 7a backticks).

## Tests

- `coding-adventures-ruby-parser`: 125 → **128** (+3 grammar tests).
- `ruby-to-semantic-ir`: 132 → **137** (+5 lowering tests, incl. validator end-to-end smoke).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (128/128 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (137/137 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — `strip_prefix`/`strip_suffix`/`find('\n')` are safe `Option`-returning operations with defensive `unwrap_or` fallbacks; same patterns as prior phases)
- [ ] CI green

Follows PR #4370 (Phase 7a — backtick command literals in parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
