### PR TITLE
feat(cas-summation): Phase 78 — One-Sqrt × Five-Log × polynomial numerator (2.14.0 → 2.15.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.16.0 — 2026-05-25
+
+### Added
+
+- **Phase 78 — One-Sqrt × Five-Log × polynomial numerator** (`_one_sqrt_five_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 5 Log factors required.  `log⁵(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase78OneSqrtFiveLogPoly`.
+
 ## 2.15.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.15.0"
+version = "2.16.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1083,6 +1083,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 78: ``Mul(Sqrt(P), Log(h1), Log(h2), Log(h3), Log(h4), Log(h5),
+    #           polynomial..., bounded...)`` numerator.
+    # One Sqrt factor + five Log factors; log⁵ sub-polynomial → 0.
+    # effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s1l5p_x2 = _one_sqrt_five_log_poly_effective_x2(num, k)
+    if s1l5p_x2 is not None:
+        den_deg_s1l5 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l5 is not None:
+            if 2 * den_deg_s1l5 > s1l5p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2664,6 +2678,75 @@ def _one_sqrt_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | Non
             continue
         return None
     if sqrt_deg_x2 is None or log_count != 4:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _one_sqrt_five_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_inner_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly one** ``Sqrt(positive-leading polynomial)`` factor,
+    **exactly five** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 78 — One-Sqrt × Five-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^d) · log(k)⁵ · k^m ≈ k^{d/2} · log⁵(k) · k^m``.
+    ``log⁵(k)`` is sub-polynomial (``o(k^ε)``), so it contributes 0.
+    Using the ×2 integer trick:
+    ``effective_x2 = d + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------+------------------+
+    | Input                                                    | Return           |
+    +==========================================================+==================+
+    | ``Mul(Sqrt(k), Log(k)×5)``                               | ``1 + 0 = 1``    |
+    | ``Mul(Sqrt(k³), Log(k)×5)``                              | ``3 + 0 = 3``    |
+    | ``Mul(Sqrt(k), Log(k)×5, k)``                            | ``1 + 2 = 3``    |
+    | ``Mul(Sqrt(k), Log(k)×4)``                               | None (4 Logs)    |
+    | ``Mul(Sqrt(k), Log(k)×6)``                               | None (6 Logs)    |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×5)``                      | None (2 Sqrts)   |
+    | ``Mul(Log(k)×5)``                                        | None (0 Sqrts)   |
+    +----------------------------------------------------------+------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 1.
+         - ``Log(diverging)`` → count; bail after 5.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded (non-polynomial, non-Log, non-Sqrt) → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 1 Sqrt AND exactly 5 Log factors.
+      4. Return ``sqrt_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                # Second Sqrt — not this phase.
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 5:
+                # Six or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 5:
         return None
     return sqrt_deg_x2 + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4150,3 +4150,75 @@ class TestPhase77FiveLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase78OneSqrtFiveLogPoly:
+    """Phase 78 — One-Sqrt × Five-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √P(k) · log(k)⁵ · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg.
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_sqrt_k_log5_k_over_k2_closes(self):
+        """√k·log(k)⁵/k²: eff_x2=1; 2·2=4 > 1 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,))))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_log5_k_over_k_refused(self):
+        """√(k³)·log(k)⁵/k: eff_x2=3; 2·1=2 not > 3 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_sqrt_k_log5_k_times_k_over_k_refused(self):
+        """√k·log(k)⁵·k/k: eff_x2=1+2=3; 2·1=2 not > 3 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.16.0 — 2026-05-25
+
+### Added
+
+- **Phase 78 — One-Sqrt × Five-Log × polynomial numerator** (`one_sqrt_five_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 5 Log factors required.  `log⁵(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt_inner_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase78_*`).
+
 ## 2.15.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.15.0"
+version = "2.16.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1944,6 +1944,41 @@ fn one_sqrt_four_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64>
     Some(d + 2 * poly_deg)
 }
 
+/// Phase 78 — One-Sqrt × Five-Log × polynomial numerator.
+///
+/// Returns `sqrt_deg_x2 + 2·poly_deg` when `node` is a `Mul` with exactly one
+/// `Sqrt(positive-leading polynomial)` factor, exactly five `Log(diverging-in-k)`
+/// factors, any polynomial factors, and any bounded factors; `None` otherwise.
+///
+/// `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0.
+/// `effective_x2 = sqrt_inner_deg_x2 + 2·m`.
+/// Caller checks `2 * den_deg > effective_x2`.
+fn one_sqrt_five_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg_x2 = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 5 { return None; } // six or more Logs — refuse
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let d = sqrt_deg_x2?;
+    if log_count != 5 { return None; }
+    Some(d + 2 * poly_deg)
+}
+
 /// Phase 75 — Two-Sqrt × Four-Log × polynomial numerator.
 ///
 /// Returns `sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg` when `node` is a `Mul` with
@@ -2394,6 +2429,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(fl5_x2) = five_log_poly_effective_x2(num, k) {
         if let Some(den_deg_fl5) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_fl5 > fl5_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 78: Mul(Sqrt(P), Log(diverging)×5, polynomial..., bounded...) numerator.
+    // One Sqrt + five Log factors; log⁵ sub-polynomial — effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s1l5_x2) = one_sqrt_five_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l5) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l5 > s1l5_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2798,3 +2798,77 @@ fn phase77_log5_k_times_k3_over_k3_refused() {
     let out = evaluate_sum(f77r, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 78: One-Sqrt × Five-Log × polynomial numerator ─────────────────────
+
+#[test]
+fn phase78_sqrt_k_log5_k_over_k2_closes() {
+    // √k · log(k)^5 / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k, log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1, log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f78a = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f78a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase78_sqrt_k3_log5_k_over_k_refused() {
+    // √(k³) · log(k)^5 / k: effective_x2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3, log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3, log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k78b = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp178b = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f78b = apply(sym(SUB), vec![g_k78b, g_kp178b]);
+    let out = evaluate_sum(f78b, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase78_sqrt_k_log5_k_times_k_over_k_refused() {
+    // √k · log(k)^5 · k / k: effective_x2=1+2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k, log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1, log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k78r = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp178r = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f78r = apply(sym(SUB), vec![g_k78r, g_kp178r]);
+    let out = evaluate_sum(f78r, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.16.0 — 2026-05-25
+
+### Added
+
+- **Phase 78 — One-Sqrt × Five-Log × polynomial numerator** (`oneSqrtFiveLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 5 Log factors; `log⁵(k)` sub-polynomial — contributes 0 to
+  effective degree; effective degree = sqrtHalfDeg + polyDeg.
+  Closes when `denDeg > oneSqrtFiveLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 78" describe block.
+
 ## 2.15.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1689,6 +1689,44 @@ function oneSqrtFourLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undef
 }
 
 /**
+ * Phase 78 — One-Sqrt × Five-Log × polynomial numerator.
+ *
+ * Returns `sqrtHalfDeg + polyDeg` when `node` is a `Mul` with exactly one
+ * `Sqrt(positive-leading polynomial)` factor, exactly five `Log(diverging-in-k)`
+ * factors, any polynomial factors, and any bounded factors; `undefined` otherwise.
+ *
+ * `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective degree.
+ * TypeScript stores the actual half-degree (not ×2), so:
+ *   `effectiveDeg = sqrtHalfDeg + polyDeg`.
+ * Caller checks `denDeg > oneSqrtFiveLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtFiveLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined; // second Sqrt — refuse
+      sqrtHalfDeg = hd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 5) return undefined; // six or more Logs — refuse
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 5) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/**
  * Phase 75 — Two-Sqrt × Four-Log × polynomial numerator.
  *
  * Returns `sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg` when `node` is a `Mul`
@@ -2161,6 +2199,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegFl5 = polynomialDegreeInK(den, k);
     if (denDegFl5 !== undefined) {
       if (denDegFl5 > fl5Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 78: Mul(Sqrt(P), Log(diverging)×5, polynomial..., bounded...) numerator.
+  // One Sqrt + five Log factors; log⁵ sub-polynomial — contributes 0.
+  // effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtFiveLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l5Deg = oneSqrtFiveLogPolyEffectiveDeg(num, k);
+  if (s1l5Deg !== undefined) {
+    const denDegS1l5 = polynomialDegreeInK(den, k);
+    if (denDegS1l5 !== undefined) {
+      if (denDegS1l5 > s1l5Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -2985,3 +2985,92 @@ describe("Phase 77 — Five-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 78 — One-Sqrt × Five-Log × polynomial numerator", () => {
+  it("√k·log(k)⁵/k² closes (effective=0.5, denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK78a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp178a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK78a = { kind: "apply" as const, head: DIV, args: [numK78a, k2] };
+    const gKp178a = { kind: "apply" as const, head: DIV, args: [numKp178a, kp1_2] };
+    const f78a = { kind: "apply" as const, head: SUB, args: [gK78a, gKp178a] };
+    const result = evaluateSum(f78a, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf=0.5, log⁵ sub-poly → effective=0.5; denDeg=2 > 0.5 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·log(k)⁵/k refused (effective=1.5, denDeg=1 not > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK78b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp178b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK78b = { kind: "apply" as const, head: DIV, args: [numK78b, k] };
+    const gKp178b = { kind: "apply" as const, head: DIV, args: [numKp178b, kp1] };
+    const f78b = { kind: "apply" as const, head: SUB, args: [gK78b, gKp178b] };
+    const result = evaluateSum(f78b, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf=1.5; denDeg=1 not > 1.5 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)⁵·k/k refused (effective=1.5, denDeg=1 not > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK78r = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp178r = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK78r = { kind: "apply" as const, head: DIV, args: [numK78r, k] };
+    const gKp178r = { kind: "apply" as const, head: DIV, args: [numKp178r, kp1] };
+    const f78r = { kind: "apply" as const, head: SUB, args: [gK78r, gKp178r] };
+    const result = evaluateSum(f78r, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf=0.5, polyDeg=1 → effective=1.5; denDeg=1 not > 1.5 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Phase 78 convergence recognizer: numerator = `Sqrt(P(k)) · log(k)⁵ · poly(k)`.
- Exactly 1 Sqrt + exactly 5 Log factors; `log⁵(k)` sub-polynomial → contributes 0.
- Python/Rust: `effective_x2 = sqrt_inner_deg_x2 + 2·poly_deg`; closes when `2·den_deg > effective_x2`.
- TypeScript: `effectiveDeg = sqrtHalfDeg + polyDeg`; closes when `denDeg > effectiveDeg`.
- Helper placed after Phase 74 (One-Sqrt × Four-Log); dispatch block placed after Phase 76.

## Test plan

- [x] Python: `mise exec -- python -m pytest tests/test_summation.py --no-cov` → 196 passed
- [x] TypeScript: `mise exec -- npm test` → 149 passed
- [x] Rust: `cargo test` → 132 passed
- [x] Security review: PASSED — no vulnerabilities found

**Note**: This PR branches from `main` (2.14.0 = Phase 76). PR #4412 (Phase 77 — Five-Log × polynomial, 0 Sqrt) is in CI simultaneously. When #4412 merges, this branch will be rebased to pick up Phase 77 and version bumped to 2.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)