### PR TITLE
Track browser form submitter metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -532,6 +532,7 @@ def check_browser_expected_lists(
         require_optional_nullable_string(form_path, form, "rel", errors)
         require_optional_boolean(form_path, form, "novalidate", errors)
         require_object_list(form_path, form, "controls", errors)
+        require_optional_object_list(form_path, form, "submitters", errors)
         for control_index, control in enumerate(object_list_items(form, "controls")):
             control_path = f"{form_path}.controls[{control_index}]"
             require_optional_nullable_string(control_path, control, "id", errors)
@@ -581,6 +582,22 @@ def check_browser_expected_lists(
             require_optional_boolean(control_path, control, "form_novalidate", errors)
             require_string(control_path, control, "text", errors)
             require_string_list(control_path, control, "options", errors)
+        for submitter_index, submitter in enumerate(object_list_items(form, "submitters")):
+            submitter_path = f"{form_path}.submitters[{submitter_index}]"
+            require_optional_nullable_string(submitter_path, submitter, "id", errors)
+            require_string(submitter_path, submitter, "control_type", errors)
+            require_string(submitter_path, submitter, "method", errors)
+            for field in (
+                "name",
+                "accessible_name",
+                "action",
+                "resolved_action",
+                "enctype",
+                "target",
+                "value",
+            ):
+                require_optional_nullable_string(submitter_path, submitter, field, errors)
+            require_optional_boolean(submitter_path, submitter, "novalidate", errors)
 
     for index, table in enumerate(object_list_items(expected, "tables")):
         table_path = f"{case_path}.expected.tables[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1453,6 +1453,7 @@ pub struct BrowserForm {
     pub rel: Option<String>,
     pub novalidate: bool,
     pub controls: Vec<BrowserFormControl>,
+    pub submitters: Vec<BrowserFormSubmitter>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1501,6 +1502,21 @@ pub struct BrowserFormControl {
     pub multiple: bool,
     pub text: String,
     pub options: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormSubmitter {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub accessible_name: Option<String>,
+    pub action: Option<String>,
+    pub resolved_action: Option<String>,
+    pub method: String,
+    pub enctype: Option<String>,
+    pub target: Option<String>,
+    pub novalidate: bool,
+    pub value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8768,30 +8784,12 @@ fn collect_browser_facts(
             "style" => summary
                 .stylesheets
                 .push(browser_style_element(element, summary.base_href.as_deref())),
-            "form" => summary.forms.push(BrowserForm {
-                id: element.attribute("id").map(ToOwned::to_owned),
-                action: element.attribute("action").map(ToOwned::to_owned),
-                resolved_action: element
-                    .attribute("action")
-                    .and_then(|action| resolve_browser_url(action, summary.base_href.as_deref())),
-                name: element.attribute("name").map(ToOwned::to_owned),
-                method: element
-                    .attribute("method")
-                    .map(|method| method.to_ascii_lowercase())
-                    .unwrap_or_else(|| "get".to_string()),
-                enctype: element.attribute("enctype").map(ToOwned::to_owned),
-                target: element.attribute("target").map(ToOwned::to_owned),
-                accept_charset: element.attribute("accept-charset").map(ToOwned::to_owned),
-                autocomplete: element.attribute("autocomplete").map(ToOwned::to_owned),
-                rel: element.attribute("rel").map(ToOwned::to_owned),
-                novalidate: element.attribute("novalidate").is_some(),
-                controls: collect_form_controls_for_form(
-                    body_root,
-                    element,
-                    labels,
-                    summary.base_href.as_deref(),
-                ),
-            }),
+            "form" => summary.forms.push(browser_form(
+                body_root,
+                element,
+                labels,
+                summary.base_href.as_deref(),
+            )),
             "table" => summary.tables.push(BrowserTable {
                 caption: find_first_element_in_nodes(&element.children, "caption")
                     .map(element_text),
@@ -11696,6 +11694,97 @@ fn collect_form_controls_for_form(
     controls
 }
 
+fn browser_form(
+    body_root: &[Node],
+    element: &Element,
+    labels: &[(String, String)],
+    base_href: Option<&str>,
+) -> BrowserForm {
+    let action = element.attribute("action").map(ToOwned::to_owned);
+    let resolved_action = action
+        .as_deref()
+        .and_then(|action| resolve_browser_url(action, base_href));
+    let method = element
+        .attribute("method")
+        .map(|method| method.to_ascii_lowercase())
+        .unwrap_or_else(|| "get".to_string());
+    let enctype = element.attribute("enctype").map(ToOwned::to_owned);
+    let target = element.attribute("target").map(ToOwned::to_owned);
+    let novalidate = element.attribute("novalidate").is_some();
+    let controls = collect_form_controls_for_form(body_root, element, labels, base_href);
+    let submitters = browser_form_submitters(
+        &controls,
+        action.as_deref(),
+        resolved_action.as_deref(),
+        &method,
+        enctype.as_deref(),
+        target.as_deref(),
+        novalidate,
+    );
+    BrowserForm {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        action,
+        resolved_action,
+        name: element.attribute("name").map(ToOwned::to_owned),
+        method,
+        enctype,
+        target,
+        accept_charset: element.attribute("accept-charset").map(ToOwned::to_owned),
+        autocomplete: element.attribute("autocomplete").map(ToOwned::to_owned),
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        novalidate,
+        controls,
+        submitters,
+    }
+}
+
+fn browser_form_submitters(
+    controls: &[BrowserFormControl],
+    action: Option<&str>,
+    resolved_action: Option<&str>,
+    method: &str,
+    enctype: Option<&str>,
+    target: Option<&str>,
+    novalidate: bool,
+) -> Vec<BrowserFormSubmitter> {
+    controls
+        .iter()
+        .filter(|control| is_browser_form_submitter(control))
+        .map(|control| BrowserFormSubmitter {
+            id: control.id.clone(),
+            control_type: control.control_type.clone(),
+            name: control.name.clone(),
+            accessible_name: control.accessible_name.clone().or_else(|| control.alt.clone()),
+            action: control
+                .form_action
+                .clone()
+                .or_else(|| action.map(ToOwned::to_owned)),
+            resolved_action: control
+                .resolved_form_action
+                .clone()
+                .or_else(|| resolved_action.map(ToOwned::to_owned)),
+            method: control
+                .form_method
+                .clone()
+                .unwrap_or_else(|| method.to_string()),
+            enctype: control
+                .form_enctype
+                .clone()
+                .or_else(|| enctype.map(ToOwned::to_owned)),
+            target: control
+                .form_target
+                .clone()
+                .or_else(|| target.map(ToOwned::to_owned)),
+            novalidate: novalidate || control.form_novalidate,
+            value: control.value.clone(),
+        })
+        .collect()
+}
+
+fn is_browser_form_submitter(control: &BrowserFormControl) -> bool {
+    !control.disabled && matches!(control.control_type.as_str(), "submit" | "image")
+}
+
 fn collect_form_controls_for_form_into(
     nodes: &[Node],
     controls: &mut Vec<BrowserFormControl>,
@@ -13129,6 +13218,38 @@ mod tests {
         assert_eq!(controls[8].form_owner.as_deref(), Some("f"));
         assert_eq!(controls[8].accessible_name.as_deref(), Some("Outside"));
         assert_eq!(controls[8].placeholder.as_deref(), Some("Outside"));
+
+        let submitters = &summary.forms[0].submitters;
+        assert_eq!(submitters.len(), 2);
+        assert_eq!(submitters[0].id.as_deref(), Some("go"));
+        assert_eq!(submitters[0].control_type, "submit");
+        assert_eq!(submitters[0].accessible_name.as_deref(), Some("Run search"));
+        assert_eq!(submitters[0].action.as_deref(), Some("run.html"));
+        assert_eq!(
+            submitters[0].resolved_action.as_deref(),
+            Some("https://example.test/search/run.html")
+        );
+        assert_eq!(submitters[0].method, "post");
+        assert_eq!(
+            submitters[0].enctype.as_deref(),
+            Some("application/x-www-form-urlencoded")
+        );
+        assert_eq!(submitters[0].target.as_deref(), Some("results"));
+        assert!(submitters[0].novalidate);
+        assert_eq!(submitters[1].id.as_deref(), Some("imageGo"));
+        assert_eq!(submitters[1].control_type, "image");
+        assert_eq!(submitters[1].name.as_deref(), Some("image-go"));
+        assert_eq!(
+            submitters[1].accessible_name.as_deref(),
+            Some("Search image")
+        );
+        assert_eq!(submitters[1].action.as_deref(), Some("find.html"));
+        assert_eq!(
+            submitters[1].resolved_action.as_deref(),
+            Some("https://example.test/search/find.html")
+        );
+        assert_eq!(submitters[1].method, "post");
+        assert!(submitters[1].novalidate);
 
         let content_tree = BrowserContentTree::from_document(&document);
         let form = &content_tree.children[0];

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,8 +1,8 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata, BrowserForm,
-    BrowserFormControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
-    BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh,
-    BrowserResource, BrowserResourceHint, BrowserScript, BrowserStructuredItem,
+    BrowserFormControl, BrowserFormSubmitter, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageSource, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserStructuredItem,
     BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
@@ -464,6 +464,8 @@ struct ExpectedForm {
     #[serde(default)]
     novalidate: bool,
     controls: Vec<ExpectedFormControl>,
+    #[serde(default)]
+    submitters: Vec<ExpectedFormSubmitter>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -549,6 +551,30 @@ struct ExpectedFormControl {
     multiple: bool,
     text: String,
     options: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormSubmitter {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    resolved_action: Option<String>,
+    method: String,
+    #[serde(default)]
+    enctype: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    novalidate: bool,
+    #[serde(default)]
+    value: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1019,6 +1045,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormControl::into_browser_form_control)
                 .collect(),
+            submitters: self
+                .submitters
+                .into_iter()
+                .map(ExpectedFormSubmitter::into_browser_form_submitter)
+                .collect(),
         }
     }
 }
@@ -1070,6 +1101,24 @@ impl ExpectedFormControl {
             multiple: self.multiple,
             text: self.text,
             options: self.options,
+        }
+    }
+}
+
+impl ExpectedFormSubmitter {
+    fn into_browser_form_submitter(self) -> BrowserFormSubmitter {
+        BrowserFormSubmitter {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            accessible_name: self.accessible_name,
+            action: self.action,
+            resolved_action: self.resolved_action,
+            method: self.method,
+            enctype: self.enctype,
+            target: self.target,
+            novalidate: self.novalidate,
+            value: self.value,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -81,6 +81,9 @@
               { "control_type": "select", "name": "section", "value": "manuals", "disabled": false, "checked": false, "text": "Books Manuals", "options": ["Books", "Manuals"] },
               { "control_type": "textarea", "name": "notes", "value": "Line one Line two", "disabled": false, "checked": false, "text": "Line one Line two", "options": [] },
               { "control_type": "submit", "name": "go", "accessible_name": "Search", "value": null, "disabled": false, "checked": false, "text": "Search", "options": [] }
+            ],
+            "submitters": [
+              { "id": null, "control_type": "submit", "name": "go", "accessible_name": "Search", "action": "/search", "resolved_action": null, "method": "post", "enctype": "multipart/form-data", "target": "results", "novalidate": false, "value": null }
             ]
           }
         ],
@@ -182,6 +185,10 @@
               { "id": "imageGo", "control_type": "image", "name": "image-go", "src": "buttons/search.png", "resolved_src": "https://example.test/search/buttons/search.png", "alt": "Search image", "width": "32", "height": "16", "value": null, "disabled": false, "checked": false, "text": "", "options": [] },
               { "id": "total", "control_type": "output", "name": "total", "output_for": ["q", "kind"], "value": "Ready", "disabled": false, "checked": false, "text": "Ready", "options": [] },
               { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "disabled": false, "checked": false, "text": "", "options": [] }
+            ],
+            "submitters": [
+              { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "novalidate": true, "value": null },
+              { "id": "imageGo", "control_type": "image", "name": "image-go", "accessible_name": "Search image", "action": "find.html", "resolved_action": "https://example.test/search/find.html", "method": "post", "enctype": null, "target": null, "novalidate": true, "value": null }
             ]
           }
         ],


### PR DESCRIPTION
## Summary
- add structured browser form submitter metadata derived from submit/image controls
- resolve effective submit actions, methods, encodings, targets, and validation state from form defaults plus per-control overrides
- extend browser-readiness fixtures and schema governance for submitter summaries

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
