### PR TITLE
feat(cas-summation): Phase 82 — Five-Sqrt × Five-Log × polynomial numerator (v2.18.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.18.0 — 2026-05-25
+
+### Added
+
+- **Phase 82 — Five-Sqrt × Five-Log × polynomial numerator** (`_five_sqrt_five_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Sqrt(P4), Sqrt(P5), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 5 Log factors required.  `log⁵(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + sqrt4_deg_x2 + sqrt5_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase82FiveSqrtFiveLogPoly`.
+
 ## 2.17.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.17.0"
+version = "2.18.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1111,6 +1111,21 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 82: ``Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Sqrt(P4), Sqrt(P5), Log(h1), Log(h2),
+    #           Log(h3), Log(h4), Log(h5), polynomial..., bounded...)`` numerator.
+    # Five Sqrt factors + five Log factors; log⁵ sub-polynomial → 0.
+    # effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + sqrt4_deg_x2 + sqrt5_deg_x2
+    #              + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s5l5p_x2 = _five_sqrt_five_log_poly_effective_x2(num, k)
+    if s5l5p_x2 is not None:
+        den_deg_s5l5 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l5 is not None:
+            if 2 * den_deg_s5l5 > s5l5p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -2899,6 +2914,76 @@ def _two_sqrt_five_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | Non
     if len(sqrt_degs_x2) != 2 or log_count != 5:
         return None
     return sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg_sum
+
+
+def _five_sqrt_five_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + sqrt4_deg_x2 + sqrt5_deg_x2 + 2·poly_deg``
+    when ``node`` is a ``Mul`` with **exactly five** ``Sqrt(positive-leading polynomial)``
+    factors, **exactly five** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 82 — Five-Sqrt × Five-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a₁) · sqrt(k^a₂) · sqrt(k^a₃) · sqrt(k^a₄) · sqrt(k^a₅) · log(k)⁵ · k^m
+    ≈ k^{(a₁+a₂+a₃+a₄+a₅)/2} · log⁵(k) · k^m``.
+    ``log⁵(k)`` is sub-polynomial (``o(k^ε)``), contributing 0.
+    Using the ×2 integer trick:
+    ``effective_x2 = a₁ + a₂ + a₃ + a₄ + a₅ + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +--------------------------------------------------------------------------+---------------------+
+    | Input                                                                    | Return              |
+    +==========================================================================+=====================+
+    | ``Mul(Sqrt(k)×5, Log(k)×5)``                                            | ``1+1+1+1+1 = 5``   |
+    | ``Mul(Sqrt(k³)×5, Log(k)×5)``                                           | ``3+3+3+3+3 = 15``  |
+    | ``Mul(Sqrt(k)×5, Log(k)×5, k)``                                         | ``1+1+1+1+1+2 = 7`` |
+    | ``Mul(Sqrt(k)×4, Log(k)×5)``                                            | None (4 Sqrts)      |
+    | ``Mul(Sqrt(k)×6, Log(k)×5)``                                            | None (6 Sqrts)      |
+    | ``Mul(Sqrt(k)×5, Log(k)×4)``                                            | None (4 Logs)       |
+    +--------------------------------------------------------------------------+---------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 5.
+         - ``Log(diverging)`` → count; bail after 5.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 5 Sqrt AND exactly 5 Log factors.
+      4. Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + sqrt4_deg_x2 + sqrt5_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                # Sixth Sqrt factor — not this phase.
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 5:
+                # Six or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 5:
+        return None
+    return (sqrt_degs_x2[0] + sqrt_degs_x2[1] + sqrt_degs_x2[2]
+            + sqrt_degs_x2[3] + sqrt_degs_x2[4] + 2 * poly_deg_sum)
 
 
 def _three_sqrt_four_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4296,3 +4296,89 @@ class TestPhase79TwoSqrtFiveLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase82FiveSqrtFiveLogPoly:
+    """Phase 82 — Five-Sqrt × Five-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √P₁(k)·√P₂(k)·√P₃(k)·√P₄(k)·√P₅(k)·log⁵(k)·poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = deg1_x2 + deg2_x2 + deg3_x2 + deg4_x2 + deg5_x2 + 2·poly_deg.
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_five_sqrt_k_log5_k_over_k3_closes(self):
+        """√k·√k·√k·√k·√k·log(k)⁵/k³: eff_x2=1+1+1+1+1=5; 2·3=6 > 5 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_five_sqrt_k3_log5_k_over_k_refused(self):
+        """√(k³)·√(k³)·√(k³)·√(k³)·√(k³)·log(k)⁵/k: eff_x2=3+3+3+3+3=15; 2·1=2 not > 15 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+                              IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+                              IRApply(SQRT, (k3,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+                                IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+                                IRApply(SQRT, (kp1_3,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_five_sqrt_k_log5_k_times_k_over_k4_closes(self):
+        """√k·√k·√k·√k·√k·log(k)⁵·k/k⁴: eff_x2=5+2=7; 2·4=8 > 7 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), kp1))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.18.0 — 2026-05-25
+
+### Added
+
+- **Phase 82 — Five-Sqrt × Five-Log × polynomial numerator** (`five_sqrt_five_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Sqrt(P4), Sqrt(P5), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 5 Log factors required.  `log⁵(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + sqrt4_deg_x2 + sqrt5_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase82_*`).
+
 ## 2.17.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.17.0"
+version = "2.18.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2110,6 +2110,37 @@ fn two_sqrt_five_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64>
     Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg)
 }
 
+/// Phase 82 — Five-Sqrt × Five-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a₁)·…·sqrt(k^a₅)·log(k)⁵·k^m ≈ k^{(a₁+…+a₅)/2}·log⁵(k)·k^m`.
+/// `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0. Using the ×2 integer trick:
+/// `effective_x2 = a₁+a₂+a₃+a₄+a₅ + 2·m`. Caller checks `2·den_deg > effective_x2`.
+fn five_sqrt_five_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 5 { return None; } // sixth Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 5 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 5 || log_count != 5 { return None; }
+    Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + sqrt_degs_x2[2]
+         + sqrt_degs_x2[3] + sqrt_degs_x2[4] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2483,6 +2514,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s2l5_x2) = two_sqrt_five_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s2l5) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s2l5 > s2l5_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 82: Mul(Sqrt(P1)...(P5), Log(diverging)×5, polynomial..., bounded...) numerator.
+    // Five Sqrt + five Log factors; log⁵ sub-polynomial — effective_x2 = d1+d2+d3+d4+d5 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s5l5_x2) = five_sqrt_five_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l5) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l5 > s5l5_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -2954,3 +2954,85 @@ fn phase79_two_sqrt_k_log5_k_times_k_over_k2_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 82: Five-Sqrt × Five-Log × polynomial numerator ────────────────────
+
+#[test]
+fn phase82_five_sqrt_k_log5_k_over_k3_closes() {
+    // √k·√k·√k·√k·√k·log(k)^5 / k³: effective_x2=1+1+1+1+1=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k82a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp182a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k82a, g_kp182a]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase82_five_sqrt_k3_log5_k_over_k_refused() {
+    // √(k³)·√(k³)·√(k³)·√(k³)·√(k³)·log(k)^5 / k: effective_x2=3+3+3+3+3=15; 2·1=2 not > 15 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k82b = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp182b = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k82b, g_kp182b]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase82_five_sqrt_k_log5_k_times_k_over_k4_closes() {
+    // √k·√k·√k·√k·√k·log(k)^5·k / k⁴: effective_x2=1+1+1+1+1+2=7; 2·4=8 > 7 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k82c = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp182c = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f = apply(sym(SUB), vec![g_k82c, g_kp182c]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.18.0 — 2026-05-25
+
+### Added
+
+- **Phase 82 — Five-Sqrt × Five-Log × polynomial numerator** (`fiveSqrtFiveLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Sqrt(P4), Sqrt(P5), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), polynomial..., bounded...)`.
+  Exactly 5 Sqrt and exactly 5 Log factors; `log⁵(k)` sub-polynomial — contributes 0 to effective
+  degree; effective degree = sqrtHalfDeg1+sqrtHalfDeg2+sqrtHalfDeg3+sqrtHalfDeg4+sqrtHalfDeg5 + polyDeg.
+  Closes when `denDeg > fiveSqrtFiveLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 82" describe block.
+
 ## 2.17.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1871,6 +1871,40 @@ function twoSqrtFiveLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undef
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
 }
 
+/**
+ * Phase 82 — Five-Sqrt × Five-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a₁)·…·sqrt(k^a₅)·log(k)⁵·k^m ≈ k^{(a₁+…+a₅)/2}·log⁵(k)·k^m`.
+ * `log⁵(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective
+ * polynomial degree.  effective degree = sqrtHalfDeg1+sqrtHalfDeg2+sqrtHalfDeg3+sqrtHalfDeg4+sqrtHalfDeg5 + polyDeg.
+ * Caller checks `denDeg > fiveSqrtFiveLogPolyEffectiveDeg(num, k)`.
+ */
+function fiveSqrtFiveLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined; // sixth Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 5) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 5) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -2259,6 +2293,19 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l5 = polynomialDegreeInK(den, k);
     if (denDegS2l5 !== undefined) {
       if (denDegS2l5 > s2l5Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 82: Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Sqrt(P4), Sqrt(P5), Log(diverging)×5, polynomial..., bounded...) numerator.
+  // Five Sqrt + five Log factors; log⁵ sub-polynomial — contributes 0.
+  // effective degree = sqrtHalfDeg1+sqrtHalfDeg2+sqrtHalfDeg3+sqrtHalfDeg4+sqrtHalfDeg5 + polyDeg.
+  // Closes when denDeg > fiveSqrtFiveLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s5l5Deg = fiveSqrtFiveLogPolyEffectiveDeg(num, k);
+  if (s5l5Deg !== undefined) {
+    const denDegS5l5 = polynomialDegreeInK(den, k);
+    if (denDegS5l5 !== undefined) {
+      if (denDegS5l5 > s5l5Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3171,3 +3171,118 @@ describe("Phase 79 — Two-Sqrt × Five-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 82 — Five-Sqrt × Five-Log × polynomial numerator", () => {
+  it("√k·√k·√k·√k·√k·log(k)⁵/k³ closes (effective=2.5, denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK82a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp182a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK82a = { kind: "apply" as const, head: DIV, args: [numK82a, k3] };
+    const gKp182a = { kind: "apply" as const, head: DIV, args: [numKp182a, kp1_3] };
+    const f82a = { kind: "apply" as const, head: SUB, args: [gK82a, gKp182a] };
+    const result = evaluateSum(f82a, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf×5=0.5×5=2.5, polyDeg=0 → effective=2.5; denDeg=3 > 2.5 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√(k³)·√(k³)·√(k³)·√(k³)·log(k)⁵/k refused (effective=7.5, denDeg=1 not > 7.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK82b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp182b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK82b = { kind: "apply" as const, head: DIV, args: [numK82b, k] };
+    const gKp182b = { kind: "apply" as const, head: DIV, args: [numKp182b, kp1] };
+    const f82b = { kind: "apply" as const, head: SUB, args: [gK82b, gKp182b] };
+    const result = evaluateSum(f82b, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf×5=1.5×5=7.5 → effective=7.5; denDeg=1 not > 7.5 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·√k·√k·√k·log(k)⁵·k/k⁴ closes (effective=3.5, denDeg=4 > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const numK82c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp182c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK82c = { kind: "apply" as const, head: DIV, args: [numK82c, k4] };
+    const gKp182c = { kind: "apply" as const, head: DIV, args: [numKp182c, kp1_4] };
+    const f82c = { kind: "apply" as const, head: SUB, args: [gK82c, gKp182c] };
+    const result = evaluateSum(f82c, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf×5=0.5×5=2.5, polyDeg=1 → effective=3.5; denDeg=4 > 3.5 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `_five_sqrt_five_log_poly_effective_x2` (Python), `fiveSqrtFiveLogPolyEffectiveDeg` (TypeScript), `five_sqrt_five_log_poly_effective_x2` (Rust) — convergence recognizer for `Mul(√P₁…√P₅, log(·)⁵, poly, bounded…) / Q(k)` numerators
- Adds Phase 82 dispatch block in `_g_vanishes_at_infinity` / `gVanishesAtInfinity` / `g_vanishes_at_infinity` after Phase 79
- Adds 9 unit tests (3 per language): closes case, refused case, closes-with-poly-factor case
- Bumps all three packages to v2.18.0

**Note:** This PR is at v2.18.0 from main (v2.17.0). PRs #4422 (Phase 80) and #4426 (Phase 81) are also at v2.18.0. This PR will be rebased to the next available version as its predecessors merge.

## Test plan

- [ ] All 3 build matrix checks pass (ubuntu/mac/windows)
- [ ] Python analysis passes (cas-summation pytest + coverage)
- [ ] TypeScript analysis passes (vitest)
- [ ] CodeQL analysis passes
- [ ] `test_five_sqrt_k_log5_k_over_k3_closes` asserts convergence
- [ ] `test_five_sqrt_k3_log5_k_over_k_refused` asserts non-convergence
- [ ] `test_five_sqrt_k_log5_k_times_k_over_k4_closes` asserts convergence with polynomial co-factor

🤖 Generated with [Claude Code](https://claude.com/claude-code)