### PR TITLE
feat(cas-summation): Phase 92 — Three-Sqrt × Seven-Log × polynomial convergence recognizer (v2.29.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.28.0 — 2026-05-27
+
+### Added
+
+- **Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator** (`_two_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase91TwoSqrtSevenLogPoly`.
+
 ## 2.27.0 — 2026-05-26
 
 ### Added

--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.29.0 — 2026-05-27
+
+### Added
+
+- **Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator** (`_three_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Sqrt(P3(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 3 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase92ThreeSqrtSevenLogPoly`.
+
 ## 2.28.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.27.0 — 2026-05-26
+
+### Added
+
+- **Phase 89 — Seven-Log × polynomial numerator** (`_seven_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), Log(h2(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 7 Log factors required; Sqrt factors explicitly refused.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase89SevenLogPoly`.
+- **Phase 90 — One-Sqrt × Seven-Log × polynomial numerator** (`_one_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase90OneSqrtSevenLogPoly`.
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.21.0"
+version = "2.27.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.28.0"
+version = "2.29.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.27.0"
+version = "2.28.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1208,6 +1208,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 91: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1), ..., Log(h7), polynomial..., bounded...)`` numerator.
+    # Two Sqrt factors + seven Log factors; log⁷ sub-polynomial → 0.
+    # effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s2l7p_x2 = _two_sqrt_seven_log_poly_effective_x2(num, k)
+    if s2l7p_x2 is not None:
+        den_deg_s2l7 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l7 is not None:
+            if 2 * den_deg_s2l7 > s2l7p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3532,6 +3545,77 @@ def _one_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | No
     if sqrt_deg_x2 is None or log_count != 7:
         return None
     return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`` when ``node`` is a
+    ``Mul`` with **exactly two** ``Sqrt(positive-leading polynomial)`` factors,
+    **exactly seven** ``Log(diverging-in-k)`` factors, any polynomial factors,
+    and any bounded factors; ``None`` otherwise.
+
+    Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · sqrt(k^b) · log(k)⁷ · k^m ≈ k^{(a+b)/2} · log⁷(k) · k^m``.
+    ``log⁷(k)`` is sub-polynomial (``o(k^ε)``), contributing 0 to the
+    effective polynomial degree.
+    Using the ×2 integer trick:
+    ``effective_x2 = a + b + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------------+-------------------+
+    | Input                                                          | Return            |
+    +================================================================+===================+
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×7)``                            | ``1 + 1 = 2``     |
+    | ``Mul(Sqrt(k³), Sqrt(k³), Log(k)×7)``                          | ``3 + 3 = 6``     |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×7, k)``                         | ``1+1+2 = 4``     |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×7, k², 3)``                     | ``1+1+4 = 6``     |
+    | ``Mul(Sqrt(k), Log(k)×7)``                                     | None (1 Sqrt)     |
+    | ``Mul(Sqrt(k)×3, Log(k)×7)``                                   | None (3 Sqrts)    |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×6)``                            | None (6 Logs)     |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×8)``                            | None (8 Logs)     |
+    +----------------------------------------------------------------+-------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 2.
+         - ``Log(diverging)`` → count; bail after 7.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 2 Sqrt AND exactly 7 Log factors.
+      4. Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                # Third Sqrt factor — not this phase.
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 7:
+                # Eight or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 7:
+        return None
+    return sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg_sum
 
 
 def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1182,6 +1182,32 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 89: ``Mul(Log(h1), ..., Log(h7), polynomial..., bounded...)`` numerator.
+    # Zero Sqrt factors + seven Log factors; log⁷ sub-polynomial → 0.
+    # effective_x2 = 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    sl7p_x2 = _seven_log_poly_effective_x2(num, k)
+    if sl7p_x2 is not None:
+        den_deg_sl7 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl7 is not None:
+            if 2 * den_deg_sl7 > sl7p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 90: ``Mul(Sqrt(P), Log(h1), ..., Log(h7), polynomial..., bounded...)`` numerator.
+    # One Sqrt factor + seven Log factors; log⁷ sub-polynomial → 0.
+    # effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s1l7p_x2 = _one_sqrt_seven_log_poly_effective_x2(num, k)
+    if s1l7p_x2 is not None:
+        den_deg_s1l7 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l7 is not None:
+            if 2 * den_deg_s1l7 > s1l7p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3375,6 +3401,137 @@ def _six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 6:
         return None
     return 2 * poly_deg_sum
