### PR TITLE
feat(ruby-parser): Phase 7d — Ruby 3.0 case/in pattern matching

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -179,8 +179,36 @@ until_statement = "until" expression { !"end" statement } "end" ;
 #     pattern matching with the proper match semantics.
 #   - `when *splat` argument splat in the value list — deferred
 #     (the grammar accepts only positional values via `expression`).
-case_statement = "case" expression { when_clause } [ else_clause ] "end" ;
-when_clause    = "when" expression { COMMA expression } { !"when" !"else" !"end" statement } ;
+case_statement = "case" expression { when_clause | in_clause } [ else_clause ] "end" ;
+when_clause    = "when" expression { COMMA expression } { !"when" !"in" !"else" !"end" statement } ;
+# Phase 7d — Ruby 3.0 case/in pattern matching.
+#
+# `case/in` is structurally similar to `case/when` — the same scrutinee
+# expression sits in front, followed by a sequence of clauses, each with
+# a body.  The difference is the pattern language: `when` does a simple
+# `==` (well, `===`) test against a value, while `in` introduces a
+# structural pattern that can bind locals on a successful match.
+#
+# Supported v0 patterns (sufficient for the most common use-cases):
+#   literal_pattern   :  NUMBER | STRING | symbol_literal | KEYWORD
+#                        (KEYWORD covers `nil` / `true` / `false`)
+#   binding_pattern   :  NAME — matches anything and binds the value
+#                        to that local
+#   array_pattern     :  LBRACKET [ pattern { COMMA pattern } ] RBRACKET
+#   hash_pattern      :  LBRACE [ hash_pattern_pair { COMMA hash_pattern_pair } ] RBRACE
+#   hash_pattern_pair :  NAME COLON [ pattern ]  — `name:` shorthand
+#                        binds; `name: <pattern>` matches sub-pattern
+#
+# Order matters: array/hash come first so their `[`/`{` openers shadow
+# the literal/binding forms; literal comes before binding so concrete
+# constants don't get swallowed as bindings.
+in_clause      = "in" pattern { !"when" !"in" !"else" !"end" statement } ;
+pattern        = array_pattern | hash_pattern | literal_pattern | binding_pattern ;
+literal_pattern   = NUMBER | STRING | symbol_literal | KEYWORD ;
+binding_pattern   = NAME ;
+array_pattern     = LBRACKET [ pattern { COMMA pattern } ] RBRACKET ;
+hash_pattern      = LBRACE [ hash_pattern_pair { COMMA hash_pattern_pair } ] RBRACE ;
+hash_pattern_pair = NAME COLON [ pattern ] ;
 # Phase 6v — `begin … rescue … ensure … end`.
 #
 # Shape:

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.31.0] - 2026-05-25
+
+### Added (Phase 7d — Ruby 3.0 `case/in` pattern matching)
+
+The existing `case_statement` rule is extended to accept either `when_clause` or `in_clause` repetitions in any source order:
+
+```ebnf
+case_statement = "case" expression { when_clause | in_clause } [ else_clause ] "end" ;
+in_clause      = "in" pattern { !"when" !"in" !"else" !"end" statement } ;
+pattern        = array_pattern | hash_pattern | literal_pattern | binding_pattern ;
+literal_pattern   = NUMBER | STRING | symbol_literal | KEYWORD ;
+binding_pattern   = NAME ;
+array_pattern     = LBRACKET [ pattern { COMMA pattern } ] RBRACKET ;
+hash_pattern      = LBRACE [ hash_pattern_pair { COMMA hash_pattern_pair } ] RBRACE ;
+hash_pattern_pair = NAME COLON [ pattern ] ;
+```
+
+Order in `pattern`: array/hash come first so their `[`/`{` openers shadow the literal/binding forms; literal comes before binding so concrete constants don't get swallowed as bindings.
+
+Regenerated `_grammar.rs` via `grammar-tools compile-grammar`.
+
+The `when_clause` body lookaheads were extended with `!"in"` so `when`/`in` can interleave cleanly in the rule's repetition (even though semantically Ruby disallows mixing — this is a grammar concern, not a semantic one).
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+`lower_case_statement` now collects both `when_clause` and `in_clause` subnodes in source order.  A new helper `lower_in_clause_pattern` dispatches on pattern kind:
+
+| Pattern        | cond                                            | body-prefix stmts        |
+|----------------|-------------------------------------------------|--------------------------|
+| `in 1`         | `BuiltinCall("==", [scrut, IntLit(1)])`         | `[]`                     |
+| `in nil`       | `BuiltinCall("==", [scrut, NilLit])`            | `[]`                     |
+| `in y`         | `BoolLit(true)`                                 | `[LetBinding(y, scrut)]` |
+| `in [1, 2]`    | `BuiltinCall("__pattern_match__", [scrut, raw])` | `[]`                    |
+| `in {name: y}` | `BuiltinCall("__pattern_match__", [scrut, raw])` | `[]`                    |
+
+The `__pattern_match__` marker carries the raw source text of the pattern (joined Token values via a depth-first walk) so downstream emitters can re-derive the structural matching at codegen time.  Same marker-builtin pattern as Phase 6v rescue/ensure, Phase 6y `__interp__`, Phase 7a `backtick`.
+
+### v0 deferred limitations
+
+- Array / hash patterns lower as a `__pattern_match__` marker — no structural decomposition or sub-bindings yet.  Downstream emitters can re-parse the marker's StrLit raw text.
+- Hash pattern shorthand `{name:}` doesn't bind `name` at SIR level (deferred along with structural decomposition).
+- Pin operators (`^x`), find patterns (`[…, *, …]`), and class patterns (`SomeClass(x)`) are not yet parsed.
+- A bare-name body inside `in` (e.g. `in y; y; end`) hits a pre-existing grammar quirk where `method_call_no_paren` greedily consumes the closing `end` as a one-arg method-call argument — unrelated to Phase 7d, observable since Phase 6h.  Workaround: wrap the body in a paren-call (`puts(y)`) or any non-bare form.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 131 → **136** (+5 grammar tests):
+  - `test_parse_case_in_with_literal_pattern` — `in 1`.
+  - `test_parse_case_in_with_binding_pattern` — `in y`.
+  - `test_parse_case_in_with_array_pattern` — `in [1, 2]`.
+  - `test_parse_case_in_with_hash_pattern` — `in {name: y}`.
+  - `test_parse_case_when_still_works_after_in_clause_addition` — regression.
+
 ## [0.30.0] - 2026-05-25
 
 ### Added (Phase 7c — Ruby 3.0 endless method definitions `def foo = expr`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -371,7 +371,10 @@ pub fn parser_grammar() -> ParserGrammar {
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"case"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"when_clause"#.to_string() }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::RuleReference { name: r#"when_clause"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"in_clause"#.to_string() },
+                    ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
@@ -388,12 +391,92 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"when"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"in"#.to_string() }) },
                         GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"else"#.to_string() }) },
                         GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
             line_number: 183,
