### PR TITLE
feat(cas-summation): Phase 96 — One-Sqrt × Eight-Log × polynomial convergence recognizer (v2.33.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.33.0 — 2026-05-27
+
+### Added
+
+- **Phase 96 — One-Sqrt × Eight-Log × polynomial numerator** (`_one_sqrt_eight_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P(k)), Log(h1(k)), ..., Log(h8(k)), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 8 Log factors required.  `log⁸(k)` is sub-polynomial
+  (`o(k^ε)`), contributing 0 to effective degree;
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  - 3 new unit tests in `TestPhase96OneSqrtEightLogPoly`.
+
 ## 2.32.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.32.0"
+version = "2.33.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1273,6 +1273,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 96: ``Mul(Sqrt(P), Log(h1), ..., Log(h8), polynomial..., bounded...)`` numerator.
+    # One Sqrt factor + eight Log factors; log⁸ sub-polynomial → 0.
+    # effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s1l8p_x2 = _one_sqrt_eight_log_poly_effective_x2(num, k)
+    if s1l8p_x2 is not None:
+        den_deg_s1l8 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l8 is not None:
+            if 2 * den_deg_s1l8 > s1l8p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -3942,6 +3955,69 @@ def _eight_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
     if log_count != 8:
         return None
     return 2 * poly_deg_sum
+
+
+def _one_sqrt_eight_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt_deg_x2 + 2·poly_deg`` when ``node`` is a ``Mul`` with
+    **exactly one** ``Sqrt(positive-polynomial)`` factor, **exactly eight**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 96 — One-Sqrt × Eight-Log × polynomial numerator.
+
+    Effective growth:
+    ``sqrt(k^a) · log(k)⁸ · k^m``.  ``log⁸(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick: ``effective_x2 = a + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    +----------------------------------------------------------+----------+
+    | Input                                                    | Return   |
+    +==========================================================+==========+
+    | ``Mul(Sqrt(k), Log(k)×8)``                               | ``1``    |
+    | ``Mul(Sqrt(k²), Log(k)×8, k)``                           | ``4``    |
+    | ``Mul(Sqrt(k), Log(k)×7)``                               | None (7) |
+    | ``Mul(Sqrt(k), Sqrt(k), Log(k)×8)``                      | None (2) |
+    +----------------------------------------------------------+----------+
+
+    Algorithm:
+      1. Require ``node = Mul(...)``.
+      2. For each factor:
+         - ``Sqrt(P)`` → record; bail on second Sqrt.
+         - ``Log(diverging)`` → count; bail after 8.
+         - Polynomial in ``k`` → accumulate degree.
+         - Bounded → accept silently.
+         - Anything else → return ``None``.
+      3. Require exactly 1 Sqrt AND exactly 8 Log factors.
+      4. Return ``sqrt_deg_x2 + 2 * poly_deg_sum``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        s_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if s_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None  # second Sqrt — not this phase
+            sqrt_deg_x2 = s_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 8:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 8:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
 
 
 def _one_sqrt_six_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -5266,3 +5266,82 @@ class TestPhase95EightLogPoly:
         f95c = IRApply(SUB, (g_k95c, g_kp1_95c))
         result = evaluate_sum(f95c, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase96OneSqrtEightLogPoly:
+    """Phase 96 — One-Sqrt × Eight-Log × polynomial numerator.
+
+    effective_x2 = sqrt_x2 + 2·poly_deg (log⁸ → 0).
+    Closes iff 2·den_deg > effective_x2 or denom is non-polynomial diverging.
+    """
+
+    def test_sqrt_k_log8_k_over_k2_closes(self):
+        """√k·log(k)⁸/k²: eff_x2=1; 2·2=4 > 1 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k2_log8_k_over_k3_closes(self):
+        """√(k²)·log(k)⁸/k³: eff_x2=2; 2·3=6 > 2 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(POW, (_k, IRInteger(2)))
+        kp1_2 = IRApply(POW, (kp1, IRInteger(2)))
+        k3 = IRApply(POW, (_k, IRInteger(3)))
+        kp1_3 = IRApply(POW, (kp1, IRInteger(3)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (k2,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                              IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1_2,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log8_k_times_k_over_k_refused(self):
+        """√k·log(k)⁸·k/k: eff_x2=1+2=3; 2·1=2 not > 3 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k96c = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                 _k))
+        num_kp1_96c = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                    kp1))
+        g_k96c = IRApply(DIV, (num_k96c, _k))
+        g_kp1_96c = IRApply(DIV, (num_kp1_96c, kp1))
+        f96c = IRApply(SUB, (g_k96c, g_kp1_96c))
+        result = evaluate_sum(f96c, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.33.0 — 2026-05-27
+
+### Added
+
+- **Phase 96 — One-Sqrt × Eight-Log × polynomial numerator** (`one_sqrt_eight_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P), Log(h1), ..., Log(h8), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 8 Log factors required.
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+  - 3 new tests: `phase96_sqrt_k_log8_k_over_k2_closes`,
+    `phase96_sqrt_k2_log8_k_over_k3_closes`,
+    `phase96_sqrt_k_log8_k_times_k_over_k_refused`.
+
 ## 2.32.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.32.0"
+version = "2.33.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2310,6 +2310,37 @@ fn eight_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
     Some(2 * poly_deg)
 }
 
+/// Phase 96 — One-Sqrt × Eight-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = a + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn one_sqrt_eight_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg_x2 = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 8 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let s = sqrt_deg_x2?;
+    if log_count != 8 { return None; }
+    Some(s + 2 * poly_deg)
+}
+
 /// Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
 ///
 /// Effective growth: `sqrt(k^a) · log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
