### PR TITLE
feat(ruby-parser): Phase 7c — Ruby 3.0 endless method `def foo = expr`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -90,6 +90,12 @@ multi_assignment = NAME COMMA NAME { COMMA NAME } EQUALS expression { COMMA expr
 # mode (modifier syntax is intrinsically a same-line construct in Ruby).
 modifier_statement = ( assignment | method_call_no_paren | method_call | expression_stmt ) ( "if_modifier" | "unless_modifier" | "while_modifier" | "until_modifier" ) expression ;
 def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"end" statement } "end" ;
+# Phase 7c — Ruby 3.0 endless method definition: `def foo = expr` and
+# `def foo(x, y) = expr`.  No `end`, no block body — just a single
+# expression after the `=`.  Placed BEFORE `def_statement` in the
+# `statement` alternation so PEG tries the endless form first; if the
+# `=` isn't present the parser falls through to the block form.
+endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expression ;
 # Phase 6f — class/module namespace declarations.  The body is a
 # sequence of statements (which may include nested `def`s).  Like
 # `def_statement`, the body repetition uses a negative lookahead so it

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.30.0] - 2026-05-25
+
+### Added (Phase 7c — Ruby 3.0 endless method definitions `def foo = expr`)
+
+New grammar rule:
+
+```
+endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expression ;
+```
+
+Placed **before** `def_statement` in the `statement` alternation so PEG tries the endless form first; when the `=` isn't present the parser falls through to the block-bodied `def`.  The two forms cannot conflict because the endless form requires `=` immediately after the signature, while the block form expects a newline + body statements + `end`.
+
+Regenerated `_grammar.rs` via `grammar-tools compile-grammar`.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+A new helper `lower_endless_def_statement` mirrors `lower_def_statement`'s parameter extraction and scope-isolation logic, but the body is the single trailing `expression` Node:
+
+```
+endless_def_statement → Function {
+    name,
+    params,
+    body: Block { stmts: [], value: <lowered expression> },
+    ...
+}
+```
+
+Both the program-level pre-pass (`collect_def_statements`) and the class/module nested pass (`collect_def_statements_from_body`) now dispatch on rule name to handle both `def_statement` and `endless_def_statement`.
+
+### v0 deferred limitations
+
+- Inherits Phase 6s's lossy-splat limitation: `def foo(*args) = args.sum` parses but the `*` prefix on the param is dropped at SIR level (`Param` has no variadic flag).
+- The endless form is not nested under classes / modules in any SIR-significant way (matches the block-bodied def's v0 limitation).
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 128 → **131** (+3 grammar tests):
+  - `test_parse_endless_def_no_params` — `def hello = 1`.
+  - `test_parse_endless_def_with_params` — `def add(x, y) = x + y`.
+  - `test_parse_endless_def_does_not_break_block_def` — regression for the block-bodied form.
+
 ## [0.29.0] - 2026-05-25
 
 ### Added (Phase 7b — heredocs in parser)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -18,6 +18,7 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"statement"#.to_string(),
             body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"endless_def_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"def_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"class_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"module_statement"#.to_string() },
@@ -98,6 +99,21 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 92,
         },
         GrammarRule {
+            name: r#"endless_def_statement"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"def"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"params"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+            ] },
+            line_number: 98,
+        },
+        GrammarRule {
             name: r#"class_statement"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"class"#.to_string() },
@@ -108,7 +124,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 97,
+            line_number: 103,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -121,7 +137,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 98,
+            line_number: 104,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -143,7 +159,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 100,
+            line_number: 106,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -151,7 +167,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 101,
+            line_number: 107,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -164,7 +180,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 102,
+            line_number: 108,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -174,7 +190,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 103,
+            line_number: 109,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -187,7 +203,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 104,
+            line_number: 110,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -195,7 +211,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 106,
+            line_number: 112,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -203,7 +219,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 107,
+            line_number: 113,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -211,7 +227,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 108,
+            line_number: 114,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -219,7 +235,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 130,
+            line_number: 136,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -243,7 +259,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 131,
+            line_number: 137,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -254,7 +270,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"param"#.to_string() },
                     ] }) },
             ] },
-            line_number: 146,
+            line_number: 152,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -265,7 +281,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 147,
+            line_number: 153,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -282,7 +298,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 148,
+            line_number: 154,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -296,7 +312,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 149,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -307,7 +323,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 150,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -322,7 +338,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 151,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -335,7 +351,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 152,
+            line_number: 158,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -348,7 +364,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 153,
+            line_number: 159,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -359,7 +375,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 176,
+            line_number: 182,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -377,7 +393,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 177,
+            line_number: 183,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -393,7 +409,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 198,
+            line_number: 204,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -411,7 +427,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 207,
+            line_number: 213,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -422,7 +438,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 208,
+            line_number: 214,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -433,7 +449,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 209,
+            line_number: 215,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -450,7 +466,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 229,
+            line_number: 235,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -470,7 +486,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 240,
+            line_number: 246,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -492,7 +508,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 241,
+            line_number: 247,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -503,7 +519,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 248,
+            line_number: 254,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -518,17 +534,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 262,
+            line_number: 268,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 263,
+            line_number: 269,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 349,
+            line_number: 355,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -541,7 +557,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 350,
+            line_number: 356,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -555,7 +571,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 351,
+            line_number: 357,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -569,7 +585,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 352,
+            line_number: 358,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -583,7 +599,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 353,
+            line_number: 359,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -594,7 +610,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 360,
+            line_number: 366,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -612,7 +628,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 361,
+            line_number: 367,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -626,7 +642,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 362,
+            line_number: 368,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -640,7 +656,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 363,
+            line_number: 369,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -664,7 +680,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 373,
+            line_number: 379,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -677,7 +693,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 392,
+            line_number: 398,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -685,7 +701,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 393,
+            line_number: 399,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -697,7 +713,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 394,
+            line_number: 400,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -712,7 +728,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 395,
+            line_number: 401,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -727,7 +743,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 396,
+            line_number: 402,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -743,7 +759,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 397,
+            line_number: 403,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2197,5 +2197,65 @@ mod tests {
             "expected canonical <<~ heredoc with indent stripped"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7c — Ruby 3.0 endless method definitions `def foo = expr`
+    //
+    // Grammar adds:
+    //   endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expression ;
+    //
+    // Placed BEFORE def_statement in the statement alternation so PEG tries
+    // the endless form first; if `=` isn't present the parser falls through
+    // to the block-bodied def.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_endless_def_no_params() {
+        // `def hello = 1` — endless method with no parameters.
+        let ast = parse_ruby("def hello = 1");
+        let d = find_descendant(&ast, "endless_def_statement")
+            .expect("expected endless_def_statement node");
+        // The method-name Name token should be present.
+        assert!(tree_has_token_value(d, "hello"));
+        // No params subnode for the bare form.
+        assert!(
+            find_descendant(d, "params").is_none(),
+            "expected no params subnode for `def hello = 1`"
+        );
+    }
+
+    #[test]
+    fn test_parse_endless_def_with_params() {
+        // `def add(x, y) = x + y` — endless method with two parameters.
+        let ast = parse_ruby("def add(x, y) = x + y");
+        let d = find_descendant(&ast, "endless_def_statement")
+            .expect("expected endless_def_statement node");
+        let p = find_descendant(d, "params").expect("expected params subnode");
+        let param_count = p
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "param"))
+            .count();
+        assert_eq!(param_count, 2, "expected 2 params, got {param_count}");
+        // The body expression should be present.
+        assert!(find_descendant(d, "expression").is_some());
+    }
+
+    #[test]
+    fn test_parse_endless_def_does_not_break_block_def() {
+        // Regression: putting `endless_def_statement` first in the
+        // alternation must not break the existing block-bodied def
+        // form when there's no `=` after the signature.
+        let ast = parse_ruby("def greet\n  puts(1)\nend");
+        assert!(
+            find_descendant(&ast, "def_statement").is_some(),
+            "expected def_statement (block-bodied) — endless variant must fall through"
+        );
+        // The endless form should NOT have matched.
+        assert!(
+            find_descendant(&ast, "endless_def_statement").is_none(),
+            "block-bodied def must not match endless_def_statement"
+        );
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.30.0] - 2026-05-25
+
+### Added (Phase 7c — Ruby 3.0 endless method definitions)
+
+A new helper `lower_endless_def_statement` lowers `def foo = expr` / `def foo(x, y) = expr` into a top-level `Function`.  The shape:
+
+```
+Function {
+    name,
+    params,
+    body: Block { stmts: [], value: <lowered expression> },
+    return_type: None,
+    captures: [],
+    effects: PURE,
+    metadata: Metadata::new(),
+}
+```
+
+The `lower_statement_inner` `def_statement` match now also matches `endless_def_statement` (both hoist to a top-level Function and emit a `NilLit` ExprStmt placeholder in the main body).  Both pre-passes — `collect_def_statements` (program-level) and `collect_def_statements_from_body` (class/module-level) — dispatch on rule name so either form gets hoisted.
+
+### Lowering details
+
+- Parameter extraction reuses the same `params` → `param` Node walk as `lower_def_statement`, with the same lossy-splat v0 limitation: `*args` / `**kw` params drop the splat prefix.
+- A fresh `declared_locals` / `current_params` scope is opened for the body expression so a parameter reference inside the body resolves to `Scope::Param` (validator-correct).
+- The body is the single `expression` Node child (PEG guarantees exactly one, after the EQUALS token).  `Block.stmts` is empty; `Block.value` is the lowered expression.
+- Function `effects` default to `PURE`; if the lowered expression contains effectful calls (e.g. `puts`), the SIR's `effects_of` inference will pick them up at validation time.
+
+### v0 deferred limitations
+
+- Lossy splat (inherited from Phase 6s): `def foo(*args) = ...` loses the `*` prefix.
+- Endless defs inside classes / modules are hoisted to top level (no class scoping in SIR v0 — same caveat as the block-bodied def).
+- No method visibility markers (`private`, `protected`) — same as block-bodied defs.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 137 → **141** (+4):
+  - `endless_def_no_params_hoists_to_top_level_function` — happy path.
+  - `endless_def_with_params_carries_param_scope` — asserts `Scope::Param` for body VarRefs.
+  - `endless_def_does_not_emit_main_body_stmt` — confirms hoisting + NilLit placeholder.
+  - `endless_def_module_passes_sir_validator` — end-to-end validator smoke.
+
 ## [0.29.0] - 2026-05-25
 
 ### Added (Phase 7b — heredoc literal lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2810,4 +2810,107 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7c — Ruby 3.0 endless method definitions
