### PR TITLE
feat(closurec): --charset US_ASCII escapes non-ASCII output (CLOC11.16)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.19.0] - 2026-05-26
+
+### Changed — CLOC11.16: `--charset` US_ASCII output escaping (BEHAVIOR DEFAULT CHANGE)
+
+Behavioral compat slice with CC's documented `--charset` default. Previously closurec accepted `--charset` and stored it but never escaped non-ASCII characters in the output — every non-ASCII codepoint passed through verbatim regardless of flag value. That diverged from CC's documented default of "UTF-8 in, US_ASCII out".
+
+Now matches CC:
+
+| `--charset` value | Output behavior                              |
+|-------------------|----------------------------------------------|
+| (unset)           | **US_ASCII — escape non-ASCII as `\uXXXX`** (matches CC default) |
+| `US_ASCII`        | same as unset                                |
+| `US-ASCII`        | accepted alias                               |
+| `UTF-8` / `UTF8`  | pass-through (raw UTF-8 bytes)               |
+| anything else     | pass-through (CC ignores unknown values)     |
+
+**This is a default-behavior change**: existing users who relied on raw-UTF-8 output and didn't pass `--charset` will now see `\uXXXX` escapes. To restore prior behavior, pass `--charset UTF-8` explicitly. CC users get this default already, so closurec invocations that worked against CC will continue to work against closurec.
+
+Escape format: BMP codepoints (`U+0000..U+FFFF`) emit `\uXXXX`. Astral codepoints (`U+10000..U+10FFFF`) emit a UTF-16 surrogate pair (`\uXXXX\uXXXX`) — not the ES2015 `\u{XXXXX}` form — for maximum compatibility with legacy minifiers / ES5-only environments.
+
+- **New `charset` module** with `OutputCharset::from_raw(&str)` + `apply_charset(&str, OutputCharset) -> String`. Pure-function, no I/O, fully deterministic.
+- **Pipeline placement**: Step 3.75 in `run_compiler`, between IIFE wrap and write. Runs *after* the output wrapper so any non-ASCII the user injected via `--output_wrapper` (e.g. a `©` banner) gets escaped too.
+- **12 new unit tests** in `charset::tests` (default → US_ASCII, value parsing for all aliases + case-insensitive, unknown → UTF-8 fallback, UTF-8 pass-through, US_ASCII pass-through for pure-ASCII text, BMP escape, CJK escape, surrogate pair, lowercase hex, byte-identical ASCII).
+- **Diff fixtures** `tests/diff/charset-us-ascii/` (default) and `tests/diff/charset-utf8/` (opt-out).
+- **New integration test** `tests/diff_charset.rs` pinning both ends of the toggle, including `is_ascii()` invariant under default.
+- **`tests/diff/js-glob/expected.stdout` regenerated**: em-dashes in test input comments now appear as `—`. This is the new default; the test continues to exercise glob expansion logic.
+
+### Pipeline matrix (cumulative across CLOC11)
+
+`run_compiler`:
+1. Resolve `--js` globs
+2. Resolve `--externs` globs
+3. `--print_tree` short-circuit
+4. `--print_tree_json` short-circuit
+5. Per-input `transform_source`
+6. Concatenate transformed inputs
+7. `--checks_only` short-circuit
+8. `--emit_use_strict` prepend
+9. `--output_wrapper` substitution (validated)
+10. `--isolation_mode IIFE` wrap
+11. **`--charset` US_ASCII escape (CLOC11.16, NEW)**
+12. Write to `--js_output_file` or stdout
+
 ## [0.18.0] - 2026-05-26
 
 ### Changed — CLOC11.55: `--version` emits CC-style banner

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/charset.rs
+++ b/code/programs/rust/closurec/src/charset.rs
@@ -1,0 +1,264 @@
+//! `charset` — `--charset` output-encoding normalization (CLOC11.16).
+//!
+//! # What CC does
+//!
+//! The upstream Java Closure Compiler's `--charset` flag controls
+//! both input and output character encoding. The flag is
+//! documented as defaulting to "UTF-8 in, US_ASCII out": CC
+//! reads input files as UTF-8, but **escapes every non-ASCII
+//! character in the output as `\uXXXX`** so the emitted JS is
+//! pure 7-bit ASCII and safe to embed in any HTTP transport,
+//! HTML attribute, or filesystem with iffy encoding behavior.
+//!
+//! Passing `--charset UTF-8` opts out of the output escaping —
+//! the compiled JS is emitted as raw UTF-8 bytes.
+//!
+//! # What we do
+//!
+//! Pre-CLOC11.16 closurec ignored `--charset` for output and
+//! always passed non-ASCII through verbatim. That diverged from
+//! CC's documented default and surprised anyone who relied on
+//! ASCII-only output (the typical case for tools that ingest
+//! closurec output into HTML/JSON/email).
+//!
+//! Now:
+//!
+//! | `--charset` value | Output behavior                              |
+//! |-------------------|----------------------------------------------|
+//! | (unset)           | US_ASCII — escape non-ASCII (matches CC)     |
+//! | `US_ASCII`        | same as unset                                |
+//! | `US-ASCII`        | accepted as alias (CC accepts both forms)    |
+//! | `UTF-8`           | pass-through (raw UTF-8 bytes)               |
+//! | `UTF8`            | accepted as alias                            |
+//! | anything else     | pass-through (CC ignores unknown values)     |
+//!
+//! # Escape format
+//!
+//! BMP codepoints (`U+0000..U+FFFF`) emit `\uXXXX` with 4 hex
+//! digits. Astral codepoints (`U+10000..U+10FFFF`) emit a
+//! surrogate pair (`\uXXXX\uXXXX`) — JS string literals require
+//! either form to encode astral characters and `\u{XXXXX}` is
+//! the ES2015+ alternative we deliberately avoid for maximum
+//! compatibility with any consumer.
+//!
+//! # Pipeline position
+//!
+//! Charset normalization is the **last** transform before write.
+//! It runs *after* the output wrapper and IIFE wrap, so any
+//! non-ASCII the user injected via `--output_wrapper` (e.g. a
+//! comment banner containing a copyright `©`) also gets
+//! escaped. That matches CC: the charset is applied to the
+//! final emitted file, not to any intermediate stage.
+
+/// Resolved charset behavior. The string `--charset` argument is
+/// projected into this typed enum so the run pipeline doesn't
+/// have to re-parse user input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputCharset {
+    /// US-ASCII output: every codepoint > 0x7F is `\uXXXX`-escaped.
+    /// Default per CC.
+    UsAscii,
+    /// UTF-8 output: pass-through, no escaping.
+    Utf8,
+}
+
+impl OutputCharset {
+    /// Resolve a raw `--charset` value into the typed enum.
+    ///
+    /// Case-insensitive. Accepts hyphenated and unhyphenated
+    /// forms (`US_ASCII`, `US-ASCII`, `UTF-8`, `UTF8`) since CC
+    /// itself accepts both. Empty string → default (US-ASCII)
+    /// per CC's documented default. Unknown values fall back to
+    /// `Utf8` (pass-through) — CC silently ignores unknown
+    /// charsets too rather than erroring.
+    pub fn from_raw(raw: &str) -> Self {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            // CC's documented default.
+            return Self::UsAscii;
+        }
+        // Normalize: lower-case, strip `_` and `-`.
+        let normalized: String = trimmed
+            .chars()
+            .filter(|c| *c != '_' && *c != '-')
+            .map(|c| c.to_ascii_lowercase())
+            .collect();
+        match normalized.as_str() {
+            "usascii" | "ascii" => Self::UsAscii,
+            "utf8" => Self::Utf8,
+            // Anything else: pass-through. Matches CC's
+            // permissive behavior on unknown charsets.
+            _ => Self::Utf8,
+        }
+    }
+}
+
+/// Apply the charset transform to the final output text.
+///
+/// Fast path: `Utf8` returns `text` ownership unchanged via
+/// `text.to_string()` — no escape scan, no allocation beyond the
+/// caller's. `UsAscii` walks the string char-by-char and emits
+/// `\uXXXX` (or a surrogate pair for astral codepoints) for any
+/// codepoint > 0x7F.
+///
+/// # Why a single pass over chars
+///
+/// `text.is_ascii()` would let us skip the allocation for the
+/// common pure-ASCII case. We don't bother — the existing
+/// pipeline already does several `to_string()` copies, and a
+/// single linear scan over the final output is cheap relative
+/// to the rest of the pipeline.
+pub fn apply_charset(text: &str, mode: OutputCharset) -> String {
+    match mode {
+        OutputCharset::Utf8 => text.to_string(),
+        OutputCharset::UsAscii => escape_non_ascii(text),
+    }
+}
+
+/// Walk `text` and emit `\uXXXX` for every codepoint > 0x7F.
+///
+/// BMP codepoints fit in one `\uXXXX` escape. Astral codepoints
+/// (U+10000..U+10FFFF) emit a UTF-16 surrogate pair:
+///
+///   high = 0xD800 + ((cp - 0x10000) >> 10)
+///   low  = 0xDC00 + ((cp - 0x10000) & 0x3FF)
+///
+/// We use surrogate pairs rather than the ES2015 `\u{XXXXX}`
+/// form to keep the emitted JS compatible with the broadest set
+/// of consumers (legacy minifiers, ES5-only environments).
+fn escape_non_ascii(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        let cp = c as u32;
+        if cp < 0x80 {
+            // ASCII passes through verbatim.
+            out.push(c);
+        } else if cp <= 0xFFFF {
+            // BMP: single `\uXXXX`.
+            out.push_str(&format!("\\u{:04x}", cp));
+        } else {
+            // Astral: surrogate pair. JavaScript string literals
+            // accept this and reassemble into the original
+            // codepoint at runtime.
+            let adjusted = cp - 0x10000;
+            let high = 0xD800 + (adjusted >> 10);
+            let low = 0xDC00 + (adjusted & 0x3FF);
+            out.push_str(&format!("\\u{:04x}\\u{:04x}", high, low));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_charset_string_defaults_to_us_ascii() {
+        // CC's documented default: US_ASCII out when --charset unset.
+        assert_eq!(OutputCharset::from_raw(""), OutputCharset::UsAscii);
+    }
+
+    #[test]
+    fn us_ascii_underscore_and_hyphen_forms_both_accepted() {
+        assert_eq!(OutputCharset::from_raw("US_ASCII"), OutputCharset::UsAscii);
+        assert_eq!(OutputCharset::from_raw("US-ASCII"), OutputCharset::UsAscii);
+        assert_eq!(OutputCharset::from_raw("ASCII"), OutputCharset::UsAscii);
+    }
+
+    #[test]
+    fn utf8_hyphen_and_unhyphenated_forms_both_accepted() {
+        assert_eq!(OutputCharset::from_raw("UTF-8"), OutputCharset::Utf8);
+        assert_eq!(OutputCharset::from_raw("UTF8"), OutputCharset::Utf8);
+    }
+
+    #[test]
+    fn case_insensitive_resolution() {
+        assert_eq!(OutputCharset::from_raw("utf-8"), OutputCharset::Utf8);
+        assert_eq!(OutputCharset::from_raw("us_ascii"), OutputCharset::UsAscii);
+        assert_eq!(OutputCharset::from_raw("uTf-8"), OutputCharset::Utf8);
+    }
+
+    #[test]
+    fn unknown_charset_falls_back_to_utf8_passthrough() {
+        // CC silently ignores unknown charsets — we match.
+        assert_eq!(OutputCharset::from_raw("KOI-8"), OutputCharset::Utf8);
+        assert_eq!(OutputCharset::from_raw("bogus"), OutputCharset::Utf8);
+    }
+
+    #[test]
+    fn utf8_mode_passes_through_verbatim() {
+        let input = "var é = '日本語'; // copyright ©";
+        assert_eq!(apply_charset(input, OutputCharset::Utf8), input);
+    }
+
+    #[test]
+    fn us_ascii_mode_passes_through_ascii_only_text() {
+        let input = "var x = 1;\nalert(\"hello\");";
+        // No non-ASCII chars → identity.
+        assert_eq!(apply_charset(input, OutputCharset::UsAscii), input);
+    }
+
+    #[test]
+    fn us_ascii_mode_escapes_bmp_codepoint_as_4hex() {
+        // `é` is U+00E9.
+        let out = apply_charset("var x = 'é';", OutputCharset::UsAscii);
+        assert_eq!(out, "var x = '\\u00e9';");
+    }
+
+    #[test]
+    fn us_ascii_mode_escapes_cjk_codepoints() {
+        // 日 is U+65E5, 本 is U+672C, 語 is U+8A9E.
+        let out = apply_charset("'日本語'", OutputCharset::UsAscii);
+        assert_eq!(out, "'\\u65e5\\u672c\\u8a9e'");
+    }
+
+    #[test]
+    fn us_ascii_mode_escapes_astral_codepoint_as_surrogate_pair() {
+        // U+1F600 (grinning face emoji) sits in the astral plane;
+        // emit a UTF-16 surrogate pair.
+        // high = 0xD800 + ((0x1F600 - 0x10000) >> 10) = 0xD83D
+        // low  = 0xDC00 + ((0x1F600 - 0x10000) & 0x3FF) = 0xDE00
+        let out = apply_charset("😀", OutputCharset::UsAscii);
+        assert_eq!(out, "\\ud83d\\ude00");
+    }
+
+    #[test]
+    fn us_ascii_mode_preserves_existing_backslash_u_escapes_verbatim() {
+        // Input that already has a JS `é` escape sequence
+        // is treated as 7 plain ASCII chars (`\`, `u`, `0`,
+        // `0`, `e`, `9`). All ASCII → no further escaping.
+        // (The double-escape "`\\u00e9` → `\\u005cu00e9`" would
+        // be wrong; we don't escape backslashes themselves.)
+        let input = "var x = '\\u00e9';";
+        assert_eq!(
+            apply_charset(input, OutputCharset::UsAscii),
+            input,
+            "existing \\u escapes must pass through verbatim"
+        );
+    }
+
+    #[test]
+    fn us_ascii_escape_uses_lowercase_hex() {
+        // Pin the hex case — lowercase matches CC's emitter.
+        let out = apply_charset("ä", OutputCharset::UsAscii);
+        assert_eq!(out, "\\u00e4");
+        assert!(!out.contains("E4"), "hex should be lowercase");
+    }
+
+    #[test]
+    fn ascii_only_with_us_ascii_mode_is_byte_identical() {
+        // Pure-ASCII input + US_ASCII mode → output bytes
+        // identical to input. The minimum-change invariant for
+        // the common case.
+        let input = "function(){return 1;}";
+        assert_eq!(
+            apply_charset(input, OutputCharset::UsAscii).as_bytes(),
+            input.as_bytes()
+        );
+    }
+}

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -67,6 +67,7 @@ use std::process::ExitCode;
 // CLOC11.06 added `whitespace_only` for --compilation_level WHITESPACE_ONLY.
 // CLOC11.19 added `defines` for --define / -D value substitution.
 // CLOC11.30 added `wrapper` for --output_wrapper / --output_wrapper_file.
+pub mod charset;
 pub mod config;
 pub mod defines;
 pub mod globs;

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -453,19 +453,36 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
         IsolationMode::None => wrapped,
     };
 