+        },
+        GrammarRule {
+            name: r#"in_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"in"#.to_string() },
+                GrammarElement::RuleReference { name: r#"pattern"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"when"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"in"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"else"#.to_string() }) },
+                        GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"end"#.to_string() }) },
+                        GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 205,
+        },
+        GrammarRule {
+            name: r#"pattern"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"array_pattern"#.to_string() },
+                GrammarElement::RuleReference { name: r#"hash_pattern"#.to_string() },
+                GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
+                GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
+            ] },
+            line_number: 206,
+        },
+        GrammarRule {
+            name: r#"literal_pattern"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
+                GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+            ] },
+            line_number: 207,
+        },
+        GrammarRule {
+            name: r#"binding_pattern"#.to_string(),
+            body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            line_number: 208,
+        },
+        GrammarRule {
+            name: r#"array_pattern"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"pattern"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"pattern"#.to_string() },
+                            ] }) },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 209,
+        },
+        GrammarRule {
+            name: r#"hash_pattern"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"hash_pattern_pair"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::RuleReference { name: r#"hash_pattern_pair"#.to_string() },
+                            ] }) },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 210,
+        },
+        GrammarRule {
+            name: r#"hash_pattern_pair"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
+            ] },
+            line_number: 211,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -409,7 +492,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 204,
+            line_number: 232,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -427,7 +510,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 213,
+            line_number: 241,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -438,7 +521,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 214,
+            line_number: 242,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -449,7 +532,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 215,
+            line_number: 243,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -466,7 +549,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 235,
+            line_number: 263,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -486,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 246,
+            line_number: 274,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -508,7 +591,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 247,
+            line_number: 275,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -519,7 +602,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 254,
+            line_number: 282,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -534,17 +617,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 268,
+            line_number: 296,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 269,
+            line_number: 297,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 355,
+            line_number: 383,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -557,7 +640,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 356,
+            line_number: 384,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -571,7 +654,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 357,
+            line_number: 385,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -585,7 +668,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 358,
+            line_number: 386,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -599,7 +682,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 359,
+            line_number: 387,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -610,7 +693,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 366,
+            line_number: 394,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -628,7 +711,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 367,
+            line_number: 395,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -642,7 +725,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 368,
+            line_number: 396,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -656,7 +739,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 369,
+            line_number: 397,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -680,7 +763,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 379,
+            line_number: 407,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -693,7 +776,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 398,
+            line_number: 426,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -701,7 +784,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 399,
+            line_number: 427,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -713,7 +796,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 400,
+            line_number: 428,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -728,7 +811,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 401,
+            line_number: 429,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -743,7 +826,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 402,
+            line_number: 430,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -759,7 +842,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 403,
+            line_number: 431,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2257,5 +2257,93 @@ mod tests {
             "block-bodied def must not match endless_def_statement"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7d — Ruby 3.0 `case/in` pattern matching
+    //
+    // Grammar extends case_statement to accept either `when_clause` or
+    // `in_clause` repetitions in any source order:
+    //   case_statement = "case" expression { when_clause | in_clause }
+    //                    [ else_clause ] "end" ;
+    //   in_clause      = "in" pattern { … statement } ;
+    //   pattern        = array_pattern | hash_pattern
+    //                  | literal_pattern | binding_pattern ;
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_case_in_with_literal_pattern() {
+        // `case x; in 1; puts("one"); end` — literal-pattern clause.
+        let ast = parse_ruby("case x\nin 1\n  puts(\"one\")\nend");
+        let cs = find_descendant(&ast, "case_statement")
+            .expect("expected case_statement node");
+        let inc = find_descendant(cs, "in_clause")
+            .expect("expected in_clause for `in 1`");
+        let pat = find_descendant(inc, "pattern").expect("expected pattern node");
+        assert!(
+            find_descendant(pat, "literal_pattern").is_some(),
+            "expected literal_pattern for `in 1`"
+        );
+    }
+
+    #[test]
+    fn test_parse_case_in_with_binding_pattern() {
+        // `case x; in y; puts(y); end` — bare-name binding pattern.
+        let ast = parse_ruby("case x\nin y\n  puts(y)\nend");
+        let cs = find_descendant(&ast, "case_statement").expect("case_statement");
+        let inc = find_descendant(cs, "in_clause").expect("in_clause");
+        let pat = find_descendant(inc, "pattern").expect("pattern");
+        assert!(
+            find_descendant(pat, "binding_pattern").is_some(),
+            "expected binding_pattern for `in y`"
+        );
+    }
+
+    #[test]
+    fn test_parse_case_in_with_array_pattern() {
+        // `case x; in [1, 2]; puts("pair"); end` — array pattern.
+        let ast = parse_ruby("case x\nin [1, 2]\n  puts(\"pair\")\nend");
+        let cs = find_descendant(&ast, "case_statement").expect("case_statement");
+        let inc = find_descendant(cs, "in_clause").expect("in_clause");
+        let pat = find_descendant(inc, "pattern").expect("pattern");
+        assert!(
+            find_descendant(pat, "array_pattern").is_some(),
+            "expected array_pattern for `in [1, 2]`"
+        );
+    }
+
+    #[test]
+    fn test_parse_case_in_with_hash_pattern() {
+        // `case x; in {name: y}; puts(y); end` — hash pattern.
+        let ast = parse_ruby("case x\nin {name: y}\n  puts(y)\nend");
+        let cs = find_descendant(&ast, "case_statement").expect("case_statement");
+        let inc = find_descendant(cs, "in_clause").expect("in_clause");
+        let pat = find_descendant(inc, "pattern").expect("pattern");
+        assert!(
+            find_descendant(pat, "hash_pattern").is_some(),
+            "expected hash_pattern for `in {{name: y}}`"
+        );
+    }
+
+    #[test]
+    fn test_parse_case_when_still_works_after_in_clause_addition() {
+        // Regression: extending the case_statement rule to accept `in_clause`
+        // alongside `when_clause` must not break the original Phase-6u
+        // `case … when … end` form.
+        let ast = parse_ruby("case x\nwhen 1\n  puts(1)\nwhen 2\n  puts(2)\nend");
+        let cs = find_descendant(&ast, "case_statement").expect("case_statement");
+        // Two when_clauses, zero in_clauses.
+        let when_count = cs
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "when_clause"))
+            .count();
+        let in_count = cs
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "in_clause"))
+            .count();
+        assert_eq!(when_count, 2, "expected 2 when_clauses");
+        assert_eq!(in_count, 0, "expected 0 in_clauses");
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.31.0] - 2026-05-25
+
+### Added (Phase 7d — Ruby 3.0 case/in pattern matching lowering)
+
+`lower_case_statement` now collects both `when_clause` and `in_clause` subnodes in source order.  Two new helpers:
+
+- `lower_when_clause_condition` — refactored out of the original Phase 6u lowerer for symmetry with `in_clause` dispatch (no behaviour change).
+- `lower_in_clause_pattern` — dispatches on pattern kind, returning `(cond, prefix_stmts)`.  Binding-pattern body-prefix stmts are prepended to the clause body so the bound local is visible from the first statement.
+
+### Pattern lowering
+
+| Pattern        | cond                                            | body-prefix stmts        |
+|----------------|-------------------------------------------------|--------------------------|
+| `in 1`         | `BuiltinCall("==", [scrut, IntLit(1)])`         | `[]`                     |
+| `in "s"`       | `BuiltinCall("==", [scrut, StrLit("s")])`       | `[]`                     |
+| `in :foo`      | `BuiltinCall("==", [scrut, SymLit("foo")])`     | `[]`                     |
+| `in nil`       | `BuiltinCall("==", [scrut, NilLit])`            | `[]`                     |
+| `in y`         | `BoolLit(true)`                                 | `[LetBinding(y, scrut)]` |
+| `in [1, 2]`    | `BuiltinCall("__pattern_match__", [scrut, StrLit(raw)])` | `[]`            |
+| `in {name: y}` | `BuiltinCall("__pattern_match__", [scrut, StrLit(raw)])` | `[]`            |
+
+The `__pattern_match__` marker carries the verbatim pattern text (joined Token values via depth-first walk) so downstream emitters can re-derive the structural matching at codegen time.  Same marker-builtin pattern as Phase 6v rescue/ensure, Phase 6y `__interp__`, Phase 7a `backtick`.
+
+The synthetic `StrLit` triggers `Feature::Strings`.
+
+A new helper `lower_pattern_literal` mirrors the factor-atom Token dispatch but narrowed to the patterns the `literal_pattern` rule admits (NUMBER, STRING, KEYWORD/`nil`/`true`/`false`, symbol_literal).  It reuses Phase 6z's `lower_numeric_literal` so every numeric shape (float/hex/bin/oct/dec) parses identically inside a pattern.
+
+### v0 deferred limitations
+
+- Array / hash patterns are kept as the `__pattern_match__` marker — no structural decomposition, no sub-bindings emitted.  A follow-up phase will walk the inner patterns and emit element comparisons + sub-`LetBinding`s.
+- Hash pattern shorthand `{name:}` doesn't bind `name` at SIR level.
+- Pin operators (`^x`), find patterns (`[…, *, …]`), and class patterns (`SomeClass(x)`) are not yet parsed.
+- Inside an `in` body, a bare-name statement (`in y; y; end`) hits a pre-existing grammar quirk where `method_call_no_paren` greedily consumes the closing `end` keyword as an argument.  Workaround in tests: use `puts(y)` rather than bare `y`.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 141 → **146** (+5):
+  - `case_in_literal_pattern_lowers_to_equality_check` — `in 1`.
+  - `case_in_binding_pattern_emits_letbinding_prefix` — `in y`.
+  - `case_in_array_pattern_lowers_to_pattern_match_marker` — `in [1, 2]`.
+  - `case_in_hash_pattern_lowers_to_pattern_match_marker` — `in {name: y}`.
+  - `case_in_with_else_clause_emits_else_branch` — `else` fallback.
+
 ## [0.30.0] - 2026-05-25
 
 ### Added (Phase 7c — Ruby 3.0 endless method definitions)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -2913,4 +2913,169 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7d — case/in pattern matching lowering
