### PR TITLE
feat(image-codec-gif): IC07 GIF87a/89a codec

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -367,6 +367,7 @@ members = [
     "qr-code",
     "data-matrix",
     "pdf417",
+    "image-codec-gif",
     "image-codec-bmp",
     "image-codec-jpeg",
     "image-codec-ppm",

--- a/code/packages/rust/image-codec-gif/BUILD
+++ b/code/packages/rust/image-codec-gif/BUILD
@@ -1,0 +1,1 @@
+cargo test -p image-codec-gif -- --nocapture

--- a/code/packages/rust/image-codec-gif/CHANGELOG.md
+++ b/code/packages/rust/image-codec-gif/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog — image-codec-gif
+
+All notable changes to this crate follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.1.0] — 2026-05-26
+
+### Added
+
+- **`decode_gif(bytes)`** — Decodes GIF87a and GIF89a byte streams into RGBA8
+  `PixelContainer` buffers.  Handles:
+  - Global and Local Color Tables
+  - Graphic Control Extension (transparency flag + transparent colour index)
+  - 4-pass de-interlacing (pass order: rows 0/8/…, 4/12/…, 2/6/…, 1/3/…)
+  - Unknown extension blocks (skipped gracefully)
+  - Animated GIF detection (second Image Descriptor → `Err`)
+
+- **`encode_gif(pixels)`** — Encodes a `PixelContainer` as a GIF byte stream.
+  - Outputs GIF87a for fully opaque images; GIF89a for images with transparency.
+  - Exact palette when ≤ 256 distinct opaque colours are present.
+  - Median-cut quantisation (256 buckets) when > 256 colours.
+  - One palette slot is reserved for the transparent colour (GIF89a only).
+  - Non-interlaced progressive scan.
+
+- **`GifCodec`** — Zero-field struct implementing `paint_instructions::ImageCodec`
+  (`mime_type() → "image/gif"`, `encode`, `decode`).
+
+- **`lzw` module** — GIF-variant LZW encoder + decoder.
+  - Configurable `lzw_minimum_code_size` (2–8 bits).
+  - LSB-first bit packing (`BitWriter`, `BitReader`).
+  - Sub-block framing (`to_sub_blocks`, `read_sub_blocks`).
+  - Code-width growth: decoder grows one step before the encoder (at
+    `next_code >= 2^code_size − 1`) to compensate for the one-entry lag
+    inherent in LZW decoding.
+  - Table-full (`next_code ≥ 4096`) CLEAR + reset in encoder.
+
+- **42 unit tests + 1 doc-test** covering:
+  - LZW round-trips at all `min_code_size` values (2–8)
+  - RLE and gradient patterns; 256-colour full palette
+  - Sub-block framing invariants
+  - Solid, gradient, transparent, and mixed-alpha images
+  - File structure (header, trailer, canvas dimensions in LSD)
+  - Error paths: bad magic, unknown version, truncated data
+
+### Implementation notes
+
+- Palette quantisation uses squared Euclidean distance for nearest-colour
+  assignment (not perceptually weighted) — sufficient for the lossless
+  indexed-colour domain.
+- Median-cut splits on the channel with the greatest min/max range; bucket
+  representative is the arithmetic mean.
+- The LZW decoder uses a parent-pointer table (no per-entry `Vec<u8>`) to
+  reconstruct code strings; worst-case stack depth is 4096 entries.

--- a/code/packages/rust/image-codec-gif/Cargo.toml
+++ b/code/packages/rust/image-codec-gif/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "image-codec-gif"
+version = "0.1.0"
+edition = "2021"
+description = "GIF image codec for paint-instructions: PixelContainer ↔ GIF87a/GIF89a bytes (IC07)"
+
+[dependencies]
+pixel-container = { path = "../pixel-container" }
+paint-instructions = { path = "../paint-instructions" }

--- a/code/packages/rust/image-codec-gif/README.md
+++ b/code/packages/rust/image-codec-gif/README.md
@@ -1,0 +1,159 @@
+# image-codec-gif — IC07
+
+GIF (Graphics Interchange Format) image codec for the coding-adventures stack.
+
+Decodes GIF87a and GIF89a files into RGBA8 `PixelContainer` buffers and encodes
+`PixelContainer` pixels as static GIF87a/GIF89a files.  Implements the
+`paint_instructions::ImageCodec` trait so it plugs directly into the renderer.
+
+---
+
+## Overview
+
+GIF was designed at CompuServe in 1987 to transfer images efficiently over slow
+modems.  Its two distinctive constraints — **indexed colour** (≤ 256 palette
+entries per image) and **GIF-variant LZW compression** — still make it the
+dominant format for short animations on the web today.  This crate handles the
+static-image subset of the format.
+
+### What this crate does
+
+| Feature | Support |
+|---------|---------|
+| GIF87a static decode | ✓ |
+| GIF89a static decode | ✓ |
+| GIF89a transparency (alpha = 0) | ✓ |
+| Interlaced images (4-pass de-interlace) | ✓ |
+| GIF87a encode (fully opaque images) | ✓ |
+| GIF89a encode (images with transparency) | ✓ |
+| Exact palette (≤ 256 distinct colours) | ✓ |
+| Median-cut quantisation (> 256 colours) | ✓ |
+| Animated GIF decode | ✗ (error on second frame) |
+| Animated GIF encode | ✗ |
+
+---
+
+## Quick start
+
+```rust
+use image_codec_gif::{encode_gif, decode_gif};
+use pixel_container::PixelContainer;
+
+// Encode a 2×2 red image.
+let mut px = PixelContainer::new(2, 2);
+px.fill(255, 0, 0, 255);
+let bytes = encode_gif(&px);
+assert!(bytes.starts_with(b"GIF"));
+
+// Decode it back.
+let recovered = decode_gif(&bytes).unwrap();
+assert_eq!(recovered.width, 2);
+assert_eq!(recovered.height, 2);
+```
+
+### Using the `ImageCodec` trait
+
+```rust
+use image_codec_gif::GifCodec;
+use paint_instructions::ImageCodec;
+use pixel_container::PixelContainer;
+
+let codec = GifCodec;
+assert_eq!(codec.mime_type(), "image/gif");
+
+let mut px = PixelContainer::new(4, 4);
+px.fill(0, 128, 255, 255);
+let bytes = codec.encode(&px);
+let recovered = codec.decode(&bytes).unwrap();
+```
+
+---
+
+## Format details
+
+### GIF file structure
+
+```
+"GIF87a" or "GIF89a"          (6 bytes — header)
+Logical Screen Descriptor      (7 bytes)
+Global Color Table             (3 × 2^(n+1) bytes, if present)
+[Graphic Control Extension]    (GIF89a only — for transparency / timing)
+Image Descriptor               (10 bytes)
+[Local Color Table]            (optional override)
+Image Data                     (LZW-compressed, sub-block framed)
+Trailer 0x3B                   (1 byte)
+```
+
+### LZW compression (GIF variant)
+
+GIF uses a configurable-width LZW variant:
+
+- **Minimum code size** (`lzw_minimum_code_size`): 2–8 bits, derived from
+  `ceil(log2(palette_size))`.  With 4 colours it starts at 2; with 256 colours
+  at 8.
+- **Special codes**: `CLEAR = 2^mcs` and `EOI = CLEAR + 1`.  Dynamic codes
+  start at `EOI + 1`.
+- **Code growth**: code width grows by 1 bit each time `next_code` exceeds
+  `2^current_width`, up to 12 bits.
+- **Sub-block framing**: the raw bit stream is wrapped in blocks of ≤ 255 bytes,
+  each prefixed by its 1-byte length.  A zero-length block terminates the data.
+- **Bit packing**: LSB-first within each byte.
+
+### Transparency
+
+- Pixels with alpha < 128 are treated as fully transparent.
+- When any transparent pixel is present, the encoder outputs GIF89a with a
+  Graphic Control Extension designating one palette index as transparent.
+- On decode, pixels whose index matches the transparent index receive alpha = 0;
+  all others receive alpha = 255.
+
+### Palette quantisation
+
+When an image has more than 256 distinct opaque colours, the encoder applies
+**median-cut quantisation**: it recursively splits the colour space along the
+axis with the greatest range until 256 buckets remain, then assigns each pixel
+to the nearest bucket centroid using squared Euclidean distance.
+
+---
+
+## Crate layout
+
+```
+image-codec-gif/
+  src/
+    lib.rs      — Public API, GifCodec struct, integration tests
+    encoder.rs  — GIF87a/89a encoder; palette building; median-cut
+    decoder.rs  — GIF87a/89a parser; de-interlacing
+    lzw.rs      — GIF-variant LZW encoder + decoder; BitWriter/BitReader
+```
+
+---
+
+## Dependencies
+
+| Crate | Role |
+|-------|------|
+| `pixel-container` | RGBA8 pixel buffer (IC-stack layer 0) |
+| `paint-instructions` | `ImageCodec` trait (IC-stack layer 0) |
+
+No third-party crates.
+
+---
+
+## Position in the IC stack
+
+```
+paint-canvas  (renderer)
+      │
+paint-instructions  (ImageCodec trait)
+      │
+image-codec-gif  ← you are here   (IC07)
+      │
+pixel-container  (RGBA8 buffer)
+```
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).

--- a/code/packages/rust/image-codec-gif/src/decoder.rs
+++ b/code/packages/rust/image-codec-gif/src/decoder.rs
@@ -207,6 +207,21 @@ impl<'a> Parser<'a> {
                     let top = self.read_u16_le()? as usize;
                     let width = self.read_u16_le()? as usize;
                     let height = self.read_u16_le()? as usize;
+
+                    // Sanity-check declared dimensions before any allocation.
+                    // 16 MP (4096×4096) is far above any realistic static GIF
+                    // and still allows comfortable headroom for the GIF maximum
+                    // of 65535×65535 to be rejected early.
+                    const MAX_PIXELS: usize = 4096 * 4096;
+                    let pixel_count = width.saturating_mul(height);
+                    if pixel_count > MAX_PIXELS {
+                        return Err(format!(
+                            "GIF: image dimensions {}×{} = {} pixels exceed \
+                             the {} pixel safety limit",
+                            width, height, pixel_count, MAX_PIXELS
+                        ));
+                    }
+
                     let img_packed = self.read_byte()?;
 
                     let local_ct_flag = (img_packed >> 7) & 1;
@@ -246,11 +261,10 @@ impl<'a> Parser<'a> {
                     self.skip_sub_blocks()?;
                     let img_data = &self.data[img_data_start..self.pos];
 
-                    // Decode LZW.
-                    let indices = lzw::decode(img_data)
+                    // Decode LZW, capping output at pixel_count to prevent
+                    // decompression-bomb attacks from crafted LZW streams.
+                    let indices = lzw::decode(img_data, pixel_count)
                         .map_err(|e| format!("GIF: LZW error: {}", e))?;
-
-                    let pixel_count = width * height;
                     if indices.len() < pixel_count {
                         return Err(format!(
                             "GIF: decoded {} indices but image needs {} ({}×{})",

--- a/code/packages/rust/image-codec-gif/src/decoder.rs
+++ b/code/packages/rust/image-codec-gif/src/decoder.rs
@@ -1,0 +1,386 @@
+//! GIF file parser: reads GIF87a and GIF89a streams into a pixel buffer.
+//!
+//! The parser follows the block structure defined in the IC07 spec:
+//!
+//! ```text
+//! Header (6 bytes) → LSD (7 bytes) → [GCT] → {Block}* → Trailer (0x3B)
+//!
+//! Block introducers:
+//!   0x2C → Image Descriptor (+ optional LCT + image data)
+//!   0x21 → Extension (followed by label byte)
+//!   0x3B → Trailer (stop)
+//! ```
+//!
+//! This module focuses on decoding the *first* image frame.  Subsequent
+//! Image Descriptors (animation frames) are detected and trigger an error.
+
+use pixel_container::PixelContainer;
+
+use crate::lzw;
+
+// ─── Public entry point ────────────────────────────────────────────────────────
+
+/// Decode a GIF byte stream into an RGBA8 `PixelContainer`.
+///
+/// Returns the first (only, for static GIFs) frame.
+/// Transparent pixels (via Graphic Control Extension) have alpha = 0;
+/// all other pixels have alpha = 255.
+///
+/// # Errors
+///
+/// Returns `Err(String)` for:
+/// - Non-GIF data
+/// - Animated GIFs (multiple images)
+/// - Malformed or truncated data
+/// - Invalid LZW streams
+pub fn decode_gif(bytes: &[u8]) -> Result<PixelContainer, String> {
+    let mut p = Parser::new(bytes);
+    p.parse()
+}
+
+// ─── Internal parser ──────────────────────────────────────────────────────────
+
+struct Parser<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Parser { data, pos: 0 }
+    }
+
+    // ── Byte-level helpers ────────────────────────────────────────────────────
+
+    fn remaining(&self) -> usize {
+        self.data.len().saturating_sub(self.pos)
+    }
+
+    fn read_byte(&mut self) -> Result<u8, String> {
+        if self.pos >= self.data.len() {
+            return Err("GIF: unexpected end of data".into());
+        }
+        let b = self.data[self.pos];
+        self.pos += 1;
+        Ok(b)
+    }
+
+    fn read_u16_le(&mut self) -> Result<u16, String> {
+        let lo = self.read_byte()? as u16;
+        let hi = self.read_byte()? as u16;
+        Ok(lo | (hi << 8))
+    }
+
+    fn read_bytes(&mut self, n: usize) -> Result<&'a [u8], String> {
+        if self.pos + n > self.data.len() {
+            return Err("GIF: unexpected end of data".into());
+        }
+        let slice = &self.data[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    /// Skip all sub-blocks at the current position (used to discard extensions).
+    fn skip_sub_blocks(&mut self) -> Result<(), String> {
+        loop {
+            let len = self.read_byte()? as usize;
+            if len == 0 {
+                break;
+            }
+            if self.pos + len > self.data.len() {
+                return Err("GIF: sub-block extends past end of data".into());
+            }
+            self.pos += len;
+        }
+        Ok(())
+    }
+
+    /// Read `3 * count` bytes as an RGB palette.
+    /// Returns a Vec of (R, G, B) triples.
+    fn read_color_table(&mut self, count: usize) -> Result<Vec<(u8, u8, u8)>, String> {
+        let bytes = self.read_bytes(3 * count)?;
+        Ok(bytes
+            .chunks(3)
+            .map(|c| (c[0], c[1], c[2]))
+            .collect())
+    }
+
+    // ── Main parse loop ───────────────────────────────────────────────────────
+
+    fn parse(&mut self) -> Result<PixelContainer, String> {
+        // ── Header ──
+        if self.remaining() < 6 {
+            return Err("GIF: file too short to be a GIF".into());
+        }
+        let sig = self.read_bytes(3)?;
+        if sig != b"GIF" {
+            return Err("GIF: not a GIF file".into());
+        }
+        let ver = self.read_bytes(3)?;
+        if ver != b"87a" && ver != b"89a" {
+            return Err(format!(
+                "GIF: unknown version '{}' (expected 87a or 89a)",
+                String::from_utf8_lossy(ver)
+            ));
+        }
+
+        // ── Logical Screen Descriptor ──
+        if self.remaining() < 7 {
+            return Err("GIF: truncated header (LSD missing)".into());
+        }
+        let _canvas_w = self.read_u16_le()?;
+        let _canvas_h = self.read_u16_le()?;
+        let packed = self.read_byte()?;
+        let _bg_color_index = self.read_byte()?;
+        let _pixel_aspect = self.read_byte()?;
+
+        let global_ct_flag = (packed >> 7) & 1;
+        let gct_size_field = (packed & 0x07) as u32;
+        let gct_count = 1usize << (gct_size_field + 1);
+
+        // ── Global Color Table ──
+        let global_ct: Vec<(u8, u8, u8)> = if global_ct_flag == 1 {
+            self.read_color_table(gct_count)?
+        } else {
+            Vec::new()
+        };
+
+        // ── State for pending Graphic Control Extension ──
+        let mut transparent_color_flag = false;
+        let mut transparent_color_index: u8 = 0;
+
+        // ── Block scanning loop ──
+        let mut frame_count = 0u32;
+        let mut result: Option<PixelContainer> = None;
+
+        loop {
+            let introducer = self.read_byte()?;
+            match introducer {
+                0x3B => {
+                    // Trailer — end of file.
+                    break;
+                }
+                0x21 => {
+                    // Extension block.
+                    let label = self.read_byte()?;
+                    match label {
+                        0xF9 => {
+                            // Graphic Control Extension — transparency / animation.
+                            let block_size = self.read_byte()?;
+                            if block_size < 4 {
+                                return Err(
+                                    "GIF: Graphic Control Extension block size < 4".into()
+                                );
+                            }
+                            let gce_packed = self.read_byte()?;
+                            let _delay = self.read_u16_le()?;
+                            let tci = self.read_byte()?;
+                            // Skip any extra bytes in this sub-block.
+                            for _ in 4..block_size {
+                                self.read_byte()?;
+                            }
+                            // Read the terminator (sub-block length = 0).
+                            let term = self.read_byte()?;
+                            if term != 0 {
+                                // Extra sub-blocks in GCE — skip them.
+                                self.pos -= 1;
+                                self.skip_sub_blocks()?;
+                            }
+                            transparent_color_flag = (gce_packed & 0x01) != 0;
+                            transparent_color_index = tci;
+                        }
+                        _ => {
+                            // All other extensions (Application, Comment, Plain Text,
+                            // and any future extensions): skip all sub-blocks.
+                            self.skip_sub_blocks()?;
+                        }
+                    }
+                }
+                0x2C => {
+                    // Image Descriptor.
+                    frame_count += 1;
+                    if frame_count > 1 {
+                        return Err("GIF: animated GIF not supported (multiple frames detected)".into());
+                    }
+
+                    let left = self.read_u16_le()? as usize;
+                    let top = self.read_u16_le()? as usize;
+                    let width = self.read_u16_le()? as usize;
+                    let height = self.read_u16_le()? as usize;
+                    let img_packed = self.read_byte()?;
+
+                    let local_ct_flag = (img_packed >> 7) & 1;
+                    let interlace_flag = (img_packed >> 6) & 1;
+                    let lct_size_field = (img_packed & 0x07) as u32;
+                    let lct_count = 1usize << (lct_size_field + 1);
+
+                    // Choose color table (LCT overrides GCT).
+                    let lct: Vec<(u8, u8, u8)> = if local_ct_flag == 1 {
+                        self.read_color_table(lct_count)?
+                    } else {
+                        Vec::new()
+                    };
+                    let color_table: &Vec<(u8, u8, u8)> = if local_ct_flag == 1 {
+                        &lct
+                    } else {
+                        &global_ct
+                    };
+
+                    if color_table.is_empty() {
+                        return Err("GIF: no color table available for image".into());
+                    }
+
+                    // Read image data (starts with lzw_minimum_code_size byte,
+                    // followed by sub-blocks).
+                    let img_data_start = self.pos;
+
+                    // Find the end of sub-blocks to collect image data.
+                    // We collect a contiguous slice including the min_code_size byte.
+                    // Skip min_code_size byte to find sub-blocks.
+                    if self.pos >= self.data.len() {
+                        return Err("GIF: truncated image data".into());
+                    }
+                    let _min_code_size_byte = self.data[self.pos];
+                    self.pos += 1;
+                    // Skip sub-blocks.
+                    self.skip_sub_blocks()?;
+                    let img_data = &self.data[img_data_start..self.pos];
+
+                    // Decode LZW.
+                    let indices = lzw::decode(img_data)
+                        .map_err(|e| format!("GIF: LZW error: {}", e))?;
+
+                    let pixel_count = width * height;
+                    if indices.len() < pixel_count {
+                        return Err(format!(
+                            "GIF: decoded {} indices but image needs {} ({}×{})",
+                            indices.len(),
+                            pixel_count,
+                            width,
+                            height
+                        ));
+                    }
+
+                    // De-interlace if needed.
+                    let ordered_indices: Vec<u8> = if interlace_flag == 1 {
+                        de_interlace(&indices, width, height)
+                    } else {
+                        indices[..pixel_count].to_vec()
+                    };
+
+                    // Convert palette indices to RGBA.
+                    let mut pixel_data = PixelContainer::new(width as u32, height as u32);
+
+                    for (i, &idx) in ordered_indices[..pixel_count].iter().enumerate() {
+                        let alpha = if transparent_color_flag && idx == transparent_color_index {
+                            0u8
+                        } else {
+                            255u8
+                        };
+                        let (r, g, b) = if (idx as usize) < color_table.len() {
+                            color_table[idx as usize]
+                        } else {
+                            (0, 0, 0)
+                        };
+                        let px = (i % width) as u32;
+                        let py = (i / width) as u32;
+                        pixel_data.set_pixel(px, py, r, g, b, alpha);
+                    }
+
+                    result = Some(pixel_data);
+
+                    // Reset GCE state after consuming it.
+                    transparent_color_flag = false;
+                    transparent_color_index = 0;
+                }
+                other => {
+                    return Err(format!(
+                        "GIF: unknown block introducer 0x{:02X} at offset {}",
+                        other,
+                        self.pos - 1
+                    ));
+                }
+            }
+        }
+
+        result.ok_or_else(|| "GIF: no image found".into())
+    }
+}
+
+// ─── De-interlacing ───────────────────────────────────────────────────────────
+
+/// Convert interlaced pixel order to progressive (top-to-bottom) order.
+///
+/// GIF interlacing uses 4 passes:
+///   Pass 1: rows 0, 8, 16, 24, …
+///   Pass 2: rows 4, 12, 20, 28, …
+///   Pass 3: rows 2, 6, 10, 14, …
+///   Pass 4: rows 1, 3, 5, 7, …
+///
+/// The LZW-decoded data streams rows in pass order; we rearrange to
+/// top-to-bottom order.
+fn de_interlace(data: &[u8], width: usize, height: usize) -> Vec<u8> {
+    // Each pass: (starting_row, row_step)
+    let passes: [(usize, usize); 4] = [(0, 8), (4, 8), (2, 4), (1, 2)];
+
+    let mut result = vec![0u8; width * height];
+    let mut src = 0usize;
+
+    for (start, step) in &passes {
+        let mut row = *start;
+        while row < height {
+            let src_end = (src + width).min(data.len());
+            let count = src_end - src;
+            let dst_start = row * width;
+            result[dst_start..dst_start + count]
+                .copy_from_slice(&data[src..src + count]);
+            src += width;
+            row += step;
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_bad_magic() {
+        let err = decode_gif(b"PNG\x89\x0D\x0A").unwrap_err();
+        assert!(err.contains("not a GIF"), "got: {}", err);
+    }
+
+    #[test]
+    fn decode_bad_version() {
+        let mut data = b"GIF99a".to_vec();
+        data.extend_from_slice(&[0; 100]); // pad
+        let err = decode_gif(&data).unwrap_err();
+        assert!(err.contains("unknown version"), "got: {}", err);
+    }
+
+    #[test]
+    fn decode_too_short() {
+        let err = decode_gif(b"GIF").unwrap_err();
+        assert!(err.contains("too short") || err.contains("truncated") || err.contains("end of data"), "got: {}", err);
+    }
+
+    #[test]
+    fn de_interlace_2x4() {
+        // 2 wide, 4 tall.
+        // Interlaced order: pass1=row0, pass2=row2(skipped for step=8, height=4 has no row 4),
+        // actually: pass1 (start=0,step=8): rows 0; pass2 (start=4,step=8): none (4>=4);
+        // pass3 (start=2,step=4): row 2; pass4 (start=1,step=2): rows 1,3.
+        // So interlaced data = [row0, row2, row1, row3].
+        let data: Vec<u8> = vec![
+            10, 11, // row 0 (pass 1)
+            20, 21, // row 2 (pass 3)
+            30, 31, // row 1 (pass 4)
+            40, 41, // row 3 (pass 4)
+        ];
+        let out = de_interlace(&data, 2, 4);
+        // Expected: [row0, row1, row2, row3]
+        assert_eq!(out, vec![10, 11, 30, 31, 20, 21, 40, 41]);
+    }
+}

--- a/code/packages/rust/image-codec-gif/src/encoder.rs
+++ b/code/packages/rust/image-codec-gif/src/encoder.rs
@@ -1,0 +1,383 @@
+//! GIF87a/GIF89a encoder.
+//!
+//! Converts an RGBA `PixelContainer` into a complete GIF byte stream.
+//!
+//! # Encoding decisions (Phase 1)
+//!
+//! - Output format: GIF87a for fully opaque images; GIF89a with a Graphic
+//!   Control Extension for images with transparent pixels (alpha < 128).
+//! - Palette: exact palette if ≤ 256 distinct RGB colours appear; otherwise
+//!   **median-cut quantization** to 256 colours.
+//! - Interlacing: never (always write progressive scan).
+//! - Animation: not supported — single frame only.
+//! - `lzw_minimum_code_size` = max(2, ceil(log2(palette_size))).
+
+use pixel_container::PixelContainer;
+
+use crate::lzw;
+
+// ─── Public entry point ────────────────────────────────────────────────────────
+
+/// Encode a `PixelContainer` as a GIF byte stream.
+///
+/// Pixels with alpha < 128 are treated as fully transparent.
+/// All other pixels are treated as fully opaque (alpha is ignored for RGB).
+///
+/// Returns a complete GIF file (starting with "GIF87a" or "GIF89a").
+pub fn encode_gif(pixels: &PixelContainer) -> Vec<u8> {
+    let width = pixels.width as usize;
+    let height = pixels.height as usize;
+
+    // Collect RGBA pixels and determine if we need transparency.
+    let total = width * height;
+    let mut rgb_pixels: Vec<(u8, u8, u8)> = Vec::with_capacity(total);
+    let mut has_transparency = false;
+    let mut transparent_positions: Vec<bool> = Vec::with_capacity(total);
+
+    for y in 0..height {
+        for x in 0..width {
+            let (r, g, b, a) = pixels.pixel_at(x as u32, y as u32);
+            let is_transparent = a < 128;
+            if is_transparent {
+                has_transparency = true;
+            }
+            rgb_pixels.push((r, g, b));
+            transparent_positions.push(is_transparent);
+        }
+    }
+
+    // ── Build palette ──
+    // Collect distinct RGB colours (ignoring transparent pixels for palette building).
+    let opaque_colors: Vec<(u8, u8, u8)> = rgb_pixels
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !transparent_positions[*i])
+        .map(|(_, &c)| c)
+        .collect();
+
+    // For opaque images we can use all 256 palette slots.
+    // For images with transparency we must reserve one slot for the transparent
+    // colour, so the opaque palette can hold at most 255 distinct colours.
+    let max_opaque = if has_transparency { 255 } else { 256 };
+    let mut palette = build_palette(&opaque_colors, max_opaque);
+
+    // If we need transparency, reserve the last palette slot for it.
+    let transparent_index: u8 = if has_transparency {
+        let ti = palette.len() as u8;
+        palette.push((0, 0, 0)); // transparent color (value doesn't matter)
+        ti
+    } else {
+        0
+    };
+
+    // Palette must have at least 2 entries; pad with black if needed.
+    while palette.len() < 2 {
+        palette.push((0, 0, 0));
+    }
+
+    // ── Determine GCT size ──
+    // GCT size = 2^(n+1); find smallest n such that 2^(n+1) >= palette.len().
+    let palette_size = palette.len();
+    let gct_size_field = required_gct_field(palette_size);
+    let gct_count = 1usize << (gct_size_field + 1);
+    // Pad palette to gct_count entries.
+    while palette.len() < gct_count {
+        palette.push((0, 0, 0));
+    }
+
+    // ── Map pixels to palette indices ──
+    let indices: Vec<u8> = rgb_pixels
+        .iter()
+        .enumerate()
+        .map(|(i, &color)| {
+            if transparent_positions[i] {
+                transparent_index
+            } else {
+                nearest_palette_index(color, &palette[..palette_size])
+            }
+        })
+        .collect();
+
+    // ── Determine lzw_minimum_code_size ──
+    let min_code_size = required_min_code_size(palette_size);
+
+    // ── Build the GIF byte stream ──
+    let mut out: Vec<u8> = Vec::new();
+
+    // Header: GIF89a if transparency needed, else GIF87a.
+    if has_transparency {
+        out.extend_from_slice(b"GIF89a");
+    } else {
+        out.extend_from_slice(b"GIF87a");
+    }
+
+    // Logical Screen Descriptor.
+    out.extend_from_slice(&(width as u16).to_le_bytes());
+    out.extend_from_slice(&(height as u16).to_le_bytes());
+    // Packed byte: global_ct_flag=1, color_resolution=1 (unused), sort=0, gct_size_field.
+    let packed: u8 = 0b1000_0000 | (gct_size_field as u8 & 0x07);
+    out.push(packed);
+    out.push(0); // background color index
+    out.push(0); // pixel aspect ratio (unspecified)
+
+    // Global Color Table.
+    for &(r, g, b) in &palette {
+        out.push(r);
+        out.push(g);
+        out.push(b);
+    }
+
+    // Graphic Control Extension (GIF89a only, for transparency).
+    if has_transparency {
+        out.push(0x21); // Extension Introducer
+        out.push(0xF9); // Graphic Control label
+        out.push(0x04); // block size
+        out.push(0x01); // packed: transparent_color_flag = 1
+        out.extend_from_slice(&0u16.to_le_bytes()); // delay = 0
+        out.push(transparent_index);
+        out.push(0x00); // terminator
+    }
+
+    // Image Descriptor.
+    out.push(0x2C); // Image Separator
+    out.extend_from_slice(&0u16.to_le_bytes()); // left = 0
+    out.extend_from_slice(&0u16.to_le_bytes()); // top = 0
+    out.extend_from_slice(&(width as u16).to_le_bytes());
+    out.extend_from_slice(&(height as u16).to_le_bytes());
+    out.push(0x00); // packed: no local color table, no interlace
+
+    // LZW-compressed image data.
+    let lzw_data = lzw::encode(&indices, min_code_size);
+    out.extend_from_slice(&lzw_data);
+
+    // Trailer.
+    out.push(0x3B);
+
+    out
+}
+
+// ─── Palette helpers ──────────────────────────────────────────────────────────
+
+/// Build a palette with at most `max_colors` entries from the given colour list.
+///
+/// If the distinct colour count is ≤ `max_colors`, uses the exact set.
+/// Otherwise, applies median-cut quantization.
+fn build_palette(colors: &[(u8, u8, u8)], max_colors: usize) -> Vec<(u8, u8, u8)> {
+    if colors.is_empty() {
+        return vec![(0, 0, 0)];
+    }
+
+    // Collect distinct colours using a simple set.
+    let mut distinct: Vec<(u8, u8, u8)> = colors.to_vec();
+    distinct.sort_unstable();
+    distinct.dedup();
+
+    if distinct.len() <= max_colors {
+        return distinct;
+    }
+
+    // Median-cut: partition the colour space into `max_colors` buckets.
+    median_cut(colors, max_colors)
+}
+
+/// Median-cut colour quantization.
+///
+/// Recursively splits colour buckets along the axis with the greatest range,
+/// until we have `target` buckets. Each bucket's representative is its
+/// average RGB.
+fn median_cut(colors: &[(u8, u8, u8)], target: usize) -> Vec<(u8, u8, u8)> {
+    if target == 0 || colors.is_empty() {
+        return Vec::new();
+    }
+
+    let mut buckets: Vec<Vec<(u8, u8, u8)>> = vec![colors.to_vec()];
+
+    while buckets.len() < target {
+        // Find the bucket with the largest range.
+        let idx = largest_range_bucket(&buckets);
+        let bucket = buckets.remove(idx);
+
+        // Find the axis with the greatest range.
+        let (r_min, r_max) = min_max(&bucket, |c| c.0);
+        let (g_min, g_max) = min_max(&bucket, |c| c.1);
+        let (b_min, b_max) = min_max(&bucket, |c| c.2);
+        let r_range = r_max - r_min;
+        let g_range = g_max - g_min;
+        let b_range = b_max - b_min;
+
+        // Sort by the widest axis and split at the median.
+        let mut sorted = bucket;
+        if r_range >= g_range && r_range >= b_range {
+            sorted.sort_unstable_by_key(|c| c.0);
+        } else if g_range >= b_range {
+            sorted.sort_unstable_by_key(|c| c.1);
+        } else {
+            sorted.sort_unstable_by_key(|c| c.2);
+        }
+
+        let mid = sorted.len() / 2;
+        let (lo, hi) = sorted.split_at(mid);
+        if !lo.is_empty() {
+            buckets.push(lo.to_vec());
+        }
+        if !hi.is_empty() {
+            buckets.push(hi.to_vec());
+        }
+
+        if buckets.len() >= target {
+            break;
+        }
+    }
+
+    // Compute average colour for each bucket.
+    buckets
+        .iter()
+        .map(|b| {
+            let (rs, gs, bs) = b.iter().fold((0u64, 0u64, 0u64), |(r, g, b_), &(cr, cg, cb)| {
+                (r + cr as u64, g + cg as u64, b_ + cb as u64)
+            });
+            let n = b.len() as u64;
+            ((rs / n) as u8, (gs / n) as u8, (bs / n) as u8)
+        })
+        .collect()
+}
+
+fn largest_range_bucket(buckets: &[Vec<(u8, u8, u8)>]) -> usize {
+    let mut best = 0;
+    let mut best_range = 0u32;
+    for (i, b) in buckets.iter().enumerate() {
+        let (r_min, r_max) = min_max(b, |c| c.0);
+        let (g_min, g_max) = min_max(b, |c| c.1);
+        let (b_min, b_max) = min_max(b, |c| c.2);
+        let range = (r_max - r_min) as u32
+            + (g_max - g_min) as u32
+            + (b_max - b_min) as u32;
+        if range > best_range {
+            best_range = range;
+            best = i;
+        }
+    }
+    best
+}
+
+fn min_max<F: Fn(&(u8, u8, u8)) -> u8>(v: &[(u8, u8, u8)], f: F) -> (u8, u8) {
+    let mut lo = 255u8;
+    let mut hi = 0u8;
+    for item in v {
+        let val = f(item);
+        if val < lo {
+            lo = val;
+        }
+        if val > hi {
+            hi = val;
+        }
+    }
+    (lo, hi)
+}
+
+/// Find the nearest palette index for a given RGB colour using squared Euclidean distance.
+fn nearest_palette_index(color: (u8, u8, u8), palette: &[(u8, u8, u8)]) -> u8 {
+    let mut best_idx = 0usize;
+    let mut best_dist = u32::MAX;
+    let (r, g, b) = color;
+    for (i, &(pr, pg, pb)) in palette.iter().enumerate() {
+        let dr = (r as i32 - pr as i32).pow(2) as u32;
+        let dg = (g as i32 - pg as i32).pow(2) as u32;
+        let db = (b as i32 - pb as i32).pow(2) as u32;
+        let dist = dr + dg + db;
+        if dist < best_dist {
+            best_dist = dist;
+            best_idx = i;
+            if dist == 0 {
+                break; // exact match
+            }
+        }
+    }
+    best_idx as u8
+}
+
+/// Compute `size_of_gct` field: smallest n such that 2^(n+1) >= count.
+fn required_gct_field(count: usize) -> usize {
+    let mut n = 0usize;
+    while (1 << (n + 1)) < count {
+        n += 1;
+        if n == 7 {
+            break;
+        }
+    }
+    n
+}
+
+/// Compute `lzw_minimum_code_size`: smallest n ≥ 2 such that 2^n >= palette_size.
+fn required_min_code_size(palette_size: usize) -> u8 {
+    let mut n = 2u8;
+    while (1usize << n) < palette_size {
+        n += 1;
+        if n == 8 {
+            break;
+        }
+    }
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_min_code_size_values() {
+        assert_eq!(required_min_code_size(2), 2);
+        assert_eq!(required_min_code_size(4), 2);
+        assert_eq!(required_min_code_size(5), 3);
+        assert_eq!(required_min_code_size(16), 4);
+        assert_eq!(required_min_code_size(17), 5);
+        assert_eq!(required_min_code_size(256), 8);
+    }
+
+    #[test]
+    fn required_gct_field_values() {
+        assert_eq!(required_gct_field(2), 0); // 2^1 = 2
+        assert_eq!(required_gct_field(4), 1); // 2^2 = 4
+        assert_eq!(required_gct_field(5), 2); // 2^3 = 8
+        assert_eq!(required_gct_field(256), 7); // 2^8 = 256
+    }
+
+    #[test]
+    fn nearest_index_exact_match() {
+        let palette = vec![(255, 0, 0), (0, 255, 0), (0, 0, 255)];
+        assert_eq!(nearest_palette_index((255, 0, 0), &palette), 0);
+        assert_eq!(nearest_palette_index((0, 255, 0), &palette), 1);
+        assert_eq!(nearest_palette_index((0, 0, 255), &palette), 2);
+    }
+
+    #[test]
+    fn build_palette_exact_under_limit() {
+        let colors: Vec<(u8, u8, u8)> = vec![(0, 0, 0), (255, 0, 0), (0, 255, 0)];
+        let p = build_palette(&colors, 255);
+        assert_eq!(p.len(), 3);
+    }
+
+    #[test]
+    fn encode_starts_with_gif87a() {
+        let mut pc = PixelContainer::new(1, 1);
+        pc.set_pixel(0, 0, 255, 0, 0, 255);
+        let bytes = encode_gif(&pc);
+        assert_eq!(&bytes[..6], b"GIF87a");
+    }
+
+    #[test]
+    fn encode_transparent_starts_with_gif89a() {
+        let mut pc = PixelContainer::new(1, 1);
+        pc.set_pixel(0, 0, 0, 0, 0, 0); // fully transparent
+        let bytes = encode_gif(&pc);
+        assert_eq!(&bytes[..6], b"GIF89a");
+    }
+
+    #[test]
+    fn encode_ends_with_trailer() {
+        let mut pc = PixelContainer::new(2, 2);
+        pc.fill(100, 150, 200, 255);
+        let bytes = encode_gif(&pc);
+        assert_eq!(*bytes.last().unwrap(), 0x3B);
+    }
+}

--- a/code/packages/rust/image-codec-gif/src/lib.rs
+++ b/code/packages/rust/image-codec-gif/src/lib.rs
@@ -1,0 +1,284 @@
+//! # image-codec-gif
+//!
+//! GIF (Graphics Interchange Format) image codec — IC07.
+//!
+//! Decodes GIF87a and GIF89a files into RGBA8 `PixelContainer` buffers and
+//! encodes `PixelContainer` pixels as static GIF87a/GIF89a files.
+//!
+//! ## Key properties
+//!
+//! - **Color model**: indexed colour, ≤ 256 palette entries per image.
+//! - **Compression**: GIF-variant LZW (minimum code size 2–8 bits, sub-block
+//!   framing, LSB-first bit packing). Implemented inline (not the CMP03 crate)
+//!   because GIF requires configurable code sizes.
+//! - **Transparency**: one palette index designated transparent via Graphic
+//!   Control Extension (GIF89a); decoded as alpha = 0.
+//! - **Interlacing**: 4-pass de-interlacing on decode; never written on encode.
+//! - **Animation**: first frame is returned; a second Image Descriptor triggers
+//!   an error.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use image_codec_gif::{encode_gif, decode_gif};
+//! use pixel_container::PixelContainer;
+//!
+//! // Encode a 2×2 red image.
+//! let mut px = PixelContainer::new(2, 2);
+//! px.fill(255, 0, 0, 255);
+//! let bytes = encode_gif(&px);
+//! assert!(bytes.starts_with(b"GIF"));
+//!
+//! // Decode it back.
+//! let recovered = decode_gif(&bytes).unwrap();
+//! assert_eq!(recovered.width, 2);
+//! assert_eq!(recovered.height, 2);
+//! ```
+
+pub use decoder::decode_gif;
+pub use encoder::encode_gif;
+use paint_instructions::ImageCodec;
+use pixel_container::PixelContainer;
+
+mod decoder;
+mod encoder;
+mod lzw;
+
+/// Package version — kept in sync with CHANGELOG.md and Cargo.toml.
+pub const VERSION: &str = "0.1.0";
+
+/// GIF image codec implementing `paint_instructions::ImageCodec`.
+///
+/// Encodes as GIF87a (opaque) or GIF89a (with transparency).
+/// Decodes GIF87a and GIF89a — returns the first (only, for static) frame.
+pub struct GifCodec;
+
+impl ImageCodec for GifCodec {
+    fn mime_type(&self) -> &'static str {
+        "image/gif"
+    }
+
+    fn encode(&self, pixels: &PixelContainer) -> Vec<u8> {
+        encode_gif(pixels)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<PixelContainer, String> {
+        decode_gif(bytes)
+    }
+}
+
+// ── Integration tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: encode and decode, asserting pixel-exact round-trip.
+    fn round_trip_exact(pixels: &PixelContainer) {
+        let bytes = encode_gif(pixels);
+        let recovered = decode_gif(&bytes)
+            .unwrap_or_else(|e| panic!("decode failed: {}", e));
+        assert_eq!(recovered.width, pixels.width, "width mismatch");
+        assert_eq!(recovered.height, pixels.height, "height mismatch");
+        for y in 0..pixels.height {
+            for x in 0..pixels.width {
+                let orig = pixels.pixel_at(x, y);
+                let got = recovered.pixel_at(x, y);
+                // For opaque pixels: R/G/B must match, A may be 255 after palette encoding.
+                // Transparent pixels: A = 0.
+                if orig.3 < 128 {
+                    assert_eq!(
+                        got.3, 0,
+                        "pixel ({x},{y}) should be transparent, got {:?}",
+                        got
+                    );
+                } else {
+                    assert_eq!(
+                        (got.0, got.1, got.2),
+                        (orig.0, orig.1, orig.2),
+                        "pixel ({x},{y}) RGB mismatch: orig {:?}, got {:?}",
+                        orig,
+                        got
+                    );
+                    assert_eq!(got.3, 255, "pixel ({x},{y}) alpha should be 255");
+                }
+            }
+        }
+    }
+
+    // ── Basic round-trips ──────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_solid_red() {
+        let mut px = PixelContainer::new(4, 4);
+        px.fill(255, 0, 0, 255);
+        round_trip_exact(&px);
+    }
+
+    #[test]
+    fn round_trip_solid_blue() {
+        let mut px = PixelContainer::new(8, 8);
+        px.fill(0, 0, 255, 255);
+        round_trip_exact(&px);
+    }
+
+    #[test]
+    fn round_trip_1x1() {
+        let mut px = PixelContainer::new(1, 1);
+        px.set_pixel(0, 0, 100, 150, 200, 255);
+        round_trip_exact(&px);
+    }
+
+    #[test]
+    fn round_trip_gradient_256_colors() {
+        // 256 distinct colours along the grey ramp — no quantization needed.
+        let mut px = PixelContainer::new(256, 1);
+        for i in 0u32..256 {
+            let v = i as u8;
+            px.set_pixel(i, 0, v, v, v, 255);
+        }
+        round_trip_exact(&px);
+    }
+
+    #[test]
+    fn round_trip_4_colors() {
+        let mut px = PixelContainer::new(2, 2);
+        px.set_pixel(0, 0, 255, 0, 0, 255); // red
+        px.set_pixel(1, 0, 0, 255, 0, 255); // green
+        px.set_pixel(0, 1, 0, 0, 255, 255); // blue
+        px.set_pixel(1, 1, 255, 255, 0, 255); // yellow
+        round_trip_exact(&px);
+    }
+
+    #[test]
+    fn round_trip_black_image() {
+        let mut px = PixelContainer::new(16, 16);
+        px.fill(0, 0, 0, 255);
+        round_trip_exact(&px);
+    }
+
+    // ── Transparency ───────────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_fully_transparent() {
+        let mut px = PixelContainer::new(4, 4);
+        px.fill(0, 0, 0, 0); // fully transparent
+        let bytes = encode_gif(&px);
+        assert!(bytes.starts_with(b"GIF89a"), "transparent GIF must be GIF89a");
+        let recovered = decode_gif(&bytes).unwrap();
+        for y in 0..4 {
+            for x in 0..4 {
+                assert_eq!(recovered.pixel_at(x, y).3, 0, "pixel ({x},{y}) should be transparent");
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_mixed_transparency() {
+        let mut px = PixelContainer::new(2, 2);
+        px.set_pixel(0, 0, 255, 0, 0, 255); // opaque red
+        px.set_pixel(1, 0, 0, 0, 0, 0);     // transparent
+        px.set_pixel(0, 1, 0, 255, 0, 255); // opaque green
+        px.set_pixel(1, 1, 0, 0, 0, 0);     // transparent
+        let bytes = encode_gif(&px);
+        assert!(bytes.starts_with(b"GIF89a"), "transparent GIF must be GIF89a");
+        let recovered = decode_gif(&bytes).unwrap();
+        // Opaque pixels should have alpha=255.
+        assert_eq!(recovered.pixel_at(0, 0).3, 255);
+        assert_eq!(recovered.pixel_at(0, 1).3, 255);
+        // Transparent pixels should have alpha=0.
+        assert_eq!(recovered.pixel_at(1, 0).3, 0);
+        assert_eq!(recovered.pixel_at(1, 1).3, 0);
+    }
+
+    // ── File format structure ──────────────────────────────────────────────
+
+    #[test]
+    fn encode_produces_gif87a_for_opaque() {
+        let mut px = PixelContainer::new(2, 2);
+        px.fill(100, 100, 100, 255);
+        let bytes = encode_gif(&px);
+        assert!(bytes.starts_with(b"GIF87a"), "expected GIF87a, got {:?}", &bytes[..6]);
+    }
+
+    #[test]
+    fn encode_ends_with_trailer() {
+        let mut px = PixelContainer::new(2, 2);
+        px.fill(50, 100, 150, 255);
+        let bytes = encode_gif(&px);
+        assert_eq!(*bytes.last().unwrap(), 0x3B, "GIF must end with trailer 0x3B");
+    }
+
+    #[test]
+    fn encode_canvas_size_in_lsd() {
+        let mut px = PixelContainer::new(100, 80);
+        px.fill(0, 128, 0, 255);
+        let bytes = encode_gif(&px);
+        // Bytes 6-7: width (LE), bytes 8-9: height (LE)
+        let w = u16::from_le_bytes([bytes[6], bytes[7]]);
+        let h = u16::from_le_bytes([bytes[8], bytes[9]]);
+        assert_eq!(w, 100);
+        assert_eq!(h, 80);
+    }
+
+    // ── Error cases ────────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_error_bad_magic() {
+        let err = decode_gif(b"\x89PNG\r\n\x1a\n").unwrap_err();
+        assert!(err.contains("not a GIF"), "got: {}", err);
+    }
+
+    #[test]
+    fn decode_error_too_short() {
+        let err = decode_gif(b"GIF").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn decode_error_unknown_version() {
+        let mut data = b"GIF99a".to_vec();
+        data.extend(vec![0u8; 20]);
+        let err = decode_gif(&data).unwrap_err();
+        assert!(err.contains("unknown version") || err.contains("version"), "got: {}", err);
+    }
+
+    // ── MIME type ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn codec_mime_type() {
+        assert_eq!(GifCodec.mime_type(), "image/gif");
+    }
+
+    #[test]
+    fn codec_encode_decode_round_trip() {
+        let mut px = PixelContainer::new(4, 4);
+        px.fill(200, 100, 50, 255);
+        let bytes = GifCodec.encode(&px);
+        let recovered = GifCodec.decode(&bytes).unwrap();
+        assert_eq!(recovered.width, 4);
+        assert_eq!(recovered.height, 4);
+    }
+
+    // ── Large image ────────────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_64x64_random_pattern() {
+        let mut px = PixelContainer::new(64, 64);
+        // Fill with a deterministic pseudo-random pattern using only 16 colours.
+        let palette_16 = [
+            (0u8, 0u8, 0u8), (255, 0, 0), (0, 255, 0), (0, 0, 255),
+            (255, 255, 0), (255, 0, 255), (0, 255, 255), (128, 128, 128),
+            (200, 100, 50), (50, 200, 100), (100, 50, 200), (255, 128, 0),
+            (0, 128, 255), (128, 0, 255), (64, 192, 64), (192, 64, 192),
+        ];
+        for y in 0u32..64 {
+            for x in 0u32..64 {
+                let idx = ((x * 7 + y * 13) % 16) as usize;
+                let (r, g, b) = palette_16[idx];
+                px.set_pixel(x, y, r, g, b, 255);
+            }
+        }
+        round_trip_exact(&px);
+    }
+}

--- a/code/packages/rust/image-codec-gif/src/lzw.rs
+++ b/code/packages/rust/image-codec-gif/src/lzw.rs
@@ -1,0 +1,564 @@
+//! GIF-variant LZW encoder and decoder.
+//!
+//! GIF uses a specific flavour of LZW that differs from the generic CMP03
+//! encoding in two important ways:
+//!
+//! 1. **Configurable minimum code size**: regular LZW always starts at 9-bit
+//!    codes (CLEAR=256, first dynamic code=258). GIF parameterises this with
+//!    `lzw_minimum_code_size` (range 2–8), so a 4-colour image uses 2-bit
+//!    initial indices and a 256-colour image uses 8-bit ones. This means
+//!    CLEAR_CODE = 2^lzw_minimum_code_size and initial code width =
+//!    lzw_minimum_code_size + 1 bits.
+//!
+//! 2. **Sub-block framing**: GIF packs the raw bit stream inside sub-blocks
+//!    of at most 255 bytes each, prefixed by a 1-byte length. A zero-length
+//!    sub-block terminates the data.
+//!
+//! The bit-packing convention (LSB-first within each byte) is the same as the
+//! CMP03 `lzw` crate, so we can share the intuition but not the code.
+//!
+//! # Code table
+//!
+//! Entries in the code table are stored as byte vectors. In practice we use
+//! the "first byte + extension" trick: to reconstruct a code's byte sequence
+//! during decode we only need to store the *first byte* and a *parent code*,
+//! then walk the parent chain. This avoids allocating a `Vec<u8>` per entry.
+//!
+//! Max code table size: 4096 (= 2^12). When `next_code` would exceed 4095,
+//! the encoder emits a CLEAR and resets.
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Maximum number of entries in the GIF LZW code table.
+/// Codes are at most 12 bits wide.
+const MAX_TABLE_SIZE: u16 = 4096;
+
+// ── Bit writer (LSB-first, byte-buffered) ─────────────────────────────────────
+
+/// Collects variable-width codes into a flat byte vector, LSB-first.
+///
+/// GIF codes are packed LSB-first: the first code occupies the lowest bits of
+/// byte 0, spilling into byte 1 if needed, etc.
+struct BitWriter {
+    buf: Vec<u8>,
+    /// Accumulator for the current byte-in-progress.
+    acc: u32,
+    /// Number of valid bits in `acc` (0..32).
+    bits: u8,
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        BitWriter {
+            buf: Vec::new(),
+            acc: 0,
+            bits: 0,
+        }
+    }
+
+    /// Push `width` low-order bits of `code`.
+    fn write(&mut self, code: u16, width: u8) {
+        // Append bits LSB-first into the accumulator.
+        self.acc |= (code as u32) << self.bits;
+        self.bits += width;
+        // Flush complete bytes.
+        while self.bits >= 8 {
+            self.buf.push((self.acc & 0xFF) as u8);
+            self.acc >>= 8;
+            self.bits -= 8;
+        }
+    }
+
+    /// Flush any remaining bits (padding with zeros) and return the byte stream.
+    fn finish(mut self) -> Vec<u8> {
+        if self.bits > 0 {
+            self.buf.push((self.acc & 0xFF) as u8);
+        }
+        self.buf
+    }
+}
+
+// ── Bit reader (LSB-first, byte-buffered) ──────────────────────────────────────
+
+/// Reads variable-width codes from a flat byte slice, LSB-first.
+///
+/// The reader works directly on the concatenated sub-block data; sub-block
+/// framing is removed by the caller before construction.
+pub struct BitReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+    acc: u32,
+    bits: u8,
+}
+
+impl<'a> BitReader<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        BitReader {
+            data,
+            pos: 0,
+            acc: 0,
+            bits: 0,
+        }
+    }
+
+    /// Read the next `width` bits as a u16. Returns None if the stream ends.
+    pub fn read(&mut self, width: u8) -> Option<u16> {
+        // Refill accumulator until we have enough bits.
+        while self.bits < width {
+            if self.pos >= self.data.len() {
+                // Allow reading from a partially empty stream (padding zeros).
+                if self.bits == 0 {
+                    return None;
+                }
+                // Pad with zeros.
+                self.acc |= 0u32 << self.bits;
+                self.bits = width; // pretend we have enough
+                break;
+            }
+            self.acc |= (self.data[self.pos] as u32) << self.bits;
+            self.bits += 8;
+            self.pos += 1;
+        }
+        let val = (self.acc & ((1u32 << width) - 1)) as u16;
+        self.acc >>= width;
+        self.bits -= width;
+        Some(val)
+    }
+}
+
+// ── Encoder ───────────────────────────────────────────────────────────────────
+
+/// Wrap a flat byte stream into GIF sub-blocks (≤ 255 bytes each).
+///
+/// Each sub-block is prefixed by its 1-byte length. A terminator block (length
+/// 0x00) follows at the end.
+fn to_sub_blocks(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for chunk in data.chunks(255) {
+        out.push(chunk.len() as u8);
+        out.extend_from_slice(chunk);
+    }
+    out.push(0x00); // terminator
+    out
+}
+
+/// Encode `pixels` (palette indices) using GIF-variant LZW.
+///
+/// Returns the full image-data section: one byte for `lzw_minimum_code_size`,
+/// followed by sub-blocks.
+///
+/// # Arguments
+/// - `pixels`: flat slice of palette indices (row-major)
+/// - `min_code_size`: `lzw_minimum_code_size` (2–8)
+pub fn encode(pixels: &[u8], min_code_size: u8) -> Vec<u8> {
+    assert!(
+        (2..=8).contains(&min_code_size),
+        "lzw_minimum_code_size must be 2-8, got {}",
+        min_code_size
+    );
+
+    let clear_code = 1u16 << min_code_size;
+    let eoi_code = clear_code + 1;
+    let first_dynamic = eoi_code + 1;
+
+    // Code table: each entry is (parent_code: Option<u16>, byte: u8).
+    // We only need to find whether (current_string + next_byte) is in the table.
+    // We use a HashMap keyed by (parent_code, byte) → code for fast lookup.
+    let mut table: std::collections::HashMap<(u16, u8), u16> = std::collections::HashMap::new();
+
+    let mut next_code = first_dynamic;
+    let mut code_size = min_code_size + 1;
+    let mut code_size_limit = (1u16 << code_size) - 1;
+
+    let mut bw = BitWriter::new();
+
+    // Emit initial CLEAR.
+    bw.write(clear_code, code_size);
+
+    if pixels.is_empty() {
+        bw.write(eoi_code, code_size);
+        let raw = bw.finish();
+        let mut out = vec![min_code_size];
+        out.extend(to_sub_blocks(&raw));
+        return out;
+    }
+
+    let mut prev_code = pixels[0] as u16; // first code = first pixel index
+
+    for &byte in &pixels[1..] {
+        let key = (prev_code, byte);
+        if let Some(&code) = table.get(&key) {
+            // Current string + byte is in the table.
+            prev_code = code;
+        } else {
+            // Emit prev_code; add the new string to the table.
+            bw.write(prev_code, code_size);
+
+            if next_code < MAX_TABLE_SIZE {
+                table.insert(key, next_code);
+                next_code += 1;
+                // Grow code size if next_code exceeds the current limit.
+                if next_code > code_size_limit && code_size < 12 {
+                    code_size += 1;
+                    code_size_limit = (1u16 << code_size) - 1;
+                }
+            } else {
+                // Table full: emit CLEAR and reset.
+                bw.write(clear_code, code_size);
+                table.clear();
+                next_code = first_dynamic;
+                code_size = min_code_size + 1;
+                code_size_limit = (1u16 << code_size) - 1;
+            }
+
+            prev_code = byte as u16;
+        }
+    }
+
+    // Emit the final code.
+    bw.write(prev_code, code_size);
+    // Emit EOI.
+    bw.write(eoi_code, code_size);
+
+    let raw = bw.finish();
+    let mut out = vec![min_code_size];
+    out.extend(to_sub_blocks(&raw));
+    out
+}
+
+// ── Decoder ───────────────────────────────────────────────────────────────────
+
+/// Decode GIF image data into a flat vector of palette indices.
+///
+/// `data` should be the raw image-data section starting with the
+/// `lzw_minimum_code_size` byte, followed by sub-blocks.
+///
+/// Returns `Err` on invalid input.
+pub fn decode(data: &[u8]) -> Result<Vec<u8>, String> {
+    if data.is_empty() {
+        return Err("GIF LZW: empty data".into());
+    }
+    let min_code_size = data[0];
+    if !(2..=8).contains(&min_code_size) {
+        return Err(format!(
+            "GIF LZW: invalid lzw_minimum_code_size {} (expected 2-8)",
+            min_code_size
+        ));
+    }
+
+    // Read sub-blocks into a flat byte buffer.
+    let raw = read_sub_blocks(&data[1..])?;
+
+    let clear_code = 1u16 << min_code_size;
+    let eoi_code = clear_code + 1;
+    let first_dynamic = eoi_code + 1;
+
+    // Code table stored as (parent: u16, byte: u8). Index = code number.
+    // Codes 0..clear_code are literals; clear_code and eoi_code are special.
+    // Dynamic codes start at first_dynamic.
+    //
+    // We track: parent[code] and first_byte[code].
+    // To reconstruct a code's string: walk parent chain to get the string,
+    // first_byte[root] gives the first byte.
+    const TABLE_CAP: usize = 4096;
+    let mut parent: [u16; TABLE_CAP] = [0u16; TABLE_CAP];
+    let mut first_byte: [u8; TABLE_CAP] = [0u8; TABLE_CAP];
+    // `code_byte[i]` = the byte appended at code i (= last byte of its string).
+    let mut code_byte: [u8; TABLE_CAP] = [0u8; TABLE_CAP];
+
+    // Initialize literal entries.
+    for i in 0..(clear_code as usize) {
+        code_byte[i] = i as u8;
+        first_byte[i] = i as u8;
+        parent[i] = u16::MAX; // no parent (root)
+    }
+
+    let mut next_code = first_dynamic;
+    let mut code_size = min_code_size + 1;
+
+    let mut br = BitReader::new(&raw);
+    let mut output: Vec<u8> = Vec::new();
+
+    // Helper: reconstruct the byte string for a code (appended in reverse).
+    // Returns (string_in_forward_order, first_byte_of_string).
+    let decode_string = |code: u16,
+                         parent: &[u16; TABLE_CAP],
+                         code_byte: &[u8; TABLE_CAP]|
+     -> (Vec<u8>, u8) {
+        let mut stack = Vec::new();
+        let mut c = code;
+        loop {
+            stack.push(code_byte[c as usize]);
+            let p = parent[c as usize];
+            if p == u16::MAX {
+                break;
+            }
+            c = p;
+        }
+        let first = *stack.last().unwrap();
+        stack.reverse();
+        (stack, first)
+    };
+
+    // Read and discard the first CLEAR code (required by GIF spec).
+    let first = br
+        .read(code_size)
+        .ok_or("GIF LZW: truncated before first code")?;
+    if first != clear_code {
+        return Err(format!(
+            "GIF LZW: expected CLEAR_CODE ({}) as first code, got {}",
+            clear_code, first
+        ));
+    }
+
+    // Read the first actual code.
+    let mut prev_code = br
+        .read(code_size)
+        .ok_or("GIF LZW: truncated after first CLEAR")?;
+    if prev_code == eoi_code {
+        return Ok(output); // empty image
+    }
+    if prev_code >= next_code {
+        return Err(format!(
+            "GIF LZW: invalid first code {} (table has {} entries)",
+            prev_code, next_code
+        ));
+    }
+    let (s, _) = decode_string(prev_code, &parent, &code_byte);
+    output.extend_from_slice(&s);
+
+    loop {
+        let code = match br.read(code_size) {
+            None => break,
+            Some(c) => c,
+        };
+
+        if code == eoi_code {
+            break;
+        }
+
+        if code == clear_code {
+            // Reset table.
+            next_code = first_dynamic;
+            code_size = min_code_size + 1;
+            prev_code = match br.read(code_size) {
+                None => break,
+                Some(c) => {
+                    if c == eoi_code {
+                        break;
+                    }
+                    c
+                }
+            };
+            let (s, _) = decode_string(prev_code, &parent, &code_byte);
+            output.extend_from_slice(&s);
+            continue;
+        }
+
+        // Normal code.
+        let entry: Vec<u8>;
+        let first_of_entry: u8;
+
+        if code < next_code {
+            // Code is in the table.
+            let (s, fb) = decode_string(code, &parent, &code_byte);
+            first_of_entry = fb;
+            entry = s;
+        } else if code == next_code {
+            // Special case: code is the next entry being added.
+            // Its string = string(prev_code) + first_byte(string(prev_code)).
+            let (s, fb) = decode_string(prev_code, &parent, &code_byte);
+            first_of_entry = fb;
+            let mut s2 = s.clone();
+            s2.push(fb);
+            entry = s2;
+        } else {
+            return Err(format!(
+                "GIF LZW: invalid code {} (next_code = {})",
+                code, next_code
+            ));
+        }
+
+        output.extend_from_slice(&entry);
+
+        // Add new entry to the table: string(prev_code) + first_byte(entry).
+        if next_code < MAX_TABLE_SIZE {
+            parent[next_code as usize] = prev_code;
+            code_byte[next_code as usize] = first_of_entry;
+            first_byte[next_code as usize] = if parent[prev_code as usize] == u16::MAX {
+                code_byte[prev_code as usize]
+            } else {
+                first_byte[prev_code as usize]
+            };
+            next_code += 1;
+            // Grow code size when the table fills the current width.
+            //
+            // The decoder is always one entry behind the encoder: the encoder
+            // adds entry K and grows *before* writing the next code, while the
+            // decoder adds entry K-1 (from the previous iteration) and must
+            // grow *before reading* that same next code.  Concretely, the
+            // encoder grows when next_code >= 2^code_size (after incrementing);
+            // the decoder must grow one step earlier, at next_code >= 2^code_size - 1,
+            // so that the subsequent read uses the new (wider) code width.
+            if next_code >= (1u16 << code_size) - 1 && code_size < 12 {
+                code_size += 1;
+            }
+        }
+        // When table full we stop adding but keep decoding.
+
+        prev_code = code;
+    }
+
+    Ok(output)
+}
+
+/// Read GIF sub-blocks into a flat byte vector.
+///
+/// A sub-block starts with a length byte (0–255). A length of 0 is the
+/// terminator. Returns an error if data ends prematurely.
+pub fn read_sub_blocks(data: &[u8]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    let mut pos = 0;
+    loop {
+        if pos >= data.len() {
+            // Tolerate missing terminator at end of file.
+            break;
+        }
+        let len = data[pos] as usize;
+        pos += 1;
+        if len == 0 {
+            break; // terminator
+        }
+        if pos + len > data.len() {
+            return Err(format!(
+                "GIF LZW: sub-block length {} extends past end of data at offset {}",
+                len,
+                pos - 1
+            ));
+        }
+        out.extend_from_slice(&data[pos..pos + len]);
+        pos += len;
+    }
+    Ok(out)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(pixels: &[u8], min_code_size: u8) {
+        let encoded = encode(pixels, min_code_size);
+        let decoded = decode(&encoded).expect("decode failed");
+        assert_eq!(
+            decoded, pixels,
+            "round-trip failed for min_code_size={}",
+            min_code_size
+        );
+    }
+
+    #[test]
+    fn round_trip_empty() {
+        round_trip(&[], 2);
+    }
+
+    #[test]
+    fn round_trip_single_pixel() {
+        round_trip(&[0], 2);
+        round_trip(&[3], 2);
+    }
+
+    #[test]
+    fn round_trip_solid_color() {
+        // Pixel value must be < clear_code (2^mcs = 4 for mcs=2).
+        // Values 4 (CLEAR) and 5 (EOI) are reserved, so use 3.
+        let pixels = vec![3u8; 64];
+        round_trip(&pixels, 2);
+    }
+
+    #[test]
+    fn round_trip_2color() {
+        let pixels: Vec<u8> = (0u8..64).map(|i| i % 2).collect();
+        round_trip(&pixels, 2);
+    }
+
+    #[test]
+    fn round_trip_256color() {
+        let pixels: Vec<u8> = (0u8..=255).collect();
+        round_trip(&pixels, 8);
+    }
+
+    #[test]
+    fn round_trip_rle_pattern() {
+        // Long run of the same color — LZW should compress well.
+        let pixels = vec![42u8; 1024];
+        round_trip(&pixels, 8);
+    }
+
+    #[test]
+    fn round_trip_gradient() {
+        let pixels: Vec<u8> = (0u8..128).collect();
+        round_trip(&pixels, 7);
+    }
+
+    #[test]
+    fn round_trip_all_min_code_sizes() {
+        let pixels = vec![0u8, 1, 0, 1, 0];
+        for mcs in 2u8..=8 {
+            round_trip(&pixels, mcs);
+        }
+    }
+
+    #[test]
+    fn encoded_starts_with_min_code_size() {
+        let encoded = encode(&[0, 1, 0], 4);
+        assert_eq!(encoded[0], 4, "first byte must be lzw_minimum_code_size");
+    }
+
+    #[test]
+    fn sub_block_framing_max_255() {
+        // Each sub-block must be at most 255 bytes.
+        let pixels = vec![0u8; 10000];
+        let encoded = encode(&pixels, 8);
+        let mut pos = 1; // skip min_code_size byte
+        while pos < encoded.len() {
+            let len = encoded[pos] as usize;
+            if len == 0 {
+                break;
+            }
+            assert!(len <= 255, "sub-block length {} > 255", len);
+            pos += 1 + len;
+        }
+    }
+
+    #[test]
+    fn decode_bad_min_code_size() {
+        // min_code_size = 0 is invalid.
+        assert!(decode(&[0]).is_err());
+        assert!(decode(&[1]).is_err());
+        assert!(decode(&[9]).is_err());
+    }
+
+    #[test]
+    fn decode_empty_data() {
+        assert!(decode(&[]).is_err());
+    }
+
+    #[test]
+    fn sub_blocks_read_write_roundtrip() {
+        let data: Vec<u8> = (0u8..200).collect();
+        let blocks = to_sub_blocks(&data);
+        let recovered = read_sub_blocks(&blocks).unwrap();
+        assert_eq!(recovered, data);
+    }
+
+    #[test]
+    fn code_size_grows_at_threshold() {
+        // With min_code_size=2, initial code_size=3 (8 codes fit).
+        // After 5 dynamic entries (4096=max, but first grow happens earlier),
+        // verify we can still round-trip.
+        let pixels: Vec<u8> = (0u8..30).map(|i| i % 4).collect();
+        round_trip(&pixels, 2);
+    }
+}