+    // Step 3.75 (CLOC11.16): apply --charset normalization.
+    //
+    // CC's documented default is "UTF-8 in, US_ASCII out": every
+    // non-ASCII character in the final output is escaped as
+    // `\uXXXX` (or a UTF-16 surrogate pair for astral
+    // codepoints) so the emitted JS is pure 7-bit ASCII and
+    // safe in any transport. We match that default.
+    //
+    // Runs last in the transform chain so any non-ASCII the
+    // user injected via `--output_wrapper` (e.g. a `©` in a
+    // banner) gets escaped alongside the body. See
+    // `crate::charset` for the table of accepted values.
+    let encoded = crate::charset::apply_charset(
+        &isolated,
+        crate::charset::OutputCharset::from_raw(&config.io.charset),
+    );
+
     // Step 4: write the output. Two cases:
     //   a) --js_output_file set → write to disk via write_output_file.
     //   b) absent → stdout via the returned `stdout_text`.
     match &config.io.js_output_file {
         Some(path) => {
-            write_output_file(path, &isolated)?;
+            write_output_file(path, &encoded)?;
             Ok(CompilerOutput {
                 stdout_text: String::new(),
                 wrote_files: vec![path.clone()],
             })
         }
         None => Ok(CompilerOutput {
-            stdout_text: isolated,
+            stdout_text: encoded,
             wrote_files: Vec::new(),
         }),
     }

--- a/code/programs/rust/closurec/tests/diff/charset-us-ascii/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/charset-us-ascii/expected.stdout
@@ -1,0 +1,2 @@
+// \u00a9 2026 \u2014 caf\u00e9
+var greeting = "\u65e5\u672c\u8a9e";

--- a/code/programs/rust/closurec/tests/diff/charset-us-ascii/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/charset-us-ascii/flags.txt
@@ -1,0 +1,2 @@
+--js
+tests/diff/charset-us-ascii/input/a.js

--- a/code/programs/rust/closurec/tests/diff/charset-us-ascii/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/charset-us-ascii/input/a.js
@@ -1,0 +1,2 @@
+// © 2026 — café
+var greeting = "日本語";

--- a/code/programs/rust/closurec/tests/diff/charset-utf8/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/charset-utf8/expected.stdout
@@ -1,0 +1,2 @@
+// © 2026 — café
+var greeting = "日本語";

--- a/code/programs/rust/closurec/tests/diff/charset-utf8/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/charset-utf8/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/charset-utf8/input/a.js
+--charset
+UTF-8

--- a/code/programs/rust/closurec/tests/diff/charset-utf8/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/charset-utf8/input/a.js
@@ -1,0 +1,2 @@
+// © 2026 — café
+var greeting = "日本語";

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.18.0
+Version: 0.19.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/js-glob/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/js-glob/expected.stdout
@@ -1,3 +1,3 @@
-// a.js — top-level included
-// b.js — nested included
-// lone.js — top-level included
+// a.js \u2014 top-level included
+// b.js \u2014 nested included
+// lone.js \u2014 top-level included

--- a/code/programs/rust/closurec/tests/diff_charset.rs
+++ b/code/programs/rust/closurec/tests/diff_charset.rs
@@ -1,0 +1,75 @@
+//! Integration tests for the `tests/diff/charset-*/` fixtures.
+//!
+//! Exercises CLOC11.16 — `--charset` output normalization. Two
+//! companion fixtures:
+//!
+//! - `charset-us-ascii/`: no `--charset` flag → CC's documented
+//!   default applies (US-ASCII out). Non-ASCII chars in the
+//!   input (©, em-dash, CJK) should appear in the output as
+//!   `\uXXXX` escapes.
+//!
+//! - `charset-utf8/`: `--charset UTF-8` opts out of escaping;
+//!   non-ASCII passes through verbatim.
+//!
+//! Pinning both ends of the toggle catches accidental swaps
+//! (e.g. if a refactor inverts the default).
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags(fixture: &str) -> Vec<String> {
+    let path = format!("tests/diff/{fixture}/flags.txt");
+    let raw = std::fs::read_to_string(&path).expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn run_fixture(fixture: &str) -> String {
+    let flags = read_flags(fixture);
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn charset_default_is_us_ascii_escaping_non_ascii() {
+    let actual = run_fixture("charset-us-ascii");
+    let expected = std::fs::read_to_string("tests/diff/charset-us-ascii/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(actual, expected);
+
+    // Sanity: the output must NOT contain raw non-ASCII bytes.
+    // If it does, our default isn't actually escaping.
+    assert!(
+        actual.is_ascii(),
+        "default --charset must produce pure-ASCII output: {actual}"
+    );
+}
+
+#[test]
+fn charset_utf8_passes_through_non_ascii_verbatim() {
+    let actual = run_fixture("charset-utf8");
+    let expected = std::fs::read_to_string("tests/diff/charset-utf8/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(actual, expected);
+
+    // Sanity: with --charset UTF-8 the output should contain
+    // the original non-ASCII characters, not escape sequences.
+    assert!(
+        !actual.is_ascii(),
+        "--charset UTF-8 should preserve non-ASCII: {actual}"
+    );
+    assert!(actual.contains("©"));
+    assert!(actual.contains("日本語"));
+}


### PR DESCRIPTION
## Summary
- **BEHAVIOR DEFAULT CHANGE.** Match CC's documented \`--charset\` default of "UTF-8 in, US_ASCII out". Every non-ASCII codepoint in the final output is now escaped as \`\uXXXX\` (or a UTF-16 surrogate pair for astral codepoints).
- Pre-CLOC11.16 closurec ignored \`--charset\` for output and passed non-ASCII through verbatim — diverged from CC.

## Charset table
\`\`\`
(unset)          -> US_ASCII (escape non-ASCII)  [matches CC]
US_ASCII forms   -> same as unset
UTF-8 / UTF8     -> pass-through (raw UTF-8)
unknown values   -> pass-through (CC ignores too)
\`\`\`

To restore the old behavior, pass \`--charset UTF-8\` explicitly. **CC invocations that worked against CC continue to work** — CC emits US_ASCII by default.

## Escape format
- BMP codepoints (\`U+0000..U+FFFF\`): \`\uXXXX\` (4 hex digits, lowercase).
- Astral codepoints (\`U+10000..U+10FFFF\`): UTF-16 surrogate pair (\`\uXXXX\uXXXX\`) — **not** the ES2015 \`\u{XXXXX}\` form — for max legacy compatibility.

## Implementation
- New \`charset\` module with \`OutputCharset::from_raw(&str)\` + \`apply_charset(&str, OutputCharset) -> String\`. Pure function.
- Pipeline placement: **Step 3.75** in \`run_compiler\`, between IIFE wrap and write. Runs **after** \`--output_wrapper\` so any non-ASCII the user injected via the wrapper (e.g. a \`©\` banner) gets escaped alongside the body. Matches CC.

## Cumulative pipeline matrix
1. Resolve \`--js\` globs
2. Resolve \`--externs\` globs
3. \`--print_tree\` short-circuit
4. \`--print_tree_json\` short-circuit
5. Per-input \`transform_source\`
6. Concatenate
7. \`--checks_only\` short-circuit
8. \`--emit_use_strict\` prepend
9. \`--output_wrapper\` substitution
10. \`--isolation_mode IIFE\` wrap
11. **\`--charset\` US_ASCII escape (NEW)**
12. Write

## Tests
- 12 new unit tests in \`charset::tests\`
- \`tests/diff/charset-us-ascii/\` + \`tests/diff/charset-utf8/\` companion fixtures
- \`tests/diff_charset.rs\` integration test with \`is_ascii()\` invariant
- \`tests/diff/js-glob/expected.stdout\` regenerated for new default (em-dashes now \`—\`)
- 186 unit tests + integration tests pass

## Versions
- \`Cargo.toml\`: 0.18.0 → 0.19.0
- \`cli.spec.json\`: 0.18.0 → 0.19.0
- Help-markdown fixture regenerated
- CHANGELOG \`[0.19.0]\` entry flagged as default-behavior change

## Security review (inline)
Pure-string transform. \`OutputCharset::from_raw\` normalizes case + strips \`_-\` for case-insensitive matching — no injection vector. \`escape_non_ascii\` walks chars, emits \`\uXXXX\`; output bounded by \`input.len() * 6\` worst case. No FS/net I/O. No \`unsafe\`. Surrogate-pair math is the standard UTF-16 formula.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 186 unit + integration tests pass
- [x] \`cargo clippy --no-deps -p coding-adventures-closurec\` — clean
- [x] Inline security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)