### PR TITLE
feat(ruby-parser): Phase 7e — Ruby 3.0 rightward assignment `expr => var`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | yield_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -261,6 +261,25 @@ ensure_clause   = "ensure" { !"end" statement } ;
 # logicals (`||`/`&&`) to avoid colliding with comparison ops which
 # the lexer fuses directly.
 assignment   = NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expression ;
+# Phase 7e — Ruby 3.0 rightward (single-line) assignment `expr => var`.
+#
+# Mirror image of the normal `var = expr` assignment: the value is on
+# the left, the binding name is on the right after `=>`.  In practice
+# it's nearly always used with the case/in pattern-match payload, but
+# Ruby 3.0 made the bare form a first-class statement.
+#
+# Placed AFTER `modifier_statement` (so `x = 1 if cond` still wins) and
+# BEFORE `assignment` (so `x = 1` falls through cleanly), and BEFORE
+# `expression_stmt` (otherwise `expr` alone would consume the entire
+# token stream before `=>` is seen).
+#
+# Conflict safety: `=>` is also the hash-rocket inside hash literals
+# (`{ "a" => 1 }`).  Rightward-assign is at the statement level — a
+# hash literal as a bare statement would parse as `expression_stmt`,
+# which sits later in the alternation; PEG backtracks cleanly because
+# rightward_assignment requires `=>` to come *after* a complete
+# expression at the statement boundary, not inside a `{...}` body.
+rightward_assignment = expression "=>" NAME ;
 # Phase 6l — method receiver chains.  `foo.bar`, `foo.bar.baz`,
 # `foo.bar(args)`, `foo(1).bar`, `foo.bar(args).baz(more)`, etc.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.32.0] - 2026-05-25
+
+### Added (Phase 7e — Ruby 3.0 rightward assignment `expr => var`)
+
+New grammar rule:
+
+```ebnf
+rightward_assignment = expression "=>" NAME ;
+```
+
+Placed AFTER `modifier_statement` (so `x = 1 if cond` still wins) and BEFORE `assignment` in the `statement` alternation.
+
+The `=>` token is shared with hash literals (`{ "a" => 1 }`), but the rightward-assignment rule only matches at the statement level — PEG cleanly backtracks when `=>` sits inside `{...}`.
+
+Regenerated `_grammar.rs` via `grammar-tools compile-grammar`.
+
+### Lowering (in `ruby-to-semantic-ir`)
+
+A new helper `lower_rightward_assignment` lowers identically to a regular `assignment`:
+
+| Source              | SIR shape                                                |
+|---------------------|----------------------------------------------------------|
+| `1 + 2 => sum`      | `LetBinding(sum, BuiltinCall("+", [IntLit 1, IntLit 2]))` |
+| `42 => x`           | `LetBinding(x, IntLit 42)`                               |
+| (re-bind) `5 => x`  | `Assign(x, IntLit 5)` + `Feature::MutableBindings`       |
+
+Rightward assignment is purely syntactic — `expr => var` and `var = expr` produce identical SIR — so downstream emitters need no new code paths.
+
+### v0 deferred limitations
+
+- Compound rightward forms (`expr += var`, etc.) are NOT supported in Ruby itself.
+- Modifier-suffix combinations like `expr => var if cond` are deferred (modifier_statement only accepts `assignment | method_call_no_paren | method_call | expression_stmt` as its LHS).
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 136 → **140** (+4 grammar tests):
+  - `test_parse_rightward_assignment_with_literal` — `1 => x`.
+  - `test_parse_rightward_assignment_with_binary_expression` — `1 + 2 => sum`.
+  - `test_parse_rightward_assignment_with_call` — `foo(1, 2) => result`.
+  - `test_parse_rightward_assignment_does_not_break_normal_assignment` — regression.
+
 ## [0.31.0] - 2026-05-25
 
 ### Added (Phase 7d — Ruby 3.0 `case/in` pattern matching)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -34,6 +34,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"modifier_statement"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rightward_assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_with_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
@@ -552,6 +553,15 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 263,
         },
         GrammarRule {
+            name: r#"rightward_assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Literal { value: r#"=>"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 282,
+        },
+        GrammarRule {
             name: r#"method_call"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
@@ -569,7 +579,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 274,
+            line_number: 293,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -591,7 +601,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 275,
+            line_number: 294,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -602,7 +612,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 282,
+            line_number: 301,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -617,17 +627,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 296,
+            line_number: 315,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 297,
+            line_number: 316,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 383,
+            line_number: 402,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -640,7 +650,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 384,
+            line_number: 403,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -654,7 +664,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
                     ] }) },
             ] },
-            line_number: 385,
+            line_number: 404,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -668,7 +678,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 386,
+            line_number: 405,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -682,7 +692,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 387,
+            line_number: 406,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -693,7 +703,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 394,
+            line_number: 413,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -711,7 +721,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 395,
+            line_number: 414,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -725,7 +735,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 396,
+            line_number: 415,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -739,7 +749,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 397,
+            line_number: 416,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -763,7 +773,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 407,
+            line_number: 426,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -776,7 +786,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 426,
+            line_number: 445,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -784,7 +794,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 427,
+            line_number: 446,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -796,7 +806,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 428,
+            line_number: 447,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -811,7 +821,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 429,
+            line_number: 448,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -826,7 +836,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 430,
+            line_number: 449,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -842,7 +852,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 431,
+            line_number: 450,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2324,6 +2324,77 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 7e — Ruby 3.0 rightward assignment `expr => var`
+    //
+    // Grammar adds:
+    //   rightward_assignment = expression "=>" NAME ;
+    //
+    // Placed AFTER modifier_statement and BEFORE assignment in the
+    // statement alternation.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_rightward_assignment_with_literal() {
+        // `1 => x` — value `1` is bound to `x`.
+        let ast = parse_ruby("1 => x");
+        let ra = find_descendant(&ast, "rightward_assignment")
+            .expect("expected rightward_assignment node");
+        assert!(
+            tree_has_token_value(ra, "x"),
+            "expected binding name `x` in rightward_assignment"
+        );
+        assert!(
+            find_descendant(ra, "expression").is_some(),
+            "expected expression node holding the value"
+        );
+    }
+
+    #[test]
+    fn test_parse_rightward_assignment_with_binary_expression() {
+        // `1 + 2 => sum` — the LHS expression is a binary +.
+        let ast = parse_ruby("1 + 2 => sum");
+        let ra = find_descendant(&ast, "rightward_assignment")
+            .expect("expected rightward_assignment node");
+        assert!(tree_has_token_value(ra, "sum"));
+        // The expression child must hold the binary form (sum node).
+        let expr = find_descendant(ra, "expression").expect("expression");
+        assert!(
+            find_descendant(expr, "sum").is_some(),
+            "expected sum node inside rightward_assignment expression"
+        );
+    }
+
+    #[test]
+    fn test_parse_rightward_assignment_with_call() {
+        // `foo(1, 2) => result` — call as LHS value.
+        let ast = parse_ruby("foo(1, 2) => result");
+        let ra = find_descendant(&ast, "rightward_assignment")
+            .expect("expected rightward_assignment node");
+        assert!(tree_has_token_value(ra, "result"));
+        let expr = find_descendant(ra, "expression").expect("expression");
+        // The expression contains a method_call somewhere inside.
+        assert!(
+            find_descendant(expr, "method_call").is_some(),
+            "expected method_call inside the LHS expression"
+        );
+    }
+
+    #[test]
+    fn test_parse_rightward_assignment_does_not_break_normal_assignment() {
+        // Regression: `x = 1` must still match `assignment`, not
+        // rightward_assignment (which requires `=>`).
+        let ast = parse_ruby("x = 1");
+        assert!(
+            find_descendant(&ast, "assignment").is_some(),
+            "expected normal assignment to still match"
+        );
+        assert!(
+            find_descendant(&ast, "rightward_assignment").is_none(),
+            "normal assignment must NOT match rightward_assignment"
+        );
+    }
+
     #[test]
     fn test_parse_case_when_still_works_after_in_clause_addition() {
         // Regression: extending the case_statement rule to accept `in_clause`

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.32.0] - 2026-05-25
+
+### Added (Phase 7e — Ruby 3.0 rightward assignment lowering)
+
+A new helper `lower_rightward_assignment` mirrors the `lower_assignment` LetBinding-on-first-sight / Assign-on-rebind dispatch.  Rightward assignment is purely syntactic — `expr => var` and `var = expr` produce identical SIR.
+
+### Lowering
+
+| Source              | SIR shape                                                |
+|---------------------|----------------------------------------------------------|
+| `1 + 2 => sum`      | `LetBinding(sum, BuiltinCall("+", [IntLit 1, IntLit 2]))` |
+| `42 => x`           | `LetBinding(x, IntLit 42)`                               |
+| `[1, 2] => arr`     | `LetBinding(arr, SeqLit([IntLit 1, IntLit 2]))`          |
+| (re-bind) `5 => x`  | `Assign(x, IntLit 5)` + `Feature::MutableBindings`       |
+
+`lower_statement_inner` dispatches `rightward_assignment` to the new helper alongside `assignment`.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 146 → **150** (+4):
+  - `rightward_assignment_lowers_to_let_binding_on_first_sight` — `1 + 2 => sum`.
+  - `rightward_assignment_with_literal_lowers_to_int_let_binding` — `42 => x`.
+  - `rightward_assignment_rebind_emits_assign_with_mutable_bindings_feature` — `Assign` + manifest gating.
+  - `rightward_assignment_module_passes_sir_validator` — end-to-end smoke.
+
 ## [0.31.0] - 2026-05-25
 
 ### Added (Phase 7d — Ruby 3.0 case/in pattern matching lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3078,4 +3078,80 @@ puts("hi #{name}")
             else_branch.value
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7e — Ruby 3.0 rightward assignment `expr => var`
+    //
+    // Lowers identically to `var = expr` — LetBinding on first sight of
+    // the name, Assign on re-bind (with Feature::MutableBindings).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rightward_assignment_lowers_to_let_binding_on_first_sight() {
+        // `1 + 2 => sum` → LetBinding(sum, BuiltinCall("+", [1, 2])).
+        let m = lower("1 + 2 => sum");
+        let b = main_body(&m);
+        match &b.stmts[0] {
+            Stmt::LetBinding { name, value, .. } => {
+                assert_eq!(name, "sum");
+                match value {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "+");
+                        assert_eq!(args.len(), 2);
+                        assert!(matches!(&args[0], Expr::IntLit { value: 1, .. }));
+                        assert!(matches!(&args[1], Expr::IntLit { value: 2, .. }));
+                    }
+                    other => panic!("expected +-BuiltinCall, got {:?}", other),
+                }
+            }
+            other => panic!("expected LetBinding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rightward_assignment_with_literal_lowers_to_int_let_binding() {
+        // `42 => x` → LetBinding(x, IntLit(42)).
+        let m = lower("42 => x");
+        let b = main_body(&m);
+        assert!(matches!(
+            &b.stmts[0],
+            Stmt::LetBinding { name, value: Expr::IntLit { value: 42, .. }, .. } if name == "x"
+        ));
+    }
+
+    #[test]
+    fn rightward_assignment_rebind_emits_assign_with_mutable_bindings_feature() {
+        // `x = 1; 2 => x` — second statement is a re-bind, so it must
+        // emit Stmt::Assign (not LetBinding) and the module manifest
+        // must declare Feature::MutableBindings.
+        let m = lower("x = 1\n2 => x\n");
+        let b = main_body(&m);
+        // stmts[0] = LetBinding(x, 1)
+        // stmts[1] = Assign(x, 2) — the rightward re-bind
+        match &b.stmts[1] {
+            Stmt::Assign { name, value, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(value, Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected Assign on re-bind, got {:?}", other),
+        }
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::MutableBindings),
+            "expected MutableBindings feature in manifest after a re-bind"
+        );
+    }
+
+    #[test]
+    fn rightward_assignment_module_passes_sir_validator() {
+        // End-to-end smoke: a module with a rightward-assign statement
+        // passes the SIR validator.  Bound name must be visible to
+        // subsequent statements.
+        let m = lower("1 + 2 => sum\nputs(sum)\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected rightward-assign module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -305,6 +305,7 @@ impl Lowerer {
     ) -> Result<Stmt, RubyLowerError> {
         match node.rule_name.as_str() {
             "assignment" => self.lower_assignment(node),
+            "rightward_assignment" => self.lower_rightward_assignment(node),
             "method_call" => {
                 let expr = self.lower_method_call(node)?;
                 Ok(Stmt::ExprStmt {
@@ -1808,6 +1809,89 @@ impl Lowerer {
             let _ = name_span;
             s
         })
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 7e — Ruby 3.0 rightward assignment `expr => var`
+    // -------------------------------------------------------------------
+
+    /// Lower a `rightward_assignment` node into the same `Stmt` shape
+    /// as a regular `assignment`.  Ruby 3.0's rightward form is purely
+    /// syntactic — `expr => var` and `var = expr` produce identical
+    /// runtime bindings — so we lower identically to the `=`-form's
+    /// LetBinding-on-first-sighting / Assign-on-rebind dispatch.
+    ///
+    /// Grammar shape:
+    ///
+    /// ```text
+    /// rightward_assignment = expression "=>" NAME ;
+    /// ```
+    ///
+    /// AST children layout: `[ expression_node, "=>" token, name_token ]`.
+    ///
+    /// Lowering table:
+    ///
+    /// | Source              | SIR shape                                          |
+    /// |---------------------|----------------------------------------------------|
+    /// | `1 + 2 => x`        | `LetBinding(x, BuiltinCall("+", [IntLit 1, IntLit 2]))` |
+    /// | `[1,2] => arr`      | `LetBinding(arr, SeqLit([IntLit 1, IntLit 2]))`    |
+    /// | (re-bind) `5 => x`  | `Assign(x, IntLit 5)` + Feature::MutableBindings   |
+    fn lower_rightward_assignment(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Stmt, RubyLowerError> {
+        // Step 1: the LHS-as-source (Ruby left side) is the value
+        // expression — the `expression` Node child.
+        let expr_node = self.find_node_child(node, "expression").ok_or_else(|| {
+            RubyLowerError {
+                message: "rightward_assignment missing LHS expression".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            }
+        })?;
+        let value = self.lower_expression(expr_node)?;
+
+        // Step 2: the binding name is the trailing `NAME` token.  Walk
+        // children in reverse to find the *last* Name-typed token (the
+        // expression itself may have contained Name tokens, but those
+        // are inside the expression Node — direct children of the
+        // rightward_assignment node are the expression Node, the `=>`
+        // Op token, and the final Name token).
+        let name_token = node
+            .children
+            .iter()
+            .rev()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+                _ => None,
+            })
+            .ok_or_else(|| RubyLowerError {
+                message: "rightward_assignment missing binding name".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        let name = name_token.value.clone();
+        let span = self.span_of(node);
+
+        // Step 3: dispatch on whether the local is already declared —
+        // same first-sighting / re-bind split as `lower_assignment`.
+        if self.declared_locals.contains(&name) {
+            self.features_used.insert(Feature::MutableBindings);
+            Ok(Stmt::Assign {
+                name,
+                scope: Scope::Local,
+                value,
+                span,
+            })
+        } else {
+            self.declared_locals.insert(name.clone());
+            Ok(Stmt::LetBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })
+        }
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 7e adds Ruby 3.0's rightward (single-line) assignment syntax `expr => var` — the mirror image of regular `var = expr` assignment.  It's purely syntactic: both forms produce identical SIR.

## Grammar

New rule:

```ebnf
rightward_assignment = expression "=>" NAME ;
```

Placed AFTER `modifier_statement` (so `x = 1 if cond` still wins) and BEFORE `assignment` in the `statement` alternation.

The `=>` token is shared with hash literals (`{ "a" => 1 }`), but the rightward-assignment rule only matches at the statement level — PEG cleanly backtracks when `=>` sits inside `{...}`.

`_grammar.rs` regenerated via `grammar-tools compile-grammar`.

## Lowering

A new helper `lower_rightward_assignment` mirrors the `lower_assignment` LetBinding-on-first-sight / Assign-on-rebind dispatch:

| Source              | SIR shape                                                |
|---------------------|----------------------------------------------------------|
| `1 + 2 => sum`      | `LetBinding(sum, BuiltinCall("+", [IntLit 1, IntLit 2]))` |
| `42 => x`           | `LetBinding(x, IntLit 42)`                               |
| `[1, 2] => arr`     | `LetBinding(arr, SeqLit([IntLit 1, IntLit 2]))`          |
| (re-bind) `5 => x`  | `Assign(x, IntLit 5)` + `Feature::MutableBindings`       |

`lower_statement_inner` dispatches `rightward_assignment` to the new helper alongside `assignment`.

## v0 deferred limitations

- Modifier-suffix combinations like `expr => var if cond` are not yet supported (the `modifier_statement` LHS alternation doesn't include `rightward_assignment`).

## Tests

- `coding-adventures-ruby-parser`: 136 → **140** (+4 grammar tests, incl. regression).
- `ruby-to-semantic-ir`: 146 → **150** (+4 lowering tests, incl. Assign + MutableBindings re-bind + validator end-to-end smoke).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (140/140 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (150/150 pass)
- [x] Self-reviewed (no I/O, no unsafe — grammar adds one declarative production; lowerer reuses existing LetBinding/Assign dispatch)
- [ ] CI green

Follows PR #4387 (Phase 7d — Ruby 3.0 case/in pattern matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
