### PR TITLE
feat(cas-summation): Phase 73 — Four-Log × polynomial numerator (2.10.0 → 2.11.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.11.0 — 2026-05-25
+
+### Added
+
+- **Phase 73 — Four-Log × polynomial numerator** (`_four_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), polynomial..., bounded...)`.
+  Exactly 4 Log factors required; Sqrt factors are refused.  `log⁴(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 5 new unit tests in `TestPhase73FourLogPoly`.
+
 ## 2.10.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.10.0"
+version = "2.11.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1012,6 +1012,21 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 73: ``Mul(Log(h1), Log(h2), Log(h3), Log(h4),
+    #           polynomial..., bounded...)`` numerator.
+    # Four Log factors; log⁴ sub-polynomial → contributes 0.
+    # effective_x2 = 2·poly_deg (no Sqrt factors).
+    # Sqrt factors refused — use Sqrt × log phases for mixed forms.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    flp4_x2 = _four_log_poly_effective_x2(num, k)
+    if flp4_x2 is not None:
+        den_deg_flp4 = _polynomial_degree_in_k(den, k)
+        if den_deg_flp4 is not None:
+            if 2 * den_deg_flp4 > flp4_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2459,6 +2474,73 @@ def _three_sqrt_three_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | 
     if len(sqrt_degs) != 3 or log_count != 3:
         return None
     return sqrt_degs[0] + sqrt_degs[1] + sqrt_degs[2] + 2 * poly_deg_sum
+
+
+def _four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly four**
+    ``Log(diverging-in-k)`` factors, any polynomial factors (total degree
+    ``m``), and any number of bounded factors; ``None`` otherwise.
+
+    Phase 73 — Four-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)⁴ · k^m ≈ o(k^{m + ε})`` for any ε > 0 (log⁴ is sub-polynomial).
+    Using the ×2 integer trick:
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    ``Sqrt`` factors are refused (belong to the Sqrt / log-Sqrt phases).
+
+    +---------------------------------------------+-----------+
+    | Input                                       | Return    |
+    +=============================================+===========+
+    | ``Mul(Log(k), Log(k), Log(k), Log(k))``     | ``0``     |
+    | ``Mul(Log(k), Log(k), Log(k), Log(k+1), k)``| ``2``     |
+    | ``Mul(Log(k)×4, k²)``                       | ``4``     |
+    | ``Mul(Log(k)×3)``                           | None (3 Logs) |
+    | ``Mul(Log(k)×5)``                           | None (5 Logs) |
+    | ``Mul(Log(k)×4, Sqrt(k))``                  | None (Sqrt)   |
+    +---------------------------------------------+-----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → count; bail after the fourth one.
+         - ``Sqrt(...)`` → bail immediately (sqrt patterns are separate).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly four Log factors.
+      4. Return ``2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        # Log(diverging) factor?
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 4:
+                # Five or more Log factors — refuse (conservative).
+                return None
+            continue
+        # Sqrt factor — refuse (belongs to sqrt / log-Sqrt phases).
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        # Polynomial factor?
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        # Bounded (non-polynomial, non-Log, non-Sqrt)?
+        if _is_bounded_in_k(arg, k):
+            continue
+        # Unrecognised factor — bail.
+        return None
+    if log_count != 4:
+        return None
+    return 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -3737,3 +3737,96 @@ class TestPhase72ThreeSqrtThreeLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase73FourLogPoly:
+    """Phase 73 — g(k)=Log(h1)·Log(h2)·Log(h3)·Log(h4)·poly / den.
+
+    effective_x2 = 2·poly_deg (log⁴ sub-polynomial, contributes 0).
+    Converges when 2·den_deg > effective_x2 (polynomial denominator) or
+    denominator diverges super-polynomially.
+    No Sqrt factors allowed.
+    """
+
+    def test_log4_k_over_k_closes(self):
+        """log(k)⁴/k: eff_x2=0; 2·1=2 > 0 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log4_k_times_k_over_k2_closes(self):
+        """log(k)⁴·k/k²: eff_x2=2; 2·2=4 > 2 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), kp1))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log4_k2_over_k3_closes(self):
+        """log(k)⁴·k²/k³: eff_x2=4; 2·3=6 > 4 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), k2))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), kp1_2))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log4_k_over_exponential_closes(self):
+        """log(k)⁴/2^k: exponential denominator → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        two_k = IRApply(POW, (IRInteger(2), _k))
+        two_kp1 = IRApply(POW, (IRInteger(2), kp1))
+        g_k = IRApply(DIV, (num_k, two_k))
+        g_kp1 = IRApply(DIV, (num_kp1, two_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log4_k_times_k_over_k_refused(self):
+        """log(k)⁴·k/k: eff_x2=2; 2·1=2 not > 2 → refused (SUM)."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.11.0 — 2026-05-25
+
+### Added
+
+- **Phase 73 — Four-Log × polynomial numerator** (`four_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), polynomial..., bounded...)`.
+  Exactly 4 Log factors required; Sqrt factors are refused.  `log⁴(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase73_*`).
+
 ## 2.10.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1878,6 +1878,36 @@ fn three_sqrt_three_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i
     Some(sqrt_degs.iter().sum::<i64>() + 2 * poly_deg)
 }
 
+/// Phase 73 — Four-Log × polynomial numerator.
+///
+/// Returns `2·poly_deg` when `node` is a `Mul` with exactly four
+/// `Log(diverging-in-k)` factors, any polynomial factors, and any bounded
+/// factors; `None` otherwise.
+///
+/// `log⁴(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to the effective
+/// degree.  `effective_x2 = 2·poly_deg` (no Sqrt factors).
+/// Sqrt factors are refused — use Sqrt × log phases for mixed forms.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 4 { return None; }
+            continue;
+        }
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; } // Sqrt → refuse
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 4 { return None; }
+    Some(2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2167,6 +2197,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(ts3l3_x2) = three_sqrt_three_log_poly_effective_x2(num, k) {
         if let Some(den_deg_ts3l3) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_ts3l3 > ts3l3_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 73: Mul(Log(diverging)×4, polynomial..., bounded...) numerator.
+    // Four Log factors; log⁴ sub-polynomial — effective_x2 = 2·poly_deg. Sqrt refused.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(flp4_x2) = four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_flp4) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_flp4 > flp4_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2457,3 +2457,57 @@ fn phase72_sqrt_k_cubed_log3_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 73: Four-Log × polynomial numerator ──────────────────────────────
+// g(k) = log(k)^4 * poly(k) / den(k); effective_x2 = 2·poly_deg.
+// Closes when 2·den_deg > effective_x2 (or denom is non-polynomial diverging).
+
+#[test]
+fn phase73_log4_k_over_k_closes() {
+    // log(k)^4 / k: effective_x2=0; 2·1=2 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k.clone(), log_k.clone(), log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase73_log4_k_times_k_over_k2_closes() {
+    // log(k)^4·k / k²: effective_x2=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k.clone(), log_k.clone(), log_k.clone(), log_k, k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, kp1.clone()]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase73_log4_k_times_k_over_k_refused() {
+    // log(k)^4·k / k: effective_x2=2; 2·1=2 not > 2 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![log_k.clone(), log_k.clone(), log_k.clone(), log_k, k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, kp1.clone()]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.11.0 — 2026-05-25
+
+### Added
+
+- **Phase 73 — Four-Log × polynomial numerator** (`fourLogPolyEffectiveDeg`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), polynomial..., bounded...)`.
+  Exactly 4 Log factors; Sqrt factors refused.  `log⁴(k)` sub-polynomial — contributes 0 to
+  effective degree; effective degree = polyDeg.
+  Closes when `denDeg > fourLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 4 new tests in the "Phase 73" describe block.
+
 ## 2.10.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1619,6 +1619,38 @@ function threeSqrtThreeLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | un
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
 }
 
+/**
+ * Phase 73 — Four-Log × polynomial numerator.
+ *
+ * Returns `polyDeg` when `node` is a `Mul` with exactly four
+ * `Log(diverging-in-k)` factors, any polynomial factors, and any bounded
+ * factors; `undefined` otherwise.
+ *
+ * `log⁴(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective
+ * polynomial degree.  effective degree = polyDeg.
+ * Sqrt factors are refused — use Sqrt × log phases for mixed forms.
+ * Caller checks `denDeg > fourLogPolyEffectiveDeg(num, k)`.
+ */
+function fourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 4) return undefined;
+      continue;
+    }
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // Sqrt → refuse
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 4) return undefined;
+  return polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1916,6 +1948,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegTs3l3 = polynomialDegreeInK(den, k);
     if (denDegTs3l3 !== undefined) {
       if (denDegTs3l3 > ts3l3Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 73: Mul(Log(diverging)×4, polynomial..., bounded...) numerator.
+  // Four Log factors; log⁴ is sub-polynomial — contributes 0 to effective degree.
+  // effective degree = polyDeg. Sqrt factors refused.
+  // Closes when denDeg > fourLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const flp4Deg = fourLogPolyEffectiveDeg(num, k);
+  if (flp4Deg !== undefined) {
+    const denDegFlp4 = polynomialDegreeInK(den, k);
+    if (denDegFlp4 !== undefined) {
+      if (denDegFlp4 > flp4Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -2519,3 +2519,102 @@ describe("Phase 72 — Three-Sqrt × Three-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 73 — Four-Log × polynomial numerator", () => {
+  // g(k) = log(k)^4 * [poly...] / den(k), effective_deg = polyDeg.
+  // Closes when denDeg > polyDeg (or denominator is non-polynomial but diverging).
+
+  it("log(k)⁴/k closes (polyDeg=0, denDeg=1 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁴·k/k² closes (polyDeg=1, denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁴/2^k closes (exponential denominator)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, { kind: "apply" as const, head: POW, args: [int(2), k] }] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, { kind: "apply" as const, head: POW, args: [int(2), kp1] }] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁴·k/k refused (polyDeg=1, denDeg=1 not > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK = { kind: "apply" as const, head: DIV, args: [numK, k] };
+    const gKp1 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1] };
+    const f = { kind: "apply" as const, head: SUB, args: [gK, gKp1] };
+    const result = evaluateSum(f, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Phase 73: `log(k)⁴ × polynomial / den(k)` convergence recognizer across Python, TypeScript, and Rust `cas-summation` packages (2.10.0 → 2.11.0)
- Extends the pure-log series: Two-Log (Phase 62) → Three-Log (Phase 67) → **Four-Log (Phase 73)**
- `log⁴(k)` is sub-polynomial (`o(k^ε)` for any ε > 0); effective degree = `poly_deg` of remaining factors
- Sqrt factors refused — those belong to Sqrt × log phases (68–72)

**New helpers:**
| Language | Helper | Returns |
|----------|--------|---------|
| Python | `_four_log_poly_effective_x2` | `2·poly_deg` |
| Rust | `four_log_poly_effective_x2` | `2·poly_deg` |
| TypeScript | `fourLogPolyEffectiveDeg` | `poly_deg` |

## Test plan

- [ ] Python: 5 new tests in `TestPhase73FourLogPoly` — 182 total, all pass locally
- [ ] Rust: 3 new tests `phase73_*` — 120 total, all pass locally
- [ ] TypeScript: 4 new tests in "Phase 73" describe block — 137 total, all pass locally
- [ ] Security review passed (pure symbolic math, no I/O)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)