### PR TITLE
feat(closurec): --help_markdown markdown flag dump (CLOC11.54)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.13.0] - 2026-05-25
+
+### Added — CLOC11.54: `--help_markdown` markdown flag dump
+
+Fourth slice of Track 11 (special modes). When `--help_markdown` is set, closurec prints a markdown document listing every flag in the CLI spec — name, type, default, description — and exits successfully. Mirrors CC's `--help_markdown`, intended for documentation tooling that pipes the output into a docs page.
+
+- **Wire format**: per-flag `### `--long` (type, default: X)` heading + body description. Heading-per-flag (not table) chosen so a diff stays readable when flags are added or descriptions change, and so GitHub's auto-anchors give linkable section IDs.
+- **Pipeline placement**: short-circuit in `main::parse_and_run` Step 3.5 — after `cfg` is built from parsed flags, before `run_compiler`. So a config-level user error (e.g. invalid `--define` value) still surfaces, but the markdown dump replaces the rest of the run.
+- **No new dependencies**. Uses `cli_builder::types::{CliSpec, FlagDef}` directly (already a transitive dep) and `serde_json::Value` for default-value rendering (already in the dep tree).
+- **Spec re-use**: clones the loaded `CliSpec` before passing it to `Parser::new` so the help-markdown branch can iterate the flag list after parsing. The clone is ~10 KB; cheap.
+- **7 new unit tests** in `help_markdown::tests` (title, version line, one section per flag, type+default in heading, body carries description, empty-string default disambiguated, no-default omits clause).
+- **2 new unit tests** in `main::tests` (flag emits markdown, doesn't run pipeline even with bogus `--js`).
+- **Diff fixture** `tests/diff/help-markdown/` with the full pinned markdown output (~400 lines, 100 flags).
+- **New integration test** `tests/diff_help_markdown.rs`. Pins the exact output so any change to the user-facing flag surface — a new flag, a renamed flag, a re-described flag — fails the diff and must be acknowledged by regenerating `expected.stdout`.
+
+### Pipeline matrix (cumulative across CLOC11)
+
+`main::parse_and_run`:
+1. Load embedded `cli.spec.json`
+2. cli-builder parses argv → typed flags
+3. `wire::config_from_parsed` → `CompilerConfig`
+4. **`--help_markdown` short-circuit (CLOC11.54, NEW) — markdown dump, return**
+5. `run::run_compiler(&cfg)`:
+   1. Resolve `--js` globs
+   2. `--print_tree` short-circuit (CLOC11.52)
+   3. `--print_tree_json` short-circuit (CLOC11.53)
+   4. Per-input `transform_source` (level + defines)
+   5. Concatenate transformed inputs
+   6. `--checks_only` short-circuit (CLOC11.51)
+   7. `--emit_use_strict` prepend (CLOC11.18)
+   8. `--output_wrapper` substitution (CLOC11.30)
+   9. `--isolation_mode IIFE` wrap (CLOC11.31)
+   10. Write to `--js_output_file` or stdout
+
 ## [0.12.0] - 2026-05-25
 
 ### Added — CLOC11.53: `--print_tree_json` JSON token-stream dump

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/help_markdown.rs
+++ b/code/programs/rust/closurec/src/help_markdown.rs
@@ -1,0 +1,262 @@
+//! `help_markdown` — `--help_markdown` markdown flag dump.
+//!
+//! # What CC does
+//!
+//! The upstream Java Closure Compiler's `--help_markdown` flag
+//! prints the full flag surface in markdown format and exits.
+//! It's intended for documentation tooling — pipe it into
+//! `cat > docs/closurec-flags.md` and you have a generated
+//! reference page that stays in sync with whatever the binary
+//! actually accepts.
+//!
+//! # What we do
+//!
+//! We iterate the loaded [`cli_builder::types::CliSpec`] — the
+//! same in-memory representation cli-builder parsed from
+//! `cli.spec.json` — and emit a markdown document with one
+//! heading per flag.
+//!
+//! Wire format:
+//!
+//! ```markdown
+//! # closurec
+//!
+//! <one-line description from spec>
+//!
+//! Version: 0.13.0
+//!
+//! ## Flags
+//!
+//! ### `--<long>` (<type>, default: <default>)
+//!
+//! <description>
+//!
+//! ### `--<long>` ...
+//! ```
+//!
+//! Why a simple heading-per-flag format rather than a table:
+//!
+//! - Diff-friendly. A pinned fixture stays readable when a flag
+//!   is added or its description changes; tables make the diff
+//!   noisy because cells reflow.
+//! - GitHub renders heading anchors. Users get linkable section
+//!   IDs like `#--checks_only` for free.
+//! - No alignment math. We never have to decide what column
+//!   width fits the longest flag name.
+
+use cli_builder::types::{CliSpec, FlagDef};
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Format the spec's flag surface as a markdown document.
+///
+/// Output ends with a newline so concatenating fixtures stays
+/// well-formed. Pure-function: no I/O, no global state, fully
+/// deterministic given `spec`.
+pub fn format_help_markdown(spec: &CliSpec) -> String {
+    let mut out = String::with_capacity(8192);
+
+    // ---------------------- title + description ----------------------
+    out.push_str("# ");
+    out.push_str(&spec.name);
+    out.push_str("\n\n");
+    out.push_str(&spec.description);
+    out.push_str("\n\n");
+
+    if let Some(v) = &spec.version {
+        out.push_str("Version: ");
+        out.push_str(v);
+        out.push_str("\n\n");
+    }
+
+    // ---------------------- flags --------------------------------------
+    out.push_str("## Flags\n\n");
+
+    // Two flag lists in the spec: global + root. CC's
+    // CommandLineRunner has only one list, so we emit both in
+    // source order — globals first (they apply everywhere),
+    // root flags second. Both lists are already in author order
+    // from cli.spec.json; we preserve it so a hand-edited spec
+    // produces predictable docs.
+    for f in &spec.global_flags {
+        append_flag_section(&mut out, f);
+    }
+    for f in &spec.flags {
+        append_flag_section(&mut out, f);
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Emit one `### `--long` (type, default: X)\n\n<desc>\n\n` section.
+fn append_flag_section(out: &mut String, f: &FlagDef) {
+    // Heading — prefer long form (always present for closurec
+    // flags), fall back to short or single-dash-long if a
+    // hand-edited spec ever lacks the long form.
+    out.push_str("### `");
+    if let Some(long) = &f.long {
+        out.push_str("--");
+        out.push_str(long);
+    } else if let Some(short) = &f.short {
+        out.push('-');
+        out.push_str(short);
+    } else if let Some(sdl) = &f.single_dash_long {
+        out.push('-');
+        out.push_str(sdl);
+    } else {
+        // Defensive — every well-formed spec must have at least
+        // one form; if it didn't, the binary wouldn't have
+        // accepted the flag at all.
+        out.push_str("(unnamed)");
+    }
+    out.push('`');
+
+    // Type + default annotation in the heading so a quick scan
+    // doesn't need the body.
+    out.push_str(" (");
+    out.push_str(&f.flag_type);
+    if let Some(d) = &f.default {
+        out.push_str(", default: ");
+        out.push_str(&format_default(d));
+    }
+    out.push_str(")\n\n");
+
+    // Body — the human-readable description verbatim, then a
+    // blank line. We don't try to escape `*` or `_` because the
+    // upstream descriptions don't contain markdown emphasis
+    // markers — they're plain English sentences.
+    out.push_str(&f.description);
+    out.push_str("\n\n");
+}
+
+/// Render a JSON `Value` default as a short literal.
+///
+/// We intentionally don't try to pretty-print arrays/objects —
+/// they don't appear as defaults in cli.spec.json. The match
+/// covers what cli.spec.json actually uses: bool, integer, float,
+/// string.
+fn format_default(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => {
+            // Empty strings show up a lot (e.g. unset path
+            // defaults). Display them as `""` so the reader can
+            // tell "unset" from "the literal string 'unset'".
+            if s.is_empty() {
+                "\"\"".to_string()
+            } else {
+                s.clone()
+            }
+        }
+        serde_json::Value::Null => "null".to_string(),
+        // Anything else: fall back to serde's debug form. Should
+        // never trigger for closurec's spec, but graceful is
+        // better than panicking.
+        other => other.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cli_builder::load_spec_from_str;
+
+    const MINI_SPEC: &str = r#"{
+      "cli_builder_spec_version": "1.0",
+      "name": "demo",
+      "description": "Demo CLI for testing.",
+      "version": "9.9.9",
+      "parsing_mode": "gnu",
+      "flags": [
+        { "id": "verbose", "long": "verbose", "short": "v", "type": "boolean", "default": false, "description": "Be loud." },
+        { "id": "out", "long": "out", "type": "string", "default": "out.txt", "description": "Output path." },
+        { "id": "level", "long": "level", "type": "integer", "default": 1, "description": "Numeric level." }
+      ]
+    }"#;
+
+    #[test]
+    fn emits_title_and_description() {
+        let spec = load_spec_from_str(MINI_SPEC).unwrap();
+        let md = format_help_markdown(&spec);
+        assert!(md.starts_with("# demo\n"));
+        assert!(md.contains("Demo CLI for testing."));
+    }
+
+    #[test]
+    fn emits_version_when_present() {
+        let spec = load_spec_from_str(MINI_SPEC).unwrap();
+        let md = format_help_markdown(&spec);
+        assert!(md.contains("Version: 9.9.9"));
+    }
+
+    #[test]
+    fn emits_one_section_per_flag() {
+        let spec = load_spec_from_str(MINI_SPEC).unwrap();
+        let md = format_help_markdown(&spec);
+        // Three flags → three `### ` headings.
+        assert_eq!(md.matches("### `").count(), 3);
+        assert!(md.contains("### `--verbose`"));
+        assert!(md.contains("### `--out`"));
+        assert!(md.contains("### `--level`"));
+    }
+
+    #[test]
+    fn heading_includes_type_and_default() {
+        let spec = load_spec_from_str(MINI_SPEC).unwrap();
+        let md = format_help_markdown(&spec);
+        assert!(md.contains("(boolean, default: false)"));
+        assert!(md.contains("(string, default: out.txt)"));
+        assert!(md.contains("(integer, default: 1)"));
+    }
+
+    #[test]
+    fn body_carries_description() {
+        let spec = load_spec_from_str(MINI_SPEC).unwrap();
+        let md = format_help_markdown(&spec);
+        assert!(md.contains("Be loud."));
+        assert!(md.contains("Output path."));
+        assert!(md.contains("Numeric level."));
+    }
+
+    #[test]
+    fn empty_string_default_is_quoted_to_disambiguate_from_unset() {
+        let spec_json = r#"{
+          "cli_builder_spec_version": "1.0",
+          "name": "demo",
+          "description": "x",
+          "flags": [
+            { "id": "p", "long": "p", "type": "string", "default": "", "description": "Path." }
+          ]
+        }"#;
+        let spec = load_spec_from_str(spec_json).unwrap();
+        let md = format_help_markdown(&spec);
+        assert!(md.contains("default: \"\""), "got: {md}");
+    }
+
+    #[test]
+    fn flag_without_default_omits_default_clause() {
+        let spec_json = r#"{
+          "cli_builder_spec_version": "1.0",
+          "name": "demo",
+          "description": "x",
+          "flags": [
+            { "id": "n", "long": "n", "type": "integer", "description": "No default." }
+          ]
+        }"#;
+        let spec = load_spec_from_str(spec_json).unwrap();
+        let md = format_help_markdown(&spec);
+        assert!(md.contains("(integer)"), "got: {md}");
+        assert!(!md.contains("default:"));
+    }
+}

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -70,6 +70,7 @@ use std::process::ExitCode;
 pub mod config;
 pub mod defines;
 pub mod globs;