+    //
+    // case_statement walks both when_clause and in_clause subnodes in
+    // source order; in_clause pattern dispatch lives in
+    // `lower_in_clause_pattern`.
+    //
+    // Patterns covered here:
+    //   literal_pattern  → `==` comparison cond, no bindings
+    //   binding_pattern  → `BoolLit(true)` cond + LetBinding prefix
+    //   array_pattern    → `__pattern_match__` marker, no bindings
+    //   hash_pattern     → `__pattern_match__` marker, no bindings
+    // -----------------------------------------------------------------------
+
+    /// Helper: extract the `Expr::If` from a top-level `case` statement
+    /// — Phase 6u/7d lowers case to `Stmt::ExprStmt(Expr::If(...))`.
+    fn extract_case_if<'a>(b: &'a semantic_ir::Block) -> &'a Expr {
+        // The case is typically the second statement (first is the
+        // `x = ...` LetBinding from the test prelude).
+        match &b.stmts[1] {
+            Stmt::ExprStmt { expr, .. } => expr,
+            other => panic!("expected ExprStmt from case, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn case_in_literal_pattern_lowers_to_equality_check() {
+        // `case x; in 1; "one"; end` — literal pattern emits the same
+        // `scrutinee == 1` shape as a `when` clause.
+        let m = lower("x = 1\ncase x\nin 1\n  \"one\"\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let cond = match if_expr {
+            Expr::If { cond, .. } => cond,
+            other => panic!("expected If from case, got {:?}", other),
+        };
+        match cond.as_ref() {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "==");
+                assert_eq!(args.len(), 2);
+                // args[0] is the scrutinee (VarRef x); args[1] is IntLit(1).
+                assert!(matches!(&args[1], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected ==-BuiltinCall as cond, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn case_in_binding_pattern_emits_letbinding_prefix() {
+        // `case x; in y; puts(y); end` — binding pattern.  Cond is true;
+        // body has a LetBinding(y, scrutinee) prepended; body trailing
+        // value is the `puts(y)` call.  Body shape is `puts(y)` (and
+        // not bare `y`) because method_call_no_paren would otherwise
+        // greedily consume the closing `end` keyword as a one-arg
+        // method-call argument — a pre-existing grammar limitation
+        // unrelated to Phase 7d.
+        let m = lower("x = 1\ncase x\nin y\n  puts(y)\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let (cond, then_branch) = match if_expr {
+            Expr::If { cond, then_branch, .. } => (cond, then_branch),
+            other => panic!("expected If from case, got {:?}", other),
+        };
+        // Condition is BoolLit(true).
+        assert!(
+            matches!(cond.as_ref(), Expr::BoolLit { value: true, .. }),
+            "expected BoolLit(true), got {:?}",
+            cond
+        );
+        // then_branch.stmts[0] should be LetBinding(y, …).
+        let prefix = then_branch
+            .stmts
+            .first()
+            .expect("expected LetBinding prefix stmt");
+        match prefix {
+            Stmt::LetBinding { name, .. } => {
+                assert_eq!(name, "y");
+            }
+            other => panic!("expected LetBinding(y), got {:?}", other),
+        }
+        // then_branch.value should be the `puts(y)` BuiltinCall whose
+        // single arg is the bound `y`.
+        match &then_branch.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "puts");
+                assert!(
+                    matches!(&args[0], Expr::VarRef { name, .. } if name == "y"),
+                    "expected puts(VarRef(y)), got args={:?}",
+                    args
+                );
+            }
+            other => panic!("expected puts BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn case_in_array_pattern_lowers_to_pattern_match_marker() {
+        // `case x; in [1, 2]; "pair"; end` — array pattern lowers as
+        // `BuiltinCall("__pattern_match__", [scrut, StrLit("<raw>")])`.
+        let m = lower("x = 1\ncase x\nin [1, 2]\n  \"pair\"\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let cond = match if_expr {
+            Expr::If { cond, .. } => cond,
+            other => panic!("expected If, got {:?}", other),
+        };
+        match cond.as_ref() {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__pattern_match__");
+                assert_eq!(args.len(), 2);
+                // args[1] is StrLit with the raw pattern text.
+                match &args[1] {
+                    Expr::StrLit { value, .. } => {
+                        assert!(
+                            value.contains('1') && value.contains('2'),
+                            "expected raw text to contain `1` and `2`, got `{}`",
+                            value
+                        );
+                    }
+                    other => panic!("expected StrLit raw pattern, got {:?}", other),
+                }
+            }
+            other => panic!("expected __pattern_match__ BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn case_in_hash_pattern_lowers_to_pattern_match_marker() {
+        // `case x; in {name: y}; "match"; end` — hash pattern uses the
+        // same `__pattern_match__` marker as array.
+        let m = lower("x = 1\ncase x\nin {name: y}\n  \"match\"\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let cond = match if_expr {
+            Expr::If { cond, .. } => cond,
+            other => panic!("expected If, got {:?}", other),
+        };
+        match cond.as_ref() {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__pattern_match__");
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[1], Expr::StrLit { .. }));
+            }
+            other => panic!("expected __pattern_match__ BuiltinCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn case_in_with_else_clause_emits_else_branch() {
+        // `case x; in 1; "one"; else; "other"; end` — else clause is
+        // the innermost If's else_branch.
+        let m = lower("x = 2\ncase x\nin 1\n  \"one\"\nelse\n  \"other\"\nend\n");
+        let b = main_body(&m);
+        let if_expr = extract_case_if(b);
+        let else_branch = match if_expr {
+            Expr::If { else_branch, .. } => else_branch,
+            other => panic!("expected If, got {:?}", other),
+        };
+        assert!(
+            matches!(&else_branch.value, Expr::StrLit { value, .. } if value == "other"),
+            "expected StrLit(\"other\") in else branch, got {:?}",
+            else_branch.value
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -788,12 +788,19 @@ impl Lowerer {
             })?;
         let scrutinee = self.lower_expression(scrutinee_node)?;
 
-        // 2. Collect every when_clause subnode.
-        let when_clauses: Vec<&GrammarASTNode> = node
+        // 2. Collect every when_clause / in_clause subnode in source order.
+        // Phase 7d — `in_clause` is treated alongside `when_clause` and
+        // the two are unwound through the same If-chain pipeline.  The
+        // dispatch on clause type happens inside the unwind loop.
+        let clauses: Vec<&GrammarASTNode> = node
             .children
             .iter()
             .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) if n.rule_name == "when_clause" => Some(n),
+                ASTNodeOrToken::Node(n)
+                    if n.rule_name == "when_clause" || n.rule_name == "in_clause" =>
+                {
+                    Some(n)
+                }
                 _ => None,
             })
             .collect();
@@ -816,57 +823,44 @@ impl Lowerer {
             }
         };
 
