### PR TITLE
Track form validation metadata

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -701,6 +701,7 @@ def check_browser_expected_lists(
             require_boolean(control_path, control, "disabled", errors)
             require_optional_boolean(control_path, control, "required", errors)
             require_optional_boolean(control_path, control, "readonly", errors)
+            require_optional_boolean(control_path, control, "will_validate", errors)
             require_boolean(control_path, control, "checked", errors)
             require_optional_boolean(control_path, control, "multiple", errors)
             require_optional_boolean(control_path, control, "autofocus", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1606,6 +1606,7 @@ pub struct BrowserFormControl {
     pub disabled: bool,
     pub required: bool,
     pub readonly: bool,
+    pub will_validate: bool,
     pub checked: bool,
     pub multiple: bool,
     pub text: String,
@@ -11627,6 +11628,18 @@ fn browser_readonly(element: &Element) -> bool {
     matches!(element.name.as_str(), "input" | "textarea") && element.attribute("readonly").is_some()
 }
 
+fn browser_control_will_validate(control_type: &str, element: &Element, disabled: bool) -> bool {
+    if disabled || browser_readonly(element) {
+        return false;
+    }
+    match element.name.as_str() {
+        "button" => control_type == "submit",
+        "input" => !matches!(control_type, "hidden" | "reset" | "button" | "image"),
+        "select" | "textarea" => true,
+        _ => false,
+    }
+}
+
 fn browser_autofocus(element: &Element) -> bool {
     matches!(
         element.name.as_str(),
@@ -12275,6 +12288,8 @@ fn browser_form_control(
 ) -> BrowserFormControl {
     let control_type = browser_content_control_type(element)
         .expect("browser_form_control is only called for form controls");
+    let disabled = element.attribute("disabled").is_some();
+    let will_validate = browser_control_will_validate(&control_type, element, disabled);
     let control_labels = browser_control_labels(element, labels, current_label_text);
     let text = match element.name.as_str() {
         "button" | "output" | "select" => visible_text_for_nodes(&element.children),
@@ -12324,9 +12339,10 @@ fn browser_form_control(
         form_novalidate: browser_control_form_novalidate(element),
         value: browser_content_value(element),
         autofocus: browser_autofocus(element),
-        disabled: element.attribute("disabled").is_some(),
+        disabled,
         required: browser_required(element),
         readonly: browser_readonly(element),
+        will_validate,
         checked: element.attribute("checked").is_some(),
         multiple: browser_multiple(element),
         text,
@@ -13631,7 +13647,9 @@ mod tests {
         );
         assert!(controls[0].autofocus);
         assert!(controls[0].required);
+        assert!(controls[0].will_validate);
         assert!(controls[1].readonly);
+        assert!(!controls[1].will_validate);
         assert_eq!(controls[1].autocapitalize.as_deref(), Some("sentences"));
         assert_eq!(controls[1].enterkeyhint.as_deref(), Some("done"));
         assert_eq!(controls[1].dirname.as_deref(), Some("notes.dir"));
@@ -13639,12 +13657,15 @@ mod tests {
         assert_eq!(controls[1].labels, vec!["NotesKeep me"]);
         assert_eq!(controls[2].control_type, "checkbox");
         assert!(controls[2].checked);
+        assert!(controls[2].will_validate);
         assert!(controls[3].multiple);
         assert_eq!(controls[3].size.as_deref(), Some("5"));
         assert_eq!(controls[3].accessible_name.as_deref(), Some("Kind"));
+        assert!(controls[3].will_validate);
         assert_eq!(controls[4].control_type, "file");
         assert_eq!(controls[4].accept.as_deref(), Some("image/png,image/jpeg"));
         assert_eq!(controls[4].capture.as_deref(), Some("environment"));
+        assert!(controls[4].will_validate);
         assert_eq!(controls[5].accessible_name.as_deref(), Some("Run search"));
         assert_eq!(controls[5].form_action.as_deref(), Some("run.html"));
         assert_eq!(
@@ -13658,6 +13679,7 @@ mod tests {
         assert_eq!(controls[5].form_method.as_deref(), Some("post"));
         assert_eq!(controls[5].form_target.as_deref(), Some("results"));
         assert!(controls[5].form_novalidate);
+        assert!(controls[5].will_validate);
         assert_eq!(controls[6].control_type, "image");
         assert_eq!(controls[6].name.as_deref(), Some("image-go"));
         assert_eq!(controls[6].src.as_deref(), Some("buttons/search.png"));
@@ -13668,16 +13690,19 @@ mod tests {
         assert_eq!(controls[6].alt.as_deref(), Some("Search image"));
         assert_eq!(controls[6].width.as_deref(), Some("32"));
         assert_eq!(controls[6].height.as_deref(), Some("16"));
+        assert!(!controls[6].will_validate);
         assert_eq!(controls[7].control_type, "output");
         assert_eq!(controls[7].name.as_deref(), Some("total"));
         assert_eq!(controls[7].output_for, vec!["q", "kind"]);
         assert_eq!(controls[7].value.as_deref(), Some("Ready"));
         assert_eq!(controls[7].text, "Ready");
+        assert!(!controls[7].will_validate);
         assert_eq!(controls[8].id.as_deref(), Some("external"));
         assert_eq!(controls[8].name.as_deref(), Some("outside"));
         assert_eq!(controls[8].form_owner.as_deref(), Some("f"));
         assert_eq!(controls[8].accessible_name.as_deref(), Some("Outside"));
         assert_eq!(controls[8].placeholder.as_deref(), Some("Outside"));
+        assert!(controls[8].will_validate);
 
         let submitters = &summary.forms[0].submitters;
         assert_eq!(submitters.len(), 2);

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -736,6 +736,8 @@ struct ExpectedFormControl {
     required: bool,
     #[serde(default)]
     readonly: bool,
+    #[serde(default)]
+    will_validate: bool,
     checked: bool,
     #[serde(default)]
     multiple: bool,
@@ -832,6 +834,26 @@ fn browser_script_style_security_metadata_tracks_nonces_and_fetch_policy() {
     assert_eq!(
         actual.stylesheets, expected.stylesheets,
         "stylesheets should preserve CSP nonces and loading policy metadata",
+    );
+}
+
+#[test]
+fn browser_form_validation_metadata_tracks_constraint_candidates() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "form-accessibility-document-page")
+        .expect("form accessibility fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("form accessibility fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.forms,
+        case.expected.into_browser_document().forms,
+        "form controls should preserve validation candidate metadata",
     );
 }
 
@@ -1553,6 +1575,7 @@ impl ExpectedFormControl {
             disabled: self.disabled,
             required: self.required,
             readonly: self.readonly,
+            will_validate: self.will_validate,
             checked: self.checked,
             multiple: self.multiple,
             text: self.text,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -75,13 +75,13 @@
             "target": "results",
             "effective_target": "results",
             "controls": [
-              { "control_type": "text", "name": "q", "value": "rust html", "disabled": false, "checked": false, "text": "", "options": [] },
+              { "control_type": "text", "name": "q", "value": "rust html", "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "control_type": "hidden", "name": "page", "value": "1", "disabled": false, "checked": false, "text": "", "options": [] },
-              { "control_type": "checkbox", "name": "in_stock", "value": "yes", "disabled": false, "checked": true, "text": "", "options": [] },
+              { "control_type": "checkbox", "name": "in_stock", "value": "yes", "disabled": false, "will_validate": true, "checked": true, "text": "", "options": [] },
               { "control_type": "text", "name": "disabled", "value": "no", "disabled": true, "checked": false, "text": "", "options": [] },
-              { "control_type": "select", "name": "section", "value": "manuals", "disabled": false, "checked": false, "text": "Books Manuals", "options": ["Books", "Manuals"] },
-              { "control_type": "textarea", "name": "notes", "value": "Line one Line two", "disabled": false, "checked": false, "text": "Line one Line two", "options": [] },
-              { "control_type": "submit", "name": "go", "accessible_name": "Search", "value": null, "disabled": false, "checked": false, "text": "Search", "options": [] }
+              { "control_type": "select", "name": "section", "value": "manuals", "disabled": false, "will_validate": true, "checked": false, "text": "Books Manuals", "options": ["Books", "Manuals"] },
+              { "control_type": "textarea", "name": "notes", "value": "Line one Line two", "disabled": false, "will_validate": true, "checked": false, "text": "Line one Line two", "options": [] },
+              { "control_type": "submit", "name": "go", "accessible_name": "Search", "value": null, "disabled": false, "will_validate": true, "checked": false, "text": "Search", "options": [] }
             ],
             "submitters": [
               { "id": null, "control_type": "submit", "name": "go", "accessible_name": "Search", "action": "/search", "resolved_action": null, "method": "post", "enctype": "multipart/form-data", "target": "results", "effective_target": "results", "novalidate": false, "value": null }
@@ -183,15 +183,15 @@
             "rel_noreferrer": true,
             "novalidate": true,
             "controls": [
-              { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "placeholder": "Search terms", "autocomplete": "search", "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "autofocus": true, "disabled": false, "required": true, "checked": false, "text": "", "options": [] },
+              { "id": "q", "control_type": "text", "name": "q", "labels": ["Query"], "accessible_name": "Query", "placeholder": "Search terms", "autocomplete": "search", "autocapitalize": "words", "enterkeyhint": "search", "dirname": "q.dir", "inputmode": "search", "pattern": "[A-Za-z ]+", "minlength": "2", "maxlength": "80", "size": "40", "list": "query-suggestions", "datalist_options": ["Rust", "HTML", "Browser APIs"], "value": null, "autofocus": true, "disabled": false, "required": true, "will_validate": true, "checked": false, "text": "", "options": [] },
               { "id": "notes", "control_type": "textarea", "name": "notes", "labels": ["NotesKeep me"], "accessible_name": "NotesKeep me", "placeholder": "Details", "autocapitalize": "sentences", "enterkeyhint": "done", "dirname": "notes.dir", "maxlength": "500", "value": "Keep me", "disabled": false, "readonly": true, "checked": false, "text": "Keep me", "options": [] },
-              { "id": "fast", "control_type": "checkbox", "name": "fast", "labels": ["Fast"], "accessible_name": "Fast", "value": "on", "disabled": false, "checked": true, "text": "", "options": [] },
-              { "id": "kind", "control_type": "select", "name": "kind", "accessible_name": "Kind", "size": "5", "value": "Books", "disabled": false, "checked": false, "multiple": true, "text": "Books Manuals", "options": ["Books", "Manuals"] },
-              { "id": "upload", "control_type": "file", "name": "upload", "accept": "image/png,image/jpeg", "capture": "environment", "value": null, "disabled": false, "checked": false, "text": "", "options": [] },
-              { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "form_action": "run.html", "resolved_form_action": "https://example.test/search/run.html", "form_enctype": "application/x-www-form-urlencoded", "form_method": "post", "form_target": "results", "form_novalidate": true, "value": null, "disabled": false, "checked": false, "text": "Go", "options": [] },
+              { "id": "fast", "control_type": "checkbox", "name": "fast", "labels": ["Fast"], "accessible_name": "Fast", "value": "on", "disabled": false, "will_validate": true, "checked": true, "text": "", "options": [] },
+              { "id": "kind", "control_type": "select", "name": "kind", "accessible_name": "Kind", "size": "5", "value": "Books", "disabled": false, "will_validate": true, "checked": false, "multiple": true, "text": "Books Manuals", "options": ["Books", "Manuals"] },
+              { "id": "upload", "control_type": "file", "name": "upload", "accept": "image/png,image/jpeg", "capture": "environment", "value": null, "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] },
+              { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "form_action": "run.html", "resolved_form_action": "https://example.test/search/run.html", "form_enctype": "application/x-www-form-urlencoded", "form_method": "post", "form_target": "results", "form_novalidate": true, "value": null, "disabled": false, "will_validate": true, "checked": false, "text": "Go", "options": [] },
               { "id": "imageGo", "control_type": "image", "name": "image-go", "src": "buttons/search.png", "resolved_src": "https://example.test/search/buttons/search.png", "alt": "Search image", "width": "32", "height": "16", "value": null, "disabled": false, "checked": false, "text": "", "options": [] },
               { "id": "total", "control_type": "output", "name": "total", "output_for": ["q", "kind"], "value": "Ready", "disabled": false, "checked": false, "text": "Ready", "options": [] },
-              { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "disabled": false, "checked": false, "text": "", "options": [] }
+              { "id": "external", "control_type": "text", "name": "outside", "form_owner": "search", "accessible_name": "Outside", "placeholder": "Outside", "value": null, "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] }
             ],
             "submitters": [
               { "id": "go", "control_type": "submit", "name": null, "accessible_name": "Run search", "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "effective_target": "results", "novalidate": true, "value": null },


### PR DESCRIPTION
## Summary
- add browser form-control will_validate metadata for constraint-validation candidates
- cover validation candidates in the browser-readiness form fixtures
- add a targeted readiness regression for form validation metadata

## Tests
- cargo test -p coding-adventures-html-parser browser_form_validation_metadata_tracks_constraint_candidates
- cargo test -p coding-adventures-html-parser browser_form_accessibility_metadata_tracks_labels_and_control_state
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_format_registry.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/test_html_fixture_case_ids.py
- python3 -m py_compile code/packages/rust/html-lexer/tests/fixtures/*.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /tmp/html5lib-tests-codex-audit
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser