### PR TITLE
Track interactive browser element metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -249,6 +249,9 @@ def check_browser_readiness_case(
         f"{case_path}.expected", expected, "embedded_contexts", errors
     )
     require_optional_object_list(
+        f"{case_path}.expected", expected, "interactive_elements", errors
+    )
+    require_optional_object_list(
         f"{case_path}.expected", expected, "structured_items", errors
     )
     require_optional_object_list(f"{case_path}.expected", expected, "templates", errors)
@@ -521,6 +524,52 @@ def check_browser_expected_lists(
         for field in ("allowfullscreen", "credentialless"):
             require_optional_boolean(context_path, context, field, errors)
         require_optional_string(context_path, context, "fallback_text", errors)
+
+    for index, element in enumerate(object_list_items(expected, "interactive_elements")):
+        element_path = f"{case_path}.expected.interactive_elements[{index}]"
+        require_string(element_path, element, "element", errors)
+        for field in (
+            "id",
+            "role",
+            "authored_role",
+            "accessible_name",
+            "aria_label",
+            "aria_current",
+            "aria_expanded",
+            "aria_pressed",
+            "aria_selected",
+            "tabindex",
+            "contenteditable",
+            "editing_mode",
+            "draggable",
+            "draggable_state",
+            "spellcheck",
+            "translate",
+            "popover",
+            "popover_target",
+            "popover_target_action",
+            "command",
+            "command_for",
+        ):
+            require_optional_nullable_string(element_path, element, field, errors)
+        require_optional_string(element_path, element, "text", errors)
+        for field in (
+            "aria_labelledby",
+            "aria_describedby",
+            "aria_controls",
+            "accesskey",
+            "event_handlers",
+        ):
+            require_optional_string_list(element_path, element, field, errors)
+        for field in (
+            "aria_hidden",
+            "hidden",
+            "inert",
+            "open",
+            "focusable",
+            "disabled",
+        ):
+            require_optional_boolean(element_path, element, field, errors)
 
     for index, item in enumerate(object_list_items(expected, "structured_items")):
         item_path = f"{case_path}.expected.structured_items[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -838,6 +838,7 @@ pub struct BrowserDocument {
     pub images: Vec<BrowserImage>,
     pub media: Vec<BrowserMedia>,
     pub embedded_contexts: Vec<BrowserEmbeddedContext>,
+    pub interactive_elements: Vec<BrowserInteractiveElement>,
     pub structured_items: Vec<BrowserStructuredItem>,
     pub templates: Vec<BrowserTemplate>,
     pub forms: Vec<BrowserForm>,
@@ -1469,6 +1470,44 @@ pub struct BrowserEmbeddedContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserInteractiveElement {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: Option<String>,
+    pub authored_role: Option<String>,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub aria_describedby: Vec<String>,
+    pub aria_controls: Vec<String>,
+    pub aria_current: Option<String>,
+    pub aria_expanded: Option<String>,
+    pub aria_pressed: Option<String>,
+    pub aria_selected: Option<String>,
+    pub aria_hidden: bool,
+    pub hidden: bool,
+    pub inert: bool,
+    pub open: bool,
+    pub tabindex: Option<String>,
+    pub accesskey: Vec<String>,
+    pub event_handlers: Vec<String>,
+    pub focusable: Option<bool>,
+    pub contenteditable: Option<String>,
+    pub editing_mode: Option<String>,
+    pub draggable: Option<String>,
+    pub draggable_state: Option<String>,
+    pub spellcheck: Option<String>,
+    pub translate: Option<String>,
+    pub popover: Option<String>,
+    pub popover_target: Option<String>,
+    pub popover_target_action: Option<String>,
+    pub command: Option<String>,
+    pub command_for: Option<String>,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserForm {
     pub id: Option<String>,
     pub action: Option<String>,
@@ -1608,7 +1647,15 @@ impl BrowserDocument {
             collect_head_browser_facts(&head.children, &mut summary);
         }
         let labels = collect_label_texts_by_control_id(body_children);
-        collect_browser_facts(body_children, &mut summary, &labels, &[], body_children);
+        let id_texts = collect_element_texts_by_id(body_children);
+        collect_browser_facts(
+            body_children,
+            &mut summary,
+            &labels,
+            &id_texts,
+            &[],
+            body_children,
+        );
         summary
     }
 }
@@ -8739,6 +8786,7 @@ fn collect_browser_facts(
     nodes: &[Node],
     summary: &mut BrowserDocument,
     labels: &[(String, String)],
+    id_texts: &[(String, String)],
     picture_sources: &[BrowserImageSource],
     body_root: &[Node],
 ) {
@@ -8752,6 +8800,9 @@ fn collect_browser_facts(
         collect_body_resource(element, summary);
         if let Some(context) = browser_embedded_context(element, summary.base_href.as_deref()) {
             summary.embedded_contexts.push(context);
+        }
+        if let Some(interactive) = browser_interactive_element(element, labels, id_texts) {
+            summary.interactive_elements.push(interactive);
         }
         if element.name == "template" {
             summary.templates.push(browser_template(element));
@@ -8774,7 +8825,7 @@ fn collect_browser_facts(
 
         match element.name.as_str() {
             "picture" => {
-                collect_browser_facts(&element.children, summary, labels, &[], body_root);
+                collect_browser_facts(&element.children, summary, labels, id_texts, &[], body_root);
                 continue;
             }
             "source" => {
@@ -8830,6 +8881,7 @@ fn collect_browser_facts(
             &element.children,
             summary,
             labels,
+            id_texts,
             picture_sources,
             body_root,
         );
@@ -9332,6 +9384,87 @@ fn browser_embedded_context(
         credentialless: browser_browsing_context_credentialless(element),
         fallback_text: visible_text_for_nodes(&element.children),
     })
+}
+
+fn browser_interactive_element(
+    element: &Element,
+    labels: &[(String, String)],
+    id_texts: &[(String, String)],
+) -> Option<BrowserInteractiveElement> {
+    let event_handlers = browser_event_handlers(element);
+    if !is_browser_interactive_summary_element(element, &event_handlers) {
+        return None;
+    }
+
+    let role = browser_content_role(&element.name).map(ToOwned::to_owned);
+    let control_labels = browser_control_labels(element, labels, None);
+    let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    Some(BrowserInteractiveElement {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        accessible_name: role
+            .as_deref()
+            .and_then(|role| browser_accessible_name(element, role, &control_labels, id_texts)),
+        role,
+        authored_role: element.attribute("role").map(ToOwned::to_owned),
+        text,
+        aria_label: browser_aria_label(element),
+        aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
+        aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
+        aria_controls: browser_aria_idrefs(element, "aria-controls"),
+        aria_current: browser_aria_state(element, "aria-current"),
+        aria_expanded: browser_aria_state(element, "aria-expanded"),
+        aria_pressed: browser_aria_state(element, "aria-pressed"),
+        aria_selected: browser_aria_state(element, "aria-selected"),
+        aria_hidden: browser_aria_hidden(element),
+        hidden: browser_hidden(element),
+        inert: browser_inert(element),
+        open: browser_open(element),
+        tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
+        accesskey: browser_accesskey(element),
+        event_handlers,
+        focusable: browser_focusable(element),
+        contenteditable: element.attribute("contenteditable").map(ToOwned::to_owned),
+        editing_mode: browser_editing_mode(element),
+        draggable: element.attribute("draggable").map(ToOwned::to_owned),
+        draggable_state: browser_draggable_state(element),
+        spellcheck: browser_spellcheck_state(element),
+        translate: browser_translate_state(element),
+        popover: element.attribute("popover").map(ToOwned::to_owned),
+        popover_target: browser_popover_target(element),
+        popover_target_action: browser_popover_target_action(element),
+        command: browser_command(element),
+        command_for: browser_command_for(element),
+        disabled: element.attribute("disabled").is_some(),
+    })
+}
+
+fn is_browser_interactive_summary_element(element: &Element, event_handlers: &[String]) -> bool {
+    if matches!(element.name.as_str(), "details" | "dialog" | "summary") {
+        return true;
+    }
+
+    !event_handlers.is_empty()
+        || element.attribute("role").is_some()
+        || element.attribute("aria-controls").is_some()
+        || element.attribute("aria-current").is_some()
+        || element.attribute("aria-expanded").is_some()
+        || element.attribute("aria-pressed").is_some()
+        || element.attribute("aria-selected").is_some()
+        || element.attribute("aria-hidden").is_some()
+        || element.attribute("hidden").is_some()
+        || element.attribute("inert").is_some()
+        || element.attribute("tabindex").is_some()
+        || element.attribute("accesskey").is_some()
+        || element.attribute("contenteditable").is_some()
+        || element.attribute("draggable").is_some()
+        || element.attribute("spellcheck").is_some()
+        || element.attribute("translate").is_some()
+        || element.attribute("popover").is_some()
+        || element.attribute("popovertarget").is_some()
+        || element.attribute("popovertargetaction").is_some()
+        || element.attribute("command").is_some()
+        || element.attribute("commandfor").is_some()
 }
 
 fn resolve_browser_url(url: &str, base_href: Option<&str>) -> Option<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,10 +1,10 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata,
     BrowserEmbeddedContext, BrowserForm, BrowserFormControl, BrowserFormSubmitter, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserLink, BrowserMedia, BrowserMeta,
-    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTemplate, BrowserThemeColor,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
+    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -62,6 +62,8 @@ struct ExpectedBrowserDocument {
     media: Vec<ExpectedMedia>,
     #[serde(default)]
     embedded_contexts: Vec<ExpectedEmbeddedContext>,
+    #[serde(default)]
+    interactive_elements: Vec<ExpectedInteractiveElement>,
     #[serde(default)]
     structured_items: Vec<ExpectedStructuredItem>,
     #[serde(default)]
@@ -499,6 +501,77 @@ struct ExpectedEmbeddedContext {
 }
 
 #[derive(Debug, Deserialize)]
+struct ExpectedInteractiveElement {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    authored_role: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    #[serde(default)]
+    aria_controls: Vec<String>,
+    #[serde(default)]
+    aria_current: Option<String>,
+    #[serde(default)]
+    aria_expanded: Option<String>,
+    #[serde(default)]
+    aria_pressed: Option<String>,
+    #[serde(default)]
+    aria_selected: Option<String>,
+    #[serde(default)]
+    aria_hidden: bool,
+    #[serde(default)]
+    hidden: bool,
+    #[serde(default)]
+    inert: bool,
+    #[serde(default)]
+    open: bool,
+    #[serde(default)]
+    tabindex: Option<String>,
+    #[serde(default)]
+    accesskey: Vec<String>,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    focusable: Option<bool>,
+    #[serde(default)]
+    contenteditable: Option<String>,
+    #[serde(default)]
+    editing_mode: Option<String>,
+    #[serde(default)]
+    draggable: Option<String>,
+    #[serde(default)]
+    draggable_state: Option<String>,
+    #[serde(default)]
+    spellcheck: Option<String>,
+    #[serde(default)]
+    translate: Option<String>,
+    #[serde(default)]
+    popover: Option<String>,
+    #[serde(default)]
+    popover_target: Option<String>,
+    #[serde(default)]
+    popover_target_action: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    command_for: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
 struct ExpectedForm {
     #[serde(default)]
     id: Option<String>,
@@ -685,6 +758,26 @@ fn browser_embedded_context_metadata_tracks_frame_object_embed_and_srcdoc() {
     );
 }
 
+#[test]
+fn browser_interactive_element_metadata_tracks_focus_editing_and_commands() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "interactive-element-state-page")
+        .expect("interactive element fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("interactive element fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.interactive_elements,
+        case.expected.into_browser_document().interactive_elements,
+        "interactive elements should preserve focus, editing, popover, command, hidden, and event metadata",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         BrowserDocument {
@@ -750,6 +843,11 @@ impl ExpectedBrowserDocument {
                 .embedded_contexts
                 .into_iter()
                 .map(ExpectedEmbeddedContext::into_browser_embedded_context)
+                .collect(),
+            interactive_elements: self
+                .interactive_elements
+                .into_iter()
+                .map(ExpectedInteractiveElement::into_browser_interactive_element)
                 .collect(),
             structured_items: self
                 .structured_items
@@ -1136,6 +1234,47 @@ impl ExpectedEmbeddedContext {
             srcdoc: self.srcdoc,
             credentialless: self.credentialless,
             fallback_text: self.fallback_text,
+        }
+    }
+}
+
+impl ExpectedInteractiveElement {
+    fn into_browser_interactive_element(self) -> BrowserInteractiveElement {
+        BrowserInteractiveElement {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            authored_role: self.authored_role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            aria_describedby: self.aria_describedby,
+            aria_controls: self.aria_controls,
+            aria_current: self.aria_current,
+            aria_expanded: self.aria_expanded,
+            aria_pressed: self.aria_pressed,
+            aria_selected: self.aria_selected,
+            aria_hidden: self.aria_hidden,
+            hidden: self.hidden,
+            inert: self.inert,
+            open: self.open,
+            tabindex: self.tabindex,
+            accesskey: self.accesskey,
+            event_handlers: self.event_handlers,
+            focusable: self.focusable,
+            contenteditable: self.contenteditable,
+            editing_mode: self.editing_mode,
+            draggable: self.draggable,
+            draggable_state: self.draggable_state,
+            spellcheck: self.spellcheck,
+            translate: self.translate,
+            popover: self.popover,
+            popover_target: self.popover_target,
+            popover_target_action: self.popover_target_action,
+            command: self.command,
+            command_for: self.command_for,
+            disabled: self.disabled,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -628,6 +628,58 @@
         "media": [
           { "kind": "video", "src": null, "resolved_src": null, "controls": true }
         ],
+        "interactive_elements": [
+          { "element": "main", "id": "app", "role": "main", "text": "Save", "event_handlers": ["onclick"] },
+          { "element": "button", "role": "control", "text": "Save", "accessible_name": "Save", "event_handlers": ["onclick", "onkeydown"] },
+          { "element": "video", "role": "media", "text": "", "event_handlers": ["onplay", "onpause"] },
+          { "element": "img", "role": "image", "text": "", "event_handlers": ["onerror"] },
+          { "element": "input", "role": "control", "text": "", "event_handlers": ["oninput", "onchange"] }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "interactive-element-state-page",
+      "description": "Browser document summaries expose focus, editing, popover, command, hidden, inert, and inline handler metadata as a flat interactive inventory.",
+      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel tabindex=0 accesskey=\"m /\" popovertarget=panel-pop popovertargetaction=toggle command=show-modal commandfor=dialog onclick=showMenu()>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help inert><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div id=action role=button tabindex=-1 aria-pressed=mixed aria-current=page contenteditable=plaintext-only draggable=auto spellcheck=false translate=no popover=manual onkeydown=keyAction()>Inline action</div><p id=editable contenteditable spellcheck=true translate=yes>Editable copy</p></section><dialog id=dialog open aria-label=\"Dialog\" accesskey=\"d x\"><p>Dialog copy</p></dialog><details id=more open><summary>More</summary><p>Extra</p></details><p id=secret hidden>Hidden copy</p><span id=decorative aria-hidden=true>Decorative</span><input id=disabled disabled value=no></main>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "app", "name": null, "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative" },
+          { "id": "menu", "name": null, "text": "Menu" },
+          { "id": "panel", "name": null, "text": "Settings Choose options Inline action Editable copy" },
+          { "id": "panel-title", "name": null, "text": "Settings" },
+          { "id": "panel-help", "name": null, "text": "Choose options" },
+          { "id": "action", "name": null, "text": "Inline action" },
+          { "id": "editable", "name": null, "text": "Editable copy" },
+          { "id": "dialog", "name": null, "text": "Dialog copy" },
+          { "id": "more", "name": null, "text": "More Extra" },
+          { "id": "secret", "name": null, "text": "Hidden copy" },
+          { "id": "decorative", "name": null, "text": "Decorative" },
+          { "id": "disabled", "name": null, "text": "" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Settings" }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [
+          { "element": "button", "id": "menu", "role": "control", "text": "Menu", "accessible_name": "Menu", "aria_controls": ["panel"], "aria_expanded": "false", "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "focusable": true, "popover_target": "panel-pop", "popover_target_action": "toggle", "command": "show-modal", "command_for": "dialog" },
+          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "inert": true },
+          { "element": "div", "id": "action", "role": "block", "authored_role": "button", "text": "Inline action", "aria_current": "page", "aria_pressed": "mixed", "tabindex": "-1", "event_handlers": ["onkeydown"], "focusable": false, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "popover": "manual" },
+          { "element": "p", "id": "editable", "role": "paragraph", "text": "Editable copy", "focusable": true, "contenteditable": "", "editing_mode": "richtext", "spellcheck": "true", "translate": "yes" },
+          { "element": "dialog", "id": "dialog", "role": "dialog", "text": "Dialog copy", "accessible_name": "Dialog", "aria_label": "Dialog", "open": true, "accesskey": ["d", "x"] },
+          { "element": "details", "id": "more", "role": "disclosure", "text": "More Extra", "open": true },
+          { "element": "summary", "role": "disclosure_summary", "text": "More" },
+          { "element": "p", "id": "secret", "role": "paragraph", "text": "Hidden copy", "hidden": true },
+          { "element": "span", "id": "decorative", "role": "inline", "text": "Decorative", "aria_hidden": true }
+        ],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- add a BrowserInteractiveElement inventory to BrowserDocument for stateful browser interaction targets
- capture focus/editing, ARIA state, popover/command, hidden/inert/open, access keys, and inline handler metadata without pulling in every plain link/control
- extend browser-readiness fixtures, schema governance, and targeted tests for inline handlers and interactive state

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_interactive_element_metadata_tracks_focus_editing_and_commands
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser