### PR TITLE
Track browser resource hint metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -296,6 +296,27 @@ def check_browser_document_metadata(
         hint_path = f"{metadata_path}.http_equiv_hints[{index}]"
         require_string(hint_path, hint, "name", errors)
         require_string(hint_path, hint, "content", errors)
+    require_optional_object_list(metadata_path, metadata, "resource_hints", errors)
+    for index, hint in enumerate(object_list_items(metadata, "resource_hints")):
+        hint_path = f"{metadata_path}.resource_hints[{index}]"
+        require_string(hint_path, hint, "kind", errors)
+        require_string(hint_path, hint, "url", errors)
+        for field in (
+            "resolved_url",
+            "rel",
+            "as_hint",
+            "type_hint",
+            "media",
+            "integrity",
+            "crossorigin",
+            "referrerpolicy",
+            "fetchpriority",
+            "blocking",
+            "imagesrcset",
+            "resolved_imagesrcset",
+            "imagesizes",
+        ):
+            require_optional_nullable_string(hint_path, hint, field, errors)
 
     for index, theme_color in enumerate(object_list_items(metadata, "theme_colors")):
         theme_color_path = f"{metadata_path}.theme_colors[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -855,6 +855,7 @@ pub struct BrowserDocumentMetadata {
     pub robots_directives: Vec<String>,
     pub color_scheme: Option<String>,
     pub http_equiv_hints: Vec<BrowserHttpEquivHint>,
+    pub resource_hints: Vec<BrowserResourceHint>,
     pub theme_colors: Vec<BrowserThemeColor>,
     pub refresh: Option<BrowserRefresh>,
     pub canonical_url: Option<String>,
@@ -873,6 +874,25 @@ pub struct BrowserMetadataDirective {
 pub struct BrowserHttpEquivHint {
     pub name: String,
     pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserResourceHint {
+    pub kind: String,
+    pub url: String,
+    pub resolved_url: Option<String>,
+    pub rel: Option<String>,
+    pub as_hint: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub imagesrcset: Option<String>,
+    pub resolved_imagesrcset: Option<String>,
+    pub imagesizes: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8955,6 +8975,11 @@ fn collect_link_document_metadata(element: &Element, summary: &mut BrowserDocume
             summary.metadata.resolved_manifest_url =
                 resolve_browser_url(href, summary.base_href.as_deref());
         }
+        if let Some(resource_hint) =
+            browser_resource_hint_from_link(element, href, summary.base_href.as_deref())
+        {
+            summary.metadata.resource_hints.push(resource_hint);
+        }
     }
 }
 
@@ -9062,6 +9087,50 @@ fn browser_metadata_list(content: &str) -> Vec<String> {
         .map(trim_browser_metadata_token)
         .filter(|part| !part.is_empty())
         .collect()
+}
+
+fn browser_resource_hint_from_link(
+    element: &Element,
+    href: &str,
+    base_href: Option<&str>,
+) -> Option<BrowserResourceHint> {
+    let kind = browser_link_resource_hint_kind(element.attribute("rel"))?;
+    let imagesrcset = element.attribute("imagesrcset").map(ToOwned::to_owned);
+    Some(BrowserResourceHint {
+        kind,
+        url: href.to_string(),
+        resolved_url: resolve_browser_url(href, base_href),
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        as_hint: element.attribute("as").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
+        integrity: element.attribute("integrity").map(ToOwned::to_owned),
+        crossorigin: element.attribute("crossorigin").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        fetchpriority: element.attribute("fetchpriority").map(ToOwned::to_owned),
+        blocking: element.attribute("blocking").map(ToOwned::to_owned),
+        resolved_imagesrcset: imagesrcset
+            .as_deref()
+            .map(|srcset| resolve_browser_srcset(srcset, base_href)),
+        imagesrcset,
+        imagesizes: element.attribute("imagesizes").map(ToOwned::to_owned),
+    })
+}
+
+fn browser_link_resource_hint_kind(rel: Option<&str>) -> Option<String> {
+    let rel = rel?;
+    for token in rel.split_ascii_whitespace() {
+        match token.to_ascii_lowercase().as_str() {
+            "preconnect" => return Some("preconnect".to_string()),
+            "dns-prefetch" => return Some("dns-prefetch".to_string()),
+            "preload" => return Some("preload".to_string()),
+            "modulepreload" => return Some("modulepreload".to_string()),
+            "prefetch" => return Some("prefetch".to_string()),
+            "prerender" => return Some("prerender".to_string()),
+            _ => {}
+        }
+    }
+    None
 }
 
 fn trim_browser_metadata_token(value: &str) -> String {
@@ -13472,6 +13541,27 @@ mod tests {
             Some("https://example.test/app/late.js")
         );
         assert!(late_script.defer_script);
+
+        assert_eq!(summary.metadata.resource_hints.len(), 1);
+        let stylesheet_preload = &summary.metadata.resource_hints[0];
+        assert_eq!(stylesheet_preload.kind, "preload");
+        assert_eq!(
+            stylesheet_preload.rel.as_deref(),
+            Some("stylesheet preload")
+        );
+        assert_eq!(
+            stylesheet_preload.resolved_url.as_deref(),
+            Some("https://example.test/app/app.css")
+        );
+        assert_eq!(stylesheet_preload.media.as_deref(), Some("screen"));
+        assert_eq!(stylesheet_preload.integrity.as_deref(), Some("sha256-css"));
+        assert_eq!(stylesheet_preload.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(
+            stylesheet_preload.referrerpolicy.as_deref(),
+            Some("no-referrer")
+        );
+        assert_eq!(stylesheet_preload.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(stylesheet_preload.blocking.as_deref(), Some("render"));
     }
 
     #[test]
@@ -13538,6 +13628,42 @@ mod tests {
             summary.resources[7].type_hint.as_deref(),
             Some("image/x-icon")
         );
+
+        assert_eq!(summary.metadata.resource_hints.len(), 5);
+        let preconnect_hint = &summary.metadata.resource_hints[0];
+        assert_eq!(preconnect_hint.kind, "preconnect");
+        assert_eq!(
+            preconnect_hint.resolved_url.as_deref(),
+            Some("https://cdn.example.test")
+        );
+        assert_eq!(preconnect_hint.crossorigin.as_deref(), Some(""));
+
+        let font_hint = &summary.metadata.resource_hints[1];
+        assert_eq!(font_hint.kind, "preload");
+        assert_eq!(font_hint.as_hint.as_deref(), Some("font"));
+        assert_eq!(font_hint.type_hint.as_deref(), Some("font/woff2"));
+        assert_eq!(font_hint.integrity.as_deref(), Some("sha384-font"));
+        assert_eq!(font_hint.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(font_hint.fetchpriority.as_deref(), Some("high"));
+
+        let module_hint = &summary.metadata.resource_hints[2];
+        assert_eq!(module_hint.kind, "modulepreload");
+        assert_eq!(module_hint.integrity.as_deref(), Some("sha384-module"));
+        assert_eq!(module_hint.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(module_hint.blocking.as_deref(), Some("render"));
+
+        let image_hint = &summary.metadata.resource_hints[3];
+        assert_eq!(image_hint.kind, "preload");
+        assert_eq!(image_hint.as_hint.as_deref(), Some("image"));
+        assert_eq!(
+            image_hint.resolved_imagesrcset.as_deref(),
+            Some("https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w")
+        );
+        assert_eq!(image_hint.imagesizes.as_deref(), Some("50vw"));
+
+        let prefetch_hint = &summary.metadata.resource_hints[4];
+        assert_eq!(prefetch_hint.kind, "prefetch");
+        assert_eq!(prefetch_hint.as_hint.as_deref(), Some("document"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,8 +2,8 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata, BrowserForm,
     BrowserFormControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
     BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh,
-    BrowserResource, BrowserScript, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserResource, BrowserResourceHint, BrowserScript, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -90,6 +90,8 @@ struct ExpectedDocumentMetadata {
     #[serde(default)]
     http_equiv_hints: Vec<ExpectedHttpEquivHint>,
     #[serde(default)]
+    resource_hints: Vec<ExpectedResourceHint>,
+    #[serde(default)]
     theme_colors: Vec<ExpectedThemeColor>,
     #[serde(default)]
     refresh: Option<ExpectedRefresh>,
@@ -114,6 +116,38 @@ struct ExpectedMetadataDirective {
 struct ExpectedHttpEquivHint {
     name: String,
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedResourceHint {
+    kind: String,
+    url: String,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    as_hint: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    imagesrcset: Option<String>,
+    #[serde(default)]
+    resolved_imagesrcset: Option<String>,
+    #[serde(default)]
+    imagesizes: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -657,6 +691,11 @@ impl ExpectedDocumentMetadata {
                 .into_iter()
                 .map(ExpectedHttpEquivHint::into_browser_http_equiv_hint)
                 .collect(),
+            resource_hints: self
+                .resource_hints
+                .into_iter()
+                .map(ExpectedResourceHint::into_browser_resource_hint)
+                .collect(),
             theme_colors: self
                 .theme_colors
                 .into_iter()
@@ -685,6 +724,28 @@ impl ExpectedHttpEquivHint {
         BrowserHttpEquivHint {
             name: self.name,
             content: self.content,
+        }
+    }
+}
+
+impl ExpectedResourceHint {
+    fn into_browser_resource_hint(self) -> BrowserResourceHint {
+        BrowserResourceHint {
+            kind: self.kind,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            rel: self.rel,
+            as_hint: self.as_hint,
+            type_hint: self.type_hint,
+            media: self.media,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            imagesrcset: self.imagesrcset,
+            resolved_imagesrcset: self.resolved_imagesrcset,
+            imagesizes: self.imagesizes,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -266,7 +266,19 @@
         "title": null,
         "base_href": "https://example.test/app/index.html",
         "base_target": null,
-        "metadata": { "canonical_url": "https://example.test/app/", "resolved_canonical_url": "https://example.test/app/", "manifest_url": "site.webmanifest", "resolved_manifest_url": "https://example.test/app/site.webmanifest" },
+        "metadata": {
+          "canonical_url": "https://example.test/app/",
+          "resolved_canonical_url": "https://example.test/app/",
+          "manifest_url": "site.webmanifest",
+          "resolved_manifest_url": "https://example.test/app/site.webmanifest",
+          "resource_hints": [
+            { "kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel": "preconnect", "crossorigin": "" },
+            { "kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel": "preload", "as_hint": "font", "type_hint": "font/woff2", "integrity": "sha384-font", "crossorigin": "anonymous", "fetchpriority": "high" },
+            { "kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel": "modulepreload", "integrity": "sha384-module", "referrerpolicy": "no-referrer", "blocking": "render" },
+            { "kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel": "preload", "as_hint": "image", "fetchpriority": "high", "imagesrcset": "hero-small.jpg 480w, hero-large.jpg 960w", "resolved_imagesrcset": "https://example.test/app/hero-small.jpg 480w, https://example.test/app/hero-large.jpg 960w", "imagesizes": "50vw" },
+            { "kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel": "prefetch", "as_hint": "document" }
+          ]
+        },
         "body_text": "",
         "metas": [],
         "resources": [
@@ -411,6 +423,11 @@
         "title": null,
         "base_href": "https://example.test/app/index.html",
         "base_target": null,
+        "metadata": {
+          "resource_hints": [
+            { "kind": "preload", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "rel": "stylesheet preload", "media": "screen", "integrity": "sha256-css", "crossorigin": "anonymous", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render" }
+          ]
+        },
         "body_text": "",
         "metas": [],
         "resources": [


### PR DESCRIPTION
## Summary
- add structured browser document `resource_hints` metadata for preconnect, dns-prefetch, preload, modulepreload, prefetch, and prerender links
- carry fetch-policy and responsive preload details into the metadata summary alongside existing resource entries
- extend browser-readiness fixture schema and cases for resource-hint metadata

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_link_resource_metadata_tracks_fetch_hints_and_responsive_preloads
- cargo test -p coding-adventures-html-parser browser_script_style_metadata_tracks_loading_and_inline_text
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