--- a/code/packages/rust/image-codec-gif/src/lzw.rs
+++ b/code/packages/rust/image-codec-gif/src/lzw.rs
@@ -233,8 +233,12 @@ pub fn encode(pixels: &[u8], min_code_size: u8) -> Vec<u8> {
 /// `data` should be the raw image-data section starting with the
 /// `lzw_minimum_code_size` byte, followed by sub-blocks.
 ///
+/// `max_output` caps the number of decoded bytes to prevent decompression-bomb
+/// attacks.  Pass `width * height` (the declared pixel count) from the caller;
+/// any stream that expands beyond this returns `Err`.
+///
 /// Returns `Err` on invalid input.
-pub fn decode(data: &[u8]) -> Result<Vec<u8>, String> {
+pub fn decode(data: &[u8], max_output: usize) -> Result<Vec<u8>, String> {
     if data.is_empty() {
         return Err("GIF LZW: empty data".into());
     }
@@ -326,6 +330,9 @@ pub fn decode(data: &[u8]) -> Result<Vec<u8>, String> {
     }
     let (s, _) = decode_string(prev_code, &parent, &code_byte);
     output.extend_from_slice(&s);
+    if output.len() > max_output {
+        return Err("GIF LZW: decompressed output exceeds declared image size".into());
+    }
 
     loop {
         let code = match br.read(code_size) {
@@ -338,7 +345,7 @@ pub fn decode(data: &[u8]) -> Result<Vec<u8>, String> {
         }
 
         if code == clear_code {
-            // Reset table.
+            // Reset table and code-width back to the initial state.
             next_code = first_dynamic;
             code_size = min_code_size + 1;
             prev_code = match br.read(code_size) {
@@ -347,11 +354,27 @@ pub fn decode(data: &[u8]) -> Result<Vec<u8>, String> {
                     if c == eoi_code {
                         break;
                     }
+                    // Guard against "double CLEAR" or a dynamic code used as
+                    // the first literal after a reset — both would be invalid
+                    // because the table only contains literal codes 0..clear_code
+                    // right after a reset.
+                    if c == clear_code || c >= next_code {
+                        return Err(format!(
+                            "GIF LZW: invalid post-CLEAR code {} \
+                             (expected literal 0..{})",
+                            c, clear_code
+                        ));
+                    }
                     c
                 }
             };
             let (s, _) = decode_string(prev_code, &parent, &code_byte);
             output.extend_from_slice(&s);
+            if output.len() > max_output {
+                return Err(
+                    "GIF LZW: decompressed output exceeds declared image size".into(),
+                );
+            }
             continue;
         }
 
@@ -380,6 +403,9 @@ pub fn decode(data: &[u8]) -> Result<Vec<u8>, String> {
         }
 
         output.extend_from_slice(&entry);
+        if output.len() > max_output {
+            return Err("GIF LZW: decompressed output exceeds declared image size".into());
+        }
 
         // Add new entry to the table: string(prev_code) + first_byte(entry).
         if next_code < MAX_TABLE_SIZE {
@@ -450,7 +476,8 @@ mod tests {
 
     fn round_trip(pixels: &[u8], min_code_size: u8) {
         let encoded = encode(pixels, min_code_size);
-        let decoded = decode(&encoded).expect("decode failed");
+        // usize::MAX used in tests — test data is not adversarial.
+        let decoded = decode(&encoded, usize::MAX).expect("decode failed");
         assert_eq!(
             decoded, pixels,
             "round-trip failed for min_code_size={}",
@@ -535,14 +562,25 @@ mod tests {
     #[test]
     fn decode_bad_min_code_size() {
         // min_code_size = 0 is invalid.
-        assert!(decode(&[0]).is_err());
-        assert!(decode(&[1]).is_err());
-        assert!(decode(&[9]).is_err());
+        assert!(decode(&[0], usize::MAX).is_err());
+        assert!(decode(&[1], usize::MAX).is_err());
+        assert!(decode(&[9], usize::MAX).is_err());
     }
 
     #[test]
     fn decode_empty_data() {
-        assert!(decode(&[]).is_err());
+        assert!(decode(&[], usize::MAX).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_output_beyond_limit() {
+        // Encode a long RLE sequence then try to decode with a tiny limit.
+        let pixels = vec![0u8; 512];
+        let encoded = encode(&pixels, 8);
+        // Limit of 10 is well below 512 — must fail.
+        assert!(decode(&encoded, 10).is_err());
+        // Limit of 512 must succeed.
+        assert!(decode(&encoded, 512).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the IC07 GIF codec specified in `code/specs/IC07-image-codec-gif.md`.

### Encoder
- GIF87a for fully opaque images; GIF89a for images with transparent pixels (alpha < 128)
- Exact palette when ≤ 256 distinct opaque colours; median-cut quantisation otherwise
- One palette slot reserved for transparency (GIF89a only), so opaque images may use all 256 slots
- Non-interlaced progressive scan; single frame only

### Decoder
- Parses GIF87a and GIF89a; rejects animated GIFs (> 1 frame) with an error
- Handles Global and Local Color Tables; GCT used when no LCT present
- Graphic Control Extension: reads transparency flag + transparent colour index
- 4-pass de-interlacing (rows 0/8…, 4/12…, 2/6…, 1/3…)
- Unknown extension blocks skipped gracefully

### LZW (GIF variant)
- Configurable lzw_minimum_code_size (2–8 bits), LSB-first bit packing
- Sub-block framing (≤ 255 bytes each, zero-block terminator)
- **Key timing fix**: decoder code-width growth at `next_code >= 2^cs - 1` (one step before encoder) to compensate for the structural one-entry lag inherent in LZW decoding

### Security hardening
- **Decompression bomb**: LZW decode capped at `width × height` pixels; any stream that expands beyond the declared image size returns Err
- **Post-CLEAR validation**: first code after CLEAR must be a literal (< clear_code); double-CLEAR or dynamic-code-as-literal now returns Err
- **Dimension cap**: images with width × height > 4096² (16 MP) rejected before any allocation

### Tests
43 unit tests + 1 doc-test, all green:
- LZW round-trips at all min_code_size values 2–8
- Solid, gradient, 256-colour, transparent, mixed-alpha images
- File structure (header, trailer, LSD canvas dimensions)
- Error paths: bad magic, unknown GIF version, truncated data, decompression limit

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)