+pub mod help_markdown;
 pub mod print_tree;
 pub mod run;
 pub mod whitespace_only;
@@ -127,6 +128,13 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
     argv.push("closurec".to_string());
     argv.extend(args.iter().cloned());
 
+    // Keep a clone of the spec so the --help_markdown
+    // short-circuit (CLOC11.54) can iterate the flag list after
+    // Parser::new consumes the original. A CliSpec is ~10 KB of
+    // owned strings, so the clone is cheap compared to the
+    // user-visible work that follows.
+    let spec_for_help_md = spec.clone();
+
     let parser = Parser::new(spec);
     match parser.parse(&argv) {
         Ok(ParserOutput::Parse(result)) => {
@@ -136,6 +144,21 @@ pub fn parse_and_run(args: &[String]) -> (String, ExitCode) {
                 Ok(c) => c,
                 Err(e) => return (format!("{e}\n"), ExitCode::from(1)),
             };
+
+            // Step 3.5 (CLOC11.54): --help_markdown short-circuit.
+            //
+            // Emit the markdown flag dump and exit successfully.
+            // This sits *after* config-building so a user-error in
+            // a sibling flag still surfaces (matches the behavior
+            // users expect from --help: the flag is honored even
+            // when other flags are wonky, but cli-builder catches
+            // outright unknown flags before we get here at all).
+            if cfg.special_modes.help_markdown {
+                return (
+                    help_markdown::format_help_markdown(&spec_for_help_md),
+                    ExitCode::SUCCESS,
+                );
+            }
 
             // Step 4 (CLOC11.01): run the compiler. v1 is an
             // identity pipeline — read inputs, concatenate,
@@ -393,6 +416,44 @@ mod tests {
         // accepts an empty invocation too.)
         let (text, _code) = parse_and_run(&args(&[]));
         assert!(text.contains("identity pipeline"));
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.54 — --help_markdown behavior
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn help_markdown_flag_emits_markdown_and_exits_clean() {
+        let (text, _code) = parse_and_run(&args(&["--help_markdown"]));
+        // Title comes from spec.name.
+        assert!(text.starts_with("# closurec\n"), "leading title: {text:?}");
+        // The "Flags" section header is present.
+        assert!(text.contains("## Flags\n"));
+        // Specific known flags appear as section headings.
+        assert!(text.contains("### `--js`"));
+        assert!(text.contains("### `--checks_only`"));
+        assert!(text.contains("### `--print_tree`"));
+        // Version line wired up.
+        assert!(text.contains("Version: "));
+    }
+
+    #[test]
+    fn help_markdown_does_not_run_compiler_pipeline() {
+        // Even with --js inputs and --js_output_file, the markdown
+        // emission must short-circuit without trying to read any
+        // files or write any output.
+        let (text, _code) = parse_and_run(&args(&[
+            "--help_markdown",
+            "--js",
+            "/tmp/does-not-exist-cloc11-54.js",
+            "--js_output_file",
+            "/tmp/nope.js",
+        ]));
+        assert!(text.starts_with("# closurec\n"));
+        // No "failed to read input" or "GlobError" surfaced — we
+        // never got to the pipeline.
+        assert!(!text.contains("failed to read input"));
+        assert!(!text.contains("GlobError"));
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -1,0 +1,408 @@
+# closurec
+
+closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
+
+Version: 0.13.0
+
+## Flags
+
+### `--browser_featureset_year` (integer, default: 0)
+
+Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012).
+
+### `--print_tree` (boolean, default: false)
+
+Prints out the parse tree and exits.
+
+### `--print_tree_json` (boolean, default: false)
+
+Prints out the parse tree as JSON and exits.
+
+### `--print_ast` (boolean, default: false)
+
+Prints a dot file describing the internal abstract syntax tree.
+
+### `--emit_use_strict` (boolean, default: false)
+
+Start output with 'use strict';
+
+### `--strict_mode_input` (boolean, default: true)
+
+Assume input sources are to run in strict mode.
+
+### `--jscomp_dev_mode` (enum, default: OFF)
+
+Enable extra validity checks when modifying compiler.
+
+### `--logging_level` (string, default: WARNING)
+
+Logging level for Compiler progress (java.util.logging.Level).
+
+### `--externs` (string)
+
+File containing JavaScript externs (multiple allowed).
+
+### `--js` (string)
+
+JavaScript filenames, glob patterns, or minimatch patterns (multiple allowed). Use '!' prefix to exclude.
+
+### `--jszip` (string)
+
+JavaScript zip filename (multiple allowed, hidden).
+
+### `--js_output_file` (string, default: "")
+
+Primary output filename. If not specified, output is written to stdout.
+
+### `--chunk` (string)
+
+Chunk specification in format <name>:<num-js-files>[:[<dep>,...][:]].
+
+### `--filename_to_save_to` (string)
+
+Filename to save compilation state for resuming later (hidden).
+
+### `--filename_to_restore_from` (string)
+
+Filename where compilation state was previously saved (hidden).
+
+### `--segment_of_compilation_to_run` (enum, default: ENTIRE_COMPILATION)
+
+Which segment of compilation to run (hidden).
+
+### `--variable_renaming_report` (string, default: "")
+
+File where the serialized version of the variable renaming map produced should be saved.
+
+### `--instrument_mapping_report` (string, default: "")
+
+File where encoded parameters from production instrumentation mapping are output.
+
+### `--create_renaming_reports` (boolean, default: false)
+
+Produce variable and property renaming report files (hidden).
+
+### `--source_map_include_content` (boolean, default: false)
+
+Include source contents in source map (increases size).
+
+### `--property_renaming_report` (string, default: "")
+
+File where the serialized version of the property renaming map produced should be saved.
+
+### `--third_party` (boolean, default: false)
+
+Check source validity but don't enforce Closure style conventions.
+
+### `--summary_detail_level` (integer, default: 1)
+
+Controls compilation summary detail (0-3, hidden).
+
+### `--isolation_mode` (enum, default: NONE)
+
+Output format: NONE (raw) or IIFE (wrapped in an immediately-invoked function expression).
+
+### `--output_wrapper` (string, default: "")
+
+Interpolate output into the given string at the place specified by the marker token %output%.
+
+### `--output_wrapper_file` (string, default: "")
+
+Loads the specified file and passes its contents to --output_wrapper.
+
+### `--chunk_wrapper` (string)
+
+Interpolate output for the named chunk in the given format <name>:<wrapper>. May be used multiple times.
+
+### `--chunk_output_path_prefix` (string, default: ./)
+
+Prefix for the filenames of the compiled chunks.
+
+### `--create_source_map` (string, default: "")
+
+Path to source map file mapping the generated source to original sources. %outname% is replaced with --js_output_file (or chunk name for chunk maps).
+
+### `--source_map_format` (enum, default: DEFAULT)
+
+Source map format to produce (hidden).
+
+### `--source_map_location_mapping` (string)
+
+Source map location mapping in format filesystem-path|webserver-path.
+
+### `--source_map_input` (string)
+
+Source map locations for input files in format input-file-path|input-source-map.
+
+### `--parse_inline_source_maps` (boolean, default: true)
+
+Parse inline source maps (//# sourceMappingURL=data:...).
+
+### `--apply_input_source_maps` (boolean, default: true)
+
+Apply input source maps to the output source map.
+
+### `--jscomp_error` (string)
+
+Make the named warning class an error. '*' adds every supported diagnostic.
+
+### `--jscomp_warning` (string)
+
+Make the named class a normal warning. '*' adds every supported diagnostic.
+
+### `--jscomp_off` (string)
+
+Turn off the named warning class. '*' adds every supported diagnostic.
+
+### `--define` (string)
+
+Override the value of an @define variable; format is <name>[=<val>] (boolean true if omitted).
+
+### `--charset` (string, default: "")
+
+Input and output charset for all files. Default: UTF-8 in, US_ASCII out.
+
+### `--compilation_level` (enum, default: SIMPLE)
+
+Compilation level (BUNDLE | WHITESPACE_ONLY | SIMPLE | TRANSPILE_ONLY | ADVANCED).
+
+### `--num_parallel_threads` (integer, default: 1)
+
+Use multiple threads to parallelize parts of the compilation (hidden).
+
+### `--checks_only` (boolean, default: false)
+
+Don't generate output; run checks only.
+
+### `--incremental_check_mode` (enum, default: OFF)
+
+Generate or check externs-like .i.js files for each library.
+
+### `--continue_after_errors` (boolean, default: false)
+
+Continue trying to compile after an error is encountered.
+
+### `--use_types_for_optimization` (boolean, default: true)
+
+Enable optimizations based on type information.
+
+### `--assume_function_wrapper` (boolean, default: false)
+
+Enable optimizations assuming output will be wrapped with a function wrapper.
+
+### `--warning_level` (enum, default: DEFAULT)
+
+Warning level (QUIET | DEFAULT | VERBOSE).
+
+### `--debug` (boolean, default: false)
+
+Enable debugging options. Renamed properties use long mangled names.
+
+### `--typed_ast_output_file__INTENRNAL_USE_ONLY` (string)
+
+Output in-progress typedAST format. DO NOT USE (hidden, name is intentionally misspelled upstream).
+
+### `--generate_exports` (boolean, default: true)
+
+Generates export code for symbols marked with @export.
+
+### `--export_local_property_definitions` (boolean, default: true)
+
+Generates export code for local properties marked with @export.
+
+### `--formatting` (enum)
+
+Formatting options to apply to the output JS (repeatable).
+
+### `--process_common_js_modules` (boolean, default: false)
+
+Process CommonJS modules into a concatenable form.
+
+### `--js_module_root` (string)
+
+Path prefixes to remove from ES6 and CommonJS modules (repeatable).
+
+### `--process_closure_primitives` (boolean, default: true)
+
+Processes built-ins from the Closure library (goog.require / goog.provide).
+
+### `--angular_pass` (boolean, default: false)
+
+Generates $inject properties for AngularJS functions marked with @ngInject.
+
+### `--polymer_version` (integer)
+
+Which version of Polymer is being used (1 or 2).
+
+### `--chrome_pass` (boolean, default: false)
+
+Enable Chrome-specific options for handling cr.* functions (hidden).
+
+### `--j2cl_pass` (enum, default: AUTO)
+
+Rewrite J2CL output to be compiler-friendly (hidden).
+
+### `--remove_j2cl_asserts` (boolean, default: true)
+
+Remove calls to J2CL assertions (hidden).
+
+### `--output_manifest` (string, default: "")
+
+Prints a list of all the files in the compilation. Pass blank to skip.
+
+### `--output_chunk_dependencies` (string, default: "")
+
+Prints a JSON file of dependencies between chunks.
+
+### `--language_in` (enum, default: STABLE)
+
+Language spec the input sources conform to.
+
+### `--language_out` (enum, default: ECMASCRIPT_NEXT)
+
+Language spec the output should conform to.
+
+### `--translations_file` (string, default: "")
+
+Source of translated messages (XTB format, hidden).
+
+### `--translations_project` (string)
+
+Scope translations to the specified project (hidden).
+
+### `--flagfile` (string)
+
+File(s) containing additional command-line options (hidden).
+
+### `--warnings_allowlist_file` (string, default: "")
+
+A file containing warnings to suppress.
+
+### `--hide_warnings_for` (string)
+
+Files whose path contains this string will have warnings hidden (repeatable).
+
+### `--extra_annotation_name` (string)
+
+Allowlist of tag names in JSDoc (repeatable).
+
+### `--tracer_mode` (enum, default: OFF)
+
+Shows the duration of compiler passes and output impact (hidden).
+
+### `--rename_variable_prefix` (string)
+
+Prefix prepended to all variable names.
+
+### `--rename_prefix_namespace` (string)
+
+Name of object to store all non-extern globals on.
+
+### `--conformance_configs` (string)
+
+JS Conformance configurations in text protobuf format (repeatable).
+
+### `--env` (enum, default: BROWSER)
+
+Set of builtin externs to load (BROWSER | CUSTOM).
+
+### `--json_streams` (enum, default: NONE)
+
+Use stdin/stdout as a JSON array of sources.
+
+### `--preserve_type_annotations` (boolean, default: false)
+
+Preserve type annotations in output (hidden).
+
+### `--inject_libraries` (boolean, default: true)
+
+Allow injecting runtime libraries.
+
+### `--force_inject_library` (string)
+
+Force injection of named runtime libraries (repeatable).
+
+### `--dependency_mode` (enum)
+
+How the compiler determines the set and order of files for a compilation.
+
+### `--entry_point` (string)
+
+File or namespace as a starting point for dependency inclusion (repeatable).
+
+### `--rewrite_polyfills` (boolean, default: true)
+
+Inject polyfills for ES2015+ library classes and methods.
+
+### `--isolate_polyfills` (boolean, default: false)
+
+Hide injected polyfills from the global scope and external code.
+
+### `--print_source_after_each_pass` (boolean, default: false)
+
+Print the resulting JS source after each pass (hidden).
+
+### `--module_resolution` (enum, default: BROWSER)
+
+How the compiler should locate modules.
+
+### `--browser_resolver_prefix_replacements` (string)
+
+Prefixes to replace in ES6 import paths before resolving (repeatable).
+
+### `--package_json_entry_names` (string)
+
+Ordered list of entries to look for in package.json files.
+
+### `--error_format` (enum, default: STANDARD)
+
+Format for error messages.
+
+### `--renaming` (boolean, default: true)
+
+Disable variable renaming. Cannot be combined with ADVANCED compilation level.
+
+### `--help_markdown` (boolean, default: false)
+
+Print markdown-formatted flag usage (hidden).
+
+### `--instrument_for_coverage_option` (enum, default: NONE)
+
+Enable code instrumentation for coverage analysis.
+
+### `--production_instrumentation_array_name` (string, default: "")
+
+Global array name used by production instrumentation.
+
+### `--chunk_output_type` (enum, default: GLOBAL_NAMESPACE)
+
+Format for output chunks.
+
+### `--allow_dynamic_import` (boolean, default: true)
+
+Allow dynamic import expressions in input.
+
+### `--dynamic_import_alias` (string)
+
+Replace dynamic imports with a function call using the given name.
+
+### `--assume_static_inheritance_is_not_used` (boolean, default: true)
+
+Assume static inheritance is not used; enables optimizations.
+
+### `--assume_no_prototype_method_enumeration` (boolean, default: false)
+
+Assume prototype method enumeration is not used.
+
+### `--variable_map_input_file` (string, default: "")
+
+File with serialized variable renaming map from a prior compilation.
+
+### `--property_map_input_file` (string, default: "")
+
+File with serialized property renaming map from a prior compilation.
+
+### `--expected_diagnostics` (string)
+
+Expected diagnostics in format [(line,col)]CODE:regex.
+

--- a/code/programs/rust/closurec/tests/diff/help-markdown/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/flags.txt
@@ -1,0 +1,1 @@
+--help_markdown

--- a/code/programs/rust/closurec/tests/diff_help_markdown.rs
+++ b/code/programs/rust/closurec/tests/diff_help_markdown.rs
@@ -1,0 +1,56 @@
+//! Integration test for the `tests/diff/help-markdown/` fixture.
+//!
+//! Exercises CLOC11.54 — `--help_markdown` — end-to-end via the
+//! built binary. The fixture pins the *exact* markdown output for
+//! closurec's flag surface. Whenever a flag is added, renamed,
+//! re-described, or has its default changed, this diff fails and
+//! the change must be acknowledged by regenerating the fixture.
+//!
+//! That's the intent: the user-facing flag surface is part of
+//! the binary's public contract, and a diff failure here is the
+//! right place to surface "you changed something users will see."
+//!
+//! To regenerate after an intentional change:
+//!
+//! ```sh
+//! ./target/debug/closurec --help_markdown > \
+//!   code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/help-markdown/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn help_markdown_fixture_matches_expected_dump() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/help-markdown/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.as_ref(),
+        expected,
+        "help_markdown fixture mismatch — regenerate with:\n  ./target/debug/closurec --help_markdown > code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout"
+    );
+}


### PR DESCRIPTION
## Summary
- Fourth slice of Track 11 (special modes). When \`--help_markdown\` is set, closurec prints a markdown document listing every flag in the CLI spec (name, type, default, description) and exits.
- Mirrors CC's \`--help_markdown\`, intended for documentation tooling that pipes the output into a docs page.

## Wire format
Heading-per-flag rather than a table, for diff-friendliness + GitHub anchor support:

\`\`\`markdown
### \`--checks_only\` (boolean, default: false)

Don't generate output. Run checks, but no compile pass.
\`\`\`

## Implementation
- New module \`help_markdown\` with \`format_help_markdown(&CliSpec) -> String\`. Pure function.
- Wired into \`main::parse_and_run\` Step 3.5 — after cfg is built, before \`run_compiler\`. \`CliSpec\` is cloned once before \`Parser::new\` consumes it so the markdown branch can iterate flags.
- No new dependencies — uses \`cli_builder::types::{CliSpec, FlagDef}\` and \`serde_json::Value\` (already in the dep tree).

## Cumulative pipeline matrix
\`main::parse_and_run\`:
1. Load embedded \`cli.spec.json\`
2. cli-builder parses argv → typed flags
3. \`wire::config_from_parsed\` → \`CompilerConfig\`
4. **\`--help_markdown\` short-circuit (NEW)**
5. \`run::run_compiler(&cfg)\` (existing 9-step pipeline)

## Tests
- 7 new unit tests in \`help_markdown::tests\`
- 2 new unit tests in \`main::tests\` (flag emits markdown; doesn't run pipeline even with bogus --js)
- \`tests/diff/help-markdown/\` fixture pinning the full ~400-line markdown output
- \`tests/diff_help_markdown.rs\` integration test — any change to a flag's name/type/default/description fails the diff and must be acknowledged by regenerating expected.stdout

## Versions
- \`Cargo.toml\`: 0.12.0 → 0.13.0
- \`cli.spec.json\`: 0.12.0 → 0.13.0
- CHANGELOG \`[0.13.0]\` entry

## Security review (inline)
Pure-string transform reading the embedded compile-time \`CLI_SPEC_JSON\`. No FS/net I/O at module level. Output bounded by flag count × ~500 bytes. \`format_default\` covers Bool/Number/String/Null cleanly with a defensive \`Value::to_string\` fallback. No \`unsafe\`. No untrusted deserialization at this layer.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 149 unit tests + integration tests pass
- [x] \`cargo clippy --no-deps -p coding-adventures-closurec\` — clean
- [x] Inline security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)