### PR TITLE
Track component hydration metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -252,6 +252,9 @@ def check_browser_readiness_case(
         f"{case_path}.expected", expected, "interactive_elements", errors
     )
     require_optional_object_list(
+        f"{case_path}.expected", expected, "component_hydration_targets", errors
+    )
+    require_optional_object_list(
         f"{case_path}.expected", expected, "structured_items", errors
     )
     require_optional_object_list(f"{case_path}.expected", expected, "templates", errors)
@@ -570,6 +573,33 @@ def check_browser_expected_lists(
             "disabled",
         ):
             require_optional_boolean(element_path, element, field, errors)
+
+    for index, target in enumerate(
+        object_list_items(expected, "component_hydration_targets")
+    ):
+        target_path = f"{case_path}.expected.component_hydration_targets[{index}]"
+        require_string(target_path, target, "element", errors)
+        for field in (
+            "id",
+            "custom_element_name",
+            "custom_element_is",
+            "slot",
+            "slot_name",
+            "exportparts",
+            "canvas_fallback_text",
+        ):
+            require_optional_nullable_string(target_path, target, field, errors)
+        require_optional_string(target_path, target, "text", errors)
+        for field in ("classes", "part"):
+            require_optional_string_list(target_path, target, field, errors)
+        require_optional_boolean(target_path, target, "custom_element", errors)
+        require_optional_object_list(target_path, target, "data_attributes", errors)
+        for data_index, data_attribute in enumerate(
+            object_list_items(target, "data_attributes")
+        ):
+            data_path = f"{target_path}.data_attributes[{data_index}]"
+            require_string(data_path, data_attribute, "name", errors)
+            require_optional_nullable_string(data_path, data_attribute, "value", errors)
 
     for index, item in enumerate(object_list_items(expected, "structured_items")):
         item_path = f"{case_path}.expected.structured_items[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -839,6 +839,7 @@ pub struct BrowserDocument {
     pub media: Vec<BrowserMedia>,
     pub embedded_contexts: Vec<BrowserEmbeddedContext>,
     pub interactive_elements: Vec<BrowserInteractiveElement>,
+    pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
     pub structured_items: Vec<BrowserStructuredItem>,
     pub templates: Vec<BrowserTemplate>,
     pub forms: Vec<BrowserForm>,
