### PR TITLE
feat(cas-summation): Phase 94 — Five-Sqrt × Seven-Log × polynomial convergence recognizer (v2.31.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.31.0 — 2026-05-27
+
+### Added
+
+- **Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator** (`_five_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1(k)), Sqrt(P2(k)), Sqrt(P3(k)), Sqrt(P4(k)), Sqrt(P5(k)), Log(h1(k)), ..., Log(h7(k)), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 7 Log factors required.  `log⁷(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt1_deg_x2 + sqrt2_deg_x2 + sqrt3_deg_x2 + sqrt4_deg_x2 + sqrt5_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  Completes the Seven-Log family (Phases 89–94).
+  - 3 new unit tests in `TestPhase94FiveSqrtSevenLogPoly`.
+
 ## 2.30.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.30.0"
+version = "2.31.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1247,6 +1247,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 94: ``Mul(Sqrt(P1)..Sqrt(P5), Log(h1), ..., Log(h7), polynomial..., bounded...)`` numerator.
+    # Five Sqrt factors + seven Log factors; log⁷ sub-polynomial → 0.
+    # effective_x2 = sqrt1+sqrt2+sqrt3+sqrt4+sqrt5_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s5l7p_x2 = _five_sqrt_seven_log_poly_effective_x2(num, k)
+    if s5l7p_x2 is not None:
+        den_deg_s5l7 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l7 is not None:
+            if 2 * den_deg_s5l7 > s5l7p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3780,6 +3793,75 @@ def _four_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | N
             continue
         return None
     if len(sqrt_degs_x2) != 4 or log_count != 7:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_deg_x2 + … + sqrt5_deg_x2 + 2·poly_deg``
+    when ``node`` is a ``Mul`` with **exactly five** ``Sqrt(positive-leading polynomial)``
+    factors, **exactly seven** ``Log(diverging-in-k)`` factors, any polynomial
+    factors, and any bounded factors; ``None`` otherwise.
+
+    Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · sqrt(k^e) · log(k)⁷ · k^m``.
+    ``log⁷(k)`` is sub-polynomial (``o(k^ε)``), contributing 0 to the
+    effective polynomial degree.
+    Using the ×2 integer trick:
+    ``effective_x2 = a + b + c + d + e + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +------------------------------------------------------------------------+------------------------+
+    | Input                                                                  | Return                 |
+    +========================================================================+========================+
+    | ``Mul(Sqrt(k)×5, Log(k)×7)``                                           | ``1+1+1+1+1 = 5``      |
+    | ``Mul(Sqrt(k²)×5, Log(k)×7)``                                          | ``2+2+2+2+2 = 10``     |
+    | ``Mul(Sqrt(k)×5, Log(k)×7, k)``                                        | ``5+2 = 7``            |
+    | ``Mul(Sqrt(k)×4, Log(k)×7)``                                           | None (4 Sqrts)         |
+    | ``Mul(Sqrt(k)×6, Log(k)×7)``                                           | None (6 Sqrts)         |
+    | ``Mul(Sqrt(k)×5, Log(k)×6)``                                           | None (6 Logs)          |
+    +------------------------------------------------------------------------+------------------------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(positive-leading polynomial)`` → record ×2 degree; bail after 5.
+         - ``Log(diverging)`` → count; bail after 7.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 5 Sqrt AND exactly 7 Log factors.
+      4. Return sum of all sqrt_deg_x2 values + 2 * poly_deg_sum.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                # Sixth Sqrt factor — not this phase.
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 7:
+                # Eight or more Log factors — refuse.
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 7:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -5100,3 +5100,96 @@ class TestPhase93FourSqrtSevenLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase94FiveSqrtSevenLogPoly:
+    """Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator.
+
+    effective_x2 = sqrt1_x2 + … + sqrt5_x2 + 2·poly_deg (log⁷ → 0).
+    Closes iff 2·den_deg > effective_x2 or denom is non-polynomial diverging.
+    """
+
+    def test_sqrt_k_x5_log7_k_over_k4_closes(self):
+        """√k×5·log(k)⁷/k⁴: eff_x2=5; 2·4=8 > 5 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                              IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k2_x5_log7_k_over_k6_closes(self):
+        """√(k²)×5·log(k)⁷/k⁶: eff_x2=10; 2·6=12 > 10 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k6 = IRApply(POW, (_k, IRInteger(6)))
+        kp1_6 = IRApply(POW, (kp1, IRInteger(6)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k2,)), IRApply(SQRT, (k2,)),
+                              IRApply(SQRT, (k2,)), IRApply(SQRT, (k2,)),
+                              IRApply(SQRT, (k2,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_2,)), IRApply(SQRT, (kp1_2,)),
+                                IRApply(SQRT, (kp1_2,)), IRApply(SQRT, (kp1_2,)),
+                                IRApply(SQRT, (kp1_2,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k6))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_6))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x5_log7_k_times_k_over_k3_refused(self):
+        """√k×5·log(k)⁷·k/k³: eff_x2=5+2=7; 2·3=6 not > 7 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k94 = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                                IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                                IRApply(SQRT, (_k,)),
+                                IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                IRApply(LOG, (_k,)),
+                                _k))
+        num_kp1_94 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                   IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                   IRApply(SQRT, (kp1,)),
+                                   IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                   IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                   IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                   IRApply(LOG, (kp1,)),
+                                   kp1))
+        g_k94 = IRApply(DIV, (num_k94, k3))
+        g_kp1_94 = IRApply(DIV, (num_kp1_94, kp1_3))
+        f94 = IRApply(SUB, (g_k94, g_kp1_94))
+        result = evaluate_sum(f94, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.31.0 — 2026-05-27
+
+### Added
+
+- **Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator** (`five_sqrt_seven_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1)..Sqrt(P5), Log(h1), ..., Log(h7), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 7 Log factors required.
+  `effective_x2 = sum(sqrt_deg_x2) + 2·poly_deg`.
+  Completes the Seven-Log family (Phases 89–94).
+  - 3 new tests: `phase94_sqrt_k_x5_log7_k_over_k4_closes`,
+    `phase94_sqrt_k2_x5_log7_k_over_k6_closes`,
+    `phase94_sqrt_k_x5_log7_k_times_k_over_k3_refused`.
+
 ## 2.30.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.30.0"
+version = "2.31.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2408,6 +2408,37 @@ fn four_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i6
     Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
 }
 
+/// Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a)·sqrt(k^b)·sqrt(k^c)·sqrt(k^d)·sqrt(k^e)·log(k)⁷·k^m`.
+/// `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + d + e + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn five_sqrt_seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 5 { return None; } // sixth Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 7 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 5 || log_count != 7 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     let apply_node = match g {
         IRNode::Apply(a) => a,
@@ -2901,6 +2932,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s4l7_x2) = four_sqrt_seven_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s4l7) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s4l7 > s4l7_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 94: Mul(Sqrt(P1)..Sqrt(P5), Log(diverging)×7, polynomial..., bounded...) numerator.
+    // Five Sqrt + seven Log factors; log⁷ sub-polynomial — effective_x2 = sum(sqrt_deg_x2) + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s5l7_x2) = five_sqrt_seven_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l7) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l7 > s5l7_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3790,3 +3790,93 @@ fn phase93_sqrt_k_x4_log7_k_times_k_over_k3_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 94: Five-Sqrt × Seven-Log × polynomial numerator ──────────────────
+
+#[test]
+fn phase94_sqrt_k_x5_log7_k_over_k4_closes() {
+    // √k×5·log(k)^7 / k⁴: effective_x2=5; 2·4=8 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k4 = apply(sym(POW), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym(POW), vec![kp1.clone(), int(4)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase94_sqrt_k2_x5_log7_k_over_k6_closes() {
+    // √(k²)×5·log(k)^7 / k⁶: effective_x2=10; 2·6=12 > 10 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k6 = apply(sym(POW), vec![k.clone(), int(6)]);
+    let kp1_6 = apply(sym(POW), vec![kp1.clone(), int(6)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k2.clone(), sqrt_k2.clone(), sqrt_k2.clone(), sqrt_k2.clone(), sqrt_k2,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_2.clone(), sqrt_kp1_2.clone(), sqrt_kp1_2.clone(), sqrt_kp1_2.clone(), sqrt_kp1_2,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k6]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_6]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase94_sqrt_k_x5_log7_k_times_k_over_k3_refused() {
+    // √k×5·log(k)^7·k / k³: effective_x2=5+2=7; 2·3=6 not > 7 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.31.0 — 2026-05-27
+
+### Added
+
+- **Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator** (`fiveSqrtSevenLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1)..Sqrt(P5), Log(h1), ..., Log(h7), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 7 Log factors required.
+  `effectiveDeg = sqrtHalfDeg1+…+sqrtHalfDeg5+polyDeg`.
+  Completes the Seven-Log family (Phases 89–94).
+  - 3 new tests in `Phase 94` describe block.
+
 ## 2.30.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2167,6 +2167,39 @@ function fourSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | und
 }
 
 /**
+ * Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a)·sqrt(k^b)·sqrt(k^c)·sqrt(k^d)·sqrt(k^e)·log(k)⁷·k^m`.
+ * `log⁷(k)` is sub-polynomial (`o(k^ε)`), contributing 0.
+ * effective degree = sqrtHalfDeg1 + sqrtHalfDeg2 + sqrtHalfDeg3 + sqrtHalfDeg4 + sqrtHalfDeg5 + polyDeg.
+ */
+function fiveSqrtSevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined; // sixth Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 7) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 7) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
+/**
  * Phase 84 — One-Sqrt × Six-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · log(k)⁶ · k^m`. `log⁶(k)` is sub-polynomial (`o(k^ε)`),
@@ -2711,6 +2744,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS4l7 = polynomialDegreeInK(den, k);
     if (denDegS4l7 !== undefined) {
       if (denDegS4l7 > s4l7Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 94: Mul(Sqrt(P1)..Sqrt(P5), Log(h1)×7, polynomial..., bounded...) numerator.
+  // Five Sqrt + seven Log factors; log⁷ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > fiveSqrtSevenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s5l7Deg = fiveSqrtSevenLogPolyEffectiveDeg(num, k);
+  if (s5l7Deg !== undefined) {
+    const denDegS5l7 = polynomialDegreeInK(den, k);
+    if (denDegS5l7 !== undefined) {
+      if (denDegS5l7 > s5l7Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -4241,3 +4241,129 @@ describe("Phase 93 — Four-Sqrt × Seven-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator", () => {
+  it("√k×5·log(k)^7 / k⁴ closes (eff=2.5; denDeg=4 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k4 = { kind: "apply" as const, head: POW, args: [k, int(4)] };
+    const kp1_4 = { kind: "apply" as const, head: POW, args: [kp1, int(4)] };
+    const numK94a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp194a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK94a = { kind: "apply" as const, head: DIV, args: [numK94a, k4] };
+    const gKp194a = { kind: "apply" as const, head: DIV, args: [numKp194a, kp1_4] };
+    const f94a = { kind: "apply" as const, head: SUB, args: [gK94a, gKp194a] };
+    const result = evaluateSum(f94a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k²)×5·log(k)^7 / k⁶ closes (eff=5; denDeg=6 > 5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const k6 = { kind: "apply" as const, head: POW, args: [k, int(6)] };
+    const kp1_6 = { kind: "apply" as const, head: POW, args: [kp1, int(6)] };
+    const numK94b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp194b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK94b = { kind: "apply" as const, head: DIV, args: [numK94b, k6] };
+    const gKp194b = { kind: "apply" as const, head: DIV, args: [numKp194b, kp1_6] };
+    const f94b = { kind: "apply" as const, head: SUB, args: [gK94b, gKp194b] };
+    const result = evaluateSum(f94b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k×5·log(k)^7·k / k³ refused (eff=3.5; denDeg=3 not > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK94c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp194c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK94c = { kind: "apply" as const, head: DIV, args: [numK94c, k3] };
+    const gKp194c = { kind: "apply" as const, head: DIV, args: [numKp194c, kp1_3] };
+    const f94c = { kind: "apply" as const, head: SUB, args: [gK94c, gKp194c] };
+    const result = evaluateSum(f94c, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Phase 94 — the final phase of the Seven-Log family — across all three languages. Recognises products with **exactly 5 Sqrt factors, exactly 7 Log factors, and any polynomial factors** in the numerator.

## What's new

### Python (`cas-summation` 2.31.0)
- Added `_five_sqrt_seven_log_poly_effective_x2` helper
- Added Phase 94 dispatch block in `_g_vanishes_at_infinity`
- 3 new tests in `TestPhase94FiveSqrtSevenLogPoly`
- 235 total tests, 88.50% coverage

### TypeScript (`cas-summation` 2.31.0)
- Added `fiveSqrtSevenLogPolyEffectiveDeg` helper
- Added Phase 94 dispatch block
- 3 new tests, 188 total

### Rust (`cas-summation` 2.31.0)
- Added `five_sqrt_seven_log_poly_effective_x2` helper using `iter().sum()`
- Added Phase 94 dispatch block
- 3 new tests, 171 total

## Algorithm

Exactly 5 Sqrt + 7 Log factors required. Log⁷(k) is sub-polynomial (o(k^ε)), contributing 0 effective degree. effective_x2 = sum(sqrt_deg_x2) + 2·poly_deg. Closes when 2·den_deg > effective_x2 or non-polynomial diverging denominator.

## Seven-Log Family Complete

| Phase | Sqrts | Logs |
|-------|-------|------|
| 89 | 0 | 7 |
| 90 | 1 | 7 |
| 91 | 2 | 7 |
| 92 | 3 | 7 |
| 93 | 4 | 7 |
| **94** | **5** | **7** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)