+
+
+def _seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly seven**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 89 — Seven-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)⁷ · k^m``.  ``log⁷(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick (no Sqrt factors present):
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    Sqrt factors are explicitly refused so that this function does not
+    shadow the Sqrt-bearing phases (Phase 90 onward).
+
+    +-----------------------------------------------------+----------+
+    | Input                                               | Return   |
+    +=====================================================+==========+
+    | ``Mul(Log(k)×7)``                                   | ``0``    |
+    | ``Mul(Log(k)×7, k)``                                | ``2``    |
+    | ``Mul(Log(k)×7, k², 3)``                            | ``4``    |
+    | ``Mul(Log(k)×6)``                                   | None (6) |
+    | ``Mul(Log(k)×8)``                                   | None (8) |
+    | ``Mul(Sqrt(k), Log(k)×7)``                          | None     |
+    +-----------------------------------------------------+----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → count; bail after 7.
+         - ``Sqrt(...)`` → refuse (return ``None``).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 7 Log factors.
+      4. Return ``2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 7:
+                # Eight or more Log factors — not this phase.
+                return None
+            continue
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            # Sqrt factor present — refuse so Sqrt-bearing phases handle it.
+            return None
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 7:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul`` with
+    **exactly one** ``Sqrt(positive-polynomial)`` factor, **exactly seven**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · log(k)⁷ · k^m``.  ``log⁷(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick: ``effective_x2 = a + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------+----------+
+    | Input                                                    | Return   |
+    +==========================================================+==========+
+    | ``Mul(Sqrt(k), Log(k)×7)``                               | ``1``    |
+    | ``Mul(Sqrt(k²), Log(k)×7, k)``                           | ``4``    |
+    | ``Mul(Sqrt(k), Log(k)×7, k², 3)``                        | ``5``    |
+    | ``Mul(Log(k)×7)``                                        | None     |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×7)``                      | None (2) |
+    | ``Mul(Sqrt(k), Log(k)×6)``                               | None (6) |
+    +----------------------------------------------------------+----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(P)`` → record ``sqrt_effective_half_degree_x2``; bail on second Sqrt.
+         - ``Log(diverging)`` → count; bail after 7.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 1 Sqrt and exactly 7 Log factors.
+      4. Return ``sqrt_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        s_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if s_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                # Second Sqrt — not this phase.
+                return None
+            sqrt_deg_x2 = s_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 7:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 7:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
 
 
 def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1221,6 +1221,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 92: ``Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(h1), ..., Log(h7), polynomial..., bounded...)`` numerator.
+    # Three Sqrt factors + seven Log factors; log⁷ sub-polynomial → 0.
+    # effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s3l7p_x2 = _three_sqrt_seven_log_poly_effective_x2(num, k)
+    if s3l7p_x2 is not None:
+        den_deg_s3l7 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l7 is not None:
+            if 2 * den_deg_s3l7 > s3l7p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3616,6 +3629,77 @@ def _two_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | No
     if len(sqrt_degs_x2) != 2 or log_count != 7:
         return None
     return sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg_sum
+
+
+def _three_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + 2·poly_deg`` when
+    ``node`` is a ``Mul`` with **exactly three** ``Sqrt(positive-leading polynomial)``
+    factors, **exactly seven** ``Log(diverging-in-k)`` factors, any polynomial
+    factors, and any bounded factors; ``None`` otherwise.
+
+    Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · log(k)⁷ · k^m ≈ k^{(a+b+c)/2} · log⁷(k) · k^m``.
+    ``log⁷(k)`` is sub-polynomial (``o(k^ε)``), contributing 0 to the
+    effective polynomial degree.
+    Using the ×2 integer trick:
+    ``effective_x2 = a + b + c + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------------------+---------------------+
+    | Input                                                                | Return              |
+    +======================================================================+=====================+
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k)×7)``                         | ``1 + 1 + 1 = 3``   |
+    | ``Mul(Sqrt(k³), Sqrt(k³), Sqrt(k³), Log(k)×7)``                      | ``3 + 3 + 3 = 9``   |
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k)×7, k)``                      | ``1+1+1+2 = 5``     |
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k)×7, k², 3)``                  | ``1+1+1+4 = 7``     |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×7)``                                  | None (2 Sqrts)      |
+    | ``Mul(Sqrt(k)×4, Log(k)×7)``                                         | None (4 Sqrts)      |
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k)×6)``                         | None (6 Logs)       |
+    | ``Mul(Sqrt(k), Sqrt(k), Sqrt(k), Log(k)×8)``                         | None (8 Logs)       |
+    +----------------------------------------------------------------------+---------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 3.
+         - ``Log(diverging)`` → count; bail after 7.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 3 Sqrt AND exactly 7 Log factors.
+      4. Return ``sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                # Fourth Sqrt factor — not this phase.
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 7:
+                # Eight or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 7:
+        return None
+    return sqrt_degs_x2[0] + sqrt_degs_x2[1] + sqrt_degs_x2[2] + 2 * poly_deg_sum
 
 
 def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4681,3 +4681,161 @@ class TestPhase84OneSqrtSixLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase89SevenLogPoly:
+    """Phase 89 — Seven-Log × polynomial numerator.
+
+    Convergence criterion: numerator = log(k)⁷ · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = 2·poly_deg (no Sqrt, log⁷ is sub-polynomial → 0).
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_log7_k_over_k2_closes(self):
+        """log(k)⁷/k²: eff_x2=0; 2·2=4 > 0 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,))))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log7_k_times_k2_over_k3_closes(self):
+        """log(k)⁷·k²/k³: eff_x2=4; 2·3=6 > 4 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), k2))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), kp1_2))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log7_k_times_k3_over_k3_refused(self):
+        """log(k)⁷·k³/k³: eff_x2=6; 2·3=6 not > 6 → refused."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), k3))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                  IRApply(LOG, (kp1,)), kp1_3))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase90OneSqrtSevenLogPoly:
+    """Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √(P(k)) · log(k)⁷ · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = sqrt_deg_x2 + 2·poly_deg (log⁷ is sub-polynomial → 0).
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function (exponential, etc.).
+    """
+
+    def test_sqrt_k_log7_k_over_k2_closes(self):
+        """√k·log(k)⁷/k²: eff_x2=1 (sqrt contributes 1); 2·2=4 > 1 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log7_k_times_k_over_k2_closes(self):
+        """√k·log(k)⁷·k/k²: eff_x2=1+2=3; 2·2=4 > 3 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log7_k_times_k_over_k_refused(self):
+        """√k·log(k)⁷·k/k: eff_x2=3; 2·1=2 not > 3 → refused (diverges)."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4839,3 +4839,87 @@ class TestPhase90OneSqrtSevenLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase91TwoSqrtSevenLogPoly:
+    """Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √(P₁(k)) · √(P₂(k)) · log(k)⁷ · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg (log⁷ → 0).
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function.
+    """
+
+    def test_sqrt_k_sqrt_k_log7_k_over_k2_closes(self):
+        """√k·√k·log(k)⁷/k²: eff_x2=1+1=2; 2·2=4 > 2 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_sqrt_k3_log7_k_over_k4_closes(self):
+        """√(k³)·√(k³)·log(k)⁷/k⁴: eff_x2=3+3=6; 2·4=8 > 6 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused(self):
+        """√k·√k·log(k)⁷·k/k²: eff_x2=1+1+2=4; 2·2=4 not > 4 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -4923,3 +4923,93 @@ class TestPhase91TwoSqrtSevenLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase92ThreeSqrtSevenLogPoly:
+    """Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator.
+
+    Convergence criterion: numerator = √(P₁(k)) · √(P₂(k)) · √(P₃(k)) · log(k)⁷ · poly(k),
+    denominator = polynomial or exponential.
+    effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + 2·poly_deg (log⁷ → 0).
+    Closes iff 2·den_deg > effective_x2 (polynomial denom)
+              or denom is a non-polynomial diverging function.
+    """
+
+    def test_sqrt_k_sqrt_k_sqrt_k_log7_k_over_k2_closes(self):
+        """√k·√k·√k·log(k)⁷/k²: eff_x2=1+1+1=3; 2·2=4 > 3 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k3_sqrt_k3_sqrt_k3_log7_k_over_k5_closes(self):
+        """√(k³)·√(k³)·√(k³)·log(k)⁷/k⁵: eff_x2=3+3+3=9; 2·5=10 > 9 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        k5 = IRApply(POW, (_k, IRInteger(5)))
+        kp1_5 = IRApply(POW, (kp1, IRInteger(5)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k3,)), IRApply(SQRT, (k3,)),
+                              IRApply(SQRT, (k3,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_3,)), IRApply(SQRT, (kp1_3,)),
+                                IRApply(SQRT, (kp1_3,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k5))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_5))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused(self):
+        """√k·√k·√k·log(k)⁷·k/k²: eff_x2=1+1+1+2=5; 2·2=4 not > 5 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.28.0 — 2026-05-27
+
+### Added
+
+- **Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator** (`two_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new tests: `phase91_sqrt_k_sqrt_k_log7_k_over_k2_closes`,
+    `phase91_sqrt_k3_sqrt_k3_log7_k_over_k4_closes`,
+    `phase91_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused`.
+
 ## 2.27.0 — 2026-05-26
 
 ### Added

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.29.0 — 2026-05-27
+
+### Added
+
+- **Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator** (`three_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Sqrt(P3(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 3 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new tests: `phase92_sqrt_k_sqrt_k_sqrt_k_log7_k_over_k2_closes`,
+    `phase92_sqrt_k3_sqrt_k3_sqrt_k3_log7_k_over_k5_closes`,
+    `phase92_sqrt_k_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused`.
+
 ## 2.28.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.27.0 — 2026-05-26
+
+### Added
+
+- **Phase 89 — Seven-Log × polynomial numerator** (`seven_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 7 Log factors required; Sqrt factors explicitly refused.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree; `effective_x2 = 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase89_*`).
+- **Phase 90 — One-Sqrt × Seven-Log × polynomial numerator** (`one_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt_deg_x2 + 2 * poly_deg`.
+  Closes when `2 * den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new integration tests in `tests/tests.rs` (`phase90_*`).
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.21.0"
+version = "2.27.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.27.0"
+version = "2.28.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.28.0"
+version = "2.29.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2258,6 +2258,63 @@ fn one_sqrt_six_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> 
     Some(s + 2 * poly_deg)
 }
 
+/// Phase 89 — Seven-Log × polynomial numerator.
+///
+/// Effective growth: `log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = 2·m`.
+/// Sqrt factors are explicitly refused so Sqrt-bearing phases handle them.
+/// Caller checks `2·den_deg > effective_x2`.
+fn seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 7 { return None; } // eight or more Logs — not this phase
+            continue;
+        }
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; } // Sqrt — refuse
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 7 { return None; }
+    Some(2 * poly_deg)
+}
+
+/// Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = a + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn one_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg_x2 = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 7 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let s = sqrt_deg_x2?;
+    if log_count != 7 { return None; }
+    Some(s + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2691,6 +2748,30 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s1l6_x2) = one_sqrt_six_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s1l6) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s1l6 > s1l6_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 89: Mul(Log(diverging)×7, polynomial..., bounded...) numerator — zero Sqrt factors.
+    // Seven Log + polynomial; log⁷ sub-polynomial — effective_x2 = 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(sl7_x2) = seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl7) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl7 > sl7_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 90: Mul(Sqrt(P), Log(diverging)×7, polynomial..., bounded...) numerator.
+    // One Sqrt + seven Log factors; log⁷ sub-polynomial — effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s1l7_x2) = one_sqrt_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l7) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l7 > s1l7_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2346,6 +2346,37 @@ fn two_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64
     Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg)
 }
 
+/// Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · log(k)⁷ · k^m`.
+/// `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn three_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 3 { return None; } // fourth Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 7 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 3 || log_count != 7 { return None; }
+    Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + sqrt_degs_x2[2] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2815,6 +2846,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s2l7_x2) = two_sqrt_seven_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s2l7) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s2l7 > s2l7_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 92: Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(diverging)×7, polynomial..., bounded...) numerator.
+    // Three Sqrt + seven Log factors; log⁷ sub-polynomial — effective_x2 = sqrt1+sqrt2+sqrt3_deg_x2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s3l7_x2) = three_sqrt_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l7) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l7 > s3l7_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2315,6 +2315,37 @@ fn one_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64
     Some(s + 2 * poly_deg)
 }
 
+/// Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)⁷ · k^m ≈ k^{(a+b)/2} · log⁷(k) · k^m`.
+/// `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0.
+/// Using the ×2 integer trick: `effective_x2 = a + b + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn two_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 2 { return None; } // third Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 7 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 2 || log_count != 7 { return None; }
+    Some(sqrt_degs_x2[0] + sqrt_degs_x2[1] + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2772,6 +2803,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s1l7_x2) = one_sqrt_seven_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s1l7) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s1l7 > s1l7_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 91: Mul(Sqrt(P1), Sqrt(P2), Log(diverging)×7, polynomial..., bounded...) numerator.
+    // Two Sqrt + seven Log factors; log⁷ sub-polynomial — effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s2l7_x2) = two_sqrt_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l7) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l7 > s2l7_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3526,3 +3526,91 @@ fn phase90_sqrt_k_log7_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+#[test]
+fn phase91_sqrt_k_sqrt_k_log7_k_over_k2_closes() {
+    // √k·√k·log(k)^7 / k²: effective_x2=1+1=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase91_sqrt_k3_sqrt_k3_log7_k_over_k4_closes() {
+    // √(k³)·√(k³)·log(k)^7 / k⁴: effective_x2=3+3=6; 2·4=8 > 6 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase91_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused() {
+    // √k·√k·log(k)^7·k / k²: effective_x2=1+1+2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3362,3 +3362,167 @@ fn phase84_sqrt_k_log6_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+#[test]
+fn phase89_log7_k_over_k2_closes() {
+    // log(k)^7 / k²: effective_x2=0; 2·2=4 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase89_log7_k_times_k2_over_k3_closes() {
+    // log(k)^7·k² / k³: effective_x2=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k2,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1_2,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase89_log7_k_times_k3_over_k3_refused() {
+    // log(k)^7·k³ / k³: effective_x2=6; 2·3=6 not > 6 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k3.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1_3.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase90_sqrt_k_log7_k_over_k2_closes() {
+    // √k·log(k)^7 / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase90_sqrt_k_log7_k_times_k_over_k2_closes() {
+    // √k·log(k)^7·k / k²: effective_x2=1+2=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase90_sqrt_k_log7_k_times_k_over_k_refused() {
+    // √k·log(k)^7·k / k: effective_x2=3; 2·1=2 not > 3 → refused (diverges).
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3614,3 +3614,91 @@ fn phase91_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+#[test]
+fn phase92_sqrt_k_sqrt_k_sqrt_k_log7_k_over_k2_closes() {
+    // √k·√k·√k·log(k)^7 / k²: effective_x2=1+1+1=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase92_sqrt_k3_sqrt_k3_sqrt_k3_log7_k_over_k5_closes() {
+    // √(k³)·√(k³)·√(k³)·log(k)^7 / k⁵: effective_x2=3+3+3=9; 2·5=10 > 9 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let sqrt_k3 = apply(sym("Sqrt"), vec![k3]);
+    let sqrt_kp1_3 = apply(sym("Sqrt"), vec![kp1_3]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k5 = apply(sym(POW), vec![k.clone(), int(5)]);
+    let kp1_5 = apply(sym(POW), vec![kp1.clone(), int(5)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k3.clone(), sqrt_k3.clone(), sqrt_k3,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_3.clone(), sqrt_kp1_3.clone(), sqrt_kp1_3,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k5]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_5]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase92_sqrt_k_sqrt_k_sqrt_k_log7_k_times_k_over_k2_refused() {
+    // √k·√k·√k·log(k)^7·k / k²: effective_x2=1+1+1+2=5; 2·2=4 not > 5 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.28.0 — 2026-05-27
+
+### Added
+
+- **Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator** (`twoSqrtSevenLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 2 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effectiveDeg = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg`.
+  Closes when `denDeg > effectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in `Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator` describe block.
+
 ## 2.27.0 — 2026-05-26
 
 ### Added

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.27.0 — 2026-05-26
+
+### Added
+
+- **Phase 89 — Seven-Log × polynomial numerator** (`sevenLogPolyEffectiveDeg`):
+  recognises `Mul(Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 7 Log factors required; Sqrt factors explicitly refused.  `log⁷(k)` sub-polynomial
+  — contributes 0 to effective degree; effective degree = polyDeg.
+  Closes when `denDeg > sevenLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 89" describe block.
+- **Phase 90 — One-Sqrt × Seven-Log × polynomial numerator** (`oneSqrtSevenLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt and exactly 7 Log factors required.  `log⁷(k)` sub-polynomial
+  — contributes 0 to effective degree; effective degree = sqrtHalfDeg + polyDeg.
+  Closes when `denDeg > oneSqrtSevenLogPolyEffectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in the "Phase 90" describe block.
+
 ## 2.21.0 — 2026-05-25
 
 ### Added

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.29.0 — 2026-05-27
+
+### Added
+
+- **Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator** (`threeSqrtSevenLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Sqrt(P3(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 3 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effectiveDeg = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg`.
+  Closes when `denDeg > effectiveDeg` or non-polynomial diverging denominator.
+  - 3 new tests in `Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator` describe block.
+
 ## 2.28.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.28.0",
+      "version": "2.29.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.21.0",
+  "version": "2.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.21.0",
+      "version": "2.28.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.21.0",
+  "version": "2.27.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2100,6 +2100,40 @@ function twoSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | unde
 }
 
 /**
+ * Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · log(k)⁷ · k^m ≈ k^{(a+b+c)/2} · log⁷(k) · k^m`.
+ * `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective polynomial degree.
+ * effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg.
+ * Caller checks `denDeg > threeSqrtSevenLogPolyEffectiveDeg(num, k)`.
+ */
+function threeSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined; // fourth Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 7) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 7) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+/**
  * Phase 84 — One-Sqrt × Six-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · log(k)⁶ · k^m`. `log⁶(k)` is sub-polynomial (`o(k^ε)`),
@@ -2620,6 +2654,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l7 = polynomialDegreeInK(den, k);
     if (denDegS2l7 !== undefined) {
       if (denDegS2l7 > s2l7Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 92: Mul(Sqrt(P1), Sqrt(P2), Sqrt(P3), Log(h1)×7, polynomial..., bounded...) numerator.
+  // Three Sqrt + seven Log factors; log⁷ sub-polynomial → effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg.
+  // Closes when denDeg > threeSqrtSevenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s3l7Deg = threeSqrtSevenLogPolyEffectiveDeg(num, k);
+  if (s3l7Deg !== undefined) {
+    const denDegS3l7 = polynomialDegreeInK(den, k);
+    if (denDegS3l7 !== undefined) {
+      if (denDegS3l7 > s3l7Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2066,6 +2066,40 @@ function oneSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | unde
 }
 
 /**
+ * Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)⁷ · k^m ≈ k^{(a+b)/2} · log⁷(k) · k^m`.
+ * `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective polynomial degree.
+ * effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+ * Caller checks `denDeg > twoSqrtSevenLogPolyEffectiveDeg(num, k)`.
+ */
+function twoSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined; // third Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 7) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 7) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+/**
  * Phase 84 — One-Sqrt × Six-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · log(k)⁶ · k^m`. `log⁶(k)` is sub-polynomial (`o(k^ε)`),
@@ -2574,6 +2608,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS1l7 = polynomialDegreeInK(den, k);
     if (denDegS1l7 !== undefined) {
       if (denDegS1l7 > s1l7Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 91: Mul(Sqrt(P1), Sqrt(P2), Log(h1)×7, polynomial..., bounded...) numerator.
+  // Two Sqrt + seven Log factors; log⁷ sub-polynomial → effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+  // Closes when denDeg > twoSqrtSevenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s2l7Deg = twoSqrtSevenLogPolyEffectiveDeg(num, k);
+  if (s2l7Deg !== undefined) {
+    const denDegS2l7 = polynomialDegreeInK(den, k);
+    if (denDegS2l7 !== undefined) {
+      if (denDegS2l7 > s2l7Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2003,6 +2003,69 @@ function sixLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
 }
 
 /**
+ * Phase 89 — Seven-Log × polynomial numerator.
+ *
+ * Effective growth: `log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
+ * contributing 0 to effective polynomial degree.
+ * effective degree = polyDeg.
+ * Sqrt factors are explicitly refused so Sqrt-bearing phases handle them.
+ * Caller checks `denDeg > sevenLogPolyEffectiveDeg(num, k)`.
+ */
+function sevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 7) return undefined; // eight or more Logs — not this phase
+      continue;
+    }
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // Sqrt present — refuse
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 7) return undefined;
+  return polyDeg;
+}
+
+/**
+ * Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a) · log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
+ * contributing 0 to effective polynomial degree.
+ * effective degree = sqrtHalfDeg + polyDeg.
+ * Caller checks `denDeg > oneSqrtSevenLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined; // second Sqrt — refuse
+      sqrtHalfDeg = hd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 7) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 7) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/**
  * Phase 84 — One-Sqrt × Six-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · log(k)⁶ · k^m`. `log⁶(k)` is sub-polynomial (`o(k^ε)`),
@@ -2487,6 +2550,30 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS1l6 = polynomialDegreeInK(den, k);
     if (denDegS1l6 !== undefined) {
       if (denDegS1l6 > s1l6Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 89: Mul(Log(h1)×7, polynomial..., bounded...) numerator — zero Sqrt factors.
+  // log⁷ sub-polynomial → effective degree = polyDeg.
+  // Closes when denDeg > sevenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const sl7Deg = sevenLogPolyEffectiveDeg(num, k);
+  if (sl7Deg !== undefined) {
+    const denDegSl7 = polynomialDegreeInK(den, k);
+    if (denDegSl7 !== undefined) {
+      if (denDegSl7 > sl7Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 90: Mul(Sqrt(P), Log(h1)×7, polynomial..., bounded...) numerator.
+  // One Sqrt + seven Log factors; log⁷ sub-polynomial → effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtSevenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l7Deg = oneSqrtSevenLogPolyEffectiveDeg(num, k);
+  if (s1l7Deg !== undefined) {
+    const denDegS1l7 = polynomialDegreeInK(den, k);
+    if (denDegS1l7 !== undefined) {
+      if (denDegS1l7 > s1l7Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3690,3 +3690,206 @@ describe("Phase 84 — One-Sqrt × Six-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 89 — Seven-Log × polynomial numerator", () => {
+  // log(k)^7 · poly(k) / denom — effective degree = polyDeg (log^7 sub-polynomial).
+
+  it("log(k)^7 / k² closes (eff=0; denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK89a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp189a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK89a = { kind: "apply" as const, head: DIV, args: [numK89a, k2] };
+    const gKp189a = { kind: "apply" as const, head: DIV, args: [numKp189a, kp1_2] };
+    const f89a = { kind: "apply" as const, head: SUB, args: [gK89a, gKp189a] };
+    const result = evaluateSum(f89a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^7·k² / k³ closes (eff=2; denDeg=3 > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK89b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k2,
+    ]};
+    const numKp189b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1_2,
+    ]};
+    const gK89b = { kind: "apply" as const, head: DIV, args: [numK89b, k3] };
+    const gKp189b = { kind: "apply" as const, head: DIV, args: [numKp189b, kp1_3] };
+    const f89b = { kind: "apply" as const, head: SUB, args: [gK89b, gKp189b] };
+    const result = evaluateSum(f89b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^7·k³ / k³ refused (eff=3; denDeg=3 not > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK89c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k3,
+    ]};
+    const numKp189c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      k3,
+    ]};
+    const gK89c = { kind: "apply" as const, head: DIV, args: [numK89c, k3] };
+    const gKp189c = { kind: "apply" as const, head: DIV, args: [numKp189c, kp1_3] };
+    const f89c = { kind: "apply" as const, head: SUB, args: [gK89c, gKp189c] };
+    const result = evaluateSum(f89c, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+describe("Phase 90 — One-Sqrt × Seven-Log × polynomial numerator", () => {
+  // √(P(k)) · log(k)^7 · poly(k) / denom — effective degree = sqrtHalfDeg + polyDeg.
+
+  it("√k·log(k)^7 / k² closes (eff=0.5; denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK90a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp190a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK90a = { kind: "apply" as const, head: DIV, args: [numK90a, k2] };
+    const gKp190a = { kind: "apply" as const, head: DIV, args: [numKp190a, kp1_2] };
+    const f90a = { kind: "apply" as const, head: SUB, args: [gK90a, gKp190a] };
+    const result = evaluateSum(f90a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)^7·k / k² closes (eff=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK90b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp190b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK90b = { kind: "apply" as const, head: DIV, args: [numK90b, k2] };
+    const gKp190b = { kind: "apply" as const, head: DIV, args: [numKp190b, kp1_2] };
+    const f90b = { kind: "apply" as const, head: SUB, args: [gK90b, gKp190b] };
+    const result = evaluateSum(f90b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)^7·k / k refused (eff=1.5; denDeg=1 not > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK90c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp190c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK90c = { kind: "apply" as const, head: DIV, args: [numK90c, k] };
+    const gKp190c = { kind: "apply" as const, head: DIV, args: [numKp190c, kp1] };
+    const f90c = { kind: "apply" as const, head: SUB, args: [gK90c, gKp190c] };
+    const result = evaluateSum(f90c, k, int(1), sym("%inf"), evalNode);
+    // effective=1.5; denDeg=1 not > 1.5 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -3893,3 +3893,114 @@ describe("Phase 90 — One-Sqrt × Seven-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator", () => {
+  // √(P1(k)) · √(P2(k)) · log(k)^7 · poly(k) / denom — effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + polyDeg.
+
+  it("√k·√k·log(k)^7 / k² closes (eff=1; denDeg=2 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK91a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp191a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK91a = { kind: "apply" as const, head: DIV, args: [numK91a, k2] };
+    const gKp191a = { kind: "apply" as const, head: DIV, args: [numKp191a, kp1_2] };
+    const f91a = { kind: "apply" as const, head: SUB, args: [gK91a, gKp191a] };
+    const result = evaluateSum(f91a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√(k³)·log(k)^7 / k⁴ closes (eff=3; denDeg=4 > 3)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const numK91b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp191b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK91b = { kind: "apply" as const, head: DIV, args: [numK91b, k4] };
+    const gKp191b = { kind: "apply" as const, head: DIV, args: [numKp191b, kp1_4] };
+    const f91b = { kind: "apply" as const, head: SUB, args: [gK91b, gKp191b] };
+    const result = evaluateSum(f91b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·log(k)^7·k / k² refused (eff=2; denDeg=2 not > 2)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK91c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp191c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK91c = { kind: "apply" as const, head: DIV, args: [numK91c, k2] };
+    const gKp191c = { kind: "apply" as const, head: DIV, args: [numKp191c, kp1_2] };
+    const f91c = { kind: "apply" as const, head: SUB, args: [gK91c, gKp191c] };
+    const result = evaluateSum(f91c, k, int(1), sym("%inf"), evalNode);
+    // effective=2; denDeg=2 not > 2 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -4004,3 +4004,120 @@ describe("Phase 91 — Two-Sqrt × Seven-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 92 — Three-Sqrt × Seven-Log × polynomial numerator", () => {
+  // √(P1(k)) · √(P2(k)) · √(P3(k)) · log(k)^7 · poly(k) / denom
+
+  it("√k·√k·√k·log(k)^7 / k² closes (eff=1.5; denDeg=2 > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK92a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp192a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK92a = { kind: "apply" as const, head: DIV, args: [numK92a, k2] };
+    const gKp192a = { kind: "apply" as const, head: DIV, args: [numKp192a, kp1_2] };
+    const f92a = { kind: "apply" as const, head: SUB, args: [gK92a, gKp192a] };
+    const result = evaluateSum(f92a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k³)·√(k³)·√(k³)·log(k)^7 / k⁵ closes (eff=4.5; denDeg=5 > 4.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const k5 = { kind: "apply" as const, head: POW, args: [k, int(5)] };
+    const kp1_5 = { kind: "apply" as const, head: POW, args: [kp1, int(5)] };
+    const numK92b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: SQRT, args: [k3] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp192b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_3] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK92b = { kind: "apply" as const, head: DIV, args: [numK92b, k5] };
+    const gKp192b = { kind: "apply" as const, head: DIV, args: [numKp192b, kp1_5] };
+    const f92b = { kind: "apply" as const, head: SUB, args: [gK92b, gKp192b] };
+    const result = evaluateSum(f92b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·√k·√k·log(k)^7·k / k² refused (eff=2.5; denDeg=2 not > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK92c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp192c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK92c = { kind: "apply" as const, head: DIV, args: [numK92c, k2] };
+    const gKp192c = { kind: "apply" as const, head: DIV, args: [numKp192c, kp1_2] };
+    const f92c = { kind: "apply" as const, head: SUB, args: [gK92c, gKp192c] };
+    const result = evaluateSum(f92c, k, int(1), sym("%inf"), evalNode);
+    // effective=2.5; denDeg=2 not > 2.5 → refused
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Phase 92 to the `cas-summation` convergence recognizer across all three language implementations (Python, TypeScript, Rust).

### What Phase 92 recognises

Series whose general-term numerator has the shape:
```
Mul(Sqrt(P₁(k)), Sqrt(P₂(k)), Sqrt(P₃(k)), Log(h₁(k)), …, Log(h₇(k)), polynomial…, bounded…)
```

**Exactly** 3 Sqrt factors and **exactly** 7 Log factors are required.

- `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to effective polynomial degree
- Python/Rust: `effective_x2 = a + b + c + 2·poly_deg`
- TypeScript: `effectiveDeg = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + polyDeg`
- Closes when `2·den_deg > effective_x2` (polynomial denom) or non-polynomial diverging denom

### Changes

| Package | Version | Change |
|---------|---------|--------|
| Python `cas-summation` | 2.28.0 → 2.29.0 | `_three_sqrt_seven_log_poly_effective_x2` + 3 tests |
| TypeScript `@coding-adventures/cas-summation` | 2.28.0 → 2.29.0 | `threeSqrtSevenLogPolyEffectiveDeg` + 3 tests |
| Rust `cas-summation` | 2.28.0 → 2.29.0 | `three_sqrt_seven_log_poly_effective_x2` + 3 tests |

### Test results

- Python: 229 tests pass, 88.54% coverage
- TypeScript: 182 tests pass
- Rust: 165 tests pass

### Context — Seven-Log Sqrt-count family

- Phase 89: Zero-Sqrt × Seven-Log ✅ (PR #4475)
- Phase 90: One-Sqrt × Seven-Log ✅ (PR #4475)
- Phase 91: Two-Sqrt × Seven-Log ✅ (PR #4476)
- **Phase 92: Three-Sqrt × Seven-Log ✅ (this PR)**
- Phase 93: Four-Sqrt × Seven-Log (next)
- Phase 94: Five-Sqrt × Seven-Log (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)