@@ -1023,6 +1024,29 @@ pub struct BrowserTemplate {
     pub shadowrootclonable: bool,
     pub shadowrootserializable: bool,
     pub content_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserComponentHydrationTarget {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub custom_element: bool,
+    pub custom_element_name: Option<String>,
+    pub custom_element_is: Option<String>,
+    pub slot: Option<String>,
+    pub slot_name: Option<String>,
+    pub part: Vec<String>,
+    pub exportparts: Option<String>,
+    pub data_attributes: Vec<BrowserDataAttribute>,
+    pub canvas_fallback_text: Option<String>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserDataAttribute {
+    pub name: String,
+    pub value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -8804,6 +8828,9 @@ fn collect_browser_facts(
         if let Some(interactive) = browser_interactive_element(element, labels, id_texts) {
             summary.interactive_elements.push(interactive);
         }
+        if let Some(target) = browser_component_hydration_target(element) {
+            summary.component_hydration_targets.push(target);
+        }
         if element.name == "template" {
             summary.templates.push(browser_template(element));
         }
@@ -10304,6 +10331,55 @@ fn browser_template(element: &Element) -> BrowserTemplate {
     }
 }
 
+fn browser_component_hydration_target(
+    element: &Element,
+) -> Option<BrowserComponentHydrationTarget> {
+    let slot = browser_slot_assignment(element);
+    let slot_name = browser_slot_name(element);
+    let custom_element_name = browser_custom_element_name(element);
+    let custom_element_is = browser_custom_element_is(element);
+    let part = browser_part_tokens(element);
+    let exportparts = browser_exportparts(element);
+    let data_attributes = browser_data_attributes(element);
+    let is_shadowroot_template =
+        element.name == "template" && element.attribute("shadowrootmode").is_some();
+    let is_canvas = element.name == "canvas";
+    let is_slot_element = element.name == "slot";
+    let custom_element = custom_element_name.is_some() || custom_element_is.is_some();
+
+    if !custom_element
+        && slot.is_none()
+        && slot_name.is_none()
+        && part.is_empty()
+        && exportparts.is_none()
+        && data_attributes.is_empty()
+        && !is_shadowroot_template
+        && !is_canvas
+        && !is_slot_element
+    {
+        return None;
+    }
+
+    Some(BrowserComponentHydrationTarget {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        custom_element,
+        custom_element_name,
+        custom_element_is,
+        slot,
+        slot_name,
+        part,
+        exportparts,
+        data_attributes,
+        canvas_fallback_text: is_canvas.then(|| visible_text_for_nodes(&element.children)),
+        text: visible_text_for_nodes(&element.children),
+    })
+}
+
 fn browser_slot_assignment(element: &Element) -> Option<String> {
     element.attribute("slot").map(ToOwned::to_owned)
 }
@@ -10326,6 +10402,34 @@ fn browser_custom_element_name(element: &Element) -> Option<String> {
 
 fn browser_custom_element_is(element: &Element) -> Option<String> {
     element.attribute("is").map(ToOwned::to_owned)
+}
+
+fn browser_part_tokens(element: &Element) -> Vec<String> {
+    element
+        .attribute("part")
+        .map(split_html_classes)
+        .unwrap_or_default()
+}
+
+fn browser_exportparts(element: &Element) -> Option<String> {
+    element
+        .attribute("exportparts")
+        .map(collapse_html_whitespace)
+        .filter(|exportparts| !exportparts.is_empty())
+}
+
+fn browser_data_attributes(element: &Element) -> Vec<BrowserDataAttribute> {
+    element
+        .attributes
+        .iter()
+        .filter(|attribute| {
+            attribute.name.starts_with("data-") && attribute.name != FRAGMENT_CONTEXT_MARKER
+        })
+        .map(|attribute| BrowserDataAttribute {
+            name: attribute.name.clone(),
+            value: Some(attribute.value.clone()),
+        })
+        .collect()
 }
 
 fn is_browser_custom_element_name(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,10 +1,11 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserAnchor, BrowserDocument, BrowserDocumentMetadata,
-    BrowserEmbeddedContext, BrowserForm, BrowserFormControl, BrowserFormSubmitter, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
-    BrowserMedia, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
+    BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext, BrowserForm,
+    BrowserFormControl, BrowserFormSubmitter, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
+    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -64,6 +65,8 @@ struct ExpectedBrowserDocument {
     embedded_contexts: Vec<ExpectedEmbeddedContext>,
     #[serde(default)]
     interactive_elements: Vec<ExpectedInteractiveElement>,
+    #[serde(default)]
+    component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
     #[serde(default)]
     structured_items: Vec<ExpectedStructuredItem>,
     #[serde(default)]
@@ -221,6 +224,42 @@ struct ExpectedTemplate {
     #[serde(default)]
     shadowrootserializable: bool,
     content_text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedComponentHydrationTarget {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    custom_element: bool,
+    #[serde(default)]
+    custom_element_name: Option<String>,
+    #[serde(default)]
+    custom_element_is: Option<String>,
+    #[serde(default)]
+    slot: Option<String>,
+    #[serde(default)]
+    slot_name: Option<String>,
+    #[serde(default)]
+    part: Vec<String>,
+    #[serde(default)]
+    exportparts: Option<String>,
+    #[serde(default)]
+    data_attributes: Vec<ExpectedDataAttribute>,
+    #[serde(default)]
+    canvas_fallback_text: Option<String>,
+    #[serde(default)]
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedDataAttribute {
+    name: String,
+    #[serde(default)]
+    value: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -778,6 +817,28 @@ fn browser_interactive_element_metadata_tracks_focus_editing_and_commands() {
     );
 }
 
+#[test]
+fn browser_component_hydration_metadata_tracks_custom_elements_slots_parts_and_data() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "component-template-page")
+        .expect("component template fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("component template fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.component_hydration_targets,
+        case.expected
+            .into_browser_document()
+            .component_hydration_targets,
+        "component hydration metadata should preserve custom elements, slots, parts, data attributes, and canvas fallback text",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         BrowserDocument {
@@ -848,6 +909,11 @@ impl ExpectedBrowserDocument {
                 .interactive_elements
                 .into_iter()
                 .map(ExpectedInteractiveElement::into_browser_interactive_element)
+                .collect(),
+            component_hydration_targets: self
+                .component_hydration_targets
+                .into_iter()
+                .map(ExpectedComponentHydrationTarget::into_browser_component_hydration_target)
                 .collect(),
             structured_items: self
                 .structured_items
@@ -1021,6 +1087,39 @@ impl ExpectedTemplate {
             shadowrootclonable: self.shadowrootclonable,
             shadowrootserializable: self.shadowrootserializable,
             content_text: self.content_text,
+        }
+    }
+}
+
+impl ExpectedComponentHydrationTarget {
+    fn into_browser_component_hydration_target(self) -> BrowserComponentHydrationTarget {
+        BrowserComponentHydrationTarget {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            custom_element: self.custom_element,
+            custom_element_name: self.custom_element_name,
+            custom_element_is: self.custom_element_is,
+            slot: self.slot,
+            slot_name: self.slot_name,
+            part: self.part,
+            exportparts: self.exportparts,
+            data_attributes: self
+                .data_attributes
+                .into_iter()
+                .map(ExpectedDataAttribute::into_browser_data_attribute)
+                .collect(),
+            canvas_fallback_text: self.canvas_fallback_text,
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedDataAttribute {
+    fn into_browser_data_attribute(self) -> BrowserDataAttribute {
+        BrowserDataAttribute {
+            name: self.name,
+            value: self.value,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -686,8 +686,8 @@
     },
     {
       "id": "component-template-page",
-      "description": "Browser document summaries expose inert template content and declarative shadow root metadata for component hydration.",
-      "input": "<body><template id=card-template shadowrootmode=open shadowrootdelegatesfocus shadowrootclonable shadowrootserializable><article><slot name=title>Untitled</slot><slot>Body</slot></article></template><product-card id=card><span slot=title>Widget</span><canvas id=chart width=300 height=150>Chart fallback</canvas><button is=fancy-button>Save</button><slot name=footer>Fallback footer</slot></product-card>",
+      "description": "Browser document summaries expose inert template content, declarative shadow root metadata, and component hydration targets.",
+      "input": "<body><template id=card-template data-template=card shadowrootmode=open shadowrootdelegatesfocus shadowrootclonable shadowrootserializable><article part=frame><slot name=title>Untitled</slot><slot>Body</slot></article></template><product-card id=card data-controller=product data-state=ready part=host exportparts=\"header:title, chart\"><span slot=title data-field=name part=title>Widget</span><canvas id=chart width=300 height=150 data-renderer=canvas part=chart>Chart fallback</canvas><button is=fancy-button data-action=save part=action>Save</button><slot name=footer part=footer>Fallback footer</slot></product-card>",
       "expected": {
         "title": null,
         "base_href": null,
@@ -712,6 +712,17 @@
             "shadowrootserializable": true,
             "content_text": "Untitled Body"
           }
+        ],
+        "component_hydration_targets": [
+          { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "text": "Untitled Body" },
+          { "element": "article", "part": ["frame"], "text": "Untitled Body" },
+          { "element": "slot", "slot_name": "title", "text": "Untitled" },
+          { "element": "slot", "text": "Body" },
+          { "element": "product-card", "id": "card", "custom_element": true, "custom_element_name": "product-card", "part": ["host"], "exportparts": "header:title, chart", "data_attributes": [{ "name": "data-controller", "value": "product" }, { "name": "data-state", "value": "ready" }], "text": "Widget Chart fallback Save Fallback footer" },
+          { "element": "span", "slot": "title", "part": ["title"], "data_attributes": [{ "name": "data-field", "value": "name" }], "text": "Widget" },
+          { "element": "canvas", "id": "chart", "part": ["chart"], "data_attributes": [{ "name": "data-renderer", "value": "canvas" }], "canvas_fallback_text": "Chart fallback", "text": "Chart fallback" },
+          { "element": "button", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attributes": [{ "name": "data-action", "value": "save" }], "text": "Save" },
+          { "element": "slot", "slot_name": "footer", "part": ["footer"], "text": "Fallback footer" }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
## Summary
- add BrowserDocument component hydration targets for custom elements, slots, part/exportparts, data attributes, and canvas fallback text
- extend the component-template browser-readiness fixture to govern declarative shadow root and hydration metadata
- teach the HTML fixture schema checker about component_hydration_targets

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_component_hydration_metadata_tracks_custom_elements_slots_parts_and_data
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser