### PR TITLE
feat(closurec): --create_source_map writes minimal v3 source map (CLOC11.42)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.20.0] - 2026-05-26
+
+### Added — CLOC11.42: `--create_source_map` writes minimal v3 source map
+
+Behavioral compat slice with CC's `--create_source_map=path` flag. Previously closurec parsed the flag and stored the path but never wrote any file — build scripts expecting a source map at the path saw nothing. Now writes a minimal valid v3 source map JSON at the path.
+
+Wire format:
+
+```json
+{
+  "version": 3,
+  "file": "<--js_output_file basename or empty>",
+  "lineCount": 0,
+  "sourceRoot": "",
+  "sources": [],
+  "sourcesContent": [],
+  "names": [],
+  "mappings": ""
+}
+```
+
+The mappings are intentionally empty — real position tracking lands with the parser-bridge in CLOC11.07+. The goal of this slice is that build pipelines (Bazel rules, webpack `source-map-loader` shims, etc.) expecting a file at the path see one with the right shape. Debuggers that try to use the map for position lookup get the correct response of "no information available" rather than a broken document.
+
+- **New `source_map` module** with `format_minimal_v3(Option<&Path>) -> String`. Pure function: no I/O, fully deterministic.
+- **Pipeline placement**: Step 5 in `run_compiler`, after the JS output write. Source map write runs *after* the JS write so callers get a consistent on-disk pair (or no source map at all if the flag is unset).
+- **Source-map writing works even when `--js_output_file` is absent** (compiled JS goes to stdout). In that case the map's `file` field is empty.
+- **`file` field is the basename** of the compiled-output path, not the full path — keeps the map portable across CDN paths.
+- **9 new unit tests** in `source_map::tests` (empty-path → empty file key, basename extraction, version-3 marker, eight required keys present, empty arrays well-formed, empty mappings string, trailing newline, JSON escaping of weird file names, byte-stable output).
+- **4 new unit tests** in `run::tests` (writes file when path set, no-write when path empty, stdout+map combination, basename-only `file` field).
+
+### Pipeline matrix (cumulative across CLOC11)
+
+`run_compiler`:
+1. Resolve `--js` globs
+2. Resolve `--externs` globs
+3. `--print_tree` short-circuit
+4. `--print_tree_json` short-circuit
+5. Per-input `transform_source`
+6. Concatenate transformed inputs
+7. `--checks_only` short-circuit
+8. `--emit_use_strict` prepend
+9. `--output_wrapper` substitution
+10. `--isolation_mode IIFE` wrap
+11. `--charset` US_ASCII escape
+12. Write JS to `--js_output_file` or stdout
+13. **Write source map to `--create_source_map` path if set (CLOC11.42, NEW)**
+
 ## [0.19.0] - 2026-05-26
 
 ### Changed — CLOC11.16: `--charset` US_ASCII output escaping (BEHAVIOR DEFAULT CHANGE)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/main.rs
+++ b/code/programs/rust/closurec/src/main.rs
@@ -74,6 +74,7 @@ pub mod globs;
 pub mod help_markdown;
 pub mod print_tree;
 pub mod run;
+pub mod source_map;
 pub mod whitespace_only;
 pub mod wire;
 pub mod wrapper;

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -473,19 +473,44 @@ pub fn run_compiler(config: &CompilerConfig) -> Result<CompilerOutput, CompilerE
     // Step 4: write the output. Two cases:
     //   a) --js_output_file set → write to disk via write_output_file.
     //   b) absent → stdout via the returned `stdout_text`.
-    match &config.io.js_output_file {
+    //
+    // Step 5 (CLOC11.42): when --create_source_map=path is set,
+    // write a minimal v3 source map at that path. Today the
+    // mappings are empty (real position tracking lands with the
+    // parser-bridge in CLOC11.07+); the goal of this slice is
+    // that build pipelines expecting a file at the path see one.
+    // The source-map write runs *after* the JS write so callers
+    // get a consistent on-disk pair (or no source map at all if
+    // the flag is unset).
+    let result = match &config.io.js_output_file {
         Some(path) => {
             write_output_file(path, &encoded)?;
-            Ok(CompilerOutput {
+            CompilerOutput {
                 stdout_text: String::new(),
                 wrote_files: vec![path.clone()],
-            })
+            }
         }
-        None => Ok(CompilerOutput {
+        None => CompilerOutput {
             stdout_text: encoded,
             wrote_files: Vec::new(),
-        }),
+        },
+    };
+
+    if !config.source_map.path_template.is_empty() {
+        let map_path = std::path::PathBuf::from(&config.source_map.path_template);
+        let map_body = crate::source_map::format_minimal_v3(
+            config.io.js_output_file.as_deref(),
+        );
+        write_output_file(&map_path, &map_body)?;
+        let mut wrote_files = result.wrote_files;
+        wrote_files.push(map_path);
+        return Ok(CompilerOutput {
+            stdout_text: result.stdout_text,
+            wrote_files,
+        });
     }
+
+    Ok(result)
 }
 
 /// Write `contents` to `path`, creating any missing parent
@@ -1360,5 +1385,123 @@ mod tests {
         assert!(out.stdout_text.contains("var x"));
         let _ = fs::remove_file(&in_path);
         let _ = fs::remove_file(&ext_path);
+    }
+
+    // ------------------------------------------------------------------
+    // CLOC11.42 — --create_source_map minimal v3 emission
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn create_source_map_writes_file_when_path_set() {
+        let in_path = temp_path("smap-input.js");
+        let out_path = temp_path("smap-out.js");
+        let map_path = temp_path("smap-out.js.map");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            source_map: crate::config::SourceMapConfig {
+                path_template: map_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(out.wrote_files.contains(&out_path), "JS written");
+        assert!(out.wrote_files.contains(&map_path), "map written");
+        let map_body = fs::read_to_string(&map_path).expect("read map");
+        assert!(map_body.contains("\"version\": 3"));
+        assert!(map_body.contains("\"file\": \""));
+        assert!(map_body.contains("\"mappings\": \"\""));
+        let _ = fs::remove_file(&in_path);
+        let _ = fs::remove_file(&out_path);
+        let _ = fs::remove_file(&map_path);
+    }
+
+    #[test]
+    fn create_source_map_empty_path_writes_no_map() {
+        // Default behavior: --create_source_map unset → no map
+        // file written. Pin this regression so a future refactor
+        // of the gate doesn't accidentally emit one always.
+        let in_path = temp_path("no-smap.js");
+        let out_path = temp_path("no-smap-out.js");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        // Only the JS output file is written.
+        assert_eq!(out.wrote_files, vec![out_path.clone()]);
+        let _ = fs::remove_file(&in_path);
+        let _ = fs::remove_file(&out_path);
+    }
+
+    #[test]
+    fn create_source_map_with_stdout_output_writes_map_with_empty_file_key() {
+        // Source-map writing works even when there's no
+        // --js_output_file (compiled JS goes to stdout). In that
+        // case the map's `file` field is empty per the
+        // source_map module's contract.
+        let in_path = temp_path("stdout-smap.js");
+        let map_path = temp_path("stdout-smap.js.map");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: None,
+                ..Default::default()
+            },
+            source_map: crate::config::SourceMapConfig {
+                path_template: map_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let out = run_compiler(&cfg).expect("ok");
+        assert!(out.stdout_text.contains("var x"));
+        assert!(out.wrote_files.contains(&map_path));
+        let map_body = fs::read_to_string(&map_path).expect("read map");
+        assert!(map_body.contains("\"file\": \"\""));
+        let _ = fs::remove_file(&in_path);
+        let _ = fs::remove_file(&map_path);
+    }
+
+    #[test]
+    fn create_source_map_uses_basename_of_output_file() {
+        // The map's `file` field should be the basename of the
+        // compiled-output path, not the full path. Lets the map
+        // be served from a different directory than the JS.
+        let dir = temp_path("smap-basename-dir");
+        fs::create_dir_all(&dir).expect("setup");
+        let in_path = dir.join("in.js");
+        let out_path = dir.join("nested").join("out.min.js");
+        let map_path = dir.join("nested").join("out.min.js.map");
+        fs::write(&in_path, "var x;").expect("setup");
+        let cfg = CompilerConfig {
+            io: IoConfig {
+                js_patterns: vec![in_path.to_string_lossy().to_string()],
+                js_output_file: Some(out_path.clone()),
+                ..Default::default()
+            },
+            source_map: crate::config::SourceMapConfig {
+                path_template: map_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let _ = run_compiler(&cfg).expect("ok");
+        let map_body = fs::read_to_string(&map_path).expect("read map");
+        // Basename only — no directory components.
+        assert!(map_body.contains("\"file\": \"out.min.js\""), "got: {map_body}");
+        assert!(!map_body.contains("\"file\": \"nested/"));
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/code/programs/rust/closurec/src/source_map.rs
+++ b/code/programs/rust/closurec/src/source_map.rs
@@ -1,0 +1,218 @@
+//! `source_map` — `--create_source_map` minimal v3 emission (CLOC11.42).
+//!
+//! # What CC does
+//!
+//! The upstream Java Closure Compiler's `--create_source_map=path`
+//! flag writes a Source Map v3 JSON document at `path` after the
+//! compile completes. The document maps positions in the
+//! compiled output back to positions in the input files, so
+//! browsers/debuggers can show the user the original source
+//! when they hit a breakpoint or read a stack trace.
+//!
+//! # What we do today
+//!
+//! Real source-map generation needs the parser to track byte
+//! positions through every transform — that bridge lands with
+//! CLOC11.07+. Until then we emit a **minimal valid v3 source
+//! map**: empty `sources` / `sourcesContent` / `names` arrays
+//! and an empty `mappings` VLQ string. Build pipelines that
+//! check for the file's existence (Bazel rules, `webpack`
+//! `source-map-loader` shims) see what they expect; debuggers
+//! that try to use the map for a position lookup get the
+//! correct response of "no information available."
+//!
+//! Wire format:
+//!
+//! ```json
+//! {
+//!   "version": 3,
+//!   "file": "<--js_output_file basename or empty>",
+//!   "lineCount": 0,
+//!   "sourceRoot": "",
+//!   "sources": [],
+//!   "sourcesContent": [],
+//!   "names": [],
+//!   "mappings": ""
+//! }
+//! ```
+//!
+//! When real generation lands, the public function signature
+//! stays the same — only the inner content evolves.
+//!
+//! # Why hand-roll the JSON
+//!
+//! Same reason as `print_tree::format_token_dump_json`: the
+//! structure is fixed (eight known keys), zero new dependencies,
+//! and the byte-stable output keeps diff fixtures readable.
+
+use std::path::Path;
+
+/// Format the minimal v3 source map JSON for a given output file.
+///
+/// `output_path` is the resolved `--js_output_file` (when set);
+/// its basename becomes the `file` key. When `--js_output_file`
+/// is absent (stdout output), pass `None` and `file` is `""`.
+///
+/// Pure function: no I/O, fully deterministic given the input.
+/// Output ends with a trailing newline so concatenation stays
+/// well-formed.
+pub fn format_minimal_v3(output_path: Option<&Path>) -> String {
+    let file = match output_path {
+        Some(p) => p
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        None => String::new(),
+    };
+
+    // 8 keys × ~20 bytes baseline + the file basename.
+    let mut out = String::with_capacity(256);
+    out.push_str("{\n");
+    out.push_str("  \"version\": 3,\n");
+    out.push_str("  \"file\": \"");
+    append_json_escaped(&mut out, &file);
+    out.push_str("\",\n");
+    out.push_str("  \"lineCount\": 0,\n");
+    out.push_str("  \"sourceRoot\": \"\",\n");
+    out.push_str("  \"sources\": [],\n");
+    out.push_str("  \"sourcesContent\": [],\n");
+    out.push_str("  \"names\": [],\n");
+    out.push_str("  \"mappings\": \"\"\n");
+    out.push_str("}\n");
+    out
+}
+
+/// JSON-escape `s` per RFC 8259 §7 for embedding inside a string.
+///
+/// Identical policy to [`crate::print_tree::append_json_escaped`]
+/// — duplicated here to keep `source_map` independent of the
+/// `print_tree` module's internals. The two formatters could
+/// share a helper if a third caller appears.
+fn append_json_escaped(out: &mut String, s: &str) {
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000C}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn minimal_v3_with_no_output_path_has_empty_file_key() {
+        let s = format_minimal_v3(None);
+        assert!(s.contains("\"file\": \"\""));
+    }
+
+    #[test]
+    fn minimal_v3_uses_basename_of_output_path() {
+        // The Source Map v3 `file` field is the basename of the
+        // compiled output, not the full path — keeps the map
+        // portable across CDN paths.
+        let p = PathBuf::from("build/dist/app.min.js");
+        let s = format_minimal_v3(Some(&p));
+        assert!(s.contains("\"file\": \"app.min.js\""), "got: {s}");
+        assert!(!s.contains("build/"), "should not contain dir path: {s}");
+    }
+
+    #[test]
+    fn minimal_v3_declares_version_three() {
+        // The v3 marker is what distinguishes this from v2/v1;
+        // tools dispatch on this field.
+        let s = format_minimal_v3(None);
+        assert!(s.contains("\"version\": 3"));
+    }
+
+    #[test]
+    fn minimal_v3_has_all_eight_required_keys() {
+        let s = format_minimal_v3(None);
+        for key in &[
+            "version",
+            "file",
+            "lineCount",
+            "sourceRoot",
+            "sources",
+            "sourcesContent",
+            "names",
+            "mappings",
+        ] {
+            assert!(s.contains(&format!("\"{key}\"")), "missing key {key}: {s}");
+        }
+    }
+
+    #[test]
+    fn minimal_v3_empty_arrays_are_well_formed() {
+        // Empty arrays as `[]`, not `null`. Some debuggers reject
+        // `null` for these fields, and the spec requires arrays.
+        let s = format_minimal_v3(None);
+        assert!(s.contains("\"sources\": []"));
+        assert!(s.contains("\"sourcesContent\": []"));
+        assert!(s.contains("\"names\": []"));
+    }
+
+    #[test]
+    fn minimal_v3_empty_mappings_string() {
+        // The `mappings` field is a VLQ-encoded string. Empty
+        // mappings = empty string. Some tools accept the field
+        // being absent, but emitting "" is more robust and lets
+        // a consumer that always reads it not have to branch.
+        let s = format_minimal_v3(None);
+        assert!(s.contains("\"mappings\": \"\""));
+    }
+
+    #[test]
+    fn minimal_v3_ends_with_newline() {
+        // Trailing newline so the file works with line-counting
+        // tools (`wc -l`) and concatenation.
+        let s = format_minimal_v3(None);
+        assert!(s.ends_with("}\n"));
+    }
+
+    #[test]
+    fn minimal_v3_escapes_quotes_and_backslashes_in_file_name() {
+        // A file basename containing a `"` is a pathological
+        // case but we should still emit valid JSON. RFC 8259
+        // forbids unescaped `"` and `\` inside strings.
+        let p = PathBuf::from("weird\"name.js");
+        let s = format_minimal_v3(Some(&p));
+        // The output should contain `weird\"name.js` (escaped)
+        // not a raw quote.
+        assert!(s.contains("weird\\\"name.js"), "got: {s}");
+        // Balanced quotes: every `"` not preceded by `\` is part
+        // of the JSON framing. Count must be even.
+        let unescaped_quotes: usize = s
+            .char_indices()
+            .filter(|(i, c)| {
+                *c == '"' && (*i == 0 || s.as_bytes()[*i - 1] != b'\\')
+            })
+            .count();
+        assert!(unescaped_quotes % 2 == 0, "balanced quotes: {s}");
+    }
+
+    #[test]
+    fn minimal_v3_byte_stable_across_invocations() {
+        // Same input → byte-identical output. Diff fixtures
+        // depend on this.
+        let p = PathBuf::from("a.js");
+        let a = format_minimal_v3(Some(&p));
+        let b = format_minimal_v3(Some(&p));
+        assert_eq!(a, b);
+    }
+}

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.19.0
+Version: 0.20.0
 
 ## Flags
 


### PR DESCRIPTION
## Summary
- Behavioral compat slice with CC's \`--create_source_map=path\`. Previously closurec parsed the flag but never wrote any file.
- Now writes a minimal valid v3 source-map JSON at the path so build pipelines (Bazel, webpack source-map-loader) see what they expect.

## Wire format
\`\`\`json
{
  "version": 3,
  "file": "<--js_output_file basename or empty>",
  "lineCount": 0,
  "sourceRoot": "",
  "sources": [],
  "sourcesContent": [],
  "names": [],
  "mappings": ""
}
\`\`\`

Mappings are intentionally empty — real position tracking lands with CLOC11.07+ parser bridge. Debuggers attempting lookup get "no information available" rather than a broken document.

## Implementation
- New \`source_map\` module with \`format_minimal_v3(Option<&Path>) -> String\` (pure function).
- Pipeline placement: **Step 5** in \`run_compiler\`, after the JS output write. Source-map write runs after JS write so callers get a consistent on-disk pair.
- Works even when \`--js_output_file\` is absent (compiled JS → stdout); map's \`file\` field is empty in that case.
- \`file\` field is the basename of compiled output, not full path — keeps maps portable across CDN paths.

## Cumulative pipeline matrix
1. Resolve \`--js\` globs
2. Resolve \`--externs\` globs
3. \`--print_tree\` short-circuit
4. \`--print_tree_json\` short-circuit
5. \`transform_source\`
6. Concatenate
7. \`--checks_only\` short-circuit
8. \`--emit_use_strict\` prepend
9. \`--output_wrapper\` substitution
10. \`--isolation_mode IIFE\` wrap
11. \`--charset\` escape
12. Write JS
13. **Write source map (NEW)**

## Tests
- 9 new unit tests in \`source_map::tests\`
- 4 new unit tests in \`run::tests\`
- 199 unit tests + integration tests pass

## Versions
- \`Cargo.toml\`: 0.19.0 → 0.20.0
- \`cli.spec.json\`: 0.19.0 → 0.20.0
- Help-markdown fixture regenerated
- CHANGELOG \`[0.20.0]\` entry

## Security review (inline)
Pure-string transform. Basename flows through \`append_json_escaped\` (RFC 8259), so paths with \`"\`/\`\\\`/control chars can't break the JSON. No FS/net I/O at module level. \`write_output_file\` handles the disk write (battle-tested, auto-creates parents, typed error). No \`unsafe\`.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test\` — 199 unit + integration tests pass
- [x] \`cargo clippy --no-deps -p coding-adventures-closurec\` — clean
- [x] Inline security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)