### PR TITLE
feat(mosaic-pkg-grid): v0.2.0 — UI28-1 cell-and-column composition complete

### DIFF
--- a/code/packages/mosaic-pkg-grid/CHANGELOG.md
+++ b/code/packages/mosaic-pkg-grid/CHANGELOG.md
@@ -4,6 +4,116 @@ All notable changes to `mosaic-pkg-grid` are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/) and
 the package follows semantic versioning.
 
+## 0.2.0 — 2026-05-25 — UI28-1 cell-and-column composition complete
+
+The v0.1.0 scaffold finishes. The two declared v0.1.0 follow-ups
+(empty header row; body shows only `row`, not per-column cells) are
+both closed. Grid now renders ALL cells across both axes, the header
+row carries one `<th>` per column, the `<colgroup>` carries per-
+column widths, and per-cell selection / editing predicates are
+computed at the Cell call site without spilling the comparison logic
+to either the host (encapsulation upward) or to Cell (encapsulation
+downward).
+
+This is the version UI28-1 §3 specifies — the userland-Grid
+counterpart to UI28's never-shipped Cell-as-kernel-primitive draft.
+
+### Added
+
+- **`Cell.mil`** gains an `is-selected: bool` slot. The Cell.mll
+  layout doesn't branch on it directly — sub-part styling
+  (`cell:selected`) does — but the slot has to be declared so Grid
+  can thread the value through the component-ref boundary.
+- **`Grid.mil`** gains two parallel-array slots:
+  - `column-headers : list<text>` — one header label per column.
+  - `column-widths  : list<number>` — pixel width per column.
+  Per UI28-1 §9 open-question note: parallel arrays are a v0.2.0
+  pragmatism. mosmodel doesn't yet support record types, so we
+  cannot declare `list<column-meta>`. v0.3.0 migrates.
+- **`Grid.mll`** is the headline change. It now contains:
+  - **`HostTableColGroup`** section with `For (each: slot:
+    column-widths, ...)` driving one `<col width>` per column.
+  - **`HostTableHead`** section with `For (each: slot:
+    column-headers, ...)` rendering the header row — previously
+    empty.
+  - **`HostTableBody`** with nested For: outer over rows, inner
+    over each row's cells. The inner uses UI29 §3.4 (For-binding-
+    as-iterable: `For (each: row, as: v, index: c)` — landed in
+    [PR #4398](https://github.com/adhithyan15/coding-adventures/pull/4398)).
+    Each Cell receives its `(r, c)`-determined `value` plus the
+    predicate-computed `is-editing` / `is-selected` booleans.
+- **Per-cell predicates via expression-in-slot-binding** at the
+  Cell call site:
+  - `is-editing: ( r == editRow && c == editCol )`
+  - `is-selected: ( r == selectedRow && c == selectedCol )`
+  The `(...)` grouping triggers the moslayout-compiler's Expr
+  branch (UI29 §3.3); the expression text passes verbatim into the
+  target language at each emitter.
+- **Stable iteration keys** flow through every For via explicit
+  `index:` bindings (`cw`, `ch`, `r`, `c`). Each emitter threads
+  these into its framework-native list key: React `key={r}` (UI28-1
+  §6.3, [PR #4396](https://github.com/adhithyan15/coding-adventures/pull/4396)),
+  Flutter `KeyedSubtree(ValueKey(r))` (§6.2, [PR #4393](https://github.com/adhithyan15/coding-adventures/pull/4393)),
+  SwiftUI `ForEach(id: \.offset)`, Qt `Repeater` index property,
+  XAML `ItemsRepeater` x:Bind. HTML/WebComponent are static so no
+  key is needed.
+- **7 new tests** added to `tests/package_compiles.rs`:
+  - `ui28_1_cell_declares_is_selected_slot`
+  - `ui28_1_grid_declares_column_headers_and_widths_slots`
+  - `ui28_1_grid_mll_uses_nested_for_via_u29_3_4_scope` (the
+    end-to-end regression guard for PR #4398's scope walker)
+  - `ui28_1_grid_mll_predicate_uses_expression_in_slot_binding`
+  - `ui28_1_grid_mll_has_colgroup_section_for_column_widths`
+  - `ui28_1_grid_mll_header_for_renders_column_headers`
+  - `ui28_1_no_new_kernel_primitive_was_added` (sanity guard:
+    every tag in our .mll files is either UI29 kernel or this
+    package's userland Cell/Column — Cell-as-component per UI28-1
+    §2 constraint 1 must hold)
+
+  Total tests: 12 (was 5, +7). All green.
+
+### Changed
+
+- **`Cell.mil`** preamble rewritten to spell out the encapsulation
+  contract (UI28-1 §2 constraint 4): the host pushes plain
+  coordinate numbers, Grid composes per-cell predicates, Cell
+  receives bools.
+- **`Grid.mil`** preamble rewritten to enumerate the v0.2.0
+  changes, document the slot vocabulary's parallel-array shape,
+  and note the upcoming v0.3.0 record-type migration path.
+- **`Grid.mll`** preamble explains the composition end-to-end:
+  primitive map, why each section exists, how per-cell predicates
+  resolve, where stable keys live, what's out of scope for v0.2.0
+  (sticky-header, custom renderers, list virtualization inside
+  Grid, etc.).
+
+### Enabled by — three landed dependencies
+
+This release was unblocked by three companion PRs that ship the
+mechanical capabilities Grid v0.2.0 builds on. Every one of them
+ships kernel-mechanism work — none promote new kernel primitives:
+
+- **[PR #4388](https://github.com/adhithyan15/coding-adventures/pull/4388)** — UI28-1 spec (the authoritative design)
+- **[PR #4393](https://github.com/adhithyan15/coding-adventures/pull/4393)** — Flutter For/If/Else lowering (§6.2)
+- **[PR #4396](https://github.com/adhithyan15/coding-adventures/pull/4396)** — React For auto-key from `index:` (§6.3)
+- **[PR #4398](https://github.com/adhithyan15/coding-adventures/pull/4398)** — UI29 §3.4 For-loop binding scope + 5-emitter Keyword arm (§6.1)
+
+### Known limitations / out of scope
+
+The list from UI28-1 §7, restated here for the changelog reader:
+
+- **Sticky header** — author composes `HostScroll { Grid {...} }`
+  themselves. Deferred per UI28-1 §2 constraint 5.
+- **Custom cell renderers** (image, button, checkbox, sparkline) —
+  v0.3.0 will extend Cell's `cell-type` to switch.
+- **Column groups, sortable headers, pinned columns** — each its
+  own design problem (UI28-2).
+- **List virtualization INSIDE Grid** — needs a `HostVirtualList`
+  kernel primitive. Today the HOST slices to viewport before
+  pushing, which works fine for the VisiCalc-scale (100×26).
+- **Mosmodel record type** — when it lands, `column-headers` +
+  `column-widths` collapse to `columns: list<column-meta>`.
+
 ## 0.1.0 — 2026-05-19
 
 Initial release. Exports Grid, Cell, Column. Built on UI29 kernel

--- a/code/packages/mosaic-pkg-grid/Cargo.toml
+++ b/code/packages/mosaic-pkg-grid/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name        = "mosaic-pkg-grid"
-version     = "0.1.0"
+version     = "0.2.0"
 edition     = "2021"
 description = "Smoke-test harness for the mosaic-pkg-grid component package"
 publish     = false

--- a/code/packages/mosaic-pkg-grid/README.md
+++ b/code/packages/mosaic-pkg-grid/README.md
@@ -64,47 +64,97 @@ React's ecosystem treats data-grid libraries as userland.
 * The smoke test at `tests/package_compiles.rs` round-trips every source
   file through its respective compiler crate.
 
-## v0.2.0 caveats (deliberate scope cuts)
+## v0.2.0 — what's done (the v0.1.0 caveats are CLOSED)
 
-* **Header row is empty.**  `Grid.mll`'s `HostTableHead` contains a Row
-  with no cells.  Rendering one `<th>` per declared Column requires
-  Grid's interface to accept a `columns` list slot so a
-  `For (each: slot: columns, as: col)` can drive the header.
-* **Body emits ONE Cell per row.**  Each row shows `row` (the For-bound
-  iteration variable resolved as a Keyword-valued prop), not `row[0]`,
-  `row[1]`, ... — full per-column iteration needs the same `columns`
-  slot, plus the expression-grammar `row[c]` field-access syntax that
-  UI29 §3.3 defines but UI29-G3 has not yet landed.
-* **No theming cascade.**  The package ships `dark.msl` only; light-mode
-  styles and host overrides arrive once the multi-theme cascade lands
-  in mosstyle.
+v0.1.0 shipped a working scaffold with two declared follow-ups. As of
+v0.2.0 (per [UI28-1](../../specs/UI28-1-grid-v3-userland-revised.md)),
+both are CLOSED:
 
-These are not bugs.  The architecture (manifest-driven, kernel-
-primitive-only composition, backend-agnostic) is what v0.1.0 proves;
-v0.2.0 fills in the Grid behaviour once the underlying grammar and
-resolver PRs land.
+* **Header row renders.** `Grid.mll`'s `HostTableHead` now contains
+  `For (each: slot: column-headers, as: h)` producing one `<th>` per
+  column. Grid.mil gained a `column-headers: list<text>` slot.
+* **Body iterates per-column.** The body is nested-For now:
+  `For (each: slot: viewport-rows, as: row) { Row { For (each: row,
+  as: v) { Cell ( value: ( v ), ... ) } } }`. The inner
+  `For ( each: row, ... )` is the UI29 §3.4 "For-binding-as-iterable"
+  shape ([PR #4398](https://github.com/adhithyan15/coding-adventures/pull/4398)).
+* **`<colgroup>` carries per-column widths.** `HostTableColGroup`
+  with `For (each: slot: column-widths, as: w)` emits one `<col>`
+  per column with its declared width.
 
-## Usage (conceptual; resolver lands in U29-R2)
+Per-cell `is-editing` / `is-selected` predicates are computed at the
+Cell call site using expression-in-slot-binding:
+
+```
+is-editing:  ( r == editRow && c == editCol )
+is-selected: ( r == selectedRow && c == selectedCol )
+```
+
+The host pushes only the plain coordinate slots (`edit-row`,
+`selected-col`, …). Grid is the encapsulation boundary that converts
+coordinates → per-cell booleans. Cell receives booleans, never
+coordinates.
+
+## What's still out of scope (deferred to UI28-2 / v0.3.0)
+
+* **Sticky header.** Authors compose `HostScroll { Grid { ... } }`
+  themselves (UI28-1 §2 constraint 5).
+* **Custom cell renderers** (image, button, checkbox, sparkline).
+  v0.3.0 extends Cell's `cell-type` to switch.
+* **Column groups, sortable headers, pinned columns.** UI28-2.
+* **List virtualization INSIDE Grid.** Today the host slices to
+  viewport before pushing — `viewport-rows` IS the visible window.
+* **Mosmodel record type.** When it lands, the parallel
+  `column-headers` + `column-widths` slots collapse to
+  `columns: list<column-meta>`.
+* **Multi-theme cascade.** Ships `dark.msl` only; light-mode and
+  host overrides arrive once the mosstyle cascade lands.
+
+## Usage (v0.2.0, working end-to-end)
+
+The host declares the data + viewport coordinates as slots and wires
+emits to its reducer. The Grid does the rest:
 
 ```moslayout
 // In a host component's .mll:
 layout SpreadsheetApp {
   Column [ root ] {
     Grid (
-      viewport-rows: slot: data-rows ,
-      edit-row:      slot: app-edit-row ,
-      edit-col:      slot: app-edit-col ,
-      onEditCommit:  emit: handleCommit
-    ) {
-      // Future v0.2.0: Column children declare the columns.
-      Column ( key: "name",  header: "Name",  width: 120 , editable: true ,
-               cell-type: "text" , default-alignment: "left" )
-      Column ( key: "price", header: "Price", width:  80 , editable: true ,
-               cell-type: "number" , default-alignment: "right" )
-    }
+      viewport-rows:  slot: viewport-rows ,
+      column-headers: slot: column-headers ,
+      column-widths:  slot: column-widths ,
+      selected-row:   slot: app-selected-row ,
+      selected-col:   slot: app-selected-col ,
+      edit-row:       slot: app-edit-row ,
+      edit-col:       slot: app-edit-col ,
+      edit-content:   slot: app-edit-content ,
+      onNavigate:     emit: handleNavigate ,
+      onEditCommit:   emit: handleCommit ,
+      onEditCancel:   emit: handleCancel
+    )
   }
 }
 ```
+
+Grid produces semantic table markup on every backend that has the
+UI31 HostTable lowering — React `<table>`, HTML `<table>`,
+WebComponent shadow-DOM `<table>`, Flutter `DataTable`, Qt `TableView`
+/ `Repeater`, SwiftUI `Grid` / `Table`, XAML `ItemsRepeater` with row
+view-models.
+
+### What the host pushes
+
+* `viewport-rows: list<list<text>>` — sliced to the visible window;
+  one inner list per displayed row, one cell per column. Grid
+  iterates BOTH axes per-render.
+* `column-headers: list<text>` — header labels, one per column,
+  parallel-shaped to each `viewport-rows[r]`.
+* `column-widths: list<number>` — pixel widths, parallel-shaped to
+  column-headers. Drives the `<colgroup>`.
+* `selected-row` / `selected-col` / `edit-row` / `edit-col` —
+  plain numbers, `-1` means "none". Grid composes per-cell
+  `is-editing` / `is-selected` from these internally.
+* `edit-content: text` — the in-progress edit buffer the host owns.
 
 ## Smoke test
 
@@ -130,14 +180,18 @@ userland component references.
 
 ## Position in UI29's roadmap
 
-* **U29-P1 (this package)**: ship the source tree, declare the manifest,
-  prove the smoke test.
-* **U29-D1**: migrate `demo/visicalc` to import this package's `Grid`
-  instead of carrying its own bespoke copy.
-* **U29-X1**: remove dead `emit_grid_jsx_*` / `emit_input_jsx` /
-  `emit_cell_jsx_*` / `emit_column_jsx_*` from every backend now that
-  Grid is userland and only kernel-primitive lowering is on the
-  critical path.
+* **U29-P1**: ship the source tree, declare the manifest, prove the
+  smoke test. **Done in v0.1.0.**
+* **UI28-1 v0.2.0 (this release)**: complete the Cell-and-Column
+  composition — full header row, nested-For body, per-cell
+  predicates, stable iteration keys. **Done.**
+* **U29-D1**: migrate `demo/visicalc/mosaic/Grid.{desktop,touch}.mll`
+  to reference this package's `Grid` (replacing the local degraded
+  HostTable composition the L10 migration shipped). Next.
+* **U29-X1**: remove the legacy `Grid` built-in primitive from
+  `moslayout-compiler::PRIMITIVES` + its special-case lowering in
+  `mosaic-emit-react`, now that Grid is fully userland and only
+  kernel-primitive lowering is on the critical path.
 
 ## License
 

--- a/code/packages/mosaic-pkg-grid/mosaic-package.toml
+++ b/code/packages/mosaic-pkg-grid/mosaic-package.toml
@@ -8,8 +8,8 @@
 
 [package]
 name = "mosaic-pkg-grid"
-version = "0.1.0"
-description = "Spreadsheet-style data grid built on UI29 kernel primitives"
+version = "0.2.0"
+description = "Spreadsheet-style data grid built on UI29 kernel primitives (UI28-1 §3 composition)"
 license = "MIT OR Apache-2.0"
 
 [components]

--- a/code/packages/mosaic-pkg-grid/src/Cell.mil
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mil
@@ -5,6 +5,29 @@
 // the is-editing slot.  Composed by Grid; usable standalone if a host
 // wants a one-off editable cell outside a Grid.
 //
+// v0.2.0 changes
+// --------------
+//
+//   Added `is-selected: bool` so the cell can style itself differently
+//   when the host (via Grid) has flagged it as the currently-selected
+//   cell.  The Cell.mll layout doesn't branch on it — the sub-part
+//   styling (`cell:selected`) does — but the slot has to be declared
+//   for Grid to thread the value in through the component-ref boundary.
+//
+// Encapsulation contract (UI28-1 §2 constraint 4)
+// -----------------------------------------------
+//
+//   The host does NOT compute per-cell `is-editing` / `is-selected`
+//   booleans.  The host pushes plain coordinate numbers (`edit-row`,
+//   `edit-col`, `selected-row`, `selected-col`) to the *Grid*, and the
+//   Grid composes the predicate at the Cell call site using
+//   expression-in-slot-binding:
+//
+//     Cell ( is-editing: ( r == editRow && c == editCol ) , ... )
+//
+//   Cell receives the bool result.  Cell never learns anything about
+//   Grid's internal cell-coordinate mechanics.
+//
 // Slot vocabulary
 // ---------------
 //   value         the text currently displayed (and the seed for the
@@ -13,10 +36,14 @@
 //                 (advisory; the Grid host enforces the policy by setting
 //                 is-editing or not)
 //   is-editing    when true, the cell renders HostInput; otherwise Text
+//   is-selected   when true, the cell is the host's currently-selected
+//                 cell.  Used by the sub-part styling system
+//                 (`cell:selected`) to render a highlight; the Cell.mll
+//                 layout itself does not branch on it.
 //   alignment     visual alignment hint ("left" | "right" | "center")
 //   cell-type     advisory type hint ("text" | "number"); v1 treats both
 //                 the same — number-specific formatting/validation is a
-//                 v0.2.0 concern
+//                 v0.3.0 concern
 //
 // Emit vocabulary
 // ---------------
@@ -26,11 +53,12 @@
 //   onCancel      fired when an in-progress edit is abandoned
 
 component Cell {
-  slot value      : text ;
-  slot editable   : bool ;
-  slot is-editing : bool ;
-  slot alignment  : text ;
-  slot cell-type  : text ;
+  slot value       : text ;
+  slot editable    : bool ;
+  slot is-editing  : bool ;
+  slot is-selected : bool ;
+  slot alignment   : text ;
+  slot cell-type   : text ;
 
   emit onClick ;
   emit onCommit ( value : text ) ;

--- a/code/packages/mosaic-pkg-grid/src/Grid.mil
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mil
@@ -1,38 +1,91 @@
 // Grid.mil — interface for the spreadsheet-style data grid.
 //
-// Grid is the headline composition of UI29: a Cell-and-Column composer
-// built entirely from kernel primitives (HostTable + HostTableHead +
-// HostTableBody + Row + For + Cell).  No bespoke per-backend code; the
-// React, SwiftUI, Qt, WebComponent and HTML emitters lower this purely
-// by running their kernel-primitive lowerings.
+// Grid is the headline composition of UI28-1: a Cell-and-Column
+// composer built entirely from kernel primitives (HostTable +
+// HostTableColGroup + HostTableHead + HostTableBody + Row + For +
+// HostInput + If/Else + Box + Text) plus the userland Cell + Column
+// components from this same package.
+//
+// No bespoke per-backend code.  Every Mosaic backend (React, HTML,
+// WebComponent, Flutter, Qt, SwiftUI, XAML) lowers this purely by
+// running its kernel-primitive lowerings.  The three enabling
+// dependencies UI28-1 §6 names are all live on main as of v0.2.0:
+//
+//   - §6.1 UI29 §3.4 For-binding scope (PR #4398)
+//   - §6.2 Flutter For/If/Else lowering (PR #4393)
+//   - §6.3 React For auto-key from `index:` (PR #4396)
+//
+// v0.2.0 changes from v0.1.0
+// --------------------------
+//
+//   Added two parallel-array column slots so the header row can
+//   actually render and per-column widths reach the `<colgroup>`:
+//
+//     slot column-headers : list<text>    one header label per column
+//     slot column-widths  : list<number>  pixel width per column
+//
+//   UI28-1 §9 calls this out as a v0.2.0 pragmatism — record types
+//   would let us declare `list<column-meta>` instead of two parallel
+//   arrays, but mosmodel doesn't have records yet (a v0.3.0 language
+//   concern).  Parallel arrays let the host wire concrete data today.
+//
+//   The Grid layout (Grid.mll) now does the **nested** body iteration
+//   that v0.1.0 deferred: outer For over rows, inner For over each
+//   row's cells, producing one Cell per (row, col) intersection.  This
+//   uses UI29 §3.4 (For-binding-as-iterable in nested For's `each:`)
+//   which landed in PR #4398.
 //
 // Slot vocabulary
 // ---------------
+//
 //   viewport-rows   the data to render, one inner list per row.  Each
-//                   row[c] is the cell text for column c.  In v0.1.0
-//                   only row[0] is wired (see Grid.mll comment) — full
-//                   per-column iteration arrives with the v0.2.0
-//                   `columns` metadata slot.
-//   selected-row    the row index currently selected (for highlight)
-//   selected-col    the column index currently selected (for highlight)
-//   edit-row        the row index currently being edited (-1 = none)
-//   edit-col        the column index currently being edited (-1 = none)
+//                   row[c] is the cell text for column c.  In v0.2.0
+//                   ALL cells render (was: row[0] only in v0.1.0).
+//                   The host slices to the viewport BEFORE pushing,
+//                   so a 1,000,000-row sheet with a 30-row viewport
+//                   pushes a 30-row viewport-rows per render.
+//   column-headers  one header label per column.  Drives the `<thead>`
+//                   row.  Must be parallel-shaped to column-widths
+//                   AND to each viewport-rows[r]'s length.
+//   column-widths   per-column pixel widths.  Threaded through the
+//                   `<colgroup>` (or the platform equivalent) so cells
+//                   align even when content is short.
+//   selected-row    the row index currently selected (for highlight).
+//                   -1 = none.
+//   selected-col    the column index currently selected (-1 = none).
+//   edit-row        the row index currently being edited (-1 = none).
+//   edit-col        the column index currently being edited (-1 = none).
 //   edit-content    the in-progress edit value (echoed back to the cell
-//                   so the host owns the edit-buffer state)
+//                   so the host owns the edit-buffer state).
 //
 // Emit vocabulary
 // ---------------
-//   onNavigate      fired when a different cell is activated
-//   onEditCommit    fired when the in-progress edit confirms
-//   onEditCancel    fired when the in-progress edit is abandoned
+//
+//   onNavigate      fired when a cell is clicked.  Payload (row, col)
+//                   is the clicked-cell coordinate.  The host updates
+//                   selected-row / selected-col in response.
+//   onEditCommit    fired when an in-progress edit confirms (Enter).
+//   onEditCancel    fired when an in-progress edit is abandoned (Esc).
+//
+// Encapsulation note (UI28-1 §2 constraint 4)
+// -------------------------------------------
+//
+// The host pushes ONLY the plain coordinate numbers (`edit-row`,
+// `edit-col`, `selected-row`, `selected-col`).  The host does NOT
+// compute per-cell `is-editing` / `is-selected` masks — Grid does that
+// internally at the Cell call site using expression-in-slot-binding
+// (see Grid.mll's body Cell args).  Host code stays portable across
+// any Grid implementation that exposes the same slot interface.
 
 component Grid {
-  slot viewport-rows : list<list<text>> ;
-  slot selected-row  : number ;
-  slot selected-col  : number ;
-  slot edit-row      : number ;
-  slot edit-col      : number ;
-  slot edit-content  : text ;
+  slot viewport-rows  : list<list<text>> ;
+  slot column-headers : list<text> ;
+  slot column-widths  : list<number> ;
+  slot selected-row   : number ;
+  slot selected-col   : number ;
+  slot edit-row       : number ;
+  slot edit-col       : number ;
+  slot edit-content   : text ;
 
   emit onNavigate    ( row : number , col : number ) ;
   emit onEditCommit  ( value : text ) ;

--- a/code/packages/mosaic-pkg-grid/src/Grid.mll
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mll
@@ -1,56 +1,145 @@
-// Grid.mll — layout for the spreadsheet-style data grid.
+// Grid.mll — layout for the spreadsheet-style data grid (v0.2.0).
 //
-// Composition (kernel primitives only):
+// Composition (kernel primitives + this package's Cell only):
 //
-//   HostTable [sheet]                  ← semantic data table (UI29 §2.1)
-//     HostTableHead
-//       Row                            ← header row (intentionally empty
-//                                        in v0.1.0 — see note below)
-//     HostTableBody
-//       For (each: slot: viewport-rows, as: row, index: r)
-//         Row [data-row]
-//           Cell [body] ( value: row, ... )
+//   HostTable [sheet]                  ← semantic data table
+//     HostTableColGroup                ← <colgroup> + <col> per column
+//       For ( each: slot: column-widths, as: w, index: cw )
+//         Col [ col ] ( width: ( w ) )
+//     HostTableHead                    ← <thead>
+//       Row [ header-row ]             ← <tr>
+//         For ( each: slot: column-headers, as: h, index: ch )
+//           Box [ header-cell ]        ← <th>
+//             Text ( content: ( h ) )
+//     HostTableBody                    ← <tbody>
+//       For ( each: slot: viewport-rows, as: row, index: r )
+//         Row [ data-row ]             ← <tr>
+//           For ( each: row, as: v, index: c )    ← UI29 §3.4
+//             Cell ( value: ( v ), is-editing: ( r == editRow && c == editCol ),
+//                    is-selected: ( r == selectedRow && c == selectedCol ),
+//                    editable: true, alignment: "left", cell-type: "text",
+//                    onClick: emit: onNavigate, onCommit: emit: onEditCommit,
+//                    onCancel: emit: onEditCancel )
 //
-// Why this shape?  HostTable carries the screen-reader-accessible
-// `<table role="grid">` semantics that "div-soup" cannot provide.
-// HostTableHead / HostTableBody select the `<thead>` / `<tbody>`
-// children.  Row maps to `<tr>` (or SwiftUI's row builder / Qt's row
-// delegate).  For iterates the data slot; Cell is the userland Cell
-// component from this same package.
+// Why this shape
+// --------------
 //
-// v0.1.0 caveats (intentional — full fix in v0.2.0)
-// -------------------------------------------------
-//   1. Header row is left empty.  Rendering one `<th>` per declared
-//      Column requires Grid's interface to accept a `columns` list slot
-//      so a `For (each: slot: columns, ...)` can drive the header — out
-//      of scope for v0.1.0.
-//   2. Body emits ONE Cell per row, displaying `row` (which here
-//      resolves to a NAME-valued prop — Keyword("row") — picked up by
-//      the resolver as the For-bound iteration variable).  Full
-//      per-column iteration also needs the `columns` slot.
+// HostTable carries the screen-reader-accessible `<table role="grid">`
+// semantics that "div-soup" cannot provide.  HostTableColGroup /
+// HostTableHead / HostTableBody select the matching `<colgroup>` /
+// `<thead>` / `<tbody>` children.  Col is the cell-definition sub-tag
+// inside `<colgroup>` (UI31 §3.2).  Row maps to `<tr>` (or SwiftUI's
+// row builder, Qt's row delegate, Flutter's DataRow).  For iterates
+// each data slot; Cell is the userland Cell component from this same
+// package; HostInput inside Cell provides inline edit.
 //
-// IMPORTANT (UI29-P1, v0.1.0): `For`, `HostTable`, `HostTableHead`,
-// `HostTableBody`, `Row`, and `Cell` are all NAME tokens in the current
-// moslayout grammar, so this file parses today.  Backend emitters lower
-// them as their respective U29-K-* PRs land; until then the artifact
-// builder may refuse Grid.  That is expected.
+// What v0.2.0 finishes that v0.1.0 deferred
+// ------------------------------------------
+//
+//   1. Header row now renders — `For (each: slot: column-headers, ...)`
+//      drives one `<th>` per column.
+//   2. Body now renders ALL cells per row via NESTED For — the inner
+//      `For ( each: row, as: v, index: c )` uses UI29 §3.4 (For-binding
+//      as the inner loop's iterable) which landed in PR #4398.  Each
+//      Cell receives its (r, c)-determined `value`, plus the predicate-
+//      computed `is-editing` / `is-selected` booleans.
+//   3. Column widths reach the `<colgroup>` — the outer
+//      `For (each: slot: column-widths, ...)` emits one `<col width>`
+//      per column.  When omitted at the HTML / WebComponent layer, the
+//      table auto-sizes; explicit widths give stable column widths
+//      independent of content.
+//
+// Per-cell predicates: where does the comparison live?
+// ----------------------------------------------------
+//
+// The host pushes the *coordinate* slots only (`edit-row`, `edit-col`,
+// `selected-row`, `selected-col`).  Grid is the encapsulation boundary
+// that turns those into per-Cell booleans.  The comparison is done
+// using **expression-in-slot-binding** at the Cell call site:
+//
+//   is-editing:  ( r == editRow && c == editCol )
+//   is-selected: ( r == selectedRow && c == selectedCol )
+//
+// The `(...)` grouping triggers the moslayout-compiler's Expr branch
+// (UI29 §3.3), so the expression text passes verbatim into the target
+// language.  At runtime:
+//
+//   - `r` and `c` are the .map / ForEach / Repeater loop variables
+//     (the camelCased `as:` / `index:` bindings — single letters here
+//     so the Expr text is target-language-clean without further
+//     transformation).
+//   - `editRow`, `editCol`, `selectedRow`, `selectedCol` are the
+//     camelCased slot names — every backend's slot-reference lowering
+//     produces these identifiers, so the Expr resolves correctly in
+//     the target component's scope.
+//
+// Stable iteration keys (performance)
+// -----------------------------------
+//
+// Every For binds an explicit `index:` (`cw`, `ch`, `r`, `c`) so each
+// backend's For lowering threads it into the framework-native list
+// key:
+//
+//   - React           — `key={r}` / `key={c}` on each <React.Fragment>
+//                       (auto-emitted by mosaic-emit-react via UI28-1
+//                       §6.3 / PR #4396).
+//   - SwiftUI         — `ForEach(..., id: \.offset)` keyed by index.
+//   - Flutter         — `KeyedSubtree(key: ValueKey(r), ...)`
+//                       (UI28-1 §6.2 / PR #4393).
+//   - Qt              — Repeater delegate's `property int index`.
+//   - HTML / WebComp  — static-rendered, no key needed.
+//   - XAML            — `ItemsRepeater` consumes the index via
+//                       `x:Bind` on the row-VM property.
+//
+// This is the UI28-1 §5 performance property.  For VisiCalc-scale
+// data (100 rows × 26 cols = 2,600 keyed cells) the React diff cost
+// drops from O(n) to O(1) per render.
+//
+// What is NOT in v0.2.0 (deferred to UI28-2)
+// ------------------------------------------
+//
+//   - Sticky header.  Per UI28-1 §2 constraint 5.  Authors compose
+//     `HostScroll { Grid { ... } }` themselves or wait.
+//   - Custom cell renderers (image, button, checkbox, sparkline).
+//     v0.3.0 extends Cell's `cell-type` to switch.
+//   - List virtualization INSIDE Grid (renders only visible rows of
+//     a large viewport-rows).  Today, the host slices to viewport
+//     before pushing — `viewport-rows` IS the visible window.
+//   - Mosmodel record type so `columns: list<column-meta>` replaces
+//     parallel-array `column-headers` + `column-widths`.
 
 layout Grid {
   HostTable [ sheet ] {
+    HostTableColGroup {
+      For ( each: slot: column-widths , as: w , index: cw ) {
+        Col [ col ] ( width: ( w ) )
+      }
+    }
     HostTableHead {
-      Row { }
+      Row [ header-row ] {
+        For ( each: slot: column-headers , as: h , index: ch ) {
+          Box [ header-cell ] {
+            Text ( content: ( h ) )
+          }
+        }
+      }
     }
     HostTableBody {
       For ( each: slot: viewport-rows , as: row , index: r ) {
         Row [ data-row ] {
-          Cell [ body ] (
-            value:      row ,
-            editable:   true ,
-            is-editing: slot: edit-row ,
-            onCommit:   emit: onEditCommit ,
-            onCancel:   emit: onEditCancel ,
-            onClick:    emit: onNavigate
-          )
+          For ( each: row , as: v , index: c ) {
+            Cell [ body ] (
+              value:        ( v ) ,
+              is-editing:   ( r == editRow && c == editCol ) ,
+              is-selected:  ( r == selectedRow && c == selectedCol ) ,
+              editable:     true ,
+              alignment:    "left" ,
+              cell-type:    "text" ,
+              onClick:      emit: onNavigate ,
+              onCommit:     emit: onEditCommit ,
+              onCancel:     emit: onEditCancel
+            )
+          }
         }
       }
     }

--- a/code/packages/mosaic-pkg-grid/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-grid/tests/package_compiles.rs
@@ -92,7 +92,7 @@ fn manifest_declares_expected_exports() {
         .and_then(|p| p.get("version"))
         .and_then(|v| v.as_str())
         .expect("[package].version must be set");
-    assert_eq!(version, "0.1.0", "[package].version must be 0.1.0 for U29-P1");
+    assert_eq!(version, "0.2.0", "[package].version must be 0.2.0 for the UI28-1 cell-and-column composition release");
 
     // [components].exports
     let exports = value
@@ -221,6 +221,193 @@ fn each_msl_compiles_against_its_part_map() {
 // ---------------------------------------------------------------------------
 // 5. Source-shape sanity
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// 6. UI28-1 v0.2.0 shape — additive guards
+//
+// These tests pin the v0.2.0-specific surface: the new slots on Cell and
+// Grid, the nested-For body shape in Grid.mll, and the expression-driven
+// per-cell predicates. A future refactor that drops any of these is the
+// kind of regression the v0.2.0 release commits to avoiding.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ui28_1_cell_declares_is_selected_slot() {
+    // v0.1.0 had no `is-selected` slot. v0.2.0 adds it so Grid can
+    // thread per-cell selection state down without sharing its
+    // internal coordinate-comparison logic with the host.
+    let src = read_source("Cell.mil");
+    assert!(
+        src.contains("slot is-selected"),
+        "Cell.mil must declare an `is-selected` slot (added in v0.2.0)"
+    );
+    let mil = mosmodel_compiler::compile(&src).expect("Cell.mil compiles");
+    let names: Vec<&str> = mil.component.slots.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-selected"),
+        "Cell mosmodel descriptor must expose `is-selected`, got: {:?}",
+        names
+    );
+}
+
+#[test]
+fn ui28_1_grid_declares_column_headers_and_widths_slots() {
+    // v0.1.0 had no column-metadata slots (header row was empty).
+    // v0.2.0 adds parallel-array slots so the header renders + the
+    // <colgroup> carries widths.
+    let src = read_source("Grid.mil");
+    assert!(
+        src.contains("slot column-headers"),
+        "Grid.mil must declare `column-headers: list<text>` (v0.2.0)"
+    );
+    assert!(
+        src.contains("slot column-widths"),
+        "Grid.mil must declare `column-widths: list<number>` (v0.2.0)"
+    );
+    let mil = mosmodel_compiler::compile(&src).expect("Grid.mil compiles");
+    let names: Vec<&str> = mil.component.slots.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"column-headers") && names.contains(&"column-widths"),
+        "Grid mosmodel descriptor must expose column-headers + column-widths, got: {:?}",
+        names
+    );
+}
+
+#[test]
+fn ui28_1_grid_mll_uses_nested_for_via_u29_3_4_scope() {
+    // The body must contain TWO `For` blocks (outer over rows, inner
+    // over each row's cells). Without UI29 §3.4 (PR #4398) the inner
+    // `each: row` would be rejected; the moslayout-compiler accepting
+    // this layout end-to-end is the regression guard for that PR.
+    let src = read_source("Grid.mll");
+    let for_count = src.matches("For (").count();
+    assert!(
+        for_count >= 3,
+        "Grid.mll must contain at least 3 For blocks (colgroup, head, body-outer, body-inner — found {}), got source:\n{}",
+        for_count,
+        src
+    );
+    // The inner For specifically uses the outer's `as: row` as its
+    // `each:` value. That's the UI29 §3.4 shape we depend on.
+    assert!(
+        src.contains("For ( each: row"),
+        "Grid.mll body must nest `For ( each: row, ... )` to iterate each row's cells (UI29 §3.4)"
+    );
+
+    // Round-trip the file through the validator. This is the
+    // language-frontend assertion that PR #4398's scope-walker is in
+    // place AND that v0.2.0's nested-For is well-formed.
+    let mil_src = read_source("Grid.mil");
+    let mil_out = mosmodel_compiler::compile(&mil_src).expect("Grid.mil compiles");
+    moslayout_compiler::compile(&src, Some(&mil_out.descriptor_json))
+        .expect("Grid.mll must validate against Grid.mil; if this fails the §3.4 scope walker may have regressed");
+}
+
+#[test]
+fn ui28_1_grid_mll_predicate_uses_expression_in_slot_binding() {
+    // Per UI28-1 §2 constraint 4 (encapsulation), Grid computes
+    // is-editing / is-selected at the Cell call site via Expr — the
+    // host pushes plain coordinate numbers, not pre-computed masks.
+    let src = read_source("Grid.mll");
+    // The Expr shape is `( r == editRow && c == editCol )`. We pin the
+    // operator structure rather than exact spacing; the moslayout
+    // parser collapses to a reconstructed-source Expr either way.
+    assert!(
+        src.contains("is-editing:") && src.contains("editRow") && src.contains("editCol"),
+        "Grid.mll must compose is-editing per-cell via expression-in-slot-binding"
+    );
+    assert!(
+        src.contains("is-selected:") && src.contains("selectedRow") && src.contains("selectedCol"),
+        "Grid.mll must compose is-selected per-cell via expression-in-slot-binding"
+    );
+}
+
+#[test]
+fn ui28_1_grid_mll_has_colgroup_section_for_column_widths() {
+    let src = read_source("Grid.mll");
+    assert!(
+        src.contains("HostTableColGroup"),
+        "Grid.mll must use HostTableColGroup to thread per-column widths (UI28-1 §3.3)"
+    );
+    assert!(
+        src.contains("each: slot: column-widths"),
+        "Grid.mll's HostTableColGroup must iterate the `column-widths` slot"
+    );
+}
+
+#[test]
+fn ui28_1_grid_mll_header_for_renders_column_headers() {
+    let src = read_source("Grid.mll");
+    assert!(
+        src.contains("each: slot: column-headers"),
+        "Grid.mll's HostTableHead must iterate the `column-headers` slot — v0.1.0 left the header empty, v0.2.0 fills it"
+    );
+}
+
+#[test]
+fn ui28_1_no_new_kernel_primitive_was_added() {
+    // Sanity guard: ensure nothing in Grid.mll / Cell.mll references a
+    // tag that isn't already in the UI29 kernel + this package's
+    // userland Cell / Column. The currently-allowed tag set is:
+    //
+    //   - 21 UI29 kernel primitives + UI31 HostTable family
+    //   - Userland: Grid, Cell, Column
+    //
+    // If a future change introduces e.g. `HostCell` or `HostTableRow`
+    // as a new tag, this test fires loud — Cell-as-component is the
+    // architectural contract per UI28-1 §2 constraint 1.
+    let allowed_tags: std::collections::HashSet<&str> = [
+        // Containers + leaves + control flow (UI29 kernel)
+        "Box", "Row", "Column", "Stack", "Text", "Image", "Spacer",
+        "Divider", "Icon", "If", "Else", "For",
+        // Host primitives (UI29 + UI29-1/2/4)
+        "HostInput", "HostButton", "HostTable", "HostScroll", "HostDialog",
+        "HostCheckbox", "HostRadio", "HostLink", "HostTooltip", "HostNumberInput",
+        // HostTable structural sub-tags + Col (UI31)
+        "HostTableColGroup", "HostTableHead", "HostTableBody", "HostTableFoot",
+        "Col",
+        // Legacy (still in PRIMITIVES, scheduled removal in U29-X1)
+        "Grid", "Scroll",
+        // Userland (this package)
+        "Cell", "Column",
+    ]
+    .iter()
+    .copied()
+    .collect();
+
+    for component in ["Grid", "Cell", "Column"] {
+        let src = read_source(&format!("{}.mll", component));
+        // Naive tag-extraction: any PascalCase identifier at the start of
+        // a line (possibly preceded by whitespace) is a tag candidate.
+        // Misses the rare inline tag, but the common shape catches all
+        // surface-level new primitives.
+        for raw_line in src.lines() {
+            let line = raw_line.trim_start();
+            // Strip leading `}` from "} Else {" etc.
+            let line = line.trim_start_matches('}').trim_start();
+            // Get the first identifier-looking token.
+            let token: String = line
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if token.is_empty() {
+                continue;
+            }
+            let first = token.chars().next().unwrap();
+            if !first.is_ascii_uppercase() {
+                continue;
+            }
+            assert!(
+                allowed_tags.contains(token.as_str()),
+                "{}.mll references unknown tag `{}` — if this is a new \
+                 primitive, add it to the kernel list (and review whether \
+                 UI28-1 §2 constraint 1 is being violated)",
+                component,
+                token
+            );
+        }
+    }
+}
 
 /// Belt-and-suspenders check: every file the package promises is on disk.
 #[test]


### PR DESCRIPTION
## Summary

Ships **mosaic-pkg-grid v0.2.0** — completes the UI28-1 cell-and-column composition that v0.1.0 scaffolded. **No new kernel primitives**, Cell stays a userland component (per UI28-1 §2 constraint 1).

This is the **Phase 4** deliverable from the UI28-1 plan. With this merged, **Phase 5 (VisiCalc rewire)** becomes a one-liner: VisiCalc's `Grid.{desktop,touch}.mll` imports this package's `Grid` and discards its degraded HostTable composition.

## What v0.1.0 deferred, v0.2.0 finishes

| v0.1.0 caveat | v0.2.0 fix |
|---|---|
| Header row left empty | `For (each: slot: column-headers, ...)` renders one `<th>` per column |
| Body shows only `row`, not per-column cells | Nested For: outer over rows, inner `For (each: row, ...)` per UI29 §3.4 |
| (new) `<colgroup>` not wired | `HostTableColGroup` with `For (each: slot: column-widths, ...)` |
| (new) Selection highlight not propagated | Cell.mil gains `is-selected: bool`, Grid computes per-cell predicate |

## Per-cell predicates via expression-in-slot-binding

Per UI28-1 §2 constraint 4 (encapsulation), Grid composes per-cell predicates at the Cell call site:

```
Cell (
  value:        ( v ),
  is-editing:   ( r == editRow && c == editCol ),
  is-selected:  ( r == selectedRow && c == selectedCol ),
  ...
)
```

The `(...)` grouping triggers the moslayout-compiler's Expr branch (UI29 §3.3). The expression text passes verbatim into the target language at each emitter. **Host pushes only plain coordinate numbers; Cell receives plain booleans.** Encapsulation upward AND downward.

## Stable iteration keys (UI28-1 §5 perf property)

Every For binds an explicit `index:` (`cw`, `ch`, `r`, `c`). Each backend's For lowering threads it into the framework-native list key — for VisiCalc-scale data (100×26 = 2,600 keyed cells) this is the difference between O(n) and O(1) per-render cost in React's diff.

## Tests

12/12 green (was 5, +7):

- `ui28_1_cell_declares_is_selected_slot`
- `ui28_1_grid_declares_column_headers_and_widths_slots`
- **`ui28_1_grid_mll_uses_nested_for_via_u29_3_4_scope`** — end-to-end regression guard for PR #4398's scope walker
- `ui28_1_grid_mll_predicate_uses_expression_in_slot_binding`
- `ui28_1_grid_mll_has_colgroup_section_for_column_widths`
- `ui28_1_grid_mll_header_for_renders_column_headers`
- **`ui28_1_no_new_kernel_primitive_was_added`** — scans every PascalCase tag in the .mll files; asserts each is either UI29 kernel or this package's userland Cell/Column

The 4 pre-existing round-trip tests (manifest, .mil compiles, .mll compiles against .mil, .msl compiles against part map) continue to pass — **proving the new composition shape parses + validates cleanly through every layer of the language frontend**.

## Enabled by — 4 dependencies all on main

- #4388 — UI28-1 spec (the authoritative design)
- #4393 — Flutter For/If/Else lowering (§6.2)
- #4396 — React For auto-key from `index:` (§6.3)
- #4398 — UI29 §3.4 For-loop binding scope + 5-emitter Keyword arm (§6.1)

## Test plan

- [x] `cd code/packages/mosaic-pkg-grid && cargo test` — 12/12 green
- [ ] CI passes

## Safety

Security-reviewed clean. No injection vectors, no path traversal, no secrets. The new tag-scanner test (`ui28_1_no_new_kernel_primitive_was_added`) is documented as defense-in-depth (catches surface-level PascalCase tags only — the real gate is the moslayout-compiler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)