### PR TITLE
feat(ruby-parser): Phase 7f — Ruby 3.1 hash value shorthand `{x:, y:}`

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -447,4 +447,4 @@ unary_minus  = MINUS factor ;
 symbol_literal = COLON ( NAME | KEYWORD | STRING ) ;
 array_literal = LBRACKET [ expression { COMMA expression } ] RBRACKET ;
 hash_literal = LBRACE [ hash_entry { COMMA hash_entry } ] RBRACE ;
-hash_entry   = NAME COLON expression | expression "=>" expression ;
+hash_entry   = NAME COLON expression | NAME COLON | expression "=>" expression ;

--- a/code/packages/rust/ruby-parser/.pr-body-7f.md
+++ b/code/packages/rust/ruby-parser/.pr-body-7f.md
@@ -1,0 +1,51 @@
+## Summary
+
+Phase 7f adds Ruby 3.1's hash value-omitted shorthand `{x:, y:}` — sugar for `{x: x, y: y}` where each value is a same-named local variable lookup.  This is the final chunk before full Ruby 3.4 convergence on the parser/lowering side.
+
+## Grammar
+
+Extended rule:
+
+```ebnf
+hash_entry = NAME COLON expression | NAME COLON | expression "=>" expression ;
+```
+
+The new `NAME COLON` alternative is placed AFTER `NAME COLON expression` so PEG ordered-choice tries the longer form first.  When the longer form fails (e.g. `x:` followed by `,` or `}`), the parser cleanly backtracks to the value-omitted shape.
+
+Purely additive — every prior shape (`{x: 1}`, `{a => b}`, `{x: 1, y: 2}`) parses identically.
+
+`_grammar.rs` regenerated via `grammar-tools compile-grammar`.
+
+## Lowering
+
+`lower_hash_entry` learns a third dispatch arm:
+
+| Source         | SIR shape                                                                  |
+|----------------|----------------------------------------------------------------------------|
+| `{x: 1}`       | `MapEntry { key: SymLit("x"), value: IntLit(1) }` (unchanged)             |
+| `{x => 1}`     | `MapEntry { key: <lowered x>, value: IntLit(1) }` (unchanged)             |
+| **`{x:}`**     | **`MapEntry { key: SymLit("x"), value: VarRef("x", Local/Param) }`**     |
+
+The value-omitted shorthand emits `VarRef(name, scope)` where `scope` follows the same Param-vs-Local dispatch used by bare-name factor lowering: `Param` if the name is in `current_params`, else `Local`.  This means `def f(x); {x:}; end` correctly produces `VarRef("x", Param)`.
+
+## v0 deferred limitations
+
+- `**kwargs`-style splat into a value-omitted hash is unchanged from prior phases (still parses as a method-call argument, not a hash entry).
+
+## Tests
+
+- `coding-adventures-ruby-parser`: 140 → **143** (+3 grammar tests, incl. mixed and regression).
+- `ruby-to-semantic-ir`: 150 → **155** (+5 lowering tests, incl. Param-scope inside `def`, mixed shorthand + explicit, regression, validator E2E).
+- `coding-adventures-ruby-lexer`: 169 unchanged.
+
+## Test plan
+
+- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
+- [x] `cargo test -p coding-adventures-ruby-parser` (143/143 pass)
+- [x] `cargo test -p ruby-to-semantic-ir` (155/155 pass)
+- [x] Self-reviewed (no I/O, no unsafe — grammar adds one declarative alternative; lowerer reuses existing VarRef construction with the bare-name Param/Local scope dispatch)
+- [ ] CI green
+
+Follows PR #4452 (Phase 7e — Ruby 3.0 rightward assignment).  Completes the Ruby 3.4 convergence parser queue.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.33.0] - 2026-05-26
+
+### Added (Phase 7f — Ruby 3.1 hash value-omitted shorthand `{x:, y:}`)
+
+Extended grammar rule:
+
+```ebnf
+hash_entry = NAME COLON expression | NAME COLON | expression "=>" expression ;
+```
+
+The new `NAME COLON` alternative (no trailing expression) is placed AFTER `NAME COLON expression` so PEG ordered-choice tries the longer form first.  When the longer form fails (e.g. `x:` followed by `,` or `}`), the parser cleanly backtracks to the value-omitted shape.
+
+The grammar change is purely additive — every prior shape (`{x: 1}`, `{a => b}`, `{x: 1, y: 2}`) parses identically.
+
+Regenerated `_grammar.rs` via `grammar-tools compile-grammar`.
+
+### Tests
+
+- `coding-adventures-ruby-parser`: 140 → **143** (+3):
+  - `test_parse_hash_value_shorthand_pure` — `{x:, y:}` produces two `hash_entry` subnodes each with ZERO `expression` children.
+  - `test_parse_hash_value_shorthand_mixed` — `{x:, y: 5}` produces one entry with 0 expression children and one with 1.
+  - `test_parse_hash_value_shorthand_regression_existing_form` — `{x: 1, y: 2}` still produces entries with 1 expression child each.
+
 ## [0.32.0] - 2026-05-25
 
 ### Added (Phase 7e — Ruby 3.0 rightward assignment `expr => var`)

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -847,6 +847,10 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
                 GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     GrammarElement::Literal { value: r#"=>"#.to_string() },
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -2416,5 +2416,118 @@ mod tests {
         assert_eq!(when_count, 2, "expected 2 when_clauses");
         assert_eq!(in_count, 0, "expected 0 in_clauses");
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 7f — Ruby 3.1 hash value-omitted shorthand `{x:, y:}`
+    //
+    // When a hash entry is written as `NAME COLON` (no value expression),
+    // Ruby 3.1+ treats it as a punned shorthand for `NAME COLON NAME`,
+    // i.e. the value is a local variable lookup with the same name as
+    // the symbol key.  Grammar accepts this via a new alternation
+    // `NAME COLON` placed AFTER `NAME COLON expression` so the parser
+    // tries the longer form first (PEG ordered-choice semantics).
+    //
+    // The three tests below cover (1) pure shorthand `{x:, y:}`, (2)
+    // mixed shorthand + explicit forms `{x:, y: 5}`, and (3) regression
+    // that ordinary `{x: 1, y: 2}` still parses with two `expression`
+    // children per entry (i.e. case (1) parses to ZERO `expression`
+    // children — the value-omitted shape — not one).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_hash_value_shorthand_pure() {
+        // `{x:, y:}` — two value-omitted entries.  Each `hash_entry`
+        // should have a Name token + COLON token + NO `expression`
+        // subnode (the new value-omitted shape).
+        let ast = parse_ruby("h = {x:, y:}");
+        let h = find_descendant(&ast, "hash_literal").expect("expected hash_literal");
+        let entries: Vec<&GrammarASTNode> = h
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "hash_entry" => Some(n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(entries.len(), 2, "expected 2 hash_entry subnodes");
+        for ent in &entries {
+            let expr_count = ent
+                .children
+                .iter()
+                .filter(|c| {
+                    matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")
+                })
+                .count();
+            assert_eq!(
+                expr_count, 0,
+                "value-omitted shorthand: expected 0 expression children, got {expr_count}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_hash_value_shorthand_mixed() {
+        // `{x:, y: 5}` — first entry is value-omitted, second is
+        // explicit.  Test that the parser correctly distinguishes the
+        // two shapes within a single hash literal.
+        let ast = parse_ruby("h = {x:, y: 5}");
+        let h = find_descendant(&ast, "hash_literal").expect("expected hash_literal");
+        let entries: Vec<&GrammarASTNode> = h
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "hash_entry" => Some(n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(entries.len(), 2, "expected 2 hash_entry subnodes");
+        let expr_counts: Vec<usize> = entries
+            .iter()
+            .map(|ent| {
+                ent.children
+                    .iter()
+                    .filter(|c| {
+                        matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")
+                    })
+                    .count()
+            })
+            .collect();
+        assert_eq!(
+            expr_counts,
+            vec![0, 1],
+            "expected first entry value-omitted (0 expr), second explicit (1 expr)"
+        );
+    }
+
+    #[test]
+    fn test_parse_hash_value_shorthand_regression_existing_form() {
+        // Regression: extending hash_entry with `NAME COLON` must NOT
+        // break the existing `{x: 1, y: 2}` form.  Each entry must
+        // still parse with exactly one `expression` child (the value).
+        let ast = parse_ruby("h = {x: 1, y: 2}");
+        let h = find_descendant(&ast, "hash_literal").expect("expected hash_literal");
+        let entries: Vec<&GrammarASTNode> = h
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "hash_entry" => Some(n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(entries.len(), 2);
+        for ent in &entries {
+            let expr_count = ent
+                .children
+                .iter()
+                .filter(|c| {
+                    matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")
+                })
+                .count();
+            assert_eq!(
+                expr_count, 1,
+                "explicit shorthand: expected 1 expression child, got {expr_count}"
+            );
+        }
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.33.0] - 2026-05-26
+
+### Added (Phase 7f — Ruby 3.1 hash value-omitted shorthand lowering)
+
+`lower_hash_entry` learns a third dispatch arm: when a `hash_entry` node has a `NAME` token, a `COLON` token, and ZERO `expression` children, the entry's value is emitted as `VarRef(name, scope)` — a same-named local variable lookup.  Key remains `SymLit(name)` (matching the existing keyword-style shorthand).
+
+The `scope` follows the same Param-vs-Local dispatch as bare-name factor lowering: if the binding exists in `current_params`, mark it `Param`; otherwise mark it `Local`.  This means `{x:}` inside `def f(x); …; end` correctly emits `VarRef("x", Param)`.
+
+### Lowering dispatch summary
+
+| Source            | Shape                                                                        |
+|-------------------|------------------------------------------------------------------------------|
+| `{x: 1}`          | `MapEntry { key: SymLit("x"), value: IntLit(1) }` (unchanged)               |
+| `{x => 1}`        | `MapEntry { key: <lowered x>, value: IntLit(1) }` (unchanged)               |
+| **`{x:}`**        | **`MapEntry { key: SymLit("x"), value: VarRef("x", Local/Param) }` (new)** |
+
+The change is purely additive — no existing SIR shape changes.  Both `Feature::Symbols` (for the key) and (transitively) any feature for the value expression are still recorded as before.
+
+### Tests
+
+- `ruby-to-semantic-ir`: 150 → **155** (+5):
+  - `hash_value_shorthand_emits_var_ref_value` — `{name:}` value is `VarRef("name", Local)`.
+  - `hash_value_shorthand_inside_method_uses_param_scope` — `def f(x); {x:}; end` value is `VarRef("x", Param)`.
+  - `hash_value_shorthand_mixed_with_explicit_form` — `{name:, age: 30}` first entry is VarRef, second is IntLit.
+  - `hash_explicit_form_unchanged_after_phase_7f` — `{x: 1, y: 2}` regression (still IntLit values).
+  - `hash_value_shorthand_module_passes_sir_validator` — end-to-end validator smoke.
+
 ## [0.32.0] - 2026-05-25
 
 ### Added (Phase 7e — Ruby 3.0 rightward assignment lowering)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3154,4 +3154,164 @@ puts("hi #{name}")
             result
         );
     }
+
+    // -----------------------------------------------------------------
+    // Phase 7f — Ruby 3.1 hash value-omitted shorthand `{x:, y:}`.
+    //
+    // When a hash entry omits its value (`NAME COLON` with no trailing
+    // expression), the lowerer must emit a `MapEntry` whose key is
+    // `SymLit(name)` (same as the explicit `NAME COLON expression`
+    // form) AND whose value is `VarRef(name, scope)`, where `scope`
+    // follows the same Param-vs-Local dispatch used by bare-name
+    // factor lowering.
+    //
+    // Five tests below cover (1) basic shorthand emits VarRef value,
+    // (2) the value's scope follows current_params, (3) mixed
+    // shorthand + explicit forms keep their respective shapes, (4) the
+    // existing `{x: 1}` form is unchanged (regression), and (5) an
+    // end-to-end validator smoke that exercises name resolution.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn hash_value_shorthand_emits_var_ref_value() {
+        // `name = "ada"; {name:}` — the shorthand entry's value should
+        // be VarRef("name", Local), not the SymLit it would be for the
+        // key.  Key is SymLit("name") as usual.
+        let m = lower("name = \"ada\"\nh = {name:}\n");
+        let main = main_body(&m);
+        let entries = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::LetBinding { name: n, value: Expr::MapLit { entries, .. }, .. }
+                    if n == "h" =>
+                {
+                    Some(entries)
+                }
+                _ => None,
+            })
+            .expect("expected MapLit bound to h");
+        assert_eq!(entries.len(), 1);
+        assert!(
+            matches!(&entries[0].key, Expr::SymLit { name, .. } if name == "name"),
+            "key should be SymLit(\"name\"), got {:?}",
+            entries[0].key
+        );
+        assert!(
+            matches!(
+                &entries[0].value,
+                Expr::VarRef { name, scope, .. }
+                    if name == "name" && *scope == Scope::Local
+            ),
+            "value should be VarRef(\"name\", Local), got {:?}",
+            entries[0].value
+        );
+    }
+
+    #[test]
+    fn hash_value_shorthand_inside_method_uses_param_scope() {
+        // Inside `def f(x); {x:}; end`, the shorthand value `x` should
+        // be VarRef("x", Param) — same scoping rule as bare-name
+        // factor references.
+        let m = lower("def f(x)\n  {x:}\nend\n");
+        // Locate the `f` function definition.
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "f")
+            .expect("expected def f/1 in module");
+        // The hash literal is the tail expression of f's body — it
+        // appears as Block.value (Expr::MapLit) directly because the
+        // single-expression method has no preceding statements.
+        let entries = match &f.body.value {
+            Expr::MapLit { entries, .. } => entries,
+            other => panic!("expected MapLit as tail value of f, got {:?}", other),
+        };
+        assert_eq!(entries.len(), 1);
+        assert!(
+            matches!(
+                &entries[0].value,
+                Expr::VarRef { name, scope, .. }
+                    if name == "x" && *scope == Scope::Param
+            ),
+            "value should be VarRef(\"x\", Param) inside method body, got {:?}",
+            entries[0].value
+        );
+    }
+
+    #[test]
+    fn hash_value_shorthand_mixed_with_explicit_form() {
+        // `name = "ada"; {name:, age: 30}` — first entry's value is
+        // VarRef (shorthand), second entry's value is IntLit
+        // (explicit `NAME COLON expression`).  Verifies the lowerer
+        // correctly dispatches per-entry inside a single hash literal.
+        let m = lower("name = \"ada\"\nh = {name:, age: 30}\n");
+        let main = main_body(&m);
+        let entries = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::LetBinding { name: n, value: Expr::MapLit { entries, .. }, .. }
+                    if n == "h" =>
+                {
+                    Some(entries)
+                }
+                _ => None,
+            })
+            .expect("expected MapLit bound to h");
+        assert_eq!(entries.len(), 2);
+        assert!(
+            matches!(
+                &entries[0].value,
+                Expr::VarRef { name, .. } if name == "name"
+            ),
+            "first entry value should be VarRef(\"name\"), got {:?}",
+            entries[0].value
+        );
+        assert!(
+            matches!(&entries[1].value, Expr::IntLit { value: 30, .. }),
+            "second entry value should be IntLit(30), got {:?}",
+            entries[1].value
+        );
+    }
+
+    #[test]
+    fn hash_explicit_form_unchanged_after_phase_7f() {
+        // Regression: extending hash_entry with `NAME COLON` must NOT
+        // change the SIR shape for the existing `{x: 1, y: 2}` form.
+        // Each value must still be an IntLit, not a VarRef.
+        let m = lower("h = {x: 1, y: 2}\n");
+        let main = main_body(&m);
+        let entries = main
+            .stmts
+            .iter()
+            .find_map(|s| match s {
+                Stmt::LetBinding { value: Expr::MapLit { entries, .. }, .. } => Some(entries),
+                _ => None,
+            })
+            .expect("expected MapLit");
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(&entries[0].value, Expr::IntLit { value: 1, .. }));
+        assert!(matches!(&entries[1].value, Expr::IntLit { value: 2, .. }));
+    }
+
+    #[test]
+    fn hash_value_shorthand_module_passes_sir_validator() {
+        // End-to-end smoke: a module that binds `name`, then builds
+        // `{name:}` in tail position, must pass the SIR validator —
+        // the VarRef generated for the shorthand value must
+        // successfully resolve to the prior LetBinding.
+        //
+        // We use tail-expression position (not another LetBinding) so
+        // that the parallel-let validator sees `name` in scope before
+        // the shorthand's RHS is checked — same workaround pattern as
+        // the Phase 6y interpolation smoke test.
+        let m = lower("name = \"ada\"\nputs({name:})\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected hash-shorthand module: {:?}",
+            result
+        );
+    }
 }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -3372,10 +3372,14 @@ impl Lowerer {
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<semantic_ir::nodes::MapEntry, RubyLowerError> {
-        // Two shapes are possible:
-        //   1. `NAME COLON expression` — shorthand.  The Name token
-        //      is the symbol key.
-        //   2. `expression "=>" expression` — hash-rocket.  Two
+        // Three shapes are possible:
+        //   1. `NAME COLON expression` — keyword-style shorthand.  The
+        //      Name token is the symbol key; the trailing expression
+        //      is the value.
+        //   2. `NAME COLON` — Ruby 3.1 value-omitted shorthand (Phase
+        //      7f).  The Name token is the symbol key AND the value is
+        //      a `VarRef` to a same-named local variable in scope.
+        //   3. `expression "=>" expression` — hash-rocket.  Two
         //      `expression` rule children.
         let expression_subnodes: Vec<&GrammarASTNode> = node
             .children
@@ -3391,7 +3395,7 @@ impl Lowerer {
             let value = self.lower_expression(expression_subnodes[1])?;
             return Ok(semantic_ir::nodes::MapEntry { key, value });
         }
-        // Shorthand form — find the leading Name token.
+        // Shorthand form (cases 1 and 2) — find the leading Name token.
         let key_tok = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
             _ => None,
@@ -3401,17 +3405,34 @@ impl Lowerer {
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
         })?;
+        let key_span = self.span_of_token(key_tok);
         let key = Expr::SymLit {
             name: key_tok.value.clone(),
-            span: self.span_of_token(key_tok),
+            span: key_span.clone(),
         };
         self.features_used.insert(Feature::Symbols);
-        let value_node = expression_subnodes.first().ok_or_else(|| RubyLowerError {
-            message: "hash_entry shorthand missing value expression".to_string(),
-            line: node.start_line.unwrap_or(0),
-            column: node.start_column.unwrap_or(0),
-        })?;
-        let value = self.lower_expression(value_node)?;
+        let value = if let Some(value_node) = expression_subnodes.first() {
+            // Case 1 — explicit value expression follows the colon.
+            self.lower_expression(value_node)?
+        } else {
+            // Case 2 — Ruby 3.1 value-omitted shorthand `{name:}`.
+            // Value is a `VarRef` to the same-named local variable.
+            // The scope follows the same Param-vs-Local dispatch used
+            // by the bare-name factor lowering above: if the binding
+            // exists in `current_params`, mark it `Param`; otherwise
+            // mark it `Local` and let the validator catch any unbound
+            // reference.
+            let scope = if self.current_params.contains(&key_tok.value) {
+                Scope::Param
+            } else {
+                Scope::Local
+            };
+            Expr::VarRef {
+                name: key_tok.value.clone(),
+                scope,
+                span: key_span,
+            }
+        };
         Ok(semantic_ir::nodes::MapEntry { key, value })
     }
 


### PR DESCRIPTION
## Summary

Phase 7f adds Ruby 3.1's hash value-omitted shorthand `{x:, y:}` — sugar for `{x: x, y: y}` where each value is a same-named local variable lookup.  This is the final chunk before full Ruby 3.4 convergence on the parser/lowering side.

## Grammar

Extended rule:

```ebnf
hash_entry = NAME COLON expression | NAME COLON | expression "=>" expression ;
```

The new `NAME COLON` alternative is placed AFTER `NAME COLON expression` so PEG ordered-choice tries the longer form first.  When the longer form fails (e.g. `x:` followed by `,` or `}`), the parser cleanly backtracks to the value-omitted shape.

Purely additive — every prior shape (`{x: 1}`, `{a => b}`, `{x: 1, y: 2}`) parses identically.

`_grammar.rs` regenerated via `grammar-tools compile-grammar`.

## Lowering

`lower_hash_entry` learns a third dispatch arm:

| Source         | SIR shape                                                                  |
|----------------|----------------------------------------------------------------------------|
| `{x: 1}`       | `MapEntry { key: SymLit("x"), value: IntLit(1) }` (unchanged)             |
| `{x => 1}`     | `MapEntry { key: <lowered x>, value: IntLit(1) }` (unchanged)             |
| **`{x:}`**     | **`MapEntry { key: SymLit("x"), value: VarRef("x", Local/Param) }`**     |

The value-omitted shorthand emits `VarRef(name, scope)` where `scope` follows the same Param-vs-Local dispatch used by bare-name factor lowering: `Param` if the name is in `current_params`, else `Local`.  This means `def f(x); {x:}; end` correctly produces `VarRef("x", Param)`.

## v0 deferred limitations

- `**kwargs`-style splat into a value-omitted hash is unchanged from prior phases (still parses as a method-call argument, not a hash entry).

## Tests

- `coding-adventures-ruby-parser`: 140 → **143** (+3 grammar tests, incl. mixed and regression).
- `ruby-to-semantic-ir`: 150 → **155** (+5 lowering tests, incl. Param-scope inside `def`, mixed shorthand + explicit, regression, validator E2E).
- `coding-adventures-ruby-lexer`: 169 unchanged.

## Test plan

- [x] `cargo test -p coding-adventures-ruby-lexer` (169/169 pass)
- [x] `cargo test -p coding-adventures-ruby-parser` (143/143 pass)
- [x] `cargo test -p ruby-to-semantic-ir` (155/155 pass)
- [x] Self-reviewed (no I/O, no unsafe — grammar adds one declarative alternative; lowerer reuses existing VarRef construction with the bare-name Param/Local scope dispatch)
- [ ] CI green

Follows PR #4452 (Phase 7e — Ruby 3.0 rightward assignment).  Completes the Ruby 3.4 convergence parser queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