-        // 5. Unwind when_clauses in reverse, each wrapping the
-        //    accumulated tail as its else-branch.
-        for wc in when_clauses.iter().rev() {
-            // Collect this clause's value expressions (all `expression`
-            // Node children in order).
-            let value_nodes: Vec<&GrammarASTNode> = wc
-                .children
-                .iter()
-                .filter_map(|c| match c {
-                    ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
-                    _ => None,
-                })
-                .collect();
-            if value_nodes.is_empty() {
-                return Err(RubyLowerError {
-                    message: "when_clause missing value expression(s)".to_string(),
-                    line: wc.start_line.unwrap_or(0),
-                    column: wc.start_column.unwrap_or(0),
-                });
-            }
-
-            // Build the condition: `(scrutinee == v1) || (scrutinee == v2) || ...`.
-            // Lower each value, build an `==` BuiltinCall, then OR-fold
-            // left-to-right (matches Ruby's left-to-right when evaluation).
+        // 5. Unwind clauses in reverse, each wrapping the accumulated
+        //    tail as its else-branch.  Dispatch on clause type:
+        //    when_clause keeps the existing OR-of-`==` shape; in_clause
+        //    (Phase 7d) dispatches on pattern kind via
+        //    `lower_in_clause_pattern` which returns both a match
+        //    condition AND zero or more body-prefix statements (used
+        //    for binding patterns that introduce locals on a match).
+        for wc in clauses.iter().rev() {
             let span = self.span_of(wc);
-            let mut cond: Option<Expr> = None;
-            for vn in &value_nodes {
-                let val = self.lower_expression(vn)?;
-                // Clone the scrutinee fresh for every comparison —
-                // SIR is tree-shaped, no shared subexpressions.
-                let cmp = Expr::BuiltinCall {
-                    name: "==".to_string(),
-                    args: vec![scrutinee.clone(), val],
-                    effects: EffectSet::PURE,
-                    span: span.clone(),
-                };
-                cond = Some(match cond {
-                    None => cmp,
-                    Some(prev) => Expr::BuiltinCall {
-                        name: "or".to_string(),
-                        args: vec![prev, cmp],
-                        effects: EffectSet::PURE,
-                        span: span.clone(),
-                    },
-                });
-            }
-            let cond = cond.expect("at least one when value");
+            let (cond, mut prefix_stmts) = if wc.rule_name == "when_clause" {
+                let cond = self.lower_when_clause_condition(wc, &scrutinee)?;
+                (cond, Vec::<Stmt>::new())
+            } else {
+                // in_clause — find the single `pattern` subnode and
+                // dispatch on its inner shape.
+                let pattern_node = wc
+                    .children
+                    .iter()
+                    .find_map(|c| match c {
+                        ASTNodeOrToken::Node(n) if n.rule_name == "pattern" => Some(n),
+                        _ => None,
+                    })
+                    .ok_or_else(|| RubyLowerError {
+                        message: "in_clause missing pattern".to_string(),
+                        line: wc.start_line.unwrap_or(0),
+                        column: wc.start_column.unwrap_or(0),
+                    })?;
+                self.lower_in_clause_pattern(pattern_node, &scrutinee)?
+            };
 
-            // Lower the when body — same shape as `lower_clause_statements`
-            // handles for if/elsif/else.
-            let then_block = self.lower_clause_statements(wc)?;
+            // Lower the clause body.  Binding-pattern bindings must
+            // execute BEFORE the body sees the new local, so prepend
+            // them to the body's stmts.
+            let mut then_block = self.lower_clause_statements(wc)?;
+            if !prefix_stmts.is_empty() {
+                prefix_stmts.extend(std::mem::take(&mut then_block.stmts));
+                then_block.stmts = prefix_stmts;
+            }
 
             // Wrap into an If and let `tail` become the else.
             tail = Block {
@@ -884,6 +878,264 @@ impl Lowerer {
         // The case expression is the chain's outermost If — which
         // currently sits as the `tail` Block's `value`.  Peel it out.
         Ok(tail.value)
+    }
+
+    /// Phase 6u helper — extract the OR-of-`==` condition for a single
+    /// `when_clause` (refactored out of `lower_case_statement` so that
+    /// Phase 7d's `in_clause` pattern dispatch can stay symmetric).
+    fn lower_when_clause_condition(
+        &mut self,
+        wc: &GrammarASTNode,
+        scrutinee: &Expr,
+    ) -> Result<Expr, RubyLowerError> {
+        let value_nodes: Vec<&GrammarASTNode> = wc
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            })
+            .collect();
+        if value_nodes.is_empty() {
+            return Err(RubyLowerError {
+                message: "when_clause missing value expression(s)".to_string(),
+                line: wc.start_line.unwrap_or(0),
+                column: wc.start_column.unwrap_or(0),
+            });
+        }
+        let span = self.span_of(wc);
+        let mut cond: Option<Expr> = None;
+        for vn in &value_nodes {
+            let val = self.lower_expression(vn)?;
+            let cmp = Expr::BuiltinCall {
+                name: "==".to_string(),
+                args: vec![scrutinee.clone(), val],
+                effects: EffectSet::PURE,
+                span: span.clone(),
+            };
+            cond = Some(match cond {
+                None => cmp,
+                Some(prev) => Expr::BuiltinCall {
+                    name: "or".to_string(),
+                    args: vec![prev, cmp],
+                    effects: EffectSet::PURE,
+                    span: span.clone(),
+                },
+            });
+        }
+        Ok(cond.expect("at least one when value"))
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 7d — case/in pattern matching
+    // -------------------------------------------------------------------
+
+    /// Lower an `in_clause`'s pattern against a scrutinee expression.
+    ///
+    /// Returns `(cond, prefix_stmts)`:
+    /// - `cond`: the boolean expression that decides if this clause
+    ///   matches.  When `cond` evaluates true at runtime, the clause's
+    ///   body runs; otherwise control falls through to the next clause.
+    /// - `prefix_stmts`: zero or more statements (currently always
+    ///   `LetBinding`s) that must execute *before* the body sees them.
+    ///   Empty for literal / array / hash patterns; populated for
+    ///   binding patterns that introduce a fresh local.
+    ///
+    /// ## Pattern dispatch (v0)
+    ///
+    /// | Pattern        | cond                                           | prefix_stmts            |
+    /// |----------------|------------------------------------------------|-------------------------|
+    /// | literal `1`    | `scrutinee == 1`                               | `[]`                    |
+    /// | literal `nil`  | `scrutinee == nil`                             | `[]`                    |
+    /// | binding `x`    | `BoolLit(true)`                                | `[LetBinding(x, scrut)]`|
+    /// | array `[…]`    | `BuiltinCall("__pattern_match__", [scrut, raw])` | `[]`                  |
+    /// | hash `{…}`     | `BuiltinCall("__pattern_match__", [scrut, raw])` | `[]`                  |
+    ///
+    /// ## v0 deferred limitations
+    ///
+    /// - Array / hash patterns lower as a `__pattern_match__` marker
+    ///   builtin carrying the verbatim raw text of the pattern.  No
+    ///   structural decomposition or sub-bindings are emitted yet —
+    ///   downstream emitters can re-derive the pattern from the raw
+    ///   text.  Same marker-builtin pattern as Phase 6v rescue/ensure,
+    ///   Phase 6y `__interp__`, and Phase 7a `backtick`.
+    /// - Pin operators (`^x`), find patterns (`[…, *, …]`), and class
+    ///   patterns (`SomeClass(x)`) are not yet parsed.
+    /// - Hash pattern's shorthand `{name:}` doesn't bind `name` at SIR
+    ///   level (deferred along with structural decomposition).
+    fn lower_in_clause_pattern(
+        &mut self,
+        pattern_node: &GrammarASTNode,
+        scrutinee: &Expr,
+    ) -> Result<(Expr, Vec<Stmt>), RubyLowerError> {
+        let inner = self.first_node_child(pattern_node).ok_or_else(|| {
+            RubyLowerError {
+                message: "pattern node had no inner rule child".to_string(),
+                line: pattern_node.start_line.unwrap_or(0),
+                column: pattern_node.start_column.unwrap_or(0),
+            }
+        })?;
+        let span = self.span_of(pattern_node);
+        match inner.rule_name.as_str() {
+            "literal_pattern" => {
+                // Lower the literal value, then build `scrutinee == lit`.
+                // The literal_pattern node carries exactly one Token
+                // child (NUMBER / STRING / KEYWORD) OR a symbol_literal
+                // subnode.  We delegate to lower_factor_atom by re-using
+                // the factor-atom Token dispatch.
+                let lit = self.lower_pattern_literal(inner)?;
+                Ok((
+                    Expr::BuiltinCall {
+                        name: "==".to_string(),
+                        args: vec![scrutinee.clone(), lit],
+                        effects: EffectSet::PURE,
+                        span,
+                    },
+                    Vec::new(),
+                ))
+            }
+            "binding_pattern" => {
+                // Bare NAME — matches any value and binds it.  The
+                // condition is trivially true (BoolLit(true)); the
+                // binding goes into the body's prefix stmts.
+                let name_tok = inner
+                    .children
+                    .iter()
+                    .find_map(|c| match c {
+                        ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+                        _ => None,
+                    })
+                    .ok_or_else(|| RubyLowerError {
+                        message: "binding_pattern missing Name token".to_string(),
+                        line: inner.start_line.unwrap_or(0),
+                        column: inner.start_column.unwrap_or(0),
+                    })?;
+                let bind_name = name_tok.value.clone();
+                self.declared_locals.insert(bind_name.clone());
+                let bind_span = self.span_of_token(name_tok);
+                let prefix = Stmt::LetBinding {
+                    name: bind_name,
+                    sir_type: None,
+                    value: scrutinee.clone(),
+                    span: bind_span,
+                };
+                Ok((Expr::BoolLit { value: true, span }, vec![prefix]))
+            }
+            "array_pattern" | "hash_pattern" => {
+                // v0 marker: emit `BuiltinCall("__pattern_match__",
+                // [scrutinee, StrLit(<raw pattern text>)])`.  The raw
+                // text is reconstructed by joining the immediate Token
+                // children of the pattern node — good enough for
+                // round-tripping the pattern back to a Ruby emitter.
+                let raw = self.pattern_node_raw_text(inner);
+                self.features_used.insert(Feature::Strings);
+                Ok((
+                    Expr::BuiltinCall {
+                        name: "__pattern_match__".to_string(),
+                        args: vec![
+                            scrutinee.clone(),
+                            Expr::StrLit {
+                                value: raw,
+                                span: span.clone(),
+                            },
+                        ],
+                        effects: EffectSet::PURE,
+                        span,
+                    },
+                    Vec::new(),
+                ))
+            }
+            other => Err(RubyLowerError {
+                message: format!("unknown pattern kind `{}` in in_clause", other),
+                line: inner.start_line.unwrap_or(0),
+                column: inner.start_column.unwrap_or(0),
+            }),
+        }
+    }
+
+    /// Lower a `literal_pattern` Node into its `Expr` form.  Mirrors
+    /// the factor-atom token dispatch but narrowed to the patterns the
+    /// `literal_pattern` rule admits (NUMBER, STRING, symbol_literal,
+    /// KEYWORD).
+    fn lower_pattern_literal(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        // Walk children once to find either a literal Token or a
+        // symbol_literal subnode.
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(tok) => {
+                    let span = self.span_of_token(tok);
+                    match tok.type_ {
+                        TokenType::Number => {
+                            // Reuse the Phase-6z numeric dispatch so
+                            // every shape (float/hex/bin/oct/dec) is
+                            // handled identically here.
+                            return self.lower_numeric_literal(
+                                &tok.value,
+                                span,
+                                tok.line,
+                                tok.column,
+                            );
+                        }
+                        TokenType::String => {
+                            return Ok(Expr::StrLit {
+                                value: tok.value.clone(),
+                                span,
+                            });
+                        }
+                        TokenType::Keyword => match tok.value.as_str() {
+                            "nil" => return Ok(Expr::NilLit { span }),
+                            "true" => return Ok(Expr::BoolLit { value: true, span }),
+                            "false" => return Ok(Expr::BoolLit { value: false, span }),
+                            other => {
+                                return Err(RubyLowerError {
+                                    message: format!(
+                                        "literal_pattern: unexpected keyword `{}`",
+                                        other
+                                    ),
+                                    line: tok.line,
+                                    column: tok.column,
+                                });
+                            }
+                        },
+                        _ => {}
+                    }
+                }
+                ASTNodeOrToken::Node(sub) if sub.rule_name == "symbol_literal" => {
+                    // Reuse the existing symbol-literal lowering path
+                    // (defined as part of Phase 6e).  Delegating into
+                    // lower_factor_atom would re-enter the factor
+                    // dispatch unnecessarily — instead we just emit
+                    // the SymLit directly from the symbol token.
+                    return self.lower_symbol_literal(sub);
+                }
+                _ => {}
+            }
+        }
+        Err(RubyLowerError {
+            message: "literal_pattern had no recognisable child".to_string(),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        })
+    }
+
+    /// Best-effort source-text reconstruction for an array/hash
+    /// pattern.  Walks the immediate Token children in source order,
+    /// joining their values without whitespace insertion — good enough
+    /// for the v0 marker (`BuiltinCall("__pattern_match__", …)`) where
+    /// the body is round-tripped to a Ruby emitter as-is.  This is
+    /// **not** a faithful reformatter; nested patterns are descended
+    /// into so their tokens contribute as well.
+    fn pattern_node_raw_text(&self, node: &GrammarASTNode) -> String {
+        let mut out = String::new();
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) => out.push_str(&t.value),
+                ASTNodeOrToken::Node(sub) => {
+                    out.push_str(&self.pattern_node_raw_text(sub));
+                }
+            }
+        }
+        out
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 7d adds Ruby 3.0's `case/in` structural pattern matching, with v0 support for the four basic pattern forms: literal (`in 1`), binding (`in x`), array (`in [1, 2]`), and hash (`in {name: y}`).

