### PR TITLE
Track embedded browser context metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -246,6 +246,9 @@ def check_browser_readiness_case(
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "media", errors)
     require_optional_object_list(
+        f"{case_path}.expected", expected, "embedded_contexts", errors
+    )
+    require_optional_object_list(
         f"{case_path}.expected", expected, "structured_items", errors
     )
     require_optional_object_list(f"{case_path}.expected", expected, "templates", errors)
@@ -496,6 +499,28 @@ def check_browser_expected_lists(
             require_optional_nullable_string(media_path, media, field, errors)
         for field in ("controls", "autoplay", "loop_media", "muted", "playsinline"):
             require_optional_boolean(media_path, media, field, errors)
+
+    for index, context in enumerate(object_list_items(expected, "embedded_contexts")):
+        context_path = f"{case_path}.expected.embedded_contexts[{index}]"
+        require_string(context_path, context, "element", errors)
+        for field in (
+            "url",
+            "resolved_url",
+            "browsing_context_name",
+            "title",
+            "type_hint",
+            "width",
+            "height",
+            "loading",
+            "allow",
+            "referrerpolicy",
+            "srcdoc",
+        ):
+            require_optional_nullable_string(context_path, context, field, errors)
+        require_optional_string_list(context_path, context, "sandbox", errors)
+        for field in ("allowfullscreen", "credentialless"):
+            require_optional_boolean(context_path, context, field, errors)
+        require_optional_string(context_path, context, "fallback_text", errors)
 
     for index, item in enumerate(object_list_items(expected, "structured_items")):
         item_path = f"{case_path}.expected.structured_items[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -837,6 +837,7 @@ pub struct BrowserDocument {
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub media: Vec<BrowserMedia>,
+    pub embedded_contexts: Vec<BrowserEmbeddedContext>,
     pub structured_items: Vec<BrowserStructuredItem>,
     pub templates: Vec<BrowserTemplate>,
     pub forms: Vec<BrowserForm>,
@@ -1445,6 +1446,26 @@ pub struct BrowserMedia {
     pub muted: bool,
     pub playsinline: bool,
     pub preload: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserEmbeddedContext {
+    pub element: String,
+    pub url: Option<String>,
+    pub resolved_url: Option<String>,
+    pub browsing_context_name: Option<String>,
+    pub title: Option<String>,
+    pub type_hint: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub loading: Option<String>,
+    pub sandbox: Vec<String>,
+    pub allow: Option<String>,
+    pub allowfullscreen: bool,
+    pub referrerpolicy: Option<String>,
+    pub srcdoc: Option<String>,
+    pub credentialless: bool,
+    pub fallback_text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8729,6 +8750,9 @@ fn collect_browser_facts(
 
         collect_anchor_target(element, summary);
         collect_body_resource(element, summary);
+        if let Some(context) = browser_embedded_context(element, summary.base_href.as_deref()) {
+            summary.embedded_contexts.push(context);
+        }
         if element.name == "template" {
             summary.templates.push(browser_template(element));
         }
@@ -9268,6 +9292,46 @@ fn body_resource(element: &Element) -> Option<(String, String)> {
             .map(|src| (element.name.clone(), src.to_string())),
         _ => None,
     }
+}
+
+fn browser_embedded_context(
+    element: &Element,
+    base_href: Option<&str>,
+) -> Option<BrowserEmbeddedContext> {
+    if !matches!(
+        element.name.as_str(),
+        "iframe" | "frame" | "object" | "embed"
+    ) {
+        return None;
+    }
+
+    let url = match element.name.as_str() {
+        "iframe" | "frame" | "embed" => element.attribute("src"),
+        "object" => element.attribute("data"),
+        _ => None,
+    }
+    .map(ToOwned::to_owned);
+
+    Some(BrowserEmbeddedContext {
+        element: element.name.clone(),
+        resolved_url: url
+            .as_deref()
+            .and_then(|url| resolve_browser_url(url, base_href)),
+        url,
+        browsing_context_name: browser_browsing_context_name(element),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
+        loading: browser_browsing_context_loading(element),
+        sandbox: browser_browsing_context_sandbox(element),
+        allow: browser_browsing_context_allow(element),
+        allowfullscreen: browser_browsing_context_allowfullscreen(element),
+        referrerpolicy: browser_browsing_context_referrerpolicy(element),
+        srcdoc: browser_browsing_context_srcdoc(element),
+        credentialless: browser_browsing_context_credentialless(element),
+        fallback_text: visible_text_for_nodes(&element.children),
+    })
 }
 
 fn resolve_browser_url(url: &str, base_href: Option<&str>) -> Option<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,9 +1,10 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata, BrowserForm,
-    BrowserFormControl, BrowserFormSubmitter, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageSource, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
-    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata,
+    BrowserEmbeddedContext, BrowserForm, BrowserFormControl, BrowserFormSubmitter, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserLink, BrowserMedia, BrowserMeta,
+    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -59,6 +60,8 @@ struct ExpectedBrowserDocument {
     images: Vec<ExpectedImage>,
     #[serde(default)]
     media: Vec<ExpectedMedia>,
+    #[serde(default)]
+    embedded_contexts: Vec<ExpectedEmbeddedContext>,
     #[serde(default)]
     structured_items: Vec<ExpectedStructuredItem>,
     #[serde(default)]
@@ -461,6 +464,41 @@ struct ExpectedMedia {
 }
 
 #[derive(Debug, Deserialize)]
+struct ExpectedEmbeddedContext {
+    element: String,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    browsing_context_name: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    loading: Option<String>,
+    #[serde(default)]
+    sandbox: Vec<String>,
+    #[serde(default)]
+    allow: Option<String>,
+    #[serde(default)]
+    allowfullscreen: bool,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    srcdoc: Option<String>,
+    #[serde(default)]
+    credentialless: bool,
+    #[serde(default)]
+    fallback_text: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct ExpectedForm {
     #[serde(default)]
     id: Option<String>,
@@ -627,6 +665,26 @@ fn browser_readiness_cases_extract_browser_document_facts() {
     }
 }
 
+#[test]
+fn browser_embedded_context_metadata_tracks_frame_object_embed_and_srcdoc() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "embedded-resource-page")
+        .expect("embedded resource fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("embedded resource fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.embedded_contexts,
+        case.expected.into_browser_document().embedded_contexts,
+        "embedded contexts should preserve frame, object, embed, and srcdoc-only iframe metadata",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         BrowserDocument {
@@ -687,6 +745,11 @@ impl ExpectedBrowserDocument {
                 .media
                 .into_iter()
                 .map(ExpectedMedia::into_browser_media)
+                .collect(),
+            embedded_contexts: self
+                .embedded_contexts
+                .into_iter()
+                .map(ExpectedEmbeddedContext::into_browser_embedded_context)
                 .collect(),
             structured_items: self
                 .structured_items
@@ -1050,6 +1113,29 @@ impl ExpectedMedia {
             muted: self.muted,
             playsinline: self.playsinline,
             preload: self.preload,
+        }
+    }
+}
+
+impl ExpectedEmbeddedContext {
+    fn into_browser_embedded_context(self) -> BrowserEmbeddedContext {
+        BrowserEmbeddedContext {
+            element: self.element,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            browsing_context_name: self.browsing_context_name,
+            title: self.title,
+            type_hint: self.type_hint,
+            width: self.width,
+            height: self.height,
+            loading: self.loading,
+            sandbox: self.sandbox,
+            allow: self.allow,
+            allowfullscreen: self.allowfullscreen,
+            referrerpolicy: self.referrerpolicy,
+            srcdoc: self.srcdoc,
+            credentialless: self.credentialless,
+            fallback_text: self.fallback_text,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -344,8 +344,8 @@
     },
     {
       "id": "embedded-resource-page",
-      "description": "Body resource inventory preserves embedded frame, object, video, and embed metadata for fetch, policy, and layout planning.",
-      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html name=preview loading=lazy sandbox=\"allow-scripts allow-same-origin\" allow=\"fullscreen; geolocation\" allowfullscreen referrerpolicy=no-referrer srcdoc=\"<p>Fallback</p>\" credentialless width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120>",
+      "description": "Body resource and embedded-context inventories preserve frame, object, video, embed, and srcdoc-only iframe metadata for fetch, policy, and layout planning.",
+      "input": "<base href=\"https://example.test/media/index.html\"><body><iframe src=frame.html name=preview loading=lazy sandbox=\"allow-scripts allow-same-origin\" allow=\"fullscreen; geolocation\" allowfullscreen referrerpolicy=no-referrer srcdoc=\"<p>Fallback</p>\" credentialless width=320 height=200 title=Frame></iframe><object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300></object><video src=movie.mp4 width=640 height=360 controls></video><embed src=legacy.mov type=\"video/quicktime\" width=160 height=120><iframe name=inline srcdoc=\"<h1>Inline</h1>\" sandbox allow=payment title=Inline width=240 height=120></iframe>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/media/index.html",
@@ -371,6 +371,12 @@
             "height": "360",
             "controls": true
           }
+        ],
+        "embedded_contexts": [
+          { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "browsing_context_name": "preview", "title": "Frame", "width": "320", "height": "200", "loading": "lazy", "sandbox": ["allow-scripts", "allow-same-origin"], "allow": "fullscreen; geolocation", "allowfullscreen": true, "referrerpolicy": "no-referrer", "srcdoc": "<p>Fallback</p>", "credentialless": true, "fallback_text": "" },
+          { "element": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "fallback_text": "" },
+          { "element": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "type_hint": "video/quicktime", "width": "160", "height": "120", "fallback_text": "" },
+          { "element": "iframe", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "allow": "payment", "srcdoc": "<h1>Inline</h1>", "fallback_text": "" }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
## Summary
- add BrowserEmbeddedContext summaries to BrowserDocument for iframe, frame, object, and embed elements
- preserve URL resolution, browsing context/policy attributes, sizing hints, srcdoc-only iframe metadata, and fallback text
- extend browser-readiness fixtures, schema governance, and targeted tests for embedded contexts

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_embedded_context_metadata_tracks_frame_object_embed_and_srcdoc
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser