### PR TITLE
feat(cas-summation): Phase 95 — Eight-Log × polynomial convergence recognizer (v2.32.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.32.0 — 2026-05-27
+
+### Added
+
+- **Phase 95 — Eight-Log × polynomial numerator** (`_eight_log_poly_effective_x2`):
+  recognises `Mul(Log(h1(k)), ..., Log(h8(k)), polynomial..., bounded...)` with exactly 8 Log
+  factors and no Sqrt factors.  `log⁸(k)` is sub-polynomial (`o(k^ε)`), contributing 0 to
+  effective degree; `effective_x2 = 2·poly_deg`.  Closes when `2·den_deg > effective_x2` or
+  non-polynomial diverging denominator.  Opens the Eight-Log family (Phases 95–100).
+  - 3 new unit tests in `TestPhase95EightLogPoly`.
+
 ## 2.31.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.31.0"
+version = "2.32.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1260,6 +1260,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 95: ``Mul(Log(h1), ..., Log(h8), polynomial..., bounded...)`` numerator.
+    # Zero Sqrt factors + eight Log factors; log⁸ sub-polynomial → 0.
+    # effective_x2 = 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    sl8p_x2 = _eight_log_poly_effective_x2(num, k)
+    if sl8p_x2 is not None:
+        den_deg_sl8 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl8 is not None:
+            if 2 * den_deg_sl8 > sl8p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3864,6 +3877,71 @@ def _five_sqrt_seven_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | N
     if len(sqrt_degs_x2) != 5 or log_count != 7:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _eight_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly eight**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 95 — Eight-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)⁸ · k^m``.  ``log⁸(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick (no Sqrt factors present):
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    Sqrt factors are explicitly refused so that this function does not
+    shadow the Sqrt-bearing phases (Phase 96 onward).
+
+    +-----------------------------------------------------+----------+
+    | Input                                               | Return   |
+    +=====================================================+==========+
+    | ``Mul(Log(k)×8)``                                   | ``0``    |
+    | ``Mul(Log(k)×8, k)``                                | ``2``    |
+    | ``Mul(Log(k)×8, k², 3)``                            | ``4``    |
+    | ``Mul(Log(k)×7)``                                   | None (7) |
+    | ``Mul(Log(k)×9)``                                   | None (9) |
+    | ``Mul(Sqrt(k), Log(k)×8)``                          | None     |
+    +-----------------------------------------------------+----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Log(diverging)`` → count; bail after 8.
+         - ``Sqrt(...)`` → refuse (return ``None``).
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 8 Log factors.
+      4. Return ``2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 8:
+                # Nine or more Log factors — not this phase.
+                return None
+            continue
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            # Sqrt factor present — refuse so Sqrt-bearing phases handle it.
+            return None
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 8:
+        return None
+    return 2 * poly_deg_sum
 
 
 def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -5193,3 +5193,76 @@ class TestPhase94FiveSqrtSevenLogPoly:
         f94 = IRApply(SUB, (g_k94, g_kp1_94))
         result = evaluate_sum(f94, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase95EightLogPoly:
+    """Phase 95 — Eight-Log × polynomial numerator (zero Sqrt).
+
+    effective_x2 = 2·poly_deg (log⁸ → 0).
+    Closes iff 2·den_deg > effective_x2 or denom is non-polynomial diverging.
+    """
+
+    def test_log8_k_over_k2_closes(self):
+        """log(k)⁸/k²: eff_x2=0; 2·2=4 > 0 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log8_k_times_k_over_k3_closes(self):
+        """log(k)⁸·k/k³: eff_x2=2; 2·3=6 > 2 → closes."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f95b = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f95b, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log8_k_times_k_over_k_refused(self):
+        """log(k)⁸·k/k: eff_x2=2; 2·1=2 not > 2 → refused."""
+        from symbolic_ir import SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k95c = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 _k))
+        num_kp1_95c = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    kp1))
+        g_k95c = IRApply(DIV, (num_k95c, _k))
+        g_kp1_95c = IRApply(DIV, (num_kp1_95c, kp1))
+        f95c = IRApply(SUB, (g_k95c, g_kp1_95c))
+        result = evaluate_sum(f95c, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.32.0 — 2026-05-27
+
+### Added
+
+- **Phase 95 — Eight-Log × polynomial numerator** (`eight_log_poly_effective_x2`):
+  recognises `Mul(Log(h1), ..., Log(h8), polynomial..., bounded...)` with exactly 8 Log
+  factors and no Sqrt factors.  `log⁸(k)` is sub-polynomial (`o(k^ε)`), contributing 0;
+  `effective_x2 = 2·poly_deg`.  Closes when `2·den_deg > effective_x2` or non-polynomial
+  diverging denominator.  Opens the Eight-Log family (Phases 95–100).
+  - 3 new tests: `phase95_log8_k_over_k2_closes`, `phase95_log8_k_times_k_over_k3_closes`,
+    `phase95_log8_k_times_k_over_k_refused`.
+
 ## 2.31.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.31.0"
+version = "2.32.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2284,6 +2284,32 @@ fn seven_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(2 * poly_deg)
 }
 