## Grammar

The existing `case_statement` rule is extended to accept either `when_clause` or `in_clause` repetitions in any source order:

```ebnf
case_statement = "case" expression { when_clause | in_clause } [ else_clause ] "end" ;
in_clause      = "in" pattern { !"when" !"in" !"else" !"end" statement } ;
pattern        = array_pattern | hash_pattern | literal_pattern | binding_pattern ;
literal_pattern   = NUMBER | STRING | symbol_literal | KEYWORD ;
binding_pattern   = NAME ;
array_pattern     = LBRACKET [ pattern { COMMA pattern } ] RBRACKET ;
hash_pattern      = LBRACE [ hash_pattern_pair { COMMA hash_pattern_pair } ] RBRACE ;
hash_pattern_pair = NAME COLON [ pattern ] ;
```

`_grammar.rs` regenerated via `grammar-tools compile-grammar`.  The Phase 6u `when_clause` body lookaheads were extended with `!"in"` so that `when`/`in` clauses can be parsed cleanly in the same rule.

## Lowering

`lower_case_statement` now collects both `when_clause` and `in_clause` subnodes in source order.  New helpers:

- `lower_when_clause_condition` — refactored out of Phase 6u for symmetry.
- `lower_in_clause_pattern` — dispatches on pattern kind, returns `(cond, prefix_stmts)`.
- `lower_pattern_literal` — factor-atom dispatch narrowed to literal patterns.
- `pattern_node_raw_text` — depth-first Token-value join for the array/hash marker.

