### PR TITLE
Track navigation attribution metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -462,6 +462,8 @@ def check_browser_expected_lists(
             require_optional_boolean(link_path, link, field, errors)
         require_optional_string_list(link_path, link, "ping", errors)
         require_optional_string_list(link_path, link, "resolved_ping", errors)
+        require_optional_string_list(link_path, link, "attributionsrc", errors)
+        require_optional_string_list(link_path, link, "resolved_attributionsrc", errors)
         require_string(link_path, link, "text", errors)
 
     for index, image in enumerate(object_list_items(expected, "images")):
@@ -637,9 +639,18 @@ def check_browser_expected_lists(
         require_string(form_path, form, "method", errors)
         require_optional_nullable_string(form_path, form, "enctype", errors)
         require_optional_nullable_string(form_path, form, "target", errors)
+        require_optional_nullable_string(form_path, form, "effective_target", errors)
         require_optional_nullable_string(form_path, form, "accept_charset", errors)
         require_optional_nullable_string(form_path, form, "autocomplete", errors)
         require_optional_nullable_string(form_path, form, "rel", errors)
+        require_optional_string_list(form_path, form, "rel_tokens", errors)
+        for field in (
+            "rel_external",
+            "rel_nofollow",
+            "rel_noopener",
+            "rel_noreferrer",
+        ):
+            require_optional_boolean(form_path, form, field, errors)
         require_optional_boolean(form_path, form, "novalidate", errors)
         require_object_list(form_path, form, "controls", errors)
         require_optional_object_list(form_path, form, "submitters", errors)
@@ -704,6 +715,7 @@ def check_browser_expected_lists(
                 "resolved_action",
                 "enctype",
                 "target",
+                "effective_target",
                 "value",
             ):
                 require_optional_nullable_string(submitter_path, submitter, field, errors)
@@ -884,6 +896,8 @@ def check_browser_content_node(
     require_optional_string_list(node_path, node, "rel_tokens", errors)
     require_optional_string_list(node_path, node, "ping", errors)
     require_optional_string_list(node_path, node, "resolved_ping", errors)
+    require_optional_string_list(node_path, node, "attributionsrc", errors)
+    require_optional_string_list(node_path, node, "resolved_attributionsrc", errors)
     require_optional_string_list(node_path, node, "headers", errors)
     require_optional_string_list(node_path, node, "labels", errors)
     require_optional_string_list(node_path, node, "sandbox", errors)
@@ -1095,6 +1109,8 @@ def check_browser_render_node(
     require_optional_string_list(node_path, node, "rel_tokens", errors)
     require_optional_string_list(node_path, node, "ping", errors)
     require_optional_string_list(node_path, node, "resolved_ping", errors)
+    require_optional_string_list(node_path, node, "attributionsrc", errors)
+    require_optional_string_list(node_path, node, "resolved_attributionsrc", errors)
     require_optional_string_list(node_path, node, "headers", errors)
     require_optional_string_list(node_path, node, "labels", errors)
     require_optional_string_list(node_path, node, "sandbox", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1073,6 +1073,8 @@ pub struct BrowserContentNode {
     pub download: Option<String>,
     pub ping: Vec<String>,
     pub resolved_ping: Vec<String>,
+    pub attributionsrc: Vec<String>,
+    pub resolved_attributionsrc: Vec<String>,
     pub hreflang: Option<String>,
     pub src: Option<String>,
     pub resolved_src: Option<String>,
@@ -1247,6 +1249,8 @@ pub struct BrowserRenderNode {
     pub download: Option<String>,
     pub ping: Vec<String>,
     pub resolved_ping: Vec<String>,
+    pub attributionsrc: Vec<String>,
+    pub resolved_attributionsrc: Vec<String>,
     pub hreflang: Option<String>,
     pub src: Option<String>,
     pub resolved_src: Option<String>,
@@ -1421,6 +1425,8 @@ pub struct BrowserLink {
     pub download: Option<String>,
     pub ping: Vec<String>,
     pub resolved_ping: Vec<String>,
+    pub attributionsrc: Vec<String>,
+    pub resolved_attributionsrc: Vec<String>,
     pub hreflang: Option<String>,
     pub type_hint: Option<String>,
     pub referrerpolicy: Option<String>,
@@ -1540,9 +1546,15 @@ pub struct BrowserForm {
     pub method: String,
     pub enctype: Option<String>,
     pub target: Option<String>,
+    pub effective_target: Option<String>,
     pub accept_charset: Option<String>,
     pub autocomplete: Option<String>,
     pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub rel_external: bool,
+    pub rel_nofollow: bool,
+    pub rel_noopener: bool,
+    pub rel_noreferrer: bool,
     pub novalidate: bool,
     pub controls: Vec<BrowserFormControl>,
     pub submitters: Vec<BrowserFormSubmitter>,
@@ -1607,6 +1619,7 @@ pub struct BrowserFormSubmitter {
     pub method: String,
     pub enctype: Option<String>,
     pub target: Option<String>,
+    pub effective_target: Option<String>,
     pub novalidate: bool,
     pub value: Option<String>,
 }
@@ -1747,6 +1760,8 @@ impl BrowserRenderNode {
             download: content_node.download.clone(),
             ping: content_node.ping.clone(),
             resolved_ping: content_node.resolved_ping.clone(),
+            attributionsrc: content_node.attributionsrc.clone(),
+            resolved_attributionsrc: content_node.resolved_attributionsrc.clone(),
             hreflang: content_node.hreflang.clone(),
             src: content_node.src.clone(),
             resolved_src: content_node.resolved_src.clone(),
@@ -8887,6 +8902,7 @@ fn collect_browser_facts(
                 element,
                 labels,
                 summary.base_href.as_deref(),
+                summary.base_target.as_deref(),
             )),
             "table" => summary.tables.push(BrowserTable {
                 caption: find_first_element_in_nodes(&element.children, "caption")
@@ -9246,6 +9262,11 @@ fn browser_link(
             .filter_map(|ping| resolve_browser_url(&ping, base_href))
             .collect(),
         ping: browser_anchor_ping(element),
+        resolved_attributionsrc: browser_anchor_attributionsrc(element)
+            .into_iter()
+            .filter_map(|attributionsrc| resolve_browser_url(&attributionsrc, base_href))
+            .collect(),
+        attributionsrc: browser_anchor_attributionsrc(element),
         hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
         type_hint: element.attribute("type").map(ToOwned::to_owned),
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
@@ -9754,6 +9775,8 @@ fn collect_browser_content_nodes_with_mode(
                         download: None,
                         ping: Vec::new(),
                         resolved_ping: Vec::new(),
+                        attributionsrc: Vec::new(),
+                        resolved_attributionsrc: Vec::new(),
                         hreflang: None,
                         src: None,
                         resolved_src: None,
@@ -9998,6 +10021,11 @@ fn browser_content_node_for_element(
             .filter_map(|ping| resolve_browser_url(&ping, base_href))
             .collect(),
         ping: browser_anchor_ping(element),
+        resolved_attributionsrc: browser_anchor_attributionsrc(element)
+            .into_iter()
+            .filter_map(|attributionsrc| resolve_browser_url(&attributionsrc, base_href))
+            .collect(),
+        attributionsrc: browser_anchor_attributionsrc(element),
         hreflang: browser_anchor_hreflang(element),
         resolved_src: src
             .as_deref()
@@ -11146,6 +11174,17 @@ fn browser_anchor_ping(element: &Element) -> Vec<String> {
     }
 }
 
+fn browser_anchor_attributionsrc(element: &Element) -> Vec<String> {
+    if is_browser_anchor_navigation_element(element) {
+        element
+            .attribute("attributionsrc")
+            .map(split_html_classes)
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
 fn browser_anchor_hreflang(element: &Element) -> Option<String> {
     is_browser_anchor_navigation_element(element)
         .then(|| element.attribute("hreflang").map(ToOwned::to_owned))
@@ -12055,6 +12094,7 @@ fn browser_form(
     element: &Element,
     labels: &[(String, String)],
     base_href: Option<&str>,
+    base_target: Option<&str>,
 ) -> BrowserForm {
     let action = element.attribute("action").map(ToOwned::to_owned);
     let resolved_action = action
@@ -12066,6 +12106,10 @@ fn browser_form(
         .unwrap_or_else(|| "get".to_string());
     let enctype = element.attribute("enctype").map(ToOwned::to_owned);
     let target = element.attribute("target").map(ToOwned::to_owned);
+    let effective_target = target
+        .clone()
+        .or_else(|| base_target.map(ToOwned::to_owned));
+    let rel_tokens = browser_rel_tokens(element);
     let novalidate = element.attribute("novalidate").is_some();
     let controls = collect_form_controls_for_form(body_root, element, labels, base_href);
     let submitters = browser_form_submitters(
@@ -12075,6 +12119,7 @@ fn browser_form(
         &method,
         enctype.as_deref(),
         target.as_deref(),
+        base_target,
         novalidate,
     );
     BrowserForm {
@@ -12085,9 +12130,15 @@ fn browser_form(
         method,
         enctype,
         target,
+        effective_target,
         accept_charset: element.attribute("accept-charset").map(ToOwned::to_owned),
         autocomplete: element.attribute("autocomplete").map(ToOwned::to_owned),
         rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_external: browser_rel_tokens_contain(&rel_tokens, "external"),
+        rel_nofollow: browser_rel_tokens_contain(&rel_tokens, "nofollow"),
+        rel_noopener: browser_rel_tokens_contain(&rel_tokens, "noopener"),
+        rel_noreferrer: browser_rel_tokens_contain(&rel_tokens, "noreferrer"),
+        rel_tokens,
         novalidate,
         controls,
         submitters,
@@ -12101,6 +12152,7 @@ fn browser_form_submitters(
     method: &str,
     enctype: Option<&str>,
     target: Option<&str>,
+    base_target: Option<&str>,
     novalidate: bool,
 ) -> Vec<BrowserFormSubmitter> {
     controls
@@ -12131,6 +12183,11 @@ fn browser_form_submitters(
                 .form_target
                 .clone()
                 .or_else(|| target.map(ToOwned::to_owned)),
+            effective_target: control
+                .form_target
+                .clone()
+                .or_else(|| target.map(ToOwned::to_owned))
+                .or_else(|| base_target.map(ToOwned::to_owned)),
             novalidate: novalidate || control.form_novalidate,
             value: control.value.clone(),
         })

--- a/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_content_tree_test.rs
@@ -57,6 +57,10 @@ struct ExpectedContentNode {
     #[serde(default)]
     resolved_ping: Vec<String>,
     #[serde(default)]
+    attributionsrc: Vec<String>,
+    #[serde(default)]
+    resolved_attributionsrc: Vec<String>,
+    #[serde(default)]
     hreflang: Option<String>,
     src: Option<String>,
     #[serde(default)]
@@ -402,6 +406,8 @@ impl ExpectedContentNode {
             download: self.download,
             ping: self.ping,
             resolved_ping: self.resolved_ping,
+            attributionsrc: self.attributionsrc,
+            resolved_attributionsrc: self.resolved_attributionsrc,
             hreflang: self.hreflang,
             src: self.src,
             resolved_src: self.resolved_src,

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -423,6 +423,10 @@ struct ExpectedLink {
     #[serde(default)]
     resolved_ping: Vec<String>,
     #[serde(default)]
+    attributionsrc: Vec<String>,
+    #[serde(default)]
+    resolved_attributionsrc: Vec<String>,
+    #[serde(default)]
     hreflang: Option<String>,
     #[serde(default)]
     type_hint: Option<String>,
@@ -622,11 +626,23 @@ struct ExpectedForm {
     enctype: Option<String>,
     target: Option<String>,
     #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
     accept_charset: Option<String>,
     #[serde(default)]
     autocomplete: Option<String>,
     #[serde(default)]
     rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    rel_external: bool,
+    #[serde(default)]
+    rel_nofollow: bool,
+    #[serde(default)]
+    rel_noopener: bool,
+    #[serde(default)]
+    rel_noreferrer: bool,
     #[serde(default)]
     novalidate: bool,
     controls: Vec<ExpectedFormControl>,
@@ -738,6 +754,8 @@ struct ExpectedFormSubmitter {
     #[serde(default)]
     target: Option<String>,
     #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
     novalidate: bool,
     #[serde(default)]
     value: Option<String>,
@@ -814,6 +832,40 @@ fn browser_interactive_element_metadata_tracks_focus_editing_and_commands() {
         actual.interactive_elements,
         case.expected.into_browser_document().interactive_elements,
         "interactive elements should preserve focus, editing, popover, command, hidden, and event metadata",
+    );
+}
+
+#[test]
+fn browser_navigation_attribution_metadata_tracks_links_areas_and_form_targets() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+
+    let legacy = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "legacy-directory-page")
+        .expect("legacy directory fixture case should exist");
+    let legacy_actual = parse_browser_document(&legacy.input)
+        .expect("legacy directory fixture should parse into browser document facts");
+    assert_eq!(
+        legacy_actual.links,
+        legacy.expected.into_browser_document().links,
+        "link metadata should preserve attribution source registration URLs",
+    );
+
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let forms = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "form-accessibility-document-page")
+        .expect("form accessibility fixture case should exist");
+    let forms_actual = parse_browser_document(&forms.input)
+        .expect("form accessibility fixture should parse into browser document facts");
+    assert_eq!(
+        forms_actual.forms,
+        forms.expected.into_browser_document().forms,
+        "form metadata should preserve rel tokens and base-target effective submitter targets",
     );
 }
 
@@ -1243,6 +1295,8 @@ impl ExpectedLink {
             download: self.download,
             ping: self.ping,
             resolved_ping: self.resolved_ping,
+            attributionsrc: self.attributionsrc,
+            resolved_attributionsrc: self.resolved_attributionsrc,
             hreflang: self.hreflang,
             type_hint: self.type_hint,
             referrerpolicy: self.referrerpolicy,
@@ -1388,9 +1442,15 @@ impl ExpectedForm {
             method: self.method,
             enctype: self.enctype,
             target: self.target,
+            effective_target: self.effective_target,
             accept_charset: self.accept_charset,
             autocomplete: self.autocomplete,
             rel: self.rel,
+            rel_tokens: self.rel_tokens,
+            rel_external: self.rel_external,
+            rel_nofollow: self.rel_nofollow,
+            rel_noopener: self.rel_noopener,
+            rel_noreferrer: self.rel_noreferrer,
             novalidate: self.novalidate,
             controls: self
                 .controls
@@ -1469,6 +1529,7 @@ impl ExpectedFormSubmitter {
             method: self.method,
             enctype: self.enctype,
             target: self.target,
+            effective_target: self.effective_target,
             novalidate: self.novalidate,
             value: self.value,
         }

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -58,6 +58,10 @@ struct ExpectedRenderNode {
     #[serde(default)]
     resolved_ping: Vec<String>,
     #[serde(default)]
+    attributionsrc: Vec<String>,
+    #[serde(default)]
+    resolved_attributionsrc: Vec<String>,
+    #[serde(default)]
     hreflang: Option<String>,
     src: Option<String>,
     #[serde(default)]
@@ -404,6 +408,8 @@ impl ExpectedRenderNode {
             download: self.download,
             ping: self.ping,
             resolved_ping: self.resolved_ping,
+            attributionsrc: self.attributionsrc,
+            resolved_attributionsrc: self.resolved_attributionsrc,
             hreflang: self.hreflang,
             src: self.src,
             resolved_src: self.resolved_src,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -6,7 +6,7 @@
     {
       "id": "legacy-directory-page",
       "description": "Omitted shell, title/base metadata, anchors, navigation attributes, image attributes, and implied list-item endings.",
-      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=\"next external noreferrer\" title=\"Intro\" download=intro.html ping=\"track.html https://metrics.example/p\" hreflang=en type=text/html referrerpolicy=no-referrer>Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
+      "input": "<!doctype html><title>Example &amp; Links</title><base href=\"https://example.test/docs/\" target=_top><meta charset=utf-8><link rel=stylesheet href=\"style.css\" media=screen title=default><h1 id=index>Example Directory</h1><p>Welcome to <a href=\"intro.html\" target=main rel=\"next external noreferrer\" title=\"Intro\" download=intro.html ping=\"track.html https://metrics.example/p\" attributionsrc=\"attr/register https://ad.example/register\" hreflang=en type=text/html referrerpolicy=no-referrer>Venture HTML</a>.<img src=\"logo.gif\" alt=\"Logo\" width=88 height=31><ul><li>One<li>Two",
       "expected": {
         "title": "Example & Links",
         "base_href": "https://example.test/docs/",
@@ -30,7 +30,7 @@
           { "level": 1, "text": "Example Directory" }
         ],
         "links": [
-          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "effective_target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "rel_external": true, "rel_noreferrer": true, "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "hreflang": "en", "type_hint": "text/html", "referrerpolicy": "no-referrer", "text": "Venture HTML" }
+          { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "effective_target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "rel_external": true, "rel_noreferrer": true, "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "attributionsrc": ["attr/register", "https://ad.example/register"], "resolved_attributionsrc": ["https://example.test/docs/attr/register", "https://ad.example/register"], "hreflang": "en", "type_hint": "text/html", "referrerpolicy": "no-referrer", "text": "Venture HTML" }
         ],
         "images": [
           { "src": "logo.gif", "resolved_src": "https://example.test/docs/logo.gif", "alt": "Logo", "width": "88", "height": "31" }
@@ -73,6 +73,7 @@
             "method": "post",
             "enctype": "multipart/form-data",
             "target": "results",
+            "effective_target": "results",
             "controls": [
               { "control_type": "text", "name": "q", "value": "rust html", "disabled": false, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "disabled": false, "checked": false, "text": "", "options": [] },
@@ -83,7 +84,7 @@
               { "control_type": "submit", "name": "go", "accessible_name": "Search", "value": null, "disabled": false, "checked": false, "text": "Search", "options": [] }
             ],
             "submitters": [
-              { "id": null, "control_type": "submit", "name": "go", "accessible_name": "Search", "action": "/search", "resolved_action": null, "method": "post", "enctype": "multipart/form-data", "target": "results", "novalidate": false, "value": null }
+              { "id": null, "control_type": "submit", "name": "go", "accessible_name": "Search", "action": "/search", "resolved_action": null, "method": "post", "enctype": "multipart/form-data", "target": "results", "effective_target": "results", "novalidate": false, "value": null }
             ]
           }
         ],
@@ -95,7 +96,7 @@
     {
       "id": "responsive-image-metadata-page",
       "description": "Browser document image summaries expose responsive source selection metadata and loading hints.",
-      "input": "<base href=\"https://example.test/gallery/index.html\"><body><picture><source media=\"(min-width: 800px)\" type=image/avif srcset=\"hero-wide.avif 1x, hero-wide@2x.avif 2x\" sizes=\"80vw\"><source media=\"(min-width: 400px)\" type=image/webp srcset=\"hero.webp 640w, hero-large.webp 1280w\" sizes=\"100vw\"><img src=hero.jpg srcset=\"hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w\" sizes=\"(max-width: 600px) 100vw, 50vw\" alt=\"Hero\" width=640 height=360 loading=lazy decoding=async fetchpriority=high crossorigin=anonymous referrerpolicy=no-referrer usemap=#hero-map ismap></picture><map name=hero-map><area shape=rect coords=\"0,0,120,60\" href=details.html alt=\"Details\" target=preview rel=\"nofollow external\" ping=\"track.html\" hreflang=en></map>",
+      "input": "<base href=\"https://example.test/gallery/index.html\"><body><picture><source media=\"(min-width: 800px)\" type=image/avif srcset=\"hero-wide.avif 1x, hero-wide@2x.avif 2x\" sizes=\"80vw\"><source media=\"(min-width: 400px)\" type=image/webp srcset=\"hero.webp 640w, hero-large.webp 1280w\" sizes=\"100vw\"><img src=hero.jpg srcset=\"hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w\" sizes=\"(max-width: 600px) 100vw, 50vw\" alt=\"Hero\" width=640 height=360 loading=lazy decoding=async fetchpriority=high crossorigin=anonymous referrerpolicy=no-referrer usemap=#hero-map ismap></picture><map name=hero-map><area shape=rect coords=\"0,0,120,60\" href=details.html alt=\"Details\" target=preview rel=\"nofollow external\" ping=\"track.html\" attributionsrc=\"area-attr.html\" hreflang=en></map>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/gallery/index.html",
@@ -108,7 +109,7 @@
         "anchors": [],
         "headings": [],
         "links": [
-          { "element": "area", "href": "details.html", "resolved_href": "https://example.test/gallery/details.html", "name": null, "target": "preview", "effective_target": "preview", "rel": "nofollow external", "rel_tokens": ["nofollow", "external"], "rel_external": true, "rel_nofollow": true, "title": null, "ping": ["track.html"], "resolved_ping": ["https://example.test/gallery/track.html"], "hreflang": "en", "text": "Details" }
+          { "element": "area", "href": "details.html", "resolved_href": "https://example.test/gallery/details.html", "name": null, "target": "preview", "effective_target": "preview", "rel": "nofollow external", "rel_tokens": ["nofollow", "external"], "rel_external": true, "rel_nofollow": true, "title": null, "ping": ["track.html"], "resolved_ping": ["https://example.test/gallery/track.html"], "attributionsrc": ["area-attr.html"], "resolved_attributionsrc": ["https://example.test/gallery/area-attr.html"], "hreflang": "en", "text": "Details" }
         ],
         "images": [
           {
@@ -140,11 +141,11 @@
     {
       "id": "form-accessibility-document-page",
       "description": "Browser document form summaries include labels, accessible names, submission metadata, validation hints, autocomplete, and control state.",
-      "input": "<base href=\"https://example.test/search/index.html\"><body><form id=search name=searchForm aria-label=\"Search form\" action=find.html method=post accept-charset=utf-8 autocomplete=on rel=noreferrer novalidate><label for=q>Query</label><input id=q name=q placeholder=\"Search terms\" required autocomplete=search autocapitalize=words enterkeyhint=search dirname=q.dir autofocus inputmode=search pattern=\"[A-Za-z ]+\" minlength=2 maxlength=80 size=40 list=query-suggestions><datalist id=query-suggestions><option value=Rust><option value=HTML label=Markup><option>Browser APIs</datalist><label>Notes<textarea id=notes name=notes placeholder=Details readonly maxlength=500 autocapitalize=sentences enterkeyhint=done dirname=notes.dir>Keep me</textarea></label><fieldset><legend>Options</legend><label>Fast<input id=fast type=checkbox name=fast checked></label></fieldset><select id=kind name=kind title=Kind multiple size=5><option selected>Books<option>Manuals</select><input id=upload type=file name=upload accept=\"image/png,image/jpeg\" capture=environment><button id=go type=submit aria-label=\"Run search\" formaction=run.html formenctype=\"application/x-www-form-urlencoded\" formmethod=post formtarget=results formnovalidate>Go</button><input id=imageGo type=image name=image-go src=buttons/search.png alt=\"Search image\" width=32 height=16><output id=total name=total for=\"q kind\">Ready</output></form><input id=external form=search name=outside placeholder=Outside>",
+      "input": "<base href=\"https://example.test/search/index.html\" target=_search><body><form id=search name=searchForm aria-label=\"Search form\" action=find.html method=post accept-charset=utf-8 autocomplete=on rel=\"noreferrer external\" novalidate><label for=q>Query</label><input id=q name=q placeholder=\"Search terms\" required autocomplete=search autocapitalize=words enterkeyhint=search dirname=q.dir autofocus inputmode=search pattern=\"[A-Za-z ]+\" minlength=2 maxlength=80 size=40 list=query-suggestions><datalist id=query-suggestions><option value=Rust><option value=HTML label=Markup><option>Browser APIs</datalist><label>Notes<textarea id=notes name=notes placeholder=Details readonly maxlength=500 autocapitalize=sentences enterkeyhint=done dirname=notes.dir>Keep me</textarea></label><fieldset><legend>Options</legend><label>Fast<input id=fast type=checkbox name=fast checked></label></fieldset><select id=kind name=kind title=Kind multiple size=5><option selected>Books<option>Manuals</select><input id=upload type=file name=upload accept=\"image/png,image/jpeg\" capture=environment><button id=go type=submit aria-label=\"Run search\" formaction=run.html formenctype=\"application/x-www-form-urlencoded\" formmethod=post formtarget=results formnovalidate>Go</button><input id=imageGo type=image name=image-go src=buttons/search.png alt=\"Search image\" width=32 height=16><output id=total name=total for=\"q kind\">Ready</output></form><input id=external form=search name=outside placeholder=Outside>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/search/index.html",
-        "base_target": null,
+        "base_target": "_search",
         "body_text": "Query NotesKeep me Options Fast Books Manuals Go Ready",
         "metas": [],
         "resources": [],
@@ -173,9 +174,13 @@
             "method": "post",
             "enctype": null,
             "target": null,
+            "effective_target": "_search",
             "accept_charset": "utf-8",
             "autocomplete": "on",
-            "rel": "noreferrer",
+            "rel": "noreferrer external",
+            "rel_tokens": ["noreferrer", "external"],
+            "rel_external": true,
+            "rel_noreferrer": true,
             "novalidate": true,
             "controls": [
               { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "placeholder": "Search terms", "autocomplete": "search", "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "autofocus": true, "disabled": false, "required": true, "checked": false, "text": "", "options": [] },
@@ -189,8 +194,8 @@
               { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "disabled": false, "checked": false, "text": "", "options": [] }
             ],
             "submitters": [
-              { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "novalidate": true, "value": null },
-              { "id": "imageGo", "control_type": "image", "name": "image-go", "accessible_name": "Search image", "action": "find.html", "resolved_action": "https://example.test/search/find.html", "method": "post", "enctype": null, "target": null, "novalidate": true, "value": null }
+              { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "effective_target": "results", "novalidate": true, "value": null },
+              { "id": "imageGo", "control_type": "image", "name": "image-go", "accessible_name": "Search image", "action": "find.html", "resolved_action": "https://example.test/search/find.html", "method": "post", "enctype": null, "target": null, "effective_target": "_search", "novalidate": true, "value": null }
             ]
           }
         ],


### PR DESCRIPTION
## Summary
- add attributionsrc and resolved attribution registration URLs to browser link/content/render metadata
- expose form rel tokens/flags and effective base-target resolution for forms and submitters
- extend browser-readiness fixtures and schema governance for link attribution and form target behavior

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p coding-adventures-html-parser browser_navigation_attribution_metadata_tracks_links_areas_and_form_targets
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser