### PR TITLE
feat(cas-summation): Phase 85 — Two-Sqrt × Six-Log × polynomial numerator (v2.22.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.22.0 — 2026-05-26
+
+### Added
+
+- **Phase 85 — Two-Sqrt × Six-Log × polynomial numerator** (`_two_sqrt_six_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), Log(h6(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 6 Log factors required.  `log⁶(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase85TwoSqrtSixLogPoly`.
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.21.0"
+version = "2.22.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1182,6 +1182,20 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 85: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1), Log(h2), Log(h3), Log(h4), Log(h5), Log(h6),
+    #           polynomial..., bounded...)`` numerator.
+    # Two Sqrt factors + six Log factors; log⁶ sub-polynomial → 0.
+    # effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s2l6p_x2 = _two_sqrt_six_log_poly_effective_x2(num, k)
+    if s2l6p_x2 is not None:
+        den_deg_s2l6 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l6 is not None:
+            if 2 * den_deg_s2l6 > s2l6p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3441,6 +3455,74 @@ def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None
     if sqrt_deg_x2 is None or log_count != 6:
         return None
     return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul``
+    with **exactly two** ``Sqrt(positive-leading polynomial)`` factors, **exactly six**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded factors;
+    ``None`` otherwise.
+
+    Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · sqrt(k^b) · log(k)⁶ · k^m ≈ k^{(a+b)/2} · log⁶(k) · k^m``.
+    ``log⁶(k)`` is sub-polynomial (``o(k^ε)``), contributing 0.
+    Using the ×2 integer trick:
+    ``effective_x2 = a + b + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +------------------------------------------------------------------+---------------------+
+    | Input                                                            | Return              |
+    +==================================================================+=====================+
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×6)``                              | ``1 + 1 = 2``       |
+    | ``Mul(Sqrt(k³), Sqrt(k³), Log(k)×6)``                           | ``3 + 3 = 6``       |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×6, k)``                          | ``1+1+2 = 4``       |
+    | ``Mul(Sqrt(k), Log(k)×6)``                                       | None (1 Sqrt)       |
+    | ``Mul(Sqrt(k)×3, Log(k)×6)``                                     | None (3 Sqrts)      |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×5)``                              | None (5 Logs)       |
+    +------------------------------------------------------------------+---------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 2.
+         - ``Log(diverging)`` → count; bail after 6.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 2 Sqrt AND exactly 6 Log factors.
+      4. Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                # Third Sqrt factor — not this phase.
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 6:
+                # Seven or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 6:
+        return None
+    return sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg_sum
 
 
 def _try_power_of_k(

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4681,3 +4681,79 @@ class TestPhase84OneSqrtSixLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase85TwoSqrtSixLogPoly:
+    """Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √P₁(k) · √P₂(k) · log⁶(k) · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = deg1_x2 + deg2_x2 + 2·poly_deg.
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_two_sqrt_k_log6_k_over_k2_closes(self):
+        """√k·√k·log(k)⁶/k²: eff_x2=1+1=2; 2·2=4 > 2 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_two_sqrt_k3_log6_k_over_k_refused(self):
+        """√(k³)·√(k³)·log(k)⁶/k: eff_x2=3+3=6; 2·1=2 not > 6 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+    def test_two_sqrt_k_log6_k_times_k_over_k2_refused(self):
+        """√k·√k·log(k)⁶·k/k²: eff_x2=1+1+2=4; 2·2=4 not > 4 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.22.0 — 2026-05-26
+
+### Added
+
+- **Phase 85 — Two-Sqrt × Six-Log × polynomial numerator** (`two_sqrt_six_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), Log(h6(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 6 Log factors required.  `log⁶(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase85_*`).
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.21.0"
+version = "2.22.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2258,6 +2258,36 @@ fn one_sqrt_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> 
     Some(s + 2 * poly_deg)
 }
 
+/// Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)⁶ · k^m ≈ k^{(a+b)/2} · log⁶(k) · k^m`.
+/// `log⁶(k)` is sub-polynomial (`o(k^ε)`), contributing 0. Using the ×2 integer trick:
+/// `effective_x2 = a + b + 2·m`. Caller checks `2·den_deg > effective_x2`.
+fn two_sqrt_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 2 { return None; } // third Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 6 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 2 || log_count != 6 { return None; }
+    Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2691,6 +2721,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s1l6_x2) = one_sqrt_six_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s1l6) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s1l6 > s1l6_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 85: Mul(Sqrt(P1), Sqrt(P2), Log(diverging)×6, polynomial..., bounded...) numerator.
+    // Two Sqrt + six Log factors; log⁶ sub-polynomial — effective_x2 = d1+d2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s2l6_x2) = two_sqrt_six_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l6) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l6 > s2l6_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3362,3 +3362,85 @@ fn phase84_sqrt_k_log6_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 85: Two-Sqrt × Six-Log × polynomial numerator ──────────────────────
+
+#[test]
+fn phase85_two_sqrt_k_log6_k_over_k2_closes() {
+    // √k·√k·log(k)^6 / k²: effective_x2=1+1=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k85a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp185a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k85a, g_kp185a]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase85_two_sqrt_k3_log6_k_over_k_refused() {
+    // √(k³)·√(k³)·log(k)^6 / k: effective_x2=3+3=6; 2·1=2 not > 6 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k85b = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp185b = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k85b, g_kp185b]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase85_two_sqrt_k_log6_k_times_k_over_k2_refused() {
+    // √k·√k·log(k)^6·k / k²: effective_x2=1+1+2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k85c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp185c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k85c, g_kp185c]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.22.0 — 2026-05-26
+
+### Added
+
+- **Phase 85 — Two-Sqrt × Six-Log × polynomial numerator** (`twoSqrtSixLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1), Sqrt(P2), Log(h1(k)), Log(h2(k)), Log(h3(k)), Log(h4(k)), Log(h5(k)), Log(h6(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt and exactly 6 Log factors; `log⁶(k)` sub-polynomial — contributes 0 to effective
+  degree; effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  Closes when `denDeg > twoSqrtSixLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 85" describe block.
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2036,6 +2036,40 @@ function oneSqrtSixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefi
   return sqrtHalfDeg + polyDeg;
 }
 
+/**
+ * Phase 85 — Two-Sqrt × Six-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)⁶ · k^m ≈ k^{(a+b)/2} · log⁶(k) · k^m`.
+ * `log⁶(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective polynomial degree.
+ * effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+ * Caller checks `denDeg > twoSqrtSixLogPolyEffectiveDeg(num, k)`.
+ */
+function twoSqrtSixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined; // third Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 6) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 6) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
@@ -2487,6 +2521,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS1l6 = polynomialDegreeInK(den, k);
     if (denDegS1l6 !== undefined) {
       if (denDegS1l6 > s1l6Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 85: Mul(Sqrt(P1), Sqrt(P2), Log(h1)×6, polynomial..., bounded...) numerator.
+  // Two Sqrt + six Log factors; log⁶ sub-polynomial → effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  // Closes when denDeg > twoSqrtSixLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s2l6Deg = twoSqrtSixLogPolyEffectiveDeg(num, k);
+  if (s2l6Deg !== undefined) {
+    const denDegS2l6 = polynomialDegreeInK(den, k);
+    if (denDegS2l6 !== undefined) {
+      if (denDegS2l6 > s2l6Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3690,3 +3690,106 @@ describe("Phase 84 — One-Sqrt × Six-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 85 — Two-Sqrt × Six-Log × polynomial numerator", () => {
+  it("√k·√k·log(k)⁶/k² closes (sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=0 → effective=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK85a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp185a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK85a = { kind: "apply" as const, head: DIV, args: [numK85a, k2] };
+    const gKp185a = { kind: "apply" as const, head: DIV, args: [numKp185a, kp1_2] };
+    const f85a = { kind: "apply" as const, head: SUB, args: [gK85a, gKp185a] };
+    const result = evaluateSum(f85a, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=0 → effective=1; denDeg=2 > 1 → closes
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√(k³)·log(k)⁶/k refused (sqrtHalf1=1.5, sqrtHalf2=1.5 → effective=3; denDeg=1 not > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK85b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp185b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK85b = { kind: "apply" as const, head: DIV, args: [numK85b, k] };
+    const gKp185b = { kind: "apply" as const, head: DIV, args: [numKp185b, kp1] };
+    const f85b = { kind: "apply" as const, head: SUB, args: [gK85b, gKp185b] };
+    const result = evaluateSum(f85b, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf1=1.5, sqrtHalf2=1.5 → effective=3; denDeg=1 not > 3 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·log(k)⁶·k/k² refused (sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=1 → effective=2; denDeg=2 not > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK85c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp185c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK85c = { kind: "apply" as const, head: DIV, args: [numK85c, k2] };
+    const gKp185c = { kind: "apply" as const, head: DIV, args: [numKp185c, kp1_2] };
+    const f85c = { kind: "apply" as const, head: SUB, args: [gK85c, gKp185c] };
+    const result = evaluateSum(f85c, k, int(1), sym("%inf"), evalNode);
+    // sqrtHalf1=0.5, sqrtHalf2=0.5, polyDeg=1 → effective=2; denDeg=2 not > 2 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Phase 85 of the convergence recognizer: detects numerators of the form
`Mul(Sqrt(P1), Sqrt(P2), Log(h1), Log(h2), Log(h3), Log(h4), Log(h5), Log(h6), polynomial..., bounded...)`
across all three language implementations.

## What's new

### Phase 85 — Two-Sqrt × Six-Log × polynomial

Pattern: exactly **2** Sqrt factors + exactly **6** Log factors + any polynomial factors + any bounded factors.

Effective growth rate: `sqrt(k^a) · sqrt(k^b) · log⁶(k) · k^m ≈ k^{(a+b)/2 + m}`.
`log⁶(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective degree.

Using the ×2 integer trick:
`effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`

Closes when `2·den_deg > effective_x2` (polynomial denominator) or non-polynomial diverging denominator.

### Three-language parity

| Language | Helper function | Version |
|----------|----------------|---------|
| Python | `_two_sqrt_six_log_poly_effective_x2` | 2.22.0 |
| Rust | `two_sqrt_six_log_poly_effective_x2` | 2.22.0 |
| TypeScript | `twoSqrtSixLogPolyEffectiveDeg` | 2.22.0 |

### Tests added
- 3 tests in each language (9 total)

## Note on version

Version jumps 2.20.0 → 2.22.0 (skipping 2.21.0) because Phase 81 (PR #4426) is in-flight and will occupy v2.21.0 when it merges. This branch will rebase cleanly onto main after Phase 81 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)