### PR TITLE
Surface area links in browser summaries

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -433,6 +433,7 @@ def check_browser_expected_lists(
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"
         for field in (
+            "element",
             "id",
             "href",
             "resolved_href",

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1378,6 +1378,7 @@ pub struct BrowserHeading {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserLink {
+    pub element: String,
     pub id: Option<String>,
     pub href: Option<String>,
     pub resolved_href: Option<String>,
@@ -8739,12 +8740,15 @@ fn collect_browser_facts(
             ));
         }
 
-        match element.name.as_str() {
-            "a" => summary.links.push(browser_link(
+        if is_browser_document_link(element) {
+            summary.links.push(browser_link(
                 element,
                 summary.base_href.as_deref(),
                 summary.base_target.as_deref(),
-            )),
+            ));
+        }
+
+        match element.name.as_str() {
             "picture" => {
                 collect_browser_facts(&element.children, summary, labels, &[], body_root);
                 continue;
@@ -9115,6 +9119,7 @@ fn browser_link(
     let target = element.attribute("target").map(ToOwned::to_owned);
     let rel_tokens = browser_rel_tokens(element);
     BrowserLink {
+        element: element.name.clone(),
         id: element.attribute("id").map(ToOwned::to_owned),
         href: element.attribute("href").map(ToOwned::to_owned),
         resolved_href: element
@@ -9141,7 +9146,23 @@ fn browser_link(
         hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
-        text: visible_text_for_nodes(&element.children),
+        text: browser_link_text(element),
+    }
+}
+
+fn is_browser_document_link(element: &Element) -> bool {
+    element.name == "a" || (element.name == "area" && element.attribute("href").is_some())
+}
+
+fn browser_link_text(element: &Element) -> String {
+    let text = visible_text_for_nodes(&element.children);
+    if text.is_empty() && element.name == "area" {
+        element
+            .attribute("alt")
+            .map(ToOwned::to_owned)
+            .unwrap_or_default()
+    } else {
+        text
     }
 }
 
@@ -12633,6 +12654,33 @@ mod tests {
             default_shape_area.resolved_href.as_deref(),
             Some("https://example.test/gallery/index.html#logo")
         );
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.links.len(), 2);
+        assert_eq!(summary.links[0].element, "area");
+        assert_eq!(summary.links[0].id.as_deref(), Some("cta"));
+        assert_eq!(summary.links[0].href.as_deref(), Some("details.html"));
+        assert_eq!(
+            summary.links[0].resolved_href.as_deref(),
+            Some("https://example.test/gallery/details.html")
+        );
+        assert_eq!(summary.links[0].text, "Details");
+        assert_eq!(summary.links[0].rel_tokens, vec!["nofollow", "external"]);
+        assert!(summary.links[0].rel_nofollow);
+        assert!(summary.links[0].rel_external);
+        assert_eq!(summary.links[0].target.as_deref(), Some("preview"));
+        assert_eq!(
+            summary.links[0].effective_target.as_deref(),
+            Some("preview")
+        );
+        assert_eq!(summary.links[0].ping, vec!["track.html".to_string()]);
+        assert_eq!(
+            summary.links[0].resolved_ping,
+            vec!["https://example.test/gallery/track.html".to_string()]
+        );
+        assert_eq!(summary.links[1].element, "area");
+        assert_eq!(summary.links[1].href.as_deref(), Some("#logo"));
+        assert_eq!(summary.links[1].text, "Logo");
 
         let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
         assert_eq!(render_tree.children[1].display, "none");

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -350,6 +350,8 @@ struct ExpectedHeading {
 
 #[derive(Debug, Deserialize)]
 struct ExpectedLink {
+    #[serde(default = "default_browser_link_element")]
+    element: String,
     #[serde(default)]
     id: Option<String>,
     href: Option<String>,
@@ -964,6 +966,7 @@ impl ExpectedHeading {
 impl ExpectedLink {
     fn into_browser_link(self) -> BrowserLink {
         BrowserLink {
+            element: self.element,
             id: self.id,
             href: self.href,
             resolved_href: self.resolved_href,
@@ -986,6 +989,10 @@ impl ExpectedLink {
             text: self.text,
         }
     }
+}
+
+fn default_browser_link_element() -> String {
+    "a".to_string()
 }
 
 impl ExpectedImage {

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -95,7 +95,7 @@
     {
       "id": "responsive-image-metadata-page",
       "description": "Browser document image summaries expose responsive source selection metadata and loading hints.",
-      "input": "<base href=\"https://example.test/gallery/index.html\"><body><picture><source media=\"(min-width: 800px)\" type=image/avif srcset=\"hero-wide.avif 1x, hero-wide@2x.avif 2x\" sizes=\"80vw\"><source media=\"(min-width: 400px)\" type=image/webp srcset=\"hero.webp 640w, hero-large.webp 1280w\" sizes=\"100vw\"><img src=hero.jpg srcset=\"hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w\" sizes=\"(max-width: 600px) 100vw, 50vw\" alt=\"Hero\" width=640 height=360 loading=lazy decoding=async fetchpriority=high crossorigin=anonymous referrerpolicy=no-referrer usemap=#hero-map ismap></picture>",
+      "input": "<base href=\"https://example.test/gallery/index.html\"><body><picture><source media=\"(min-width: 800px)\" type=image/avif srcset=\"hero-wide.avif 1x, hero-wide@2x.avif 2x\" sizes=\"80vw\"><source media=\"(min-width: 400px)\" type=image/webp srcset=\"hero.webp 640w, hero-large.webp 1280w\" sizes=\"100vw\"><img src=hero.jpg srcset=\"hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w\" sizes=\"(max-width: 600px) 100vw, 50vw\" alt=\"Hero\" width=640 height=360 loading=lazy decoding=async fetchpriority=high crossorigin=anonymous referrerpolicy=no-referrer usemap=#hero-map ismap></picture><map name=hero-map><area shape=rect coords=\"0,0,120,60\" href=details.html alt=\"Details\" target=preview rel=\"nofollow external\" ping=\"track.html\" hreflang=en></map>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/gallery/index.html",
@@ -107,7 +107,9 @@
         ],
         "anchors": [],
         "headings": [],
-        "links": [],
+        "links": [
+          { "element": "area", "href": "details.html", "resolved_href": "https://example.test/gallery/details.html", "name": null, "target": "preview", "effective_target": "preview", "rel": "nofollow external", "rel_tokens": ["nofollow", "external"], "rel_external": true, "rel_nofollow": true, "title": null, "ping": ["track.html"], "resolved_ping": ["https://example.test/gallery/track.html"], "hreflang": "en", "text": "Details" }
+        ],
         "images": [
           {
             "src": "hero.jpg",


### PR DESCRIPTION
## Summary
- include image-map area navigation entries in document-level browser link summaries
- add a link element discriminator while preserving default anchor expectations for existing fixtures
- use area alt text as the document-summary link text and extend browser-readiness/schema coverage

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_image_map_metadata_tracks_map_areas_and_navigation
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