@@ -2982,6 +3013,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(sl8_x2) = eight_log_poly_effective_x2(num, k) {
         if let Some(den_deg_sl8) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_sl8 > sl8_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 96: Mul(Sqrt(P), Log(diverging)×8, polynomial..., bounded...) numerator.
+    // One Sqrt + eight Log factors; log⁸ sub-polynomial — effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s1l8_x2) = one_sqrt_eight_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l8) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l8 > s1l8_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -3956,3 +3956,91 @@ fn phase95_log8_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 96: One-Sqrt × Eight-Log × polynomial numerator ───────────────────
+
+#[test]
+fn phase96_sqrt_k_log8_k_over_k2_closes() {
+    // √k·log(k)^8 / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase96_sqrt_k2_log8_k_over_k3_closes() {
+    // √(k²)·log(k)^8 / k³: effective_x2=2; 2·3=6 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k2,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_2,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase96_sqrt_k_log8_k_times_k_over_k_refused() {
+    // √k·log(k)^8·k / k: effective_x2=1+2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.33.0 — 2026-05-27
+
+### Added
+
+- **Phase 96 — One-Sqrt × Eight-Log × polynomial numerator** (`oneSqrtEightLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P), Log(h1), ..., Log(h8), polynomial..., bounded...)`.
+  Exactly 1 Sqrt factor and exactly 8 Log factors required.
+  `effectiveDeg = sqrtHalfDeg + polyDeg`.
+  - 3 new tests in `Phase 96` describe block.
+
 ## 2.32.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2061,6 +2061,40 @@ function eightLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
 }
 
 /**
+ * Phase 96 — One-Sqrt × Eight-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a) · log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial (`o(k^ε)`),
+ * contributing 0 to effective polynomial degree.
+ * effective degree = sqrtHalfDeg + polyDeg.
+ * Caller checks `denDeg > oneSqrtEightLogPolyEffectiveDeg(num, k)`.
+ */
+function oneSqrtEightLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined; // second Sqrt — refuse
+      sqrtHalfDeg = hd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 8) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 8) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+/**
  * Phase 90 — One-Sqrt × Seven-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · log(k)⁷ · k^m`. `log⁷(k)` is sub-polynomial (`o(k^ε)`),
@@ -2797,6 +2831,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegSl8 = polynomialDegreeInK(den, k);
     if (denDegSl8 !== undefined) {
       if (denDegSl8 > sl8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 96: Mul(Sqrt(P), Log(h1)×8, polynomial..., bounded...) numerator.
+  // One Sqrt + eight Log factors; log⁸ sub-polynomial → effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtEightLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l8Deg = oneSqrtEightLogPolyEffectiveDeg(num, k);
+  if (s1l8Deg !== undefined) {
+    const denDegS1l8 = polynomialDegreeInK(den, k);
+    if (denDegS1l8 !== undefined) {
+      if (denDegS1l8 > s1l8Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -4467,3 +4467,109 @@ describe("Phase 95 — Eight-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 96 — One-Sqrt × Eight-Log × polynomial numerator", () => {
+  it("√k·log(k)^8 / k² closes (eff=0.5; denDeg=2 > 0.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const numK96a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp196a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK96a = { kind: "apply" as const, head: DIV, args: [numK96a, k2] };
+    const gKp196a = { kind: "apply" as const, head: DIV, args: [numKp196a, kp1_2] };
+    const f96a = { kind: "apply" as const, head: SUB, args: [gK96a, gKp196a] };
+    const result = evaluateSum(f96a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k²)·log(k)^8 / k³ closes (eff=1; denDeg=3 > 1)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK96b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp196b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK96b = { kind: "apply" as const, head: DIV, args: [numK96b, k3] };
+    const gKp196b = { kind: "apply" as const, head: DIV, args: [numKp196b, kp1_3] };
+    const f96b = { kind: "apply" as const, head: SUB, args: [gK96b, gKp196b] };
+    const result = evaluateSum(f96b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k·log(k)^8·k / k refused (eff=1.5; denDeg=1 not > 1.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK96c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp196c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK96c = { kind: "apply" as const, head: DIV, args: [numK96c, k] };
+    const gKp196c = { kind: "apply" as const, head: DIV, args: [numKp196c, kp1] };
+    const f96c = { kind: "apply" as const, head: SUB, args: [gK96c, gKp196c] };
+    const result = evaluateSum(f96c, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Phase 96 of the Eight-Log family. Recognises products with **exactly 1 Sqrt factor, exactly 8 Log factors, and any polynomial factors** in the numerator.

## What's new

### Python (`cas-summation` 2.33.0)
- Added `_one_sqrt_eight_log_poly_effective_x2` helper
- Added Phase 96 dispatch block
- 3 new tests in `TestPhase96OneSqrtEightLogPoly`; 241 total, 88.79% coverage

### TypeScript (`cas-summation` 2.33.0)
- Added `oneSqrtEightLogPolyEffectiveDeg` helper
- Added Phase 96 dispatch block; 194 total tests

### Rust (`cas-summation` 2.33.0)
- Added `one_sqrt_eight_log_poly_effective_x2` helper; 177 total tests

## Eight-Log Family Progress

| Phase | Sqrts | Logs |
|-------|-------|------|
| 95 | 0 | 8 |
| **96** | **1** | **8** |
| 97–100 | 2–5 | 8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)