+    //
+    // `def foo = expr` and `def foo(x, y) = expr` both hoist to a top-level
+    // Function whose Block has `stmts=[]` and `value=<lowered expr>`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn endless_def_no_params_hoists_to_top_level_function() {
+        // `def hello = 1` → top-level Function named "hello" with no
+        // params and body value = IntLit(1).
+        let m = lower("def hello = 1");
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "hello")
+            .expect("expected top-level `hello` Function");
+        assert!(f.params.is_empty(), "expected no params");
+        assert!(f.body.stmts.is_empty(), "endless def body has no stmts");
+        assert!(
+            matches!(f.body.value, Expr::IntLit { value: 1, .. }),
+            "expected IntLit(1) as body value, got {:?}",
+            f.body.value
+        );
+    }
+
+    #[test]
+    fn endless_def_with_params_carries_param_scope() {
+        // `def add(x, y) = x + y` — params should bind to Scope::Param
+        // inside the body expression.
+        let m = lower("def add(x, y) = x + y");
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "add")
+            .expect("expected top-level `add` Function");
+        assert_eq!(f.params.len(), 2);
+        assert_eq!(f.params[0].name, "x");
+        assert_eq!(f.params[1].name, "y");
+        // Body value should be the `x + y` BuiltinCall with VarRefs
+        // both at Scope::Param.
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert_eq!(args.len(), 2);
+                assert!(
+                    matches!(&args[0], Expr::VarRef { name, scope, .. }
+                        if name == "x" && *scope == Scope::Param),
+                    "expected VarRef(x, Param), got {:?}",
+                    &args[0]
+                );
+                assert!(
+                    matches!(&args[1], Expr::VarRef { name, scope, .. }
+                        if name == "y" && *scope == Scope::Param),
+                    "expected VarRef(y, Param), got {:?}",
+                    &args[1]
+                );
+            }
+            other => panic!("expected +-BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn endless_def_does_not_emit_main_body_stmt() {
+        // The endless def hoists to a top-level Function; the
+        // main-body statement stream should NOT contain an
+        // assignment / call for it (just the synthetic NilLit
+        // ExprStmt placeholder, same as block-bodied def).
+        let m = lower("def hello = 1\nputs(hello())");
+        // Expect at least two functions: main + hello.
+        assert!(
+            m.functions.iter().any(|f| f.name == "hello"),
+            "expected hello Function"
+        );
+        let main = m
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("expected main");
+        // The first stmt is the no-op placeholder for the endless def.
+        match &main.body.stmts[0] {
+            Stmt::ExprStmt {
+                expr: Expr::NilLit { .. },
+                ..
+            } => {} // OK
+            other => panic!("expected NilLit ExprStmt placeholder, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn endless_def_module_passes_sir_validator() {
+        // End-to-end smoke: a module with an endless def passes
+        // the validator.  The function body's lowering must produce
+        // a well-formed Block (stmts + value).
+        let m = lower("def square(n) = n * n\nputs(square(3))\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected endless-def module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -337,12 +337,13 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
-            "def_statement" => {
-                // `def` declarations were hoisted to top-level
-                // Functions in the pre-pass; here we drop them from
-                // the main-body statement stream.  Returning a no-op
-                // ExprStmt keeps the `Block.stmts` slot occupied but
-                // valid SIR-wise.
+            "def_statement" | "endless_def_statement" => {
+                // `def` declarations (both the block-bodied form and the
+                // Phase-7c endless `def foo = expr` form) were hoisted
+                // to top-level Functions in the pre-pass; here we drop
+                // them from the main-body statement stream.  Returning
+                // a no-op ExprStmt keeps the `Block.stmts` slot occupied
+                // but valid SIR-wise.
                 Ok(Stmt::ExprStmt {
                     expr: Expr::NilLit {
                         span: self.span_of(node),
@@ -1091,11 +1092,20 @@ impl Lowerer {
                 Some(n) => n,
                 None => continue,
             };
-            if inner.rule_name != "def_statement" {
-                continue;
+            // Phase 7c — endless `def foo = expr` is also hoisted as a
+            // top-level Function.  Both forms produce a `Function`
+            // value; the helper below dispatches on rule name.
+            match inner.rule_name.as_str() {
+                "def_statement" => {
+                    let func = self.lower_def_statement(inner)?;
+                    self.user_functions.push(func);
+                }
+                "endless_def_statement" => {
+                    let func = self.lower_endless_def_statement(inner)?;
+                    self.user_functions.push(func);
+                }
+                _ => {}
             }
-            let func = self.lower_def_statement(inner)?;
-            self.user_functions.push(func);
         }
         Ok(())
     }
@@ -1122,18 +1132,153 @@ impl Lowerer {
                 Some(n) => n,
                 None => continue,
             };
-            if inner.rule_name == "def_statement" {
-                let func = self.lower_def_statement(inner)?;
-                self.user_functions.push(func);
-            } else if inner.rule_name == "class_statement"
-                || inner.rule_name == "module_statement"
-            {
-                // Nested class/module — recurse so deeply-nested
-                // `def`s still get hoisted.
-                self.collect_def_statements_from_body(inner)?;
+            // Phase 7c — both `def_statement` and `endless_def_statement`
+            // are hoisted from inside class / module bodies.
+            match inner.rule_name.as_str() {
+                "def_statement" => {
+                    let func = self.lower_def_statement(inner)?;
+                    self.user_functions.push(func);
+                }
+                "endless_def_statement" => {
+                    let func = self.lower_endless_def_statement(inner)?;
+                    self.user_functions.push(func);
+                }
+                "class_statement" | "module_statement" => {
+                    // Nested class/module — recurse so deeply-nested
+                    // `def`s still get hoisted.
+                    self.collect_def_statements_from_body(inner)?;
+                }
+                _ => {}
             }
         }
         Ok(())
+    }
+
+    /// Phase 7c — lower an endless method definition `def foo = expr`
+    /// (or `def foo(x, y) = expr`) into a top-level `Function`.
+    ///
+    /// Endless methods are Ruby 3.0's terser one-liner syntax for
+    /// pure functions: the entire method body is a single expression
+    /// after the `=`, with no `end` keyword.  The parse-tree shape is:
+    ///
+    /// ```text
+    /// endless_def_statement
+    ///   ├─ Keyword("def")
+    ///   ├─ Name(method_name)
+    ///   ├─ [params]   (optional)
+    ///   ├─ Equals
+    ///   └─ expression (node)
+    /// ```
+    ///
+    /// We reuse the parameter-extraction logic from `lower_def_statement`
+    /// (identical shape) and then collect the single trailing
+    /// `expression` Node as the function's tail value.  No statements
+    /// in the body — `Block.stmts` is empty, `Block.value` is the
+    /// lowered expression.
+    fn lower_endless_def_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Function, RubyLowerError> {
+        // Method name — first Name-typed token (skips the `def` keyword).
+        let name_token = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "endless_def_statement missing method-name token".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let name = name_token.value.clone();
+
+        // Parameter list — same `params` rule shape as `def_statement`.
+        // Reuse the same extraction (find each `param` subnode, skip
+        // splat-prefix Token, take the identifier Name).  See the
+        // matching code in `lower_def_statement` for the lossy-splat
+        // v0 limitation.
+        let params_node = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
+            _ => None,
+        });
+        let params: Vec<Param> = if let Some(pn) = params_node {
+            pn.children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(param_node) if param_node.rule_name == "param" => {
+                        param_node.children.iter().find_map(|cc| match cc {
+                            ASTNodeOrToken::Token(t)
+                                if matches!(t.type_, TokenType::Name)
+                                    && t.value != "*"
+                                    && t.value != "**" =>
+                            {
+                                Some(Param {
+                                    name: t.value.clone(),
+                                    sir_type: None,
+                                    span: self.span_of_token(t),
+                                })
+                            }
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        if !params.is_empty() {
+            self.features_used.insert(Feature::DynamicTyping);
+        }
+
+        // Set up a fresh locals + params scope for the body expression
+        // — identical to `lower_def_statement` so any VarRef to a
+        // parameter inside the expression resolves as `Scope::Param`.
+        let saved_locals = std::mem::take(&mut self.declared_locals);
+        let saved_params = std::mem::take(&mut self.current_params);
+        for p in &params {
+            self.declared_locals.insert(p.name.clone());
+            self.current_params.insert(p.name.clone());
+        }
+
+        // The body is the single `expression` Node child.  PEG
+        // guarantees exactly one such child (the grammar rule has it
+        // as a non-repeated, non-optional element after the `EQUALS`).
+        let expr_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "endless_def_statement missing body expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let value = self.lower_expression(expr_node)?;
+
+        // Restore the outer scope.
+        self.declared_locals = saved_locals;
+        self.current_params = saved_params;
+
+        Ok(Function {
+            name,
+            params,
+            return_type: None,
+            captures: Vec::new(),
+            body: Block {
+                stmts: Vec::new(),
+                value,
+                span: self.span_of(node),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: self.span_of(node),
+        })
     }
 
     fn lower_def_statement(


### PR DESCRIPTION
## Summary

Phase 7c adds Ruby 3.0's endless method definition syntax `def foo = expr` (and `def foo(x, y) = expr`).  Unlike the block-bodied `def`, the endless form has no `end` keyword — the entire method body is a single expression after the `=`.

## Grammar

New rule:

```ebnf
endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expression ;
```

Placed **before** `def_statement` in the `statement` alternation so PEG tries the endless form first; when the `=` isn't present the parser falls through to the block-bodied `def`.  The two forms cannot conflict because the endless form requires `=` immediately after the signature.

`_grammar.rs` regenerated via `grammar-tools compile-grammar`.

## Lowering

A new helper `lower_endless_def_statement` mirrors `lower_def_statement`'s parameter extraction and scope-isolation logic, but the body is the single trailing `expression` Node:

```
endless_def_statement → Function {
    name,
    params,
    body: Block { stmts: [], value: <lowered expression> },
    return_type: None,
    captures: [],
    effects: PURE,
    metadata: Metadata::new(),
}
```

Both program-level (`collect_def_statements`) and class/module-level (`collect_def_statements_from_body`) pre-passes now dispatch on rule name so either form gets hoisted.  The `lower_statement_inner` match treats `def_statement | endless_def_statement` uniformly (both emit a `NilLit` ExprStmt placeholder in the main body).

## v0 deferred limitations

- Inherits Phase 6s's lossy-splat limitation: `def foo(*args) = args.sum` parses but the `*` prefix is dropped at SIR level.
- Endless defs inside classes / modules are hoisted to top level (no class scoping in SIR v0 — same as block-bodied defs).
- No method visibility markers (`private`, `protected`).

## Tests

- `coding-adventures-ruby-parser`: 128 → **131** (+3 grammar tests).
- `ruby-to-semantic-ir`: 137 → **141** (+4 lowering tests, incl. `Scope::Param` assertion and validator end-to-end smoke).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (131/131 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (141/141 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — grammar change is a single declarative rule; lowerer reuses existing parameter-extraction and scope-isolation patterns from `lower_def_statement`)
- [ ] CI green

Follows PR #4375 (Phase 7b — heredocs in parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