| Pattern        | cond                                            | body-prefix stmts        |
|----------------|-------------------------------------------------|--------------------------|
| `in 1`         | `BuiltinCall("==", [scrut, IntLit(1)])`         | `[]`                     |
| `in nil`       | `BuiltinCall("==", [scrut, NilLit])`            | `[]`                     |
| `in y`         | `BoolLit(true)`                                 | `[LetBinding(y, scrut)]` |
| `in [1, 2]`    | `BuiltinCall("__pattern_match__", [scrut, StrLit(raw)])` | `[]`            |
| `in {name: y}` | `BuiltinCall("__pattern_match__", [scrut, StrLit(raw)])` | `[]`            |

The `__pattern_match__` marker carries the verbatim source text so downstream emitters can re-derive structural matching at codegen.  Same marker-builtin pattern as Phase 6v rescue/ensure, Phase 6y `__interp__`, Phase 7a `backtick`.

The synthetic `StrLit` triggers `Feature::Strings`.

## v0 deferred limitations

- Array / hash patterns lower as a `__pattern_match__` marker — no structural decomposition or sub-bindings yet.
- Hash shorthand `{name:}` doesn't bind `name` at SIR level.
- Pin operators (`^x`), find patterns (`[…, *, …]`), class patterns (`SomeClass(x)`) not yet parsed.
- A bare-name body inside `in` (e.g. `in y; y; end`) hits a pre-existing grammar quirk where `method_call_no_paren` greedily consumes the closing `end` as an argument.  Workaround in tests: wrap the body in a paren-call (`puts(y)`).

## Tests

- `coding-adventures-ruby-parser`: 131 → **136** (+5 grammar tests).
- `ruby-to-semantic-ir`: 141 → **146** (+5 lowering tests).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (136/136 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (146/146 pass)
- [x] Self-reviewed (no I/O, no unsafe, no unwraps on user input — grammar changes are declarative; lowerer dispatches on rule name and reuses existing helpers; marker-builtin pattern carries raw text for downstream re-parsing)
- [ ] CI green

Follows PR #4379 (Phase 7c — Ruby 3.0 endless method `def foo = expr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