+/// Phase 95 — Eight-Log × polynomial numerator (zero Sqrt).
+///
+/// Effective growth: `log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = 2·m`.
+/// Sqrt factors are explicitly refused.
+/// Caller checks `2·den_deg > effective_x2`.
+fn eight_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 8 { return None; } // nine or more Logs — not this phase
+            continue;
+        }
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; } // Sqrt — refuse
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 8 { return None; }
+    Some(2 * poly_deg)
+}
+
 /// Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
 ///
 /// Effective growth: `sqrt(k^a) · log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
@@ -2944,6 +2970,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s5l7_x2) = five_sqrt_seven_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s5l7) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s5l7 > s5l7_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 95: Mul(Log(diverging)×8, polynomial..., bounded...) numerator.
+    // Zero Sqrt + eight Log factors; log⁸ sub-polynomial — effective_x2 = 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(sl8_x2) = eight_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl8) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl8 > sl8_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3880,3 +3880,79 @@ fn phase94_sqrt_k_x5_log7_k_times_k_over_k3_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 95: Eight-Log × polynomial numerator (zero Sqrt) ──────────────────
+
+#[test]
+fn phase95_log8_k_over_k2_closes() {
+    // log(k)^8 / k²: effective_x2=0; 2·2=4 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase95_log8_k_times_k_over_k3_closes() {
+    // log(k)^8·k / k³: effective_x2=2; 2·3=6 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase95_log8_k_times_k_over_k_refused() {
+    // log(k)^8·k / k: effective_x2=2; 2·1=2 not > 2 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.32.0 — 2026-05-27
+
+### Added
+
+- **Phase 95 — Eight-Log × polynomial numerator** (`eightLogPolyEffectiveDeg`):
+  recognises `Mul(Log(h1), ..., Log(h8), polynomial..., bounded...)` with exactly 8 Log
+  factors and no Sqrt factors.  `log⁸(k)` is sub-polynomial (`o(k^ε)`), contributing 0;
+  `effectiveDeg = polyDeg`.  Closes when `denDeg > eightLogPolyEffectiveDeg` or non-polynomial
+  diverging denominator.  Opens the Eight-Log family (Phases 95–100).
+  - 3 new tests in `Phase 95` describe block.
+
 ## 2.31.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.31.0",
+      "version": "2.32.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2032,6 +2032,35 @@ function sevenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
 }
 
 /**
+ * Phase 95 — Eight-Log × polynomial numerator (zero Sqrt).
+ *
+ * Effective growth: `log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial (`o(k^ε)`),
+ * contributing 0 to effective polynomial degree.
+ * effective degree = polyDeg.
+ * Sqrt factors are explicitly refused so Sqrt-bearing phases handle them.
+ * Caller checks `denDeg > eightLogPolyEffectiveDeg(num, k)`.
+ */
+function eightLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 8) return undefined; // nine or more Logs — not this phase
+      continue;
+    }
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // Sqrt present — refuse
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 8) return undefined;
+  return polyDeg;
+}
+
+/**
  * Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
@@ -2756,6 +2785,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS5l7 = polynomialDegreeInK(den, k);
     if (denDegS5l7 !== undefined) {
       if (denDegS5l7 > s5l7Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 95: Mul(Log(h1)×8, polynomial..., bounded...) numerator.
+  // Zero Sqrt + eight Log factors; log⁸ sub-polynomial → effective degree = polyDeg.
+  // Closes when denDeg > eightLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const sl8Deg = eightLogPolyEffectiveDeg(num, k);
+  if (sl8Deg !== undefined) {
+    const denDegSl8 = polynomialDegreeInK(den, k);
+    if (denDegSl8 !== undefined) {
+      if (denDegSl8 > sl8Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -4367,3 +4367,103 @@ describe("Phase 94 — Five-Sqrt × Seven-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 95 — Eight-Log × polynomial numerator", () => {
+  it("log(k)^8 / k² closes (eff=0; denDeg=2 > 0)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK95a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp195a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK95a = { kind: "apply" as const, head: DIV, args: [numK95a, k2] };
+    const gKp195a = { kind: "apply" as const, head: DIV, args: [numKp195a, kp1_2] };
+    const f95a = { kind: "apply" as const, head: SUB, args: [gK95a, gKp195a] };
+    const result = evaluateSum(f95a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^8·k / k³ closes (eff=1; denDeg=3 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK95b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp195b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK95b = { kind: "apply" as const, head: DIV, args: [numK95b, k3] };
+    const gKp195b = { kind: "apply" as const, head: DIV, args: [numKp195b, kp1_3] };
+    const f95b = { kind: "apply" as const, head: SUB, args: [gK95b, gKp195b] };
+    const result = evaluateSum(f95b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^8·k / k refused (eff=1; denDeg=1 not > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK95c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp195c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK95c = { kind: "apply" as const, head: DIV, args: [numK95c, k] };
+    const gKp195c = { kind: "apply" as const, head: DIV, args: [numKp195c, kp1] };
+    const f95c = { kind: "apply" as const, head: SUB, args: [gK95c, gKp195c] };
+    const result = evaluateSum(f95c, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Phase 95 — the first phase of the Eight-Log family — across all three languages. Recognises products with **exactly 8 Log factors, no Sqrt factors, and any polynomial factors** in the numerator.

## What's new

### Python (`cas-summation` 2.32.0)
- Added `_eight_log_poly_effective_x2` helper (Sqrt explicitly refused)
- Added Phase 95 dispatch block in `_g_vanishes_at_infinity`
- 3 new tests in `TestPhase95EightLogPoly`
- 238 total tests, 88.79% coverage

### TypeScript (`cas-summation` 2.32.0)
- Added `eightLogPolyEffectiveDeg` helper
- Added Phase 95 dispatch block
- 3 new tests, 191 total

### Rust (`cas-summation` 2.32.0)
- Added `eight_log_poly_effective_x2` helper
- Added Phase 95 dispatch block
- 3 new tests, 174 total

## Algorithm

Exactly 8 Log factors required, no Sqrt (Sqrt explicitly refused so Sqrt-bearing phases 96–100 handle those). log⁸(k) is sub-polynomial (o(k^ε)), contributing 0 effective degree. effective_x2 = 2·poly_deg.

## Eight-Log Family (Phases 95–100)

| Phase | Sqrts | Logs |
|-------|-------|------|
| **95** | **0** | **8** |
| 96 | 1 | 8 |
| 97 | 2 | 8 |
| 98 | 3 | 8 |
| 99 | 4 | 8 |
| 100 | 5 | 8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)