### PR TITLE
Track browser link navigation metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -433,18 +433,23 @@ def check_browser_expected_lists(
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"
         for field in (
+            "id",
             "href",
             "resolved_href",
             "name",
             "target",
+            "effective_target",
             "rel",
             "title",
             "download",
             "hreflang",
             "type_hint",
+            "referrerpolicy",
         ):
             require_optional_nullable_string(link_path, link, field, errors)
         require_optional_string_list(link_path, link, "rel_tokens", errors)
+        for field in ("rel_external", "rel_nofollow", "rel_noopener", "rel_noreferrer"):
+            require_optional_boolean(link_path, link, field, errors)
         require_optional_string_list(link_path, link, "ping", errors)
         require_optional_string_list(link_path, link, "resolved_ping", errors)
         require_string(link_path, link, "text", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1378,18 +1378,25 @@ pub struct BrowserHeading {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserLink {
+    pub id: Option<String>,
     pub href: Option<String>,
     pub resolved_href: Option<String>,
     pub name: Option<String>,
     pub target: Option<String>,
+    pub effective_target: Option<String>,
     pub rel: Option<String>,
     pub rel_tokens: Vec<String>,
+    pub rel_external: bool,
+    pub rel_nofollow: bool,
+    pub rel_noopener: bool,
+    pub rel_noreferrer: bool,
     pub title: Option<String>,
     pub download: Option<String>,
     pub ping: Vec<String>,
     pub resolved_ping: Vec<String>,
     pub hreflang: Option<String>,
     pub type_hint: Option<String>,
+    pub referrerpolicy: Option<String>,
     pub text: String,
 }
 
@@ -8733,26 +8740,11 @@ fn collect_browser_facts(
         }
 
         match element.name.as_str() {
-            "a" => summary.links.push(BrowserLink {
-                href: element.attribute("href").map(ToOwned::to_owned),
-                resolved_href: element
-                    .attribute("href")
-                    .and_then(|href| resolve_browser_url(href, summary.base_href.as_deref())),
-                name: element.attribute("name").map(ToOwned::to_owned),
-                target: element.attribute("target").map(ToOwned::to_owned),
-                rel: element.attribute("rel").map(ToOwned::to_owned),
-                rel_tokens: browser_rel_tokens(element),
-                title: element.attribute("title").map(ToOwned::to_owned),
-                download: browser_anchor_download(element),
-                resolved_ping: browser_anchor_ping(element)
-                    .into_iter()
-                    .filter_map(|ping| resolve_browser_url(&ping, summary.base_href.as_deref()))
-                    .collect(),
-                ping: browser_anchor_ping(element),
-                hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
-                type_hint: element.attribute("type").map(ToOwned::to_owned),
-                text: visible_text_for_nodes(&element.children),
-            }),
+            "a" => summary.links.push(browser_link(
+                element,
+                summary.base_href.as_deref(),
+                summary.base_target.as_deref(),
+            )),
             "picture" => {
                 collect_browser_facts(&element.children, summary, labels, &[], body_root);
                 continue;
@@ -9113,6 +9105,44 @@ fn browser_resource_hint_from_link(
         imagesrcset,
         imagesizes: element.attribute("imagesizes").map(ToOwned::to_owned),
     })
+}
+
+fn browser_link(
+    element: &Element,
+    base_href: Option<&str>,
+    base_target: Option<&str>,
+) -> BrowserLink {
+    let target = element.attribute("target").map(ToOwned::to_owned);
+    let rel_tokens = browser_rel_tokens(element);
+    BrowserLink {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        href: element.attribute("href").map(ToOwned::to_owned),
+        resolved_href: element
+            .attribute("href")
+            .and_then(|href| resolve_browser_url(href, base_href)),
+        name: element.attribute("name").map(ToOwned::to_owned),
+        effective_target: target
+            .clone()
+            .or_else(|| base_target.map(ToOwned::to_owned)),
+        target,
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_external: browser_rel_tokens_contain(&rel_tokens, "external"),
+        rel_nofollow: browser_rel_tokens_contain(&rel_tokens, "nofollow"),
+        rel_noopener: browser_rel_tokens_contain(&rel_tokens, "noopener"),
+        rel_noreferrer: browser_rel_tokens_contain(&rel_tokens, "noreferrer"),
+        rel_tokens,
+        title: element.attribute("title").map(ToOwned::to_owned),
+        download: browser_anchor_download(element),
+        resolved_ping: browser_anchor_ping(element)
+            .into_iter()
+            .filter_map(|ping| resolve_browser_url(&ping, base_href))
+            .collect(),
+        ping: browser_anchor_ping(element),
+        hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        text: visible_text_for_nodes(&element.children),
+    }
 }
 
 fn browser_link_resource_hint_kind(rel: Option<&str>) -> Option<String> {
@@ -10316,7 +10346,11 @@ fn browser_link_is_stylesheet(element: &Element) -> bool {
 }
 
 fn browser_rel_contains(element: &Element, token: &str) -> bool {
-    browser_rel_tokens(element)
+    browser_rel_tokens_contain(&browser_rel_tokens(element), token)
+}
+
+fn browser_rel_tokens_contain(tokens: &[String], token: &str) -> bool {
+    tokens
         .iter()
         .any(|candidate| candidate.eq_ignore_ascii_case(token))
 }
@@ -12205,10 +12239,10 @@ mod tests {
     #[test]
     fn browser_anchor_navigation_metadata_tracks_targets_and_pings() {
         let document = parse_html(
-            "<base href=\"https://example.test/docs/current.html\">\
+            "<base href=\"https://example.test/docs/current.html\" target=_parent>\
              <body><p>Go <a id=next href=next.html target=_blank rel=\"next external noopener\" \
              title=\"Next page\" download=next.html ping=\"audit.html https://metrics.example/p\" \
-             hreflang=en-US type=text/html>Next</a></p>",
+             hreflang=en-US type=text/html>Next</a> and <a href=appendix.html>Appendix</a></p>",
         )
         .unwrap();
 
@@ -12219,9 +12253,15 @@ mod tests {
             link.resolved_href.as_deref(),
             Some("https://example.test/docs/next.html")
         );
+        assert_eq!(link.id.as_deref(), Some("next"));
         assert_eq!(link.target.as_deref(), Some("_blank"));
+        assert_eq!(link.effective_target.as_deref(), Some("_blank"));
         assert_eq!(link.rel.as_deref(), Some("next external noopener"));
         assert_eq!(link.rel_tokens, vec!["next", "external", "noopener"]);
+        assert!(link.rel_external);
+        assert!(!link.rel_nofollow);
+        assert!(link.rel_noopener);
+        assert!(!link.rel_noreferrer);
         assert_eq!(link.download.as_deref(), Some("next.html"));
         assert_eq!(link.ping, vec!["audit.html", "https://metrics.example/p"]);
         assert_eq!(
@@ -12233,6 +12273,10 @@ mod tests {
         );
         assert_eq!(link.hreflang.as_deref(), Some("en-US"));
         assert_eq!(link.type_hint.as_deref(), Some("text/html"));
+        assert_eq!(
+            summary.links[1].effective_target.as_deref(),
+            Some("_parent")
+        );
 
         let content_tree = BrowserContentTree::from_document(&document);
         let content_link = &content_tree.children[0].children[1];

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -350,13 +350,25 @@ struct ExpectedHeading {
 
 #[derive(Debug, Deserialize)]
 struct ExpectedLink {
+    #[serde(default)]
+    id: Option<String>,
     href: Option<String>,
     resolved_href: Option<String>,
     name: Option<String>,
     target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
     rel: Option<String>,
     #[serde(default)]
     rel_tokens: Vec<String>,
+    #[serde(default)]
+    rel_external: bool,
+    #[serde(default)]
+    rel_nofollow: bool,
+    #[serde(default)]
+    rel_noopener: bool,
+    #[serde(default)]
+    rel_noreferrer: bool,
     title: Option<String>,
     #[serde(default)]
     download: Option<String>,
@@ -368,6 +380,8 @@ struct ExpectedLink {
     hreflang: Option<String>,
     #[serde(default)]
     type_hint: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
     text: String,
 }
 
@@ -950,18 +964,25 @@ impl ExpectedHeading {
 impl ExpectedLink {
     fn into_browser_link(self) -> BrowserLink {
         BrowserLink {
+            id: self.id,
             href: self.href,
             resolved_href: self.resolved_href,
             name: self.name,
             target: self.target,
+            effective_target: self.effective_target,
             rel: self.rel,
             rel_tokens: self.rel_tokens,
+            rel_external: self.rel_external,
+            rel_nofollow: self.rel_nofollow,
+            rel_noopener: self.rel_noopener,
+            rel_noreferrer: self.rel_noreferrer,
             title: self.title,
             download: self.download,
             ping: self.ping,
             resolved_ping: self.resolved_ping,
             hreflang: self.hreflang,
             type_hint: self.type_hint,
+            referrerpolicy: self.referrerpolicy,
             text: self.text,
         }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -6,7 +6,7 @@
     {
       "id": "legacy-directory-page",
       "description": "Omitted shell, title/base metadata, anchors, navigation attributes, image attributes, and implied list-item endings.",
-      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=\"next external noreferrer\" title=\"Intro\" download=intro.html ping=\"track.html https://metrics.example/p\" hreflang=en type=text/html>Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
+      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=\"next external noreferrer\" title=\"Intro\" download=intro.html ping=\"track.html https://metrics.example/p\" hreflang=en type=text/html referrerpolicy=no-referrer>Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
       "expected": {
         "title": "Example & Links",
         "base_href": "https://example.test/docs/",
@@ -30,7 +30,7 @@
           { "level": 1, "text": "Example Directory" }
         ],
         "links": [
-          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "hreflang": "en", "type_hint": "text/html", "text": "Venture HTML" }
+          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "effective_target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "rel_external": true, "rel_noreferrer": true, "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "hreflang": "en", "type_hint": "text/html", "referrerpolicy": "no-referrer", "text": "Venture HTML" }
         ],
         "images": [
           { "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "width": "88", "height": "31" }


### PR DESCRIPTION
## Summary
- add document-level browser link metadata for ids, effective targets, referrer policy, and authored rel-policy booleans
- centralize anchor link extraction through a browser_link helper while preserving URL and ping resolution
- extend browser-readiness fixture expectations and schema governance for the new link fields

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_anchor_navigation_metadata_tracks_targets_and_pings
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-lexer normalized_html5lib
- cargo test -p coding-adventures-html-parser html5lib_coverage_audit_fixture_matches_checked_local_corpora
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
