### PR TITLE
feat(cas-summation): Phase 77 — Five-Log × polynomial numerator (2.14.0 → 2.15.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.15.0 — 2026-05-25
+
+### Added
+
+- **Phase 77 — Five-Log × polynomial numerator** (`_five_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 5 Log factors required; Sqrt factors explicitly refused so this phase does not shadow
+  the Sqrt-bearing phases (73–76, 78+).  `log⁵(k)` is sub-polynomial (`o(k^ε)`),
+  contributing 0 to effective degree;
+  `effective_x2 = 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase77FiveLogPoly`.
+
 ## 2.14.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.14.0"
+version = "2.15.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1069,6 +1069,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 77: ``Mul(Log(h1), Log(h2), Log(h3), Log(h4), Log(h5),
+    #           polynomial..., bounded...)`` numerator.
+    # Five Log factors; no Sqrt; log⁵ sub-polynomial → 0.
+    # effective_x2 = 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    flp5_x2 = _five_log_poly_effective_x2(num, k)
+    if flp5_x2 is not None:
+        den_deg_fl5 = _polynomial_degree_in_k(den, k)
+        if den_deg_fl5 is not None:
+            if 2 * den_deg_fl5 > flp5_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2788,6 +2802,71 @@ def _three_sqrt_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | N
     if len(sqrt_degs_x2) != 3 or log_count != 4:
         return None
     return sqrt_degs_x2[0] + sqrt_degs_x2[1] + sqrt_degs_x2[2] + 2 * poly_deg_sum
+
+
+def _five_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly five**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 77 — Five-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)⁵ · k^m``.  ``log⁵(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick (no Sqrt factors present):
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    Sqrt factors are explicitly refused so that this function does not
+    shadow the Sqrt-bearing phases (73–76, 78+).
+
+    +-----------------------------------------------------+----------+
+    | Input                                               | Return   |
+    +=====================================================+==========+
+    | ``Mul(Log(k)×5)``                                   | ``0``    |
+    | ``Mul(Log(k)×5, k)``                                | ``2``    |
+    | ``Mul(Log(k)×5, k², 3)``                            | ``4``    |
+    | ``Mul(Log(k)×4)``                                   | None (4) |
+    | ``Mul(Log(k)×6)``                                   | None (6) |
+    | ``Mul(Sqrt(k), Log(k)×5)``                          | None     |
+    +-----------------------------------------------------+----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → count; bail after 5.
+         - ``Sqrt(...)`` → refuse (return ``None``).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 5 Log factors.
+      4. Return ``2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 5:
+                # Six or more Log factors — not this phase.
+                return None
+            continue
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            # Sqrt factor present — refuse so Sqrt-bearing phases handle it.
+            return None
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 5:
+        return None
+    return 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4080,3 +4080,73 @@ class TestPhase76ThreeSqrtFourLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase77FiveLogPoly:
+    """Phase 77 — Five-Log × polynomial numerator.
+
+    Convergence criterion: numerator = log(k)⁵ · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = 2·poly_deg (no Sqrt, log⁵ is sub-polynomial → 0).
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_log5_k_over_k2_closes(self):
+        """log(k)⁵/k²: eff_x2=0; 2·2=4 > 0 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,))))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log5_k_times_k2_over_k3_closes(self):
+        """log(k)⁵·k²/k³: eff_x2=4; 2·3=6 > 4 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), k2))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), kp1_2))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log5_k_times_k3_over_k3_refused(self):
+        """log(k)⁵·k³/k³: eff_x2=6; 2·3=6 not > 6 → refused."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), k3))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), kp1_3))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.15.0 — 2026-05-25
+
+### Added
+
+- **Phase 77 — Five-Log × polynomial numerator** (`five_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 5 Log factors; Sqrt factors explicitly refused so Sqrt-bearing phases (73–76, 78+) are
+  not shadowed.  `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase77_*`).
+
 ## 2.14.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.14.0"
+version = "2.15.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2014,6 +2014,37 @@ fn three_sqrt_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i6
     Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + sqrt_degs_x2[2] + 2 * poly_deg)
 }
 
+/// Phase 77 — Five-Log × polynomial numerator.
+///
+/// Returns `2 * poly_deg` when `node` is a `Mul` with **exactly five**
+/// `Log(diverging-in-k)` factors, any polynomial factors, and any bounded
+/// factors; `None` otherwise.
+///
+/// `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0.  Using the ×2 integer trick:
+/// `effective_x2 = 2·m`.  Caller checks `2·den_deg > effective_x2`.
+///
+/// Sqrt factors are explicitly refused so this phase does not shadow the
+/// Sqrt-bearing phases (73–76, 78+).
+fn five_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 5 { return None; } // six or more Logs — not this phase
+            continue;
+        }
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; } // Sqrt — refuse
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 5 { return None; }
+    Some(2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2351,6 +2382,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s3l4_x2) = three_sqrt_four_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s3l4) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s3l4 > s3l4_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 77: Mul(Log(diverging)×5, polynomial..., bounded...) numerator.
+    // Five Log factors; no Sqrt; log⁵ sub-polynomial — effective_x2 = 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(fl5_x2) = five_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_fl5) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_fl5 > fl5_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2724,3 +2724,77 @@ fn phase76_three_sqrt_k_log4_k_times_k_over_k2_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 77: Five-Log × polynomial numerator ────────────────────────────────
+
+#[test]
+fn phase77_log5_k_over_k2_closes() {
+    // log(k)^5 / k²: effective_x2=0; 2·2=4 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f77a = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f77a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase77_log5_k_times_k2_over_k3_closes() {
+    // log(k)^5 · k² / k³: effective_x2=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k2,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1_2,
+    ]);
+    let g_k77b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp177b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f77b = apply(sym(SUB), vec![g_k77b, g_kp177b]);
+    let out = evaluate_sum(f77b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase77_log5_k_times_k3_over_k3_refused() {
+    // log(k)^5 · k³ / k³: effective_x2=6; 2·3=6 not > 6 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k3.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1_3.clone(),
+    ]);
+    let g_k77r = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp177r = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f77r = apply(sym(SUB), vec![g_k77r, g_kp177r]);
+    let out = evaluate_sum(f77r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.15.0 — 2026-05-25
+
+### Added
+
+- **Phase 77 — Five-Log × polynomial numerator** (`fiveLogPolyEffectiveDeg`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 5 Log factors; Sqrt factors explicitly refused so Sqrt-bearing phases (73–76, 78+) are
+  not shadowed.  `log⁵(k)` sub-polynomial — contributes 0 to effective degree;
+  effective degree = polyDeg.
+  Closes when `denDeg > fiveLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 77" describe block.
+
 ## 2.14.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1764,6 +1764,41 @@ function threeSqrtFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | und
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
 }
 
+/**
+ * Phase 77 — Five-Log × polynomial numerator.
+ *
+ * Returns `polyDeg` when `node` is a `Mul` with **exactly five**
+ * `Log(diverging-in-k)` factors, any polynomial factors, and any bounded
+ * factors; `undefined` otherwise.
+ *
+ * `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective degree.
+ * TypeScript stores the actual half-degree (not ×2), so:
+ *   `effectiveDeg = polyDeg`.
+ * Caller checks `denDeg > fiveLogPolyEffectiveDeg(num, k)`.
+ *
+ * Sqrt factors are explicitly refused so that Sqrt-bearing phases (73–76, 78+)
+ * are not shadowed by this function.
+ */
+function fiveLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 5) return undefined; // six or more Logs — not this phase
+      continue;
+    }
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // Sqrt present — refuse
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 5) return undefined;
+  return polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -2113,6 +2148,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS3l4 = polynomialDegreeInK(den, k);
     if (denDegS3l4 !== undefined) {
       if (denDegS3l4 > s3l4Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 77: Mul(Log(diverging)×5, polynomial..., bounded...) numerator.
+  // Five Log factors; no Sqrt; log⁵ sub-polynomial — contributes 0.
+  // effective degree = polyDeg.
+  // Closes when denDeg > fiveLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const fl5Deg = fiveLogPolyEffectiveDeg(num, k);
+  if (fl5Deg !== undefined) {
+    const denDegFl5 = polynomialDegreeInK(den, k);
+    if (denDegFl5 !== undefined) {
+      if (denDegFl5 > fl5Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -2896,3 +2896,92 @@ describe("Phase 76 — Three-Sqrt × Four-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 77 — Five-Log × polynomial numerator", () => {
+  it("log(k)⁵/k² closes (effective=0, denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK77a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp177a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK77a = { kind: "apply" as const, head: DIV, args: [numK77a, k2] };
+    const gKp177a = { kind: "apply" as const, head: DIV, args: [numKp177a, kp1_2] };
+    const f77a = { kind: "apply" as const, head: SUB, args: [gK77a, gKp177a] };
+    const result = evaluateSum(f77a, k, int(1), sym("%inf"), evalNode);
+    // log⁵ sub-poly → effective=0; denDeg=2 > 0 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵·k²/k³ closes (effective=2, denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK77b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k2,
+    ]};
+    const numKp177b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1_2,
+    ]};
+    const gK77b = { kind: "apply" as const, head: DIV, args: [numK77b, k3] };
+    const gKp177b = { kind: "apply" as const, head: DIV, args: [numKp177b, kp1_3] };
+    const f77b = { kind: "apply" as const, head: SUB, args: [gK77b, gKp177b] };
+    const result = evaluateSum(f77b, k, int(1), sym("%inf"), evalNode);
+    // polyDeg=2 → effective=2; denDeg=3 > 2 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)⁵·k³/k³ refused (effective=3, denDeg=3 not > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK77r = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k3,
+    ]};
+    const numKp177r = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1_3,
+    ]};
+    const gK77r = { kind: "apply" as const, head: DIV, args: [numK77r, k3] };
+    const gKp177r = { kind: "apply" as const, head: DIV, args: [numKp177r, kp1_3] };
+    const f77r = { kind: "apply" as const, head: SUB, args: [gK77r, gKp177r] };
+    const result = evaluateSum(f77r, k, int(1), sym("%inf"), evalNode);
+    // polyDeg=3 → effective=3; denDeg=3 not > 3 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Phase 77 convergence recognizer for telescoping sums whose `g(k)` numerator is `log(k)⁵ · poly(k)`.
- `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0; `effective_x2 = 2·poly_deg`; closes when `2·den_deg > effective_x2`.
- Sqrt factors explicitly refused to avoid shadowing Phases 73–76 and 78+.
- Implemented identically across Python (`_five_log_poly_effective_x2`), TypeScript (`fiveLogPolyEffectiveDeg`), and Rust (`five_log_poly_effective_x2`).
- 9 new tests (3 per language): closes on no-poly-factor, closes on poly-factor with sufficient den, refused when deg ties.

## Test plan

- [x] Python: `mise exec -- python -m pytest tests/test_summation.py --no-cov` → 196 passed
- [x] TypeScript: `mise exec -- npm test` → 149 passed
- [x] Rust: `cargo test` → 132 passed
- [x] Security review: PASSED — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)