### PR TITLE
feat(cas-summation): Phase 74 — One-Sqrt × Four-Log × polynomial numerator (2.11.0 → 2.12.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.12.0 — 2026-05-25
+
+### Added
+
+- **Phase 74 — One-Sqrt × Four-Log × polynomial numerator** (`_one_sqrt_four_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 4 Log factors required.  `log⁴(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 4 new unit tests in `TestPhase74OneSqrtFourLogPoly`.
+
 ## 2.11.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.11.0"
+version = "2.12.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1027,6 +1027,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 74: ``Mul(Sqrt(P), Log(h1), Log(h2), Log(h3), Log(h4),
+    #           polynomial..., bounded...)`` numerator.
+    # One Sqrt factor + four Log factors; log⁴ sub-polynomial → 0.
+    # effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s1l4p_x2 = _one_sqrt_four_log_poly_effective_x2(num, k)
+    if s1l4p_x2 is not None:
+        den_deg_s1l4 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l4 is not None:
+            if 2 * den_deg_s1l4 > s1l4p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2541,6 +2555,75 @@ def _four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 4:
         return None
     return 2 * poly_deg_sum
+
+
+def _one_sqrt_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_inner_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly one** ``Sqrt(positive-leading polynomial)`` factor,
+    **exactly four** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 74 — One-Sqrt × Four-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^d) · log(k)⁴ · k^m ≈ k^{d/2} · log⁴(k) · k^m``.
+    ``log⁴(k)`` is sub-polynomial (``o(k^ε)``), so it contributes 0.
+    Using the ×2 integer trick:
+    ``effective_x2 = d + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------+------------------+
+    | Input                                                    | Return           |
+    +==========================================================+==================+
+    | ``Mul(Sqrt(k), Log(k)×4)``                               | ``1 + 0 = 1``    |
+    | ``Mul(Sqrt(k³), Log(k)×4)``                              | ``3 + 0 = 3``    |
+    | ``Mul(Sqrt(k), Log(k)×4, k)``                            | ``1 + 2 = 3``    |
+    | ``Mul(Sqrt(k), Log(k)×3)``                               | None (3 Logs)    |
+    | ``Mul(Sqrt(k), Log(k)×5)``                               | None (5 Logs)    |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×4)``                      | None (2 Sqrts)   |
+    | ``Mul(Log(k)×4)``                                        | None (0 Sqrts)   |
+    +----------------------------------------------------------+------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 1.
+         - ``Log(diverging)`` → count; bail after 4.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 1 Sqrt AND exactly 4 Log factors.
+      4. Return ``sqrt_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                # Second Sqrt — not this phase.
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 4:
+                # Five or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 4:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -3830,3 +3830,88 @@ class TestPhase73FourLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase74OneSqrtFourLogPoly:
+    """Phase 74 — g(k)=Sqrt(P)·Log⁴·poly/den.
+
+    effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    Converges when 2·den_deg > effective_x2 (polynomial denominator) or
+    denominator diverges super-polynomially.
+    Exactly 1 Sqrt + exactly 4 Log factors required.
+    """
+
+    def test_sqrt_k_log4_k_over_k_closes(self):
+        """√k·log(k)⁴/k: eff_x2=1; 2·1=2 > 1 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_log4_k_over_k2_closes(self):
+        """√(k³)·log(k)⁴/k²: eff_x2=3; 2·2=4 > 3 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log4_k_over_exp_closes(self):
+        """√k·log(k)⁴/2^k: exponential denom → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        two_k = IRApply(POW, (IRInteger(2), _k))
+        two_kp1 = IRApply(POW, (IRInteger(2), kp1))
+        g_k = IRApply(DIV, (num_k, two_k))
+        g_kp1 = IRApply(DIV, (num_kp1, two_kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log4_k_times_k_over_k_refused(self):
+        """√k·log(k)⁴·k/k: eff_x2=1+2=3; 2·1=2 not > 3 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)), _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)), kp1))
+        g_k4 = IRApply(DIV, (num_k, _k))
+        g_kp1_4 = IRApply(DIV, (num_kp1, kp1))
+        f4 = IRApply(SUB, (g_k4, g_kp1_4))
+        # eff_x2 = 1 (sqrt k) + 2 (k factor) = 3; den_deg=1; 2*1=2 not > 3 → refused
+        result = evaluate_sum(f4, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.12.0 — 2026-05-25
+
+### Added
+
+- **Phase 74 — One-Sqrt × Four-Log × polynomial numerator** (`one_sqrt_four_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 4 Log factors required.  `log⁴(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = sqrt_inner_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase74_*`).
+
 ## 2.11.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.11.0"
+version = "2.12.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1908,6 +1908,42 @@ fn four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(2 * poly_deg)
 }
 
+/// Phase 74 — One-Sqrt × Four-Log × polynomial numerator.
+///
+/// Returns `sqrt_inner_deg_x2 + 2·poly_deg` when `node` is a `Mul` with
+/// exactly one `Sqrt(positive-leading polynomial)` factor, exactly four
+/// `Log(diverging-in-k)` factors, any polynomial factors, and any bounded
+/// factors; `None` otherwise.
+///
+/// `log⁴(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to the effective
+/// degree.  `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn one_sqrt_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg_x2 = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 4 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let d = sqrt_deg_x2?;
+    if log_count != 4 { return None; }
+    Some(d + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2209,6 +2245,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(flp4_x2) = four_log_poly_effective_x2(num, k) {
         if let Some(den_deg_flp4) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_flp4 > flp4_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 74: Mul(Sqrt(P), Log(diverging)×4, polynomial..., bounded...) numerator.
+    // One Sqrt + four Log factors; log⁴ sub-polynomial — effective_x2 = d + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s1l4_x2) = one_sqrt_four_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l4) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l4 > s1l4_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2511,3 +2511,65 @@ fn phase73_log4_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 74: One-Sqrt × Four-Log × polynomial numerator ─────────────────────
+// g(k) = √P(k) · log(k)^4 · poly(k) / den(k); effective_x2 = d + 2·poly_deg.
+// Closes when 2·den_deg > effective_x2 (or denom is non-polynomial diverging).
+
+#[test]
+fn phase74_sqrt_k_log4_k_over_k_closes() {
+    // √k·log(k)^4 / k: effective_x2=1; 2·1=2 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k, log_k.clone(), log_k.clone(), log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1, log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1]);
+    let g_k74 = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp174 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k74, g_kp174]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase74_sqrt_k3_log4_k_over_k2_closes() {
+    // √(k³)·log(k)^4 / k²: effective_x2=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k3, log_k.clone(), log_k.clone(), log_k.clone(), log_k]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1_3, log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1]);
+    let g_k74b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp174b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k74b, g_kp174b]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase74_sqrt_k_log4_k_times_k_over_k_refused() {
+    // √k·log(k)^4·k / k: effective_x2=1+2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![sqrt_k, log_k.clone(), log_k.clone(), log_k.clone(), log_k, k.clone()]);
+    let num_kp1 = apply(sym(MUL), vec![sqrt_kp1, log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1, kp1.clone()]);
+    let g_k74r = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp174r = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k74r, g_kp174r]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.12.0 — 2026-05-25
+
+### Added
+
+- **Phase 74 — One-Sqrt × Four-Log × polynomial numerator** (`oneSqrtFourLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt and exactly 4 Log factors; `log⁴(k)` sub-polynomial — contributes 0 to effective
+  degree; effective degree = sqrtHalfDeg + polyDeg.
+  Closes when `denDeg > oneSqrtFourLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 74" describe block.
+
 ## 2.11.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1651,6 +1651,43 @@ function fourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
   return polyDeg;
 }
 
+/**
+ * Phase 74 — One-Sqrt × Four-Log × polynomial numerator.
+ *
+ * Returns `sqrtHalfDeg + polyDeg` when `node` is a `Mul` with exactly one
+ * `Sqrt` factor, exactly four `Log(diverging-in-k)` factors, any polynomial
+ * factors, and any bounded factors; `undefined` otherwise.
+ *
+ * `log⁴(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective
+ * polynomial degree.  effective degree = sqrtHalfDeg + polyDeg.
+ * Caller checks `denDeg > oneSqrtFourLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined; // second Sqrt — refuse
+      sqrtHalfDeg = hd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 4) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 4) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -1961,6 +1998,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegFlp4 = polynomialDegreeInK(den, k);
     if (denDegFlp4 !== undefined) {
       if (denDegFlp4 > flp4Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 74: Mul(Sqrt(P), Log(diverging)×4, polynomial..., bounded...) numerator.
+  // One Sqrt + four Log factors; log⁴ sub-polynomial — contributes 0.
+  // effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtFourLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l4Deg = oneSqrtFourLogPolyEffectiveDeg(num, k);
+  if (s1l4Deg !== undefined) {
+    const denDegS1l4 = polynomialDegreeInK(den, k);
+    if (denDegS1l4 !== undefined) {
+      if (denDegS1l4 > s1l4Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -2618,3 +2618,87 @@ describe("Phase 73 — Four-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 74 — One-Sqrt × Four-Log × polynomial numerator", () => {
+  // g(k) = √P(k) · log(k)⁴ · [poly...] / den(k)
+  // effective_deg = sqrtHalfDeg + polyDeg; closes when denDeg > effective_deg.
+
+  it("√k·log(k)⁴/k closes (sqrtHalf=0.5, polyDeg=0, denDeg=1 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK74 = { kind: "apply" as const, head: DIV, args: [numK, k] };
+    const gKp174 = { kind: "apply" as const, head: DIV, args: [numKp1, kp1] };
+    const f74 = { kind: "apply" as const, head: SUB, args: [gK74, gKp174] };
+    const result = evaluateSum(f74, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·log(k)⁴/k² closes (sqrtHalf=1.5, polyDeg=0, denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK74b = { kind: "apply" as const, head: DIV, args: [numK, k2] };
+    const gKp174b = { kind: "apply" as const, head: DIV, args: [numKp1, kp1_2] };
+    const f74b = { kind: "apply" as const, head: SUB, args: [gK74b, gKp174b] };
+    const result = evaluateSum(f74b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁴·k/k refused (sqrtHalf=0.5, polyDeg=1, denDeg=1 not > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp1 = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK74r = { kind: "apply" as const, head: DIV, args: [numK, k] };
+    const gKp174r = { kind: "apply" as const, head: DIV, args: [numKp1, kp1] };
+    const f74r = { kind: "apply" as const, head: SUB, args: [gK74r, gKp174r] };
+    const result = evaluateSum(f74r, k, int(1), sym("%inf"), evalNode);
+    // eff_x2=1+2=3; 2*den_deg=2*1=2 not > 3 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Phase 74 convergence recogniser: `g(k) = Sqrt(P(k)) · log(k)^4 · poly(k) / den(k)`
- Uses `×2` integer trick: `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`; closes when `2·den_deg > effective_x2` or denominator is non-polynomial diverging
- Exactly 1 Sqrt + exactly 4 Log factors required; extra Sqrt/Log → refuse (not this phase)
- Implemented in Python, TypeScript, and Rust at version parity (2.12.0)

## Test plan

- [ ] Python: 228 tests pass (`pytest`), coverage 92.65% ✅
- [ ] TypeScript: 140 tests pass (`vitest`) ✅
- [ ] Rust: 123 tests pass (`cargo test`) ✅
- [ ] CI green across all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)