### PR TITLE
feat(cas-summation): Phase 100 — Five-Sqrt × Eight-Log × polynomial convergence recognizer (v2.37.0)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.37.0 — 2026-05-27
+
+### Added
+
+- **Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator** (`_five_sqrt_eight_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1(k)), ..., Sqrt(P5(k)), Log(h1(k)), ..., Log(h8(k)), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 8 Log factors required.
+  `effective_x2 = sqrt1_deg_x2 + … + sqrt5_deg_x2 + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  Completes the Eight-Log family (Phases 95–100).
+  - 3 new unit tests in `TestPhase100FiveSqrtEightLogPoly`.
+
 ## 2.36.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.36.0"
+version = "2.37.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1325,6 +1325,19 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 100: ``Mul(Sqrt(P1)..Sqrt(P5), Log(h1), ..., Log(h8), polynomial..., bounded...)`` numerator.
+    # Five Sqrt factors + eight Log factors; log⁸ sub-polynomial → 0.
+    # effective_x2 = sqrt1+sqrt2+sqrt3+sqrt4+sqrt5_deg_x2 + 2·poly_deg.
+    # Vanishes when ``2·den_deg > effective_x2`` (polynomial) or
+    # non-polynomial diverging denominator.
+    s5l8p_x2 = _five_sqrt_eight_log_poly_effective_x2(num, k)
+    if s5l8p_x2 is not None:
+        den_deg_s5l8 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l8 is not None:
+            if 2 * den_deg_s5l8 > s5l8p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 42 widening: deg(num) < deg(den) on pure polynomials in k.
     num_degree = _polynomial_degree_in_k(num, k)
     if num_degree is None:
@@ -4197,6 +4210,46 @@ def _four_sqrt_eight_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | N
             continue
         return None
     if len(sqrt_degs_x2) != 4 or log_count != 8:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_eight_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``sqrt1_x2 + … + sqrt5_x2 + 2·poly_deg`` when ``node`` is a
+    ``Mul`` with **exactly five** ``Sqrt`` factors, **exactly eight** ``Log`` factors,
+    any polynomial factors, and any bounded factors; ``None`` otherwise.
+
+    Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator.
+    Completes the Eight-Log family (Phases 95–100).
+
+    Using the ×2 integer trick: ``effective_x2 = a + b + c + d + e + 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None  # sixth Sqrt — not this phase
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 8:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 8:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -5594,3 +5594,94 @@ class TestPhase99FourSqrtEightLogPoly:
         f99c = IRApply(SUB, (g_k99c, g_kp1_99c))
         result = evaluate_sum(f99c, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase100FiveSqrtEightLogPoly:
+    """Phase 100: √k×5·log(k)^8 / k^m — completes Eight-Log family.
+
+    effective_x2 = sqrt1_x2 + … + sqrt5_x2 + 2·poly_deg.
+    Closes when 2·den_deg > effective_x2.
+    """
+
+    def test_sqrt_k_x5_log8_k_over_k3_closes(self):
+        """√k×5·log(k)^8/k³: eff_x2=5; 2·3=6 > 5 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k100a = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                                  IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                                  IRApply(SQRT, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1_100a = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                     IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                     IRApply(SQRT, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        g_k100a = IRApply(DIV, (num_k100a, k3))
+        g_kp1_100a = IRApply(DIV, (num_kp1_100a, kp1_3))
+        f100a = IRApply(SUB, (g_k100a, g_kp1_100a))
+        result = evaluate_sum(f100a, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k2_x5_log8_k_over_k6_closes(self):
+        """√(k²)×5·log(k)^8/k⁶: eff_x2=10; 2·6=12 > 10 → closes."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k100b = IRApply(MUL, (IRApply(SQRT, (k2,)), IRApply(SQRT, (k2,)),
+                                  IRApply(SQRT, (k2,)), IRApply(SQRT, (k2,)),
+                                  IRApply(SQRT, (k2,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1_100b = IRApply(MUL, (IRApply(SQRT, (kp1_2,)), IRApply(SQRT, (kp1_2,)),
+                                     IRApply(SQRT, (kp1_2,)), IRApply(SQRT, (kp1_2,)),
+                                     IRApply(SQRT, (kp1_2,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        k6 = IRApply(MUL, (k2, IRApply(MUL, (k2, k2))))
+        kp1_6 = IRApply(MUL, (kp1_2, IRApply(MUL, (kp1_2, kp1_2))))
+        g_k100b = IRApply(DIV, (num_k100b, k6))
+        g_kp1_100b = IRApply(DIV, (num_kp1_100b, kp1_6))
+        f100b = IRApply(SUB, (g_k100b, g_kp1_100b))
+        result = evaluate_sum(f100b, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x5_log8_k_times_k_over_k_refused(self):
+        """√k×5·log(k)^8·k/k: eff_x2=5+2=7; 2·1=2 not > 7 → refused."""
+        from symbolic_ir import SQRT, SUB
+
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k100c = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                                  IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                                  IRApply(SQRT, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                                  _k))
+        num_kp1_100c = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                     IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                     IRApply(SQRT, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                     kp1))
+        g_k100c = IRApply(DIV, (num_k100c, _k))
+        g_kp1_100c = IRApply(DIV, (num_kp1_100c, kp1))
+        f100c = IRApply(SUB, (g_k100c, g_kp1_100c))
+        result = evaluate_sum(f100c, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.37.0 — 2026-05-27
+
+### Added
+
+- **Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator** (`five_sqrt_eight_log_poly_effective_x2`):
+  recognises `Mul(Sqrt(P1), ..., Sqrt(P5), Log(h1), ..., Log(h8), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 8 Log factors required.
+  `effective_x2 = sum(sqrt_deg_x2) + 2·poly_deg`.
+  Closes when `2·den_deg > effective_x2` or non-polynomial diverging denominator.
+  Completes the Eight-Log family (Phases 95–100).
+  - 3 new tests (`phase100_*`).
+
 ## 2.36.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.36.0"
+version = "2.37.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2371,6 +2371,36 @@ fn two_sqrt_eight_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64
     Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
 }
 
+/// Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a)·…·sqrt(k^e)·log(k)⁸·k^m`. `log⁸(k)` is sub-polynomial.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + d + e + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`. Completes the Eight-Log family (Phases 95–100).
+fn five_sqrt_eight_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 5 { return None; } // sixth Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 8 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 5 || log_count != 8 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
 /// Phase 99 — Four-Sqrt × Eight-Log × polynomial numerator.
 ///
 /// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial.
@@ -3127,6 +3157,18 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
     if let Some(s2l8_x2) = two_sqrt_eight_log_poly_effective_x2(num, k) {
         if let Some(den_deg_s2l8) = polynomial_degree_in_k(den, k) {
             if 2 * den_deg_s2l8 > s2l8_x2 {
+                return true;
+            }
+        } else if h_diverges_at_infinity(den, k) {
+            return true;
+        }
+    }
+    // Phase 100: Mul(Sqrt×5, Log(diverging)×8, polynomial..., bounded...) numerator.
+    // Five Sqrt + eight Log factors; log⁸ sub-polynomial — effective_x2 = sum(sqrt_deg_x2) + 2·poly_deg.
+    // Closes when 2 * den_deg > effective_x2 or non-polynomial diverging denom.
+    if let Some(s5l8_x2) = five_sqrt_eight_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l8) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l8 > s5l8_x2 {
                 return true;
             }
         } else if h_diverges_at_infinity(den, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -4308,3 +4308,91 @@ fn phase99_sqrt_k_x4_log8_k_times_k_over_k_refused() {
     let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ── Phase 100: Five-Sqrt × Eight-Log × polynomial numerator (completes Eight-Log family) ─
+
+#[test]
+fn phase100_sqrt_k_x5_log8_k_over_k3_closes() {
+    // √k×5·log(k)^8 / k³: effective_x2=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k3 = apply(sym(POW), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym(POW), vec![kp1.clone(), int(3)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase100_sqrt_k2_x5_log8_k_over_k6_closes() {
+    // √(k²)×5·log(k)^8 / k⁶: effective_x2=10; 2·6=12 > 10 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym(POW), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym(POW), vec![kp1.clone(), int(2)]);
+    let sqrt_k2 = apply(sym("Sqrt"), vec![k2]);
+    let sqrt_kp1_2 = apply(sym("Sqrt"), vec![kp1_2]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let k6 = apply(sym(POW), vec![k.clone(), int(6)]);
+    let kp1_6 = apply(sym(POW), vec![kp1.clone(), int(6)]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k2.clone(), sqrt_k2.clone(), sqrt_k2.clone(), sqrt_k2.clone(), sqrt_k2,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1_2.clone(), sqrt_kp1_2.clone(), sqrt_kp1_2.clone(), sqrt_kp1_2.clone(), sqrt_kp1_2,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k6]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1_6]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase100_sqrt_k_x5_log8_k_times_k_over_k_refused() {
+    // √k×5·log(k)^8·k / k: effective_x2=5+2=7; 2·1=2 not > 7 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1 = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let out = evaluate_sum(f, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.37.0 — 2026-05-27
+
+### Added
+
+- **Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator** (`fiveSqrtEightLogPolyEffectiveDeg`):
+  recognises `Mul(Sqrt(P1), ..., Sqrt(P5), Log(h1), ..., Log(h8), polynomial..., bounded...)`.
+  Exactly 5 Sqrt factors and exactly 8 Log factors required.
+  `effectiveDeg = sum(sqrtHalfDegs) + polyDeg`.
+  Closes when `denDeg > effectiveDeg` or non-polynomial diverging denominator.
+  Completes the Eight-Log family (Phases 95–100).
+  - 3 new tests in `Phase 100` describe block.
+
 ## 2.36.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2127,6 +2127,39 @@ function twoSqrtEightLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | unde
 }
 
 /**
+ * Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator.
+ *
+ * Effective growth: `sqrt(k^a)·sqrt(k^b)·sqrt(k^c)·sqrt(k^d)·sqrt(k^e)·log(k)⁸·k^m`.
+ * `log⁸(k)` is sub-polynomial, contributing 0.
+ * effective degree = sum(sqrtHalfDegs) + polyDeg. Completes the Eight-Log family.
+ */
+function fiveSqrtEightLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined; // sixth Sqrt — refuse
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) {
+      logCount++;
+      if (logCount > 8) return undefined;
+      continue;
+    }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 8) return undefined;
+  return sqrtHalfDegs.reduce((a, b) => a + b, 0) + polyDeg;
+}
+
+/**
  * Phase 99 — Four-Sqrt × Eight-Log × polynomial numerator.
  *
  * Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial,
@@ -2951,6 +2984,18 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 100: Mul(Sqrt(P1)×5, Log(h1)×8, polynomial..., bounded...) numerator.
+  // Five Sqrt + eight Log factors; log⁸ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > fiveSqrtEightLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s5l8Deg = fiveSqrtEightLogPolyEffectiveDeg(num, k);
+  if (s5l8Deg !== undefined) {
+    const denDegS5l8 = polynomialDegreeInK(den, k);
+    if (denDegS5l8 !== undefined) {
+      if (denDegS5l8 > s5l8Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -4927,3 +4927,133 @@ describe("Phase 99 — Four-Sqrt × Eight-Log × polynomial numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+describe("Phase 100 — Five-Sqrt × Eight-Log × polynomial numerator (completes Eight-Log family)", () => {
+  it("√k×5·log(k)^8 / k³ closes (eff=2.5; denDeg=3 > 2.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k3 = { kind: "apply" as const, head: POW, args: [k, int(3)] };
+    const kp1_3 = { kind: "apply" as const, head: POW, args: [kp1, int(3)] };
+    const numK100a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1100a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK100a = { kind: "apply" as const, head: DIV, args: [numK100a, k3] };
+    const gKp1100a = { kind: "apply" as const, head: DIV, args: [numKp1100a, kp1_3] };
+    const f100a = { kind: "apply" as const, head: SUB, args: [gK100a, gKp1100a] };
+    const result = evaluateSum(f100a, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√(k²)×5·log(k)^8 / k⁶ closes (eff=5; denDeg=6 > 5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const k2 = { kind: "apply" as const, head: POW, args: [k, int(2)] };
+    const kp1_2 = { kind: "apply" as const, head: POW, args: [kp1, int(2)] };
+    const k6 = { kind: "apply" as const, head: POW, args: [k, int(6)] };
+    const kp1_6 = { kind: "apply" as const, head: POW, args: [kp1, int(6)] };
+    const numK100b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: SQRT, args: [k2] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+    ]};
+    const numKp1100b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_2] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+    ]};
+    const gK100b = { kind: "apply" as const, head: DIV, args: [numK100b, k6] };
+    const gKp1100b = { kind: "apply" as const, head: DIV, args: [numKp1100b, kp1_6] };
+    const f100b = { kind: "apply" as const, head: SUB, args: [gK100b, gKp1100b] };
+    const result = evaluateSum(f100b, k, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("√k×5·log(k)^8·k / k refused (eff=3.5; denDeg=1 not > 3.5)", () => {
+    const k = sym("k");
+    const kp1 = { kind: "apply" as const, head: ADD, args: [k, int(1)] };
+    const numK100c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: SQRT, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      { kind: "apply" as const, head: LOG, args: [k] },
+      k,
+    ]};
+    const numKp1100c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: SQRT, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      { kind: "apply" as const, head: LOG, args: [kp1] },
+      kp1,
+    ]};
+    const gK100c = { kind: "apply" as const, head: DIV, args: [numK100c, k] };
+    const gKp1100c = { kind: "apply" as const, head: DIV, args: [numKp1100c, kp1] };
+    const f100c = { kind: "apply" as const, head: SUB, args: [gK100c, gKp1100c] };
+    const result = evaluateSum(f100c, k, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

**Completes the Eight-Log family (Phases 95–100).** Adds Phase 100 convergence recognizer for telescoping series whose numerator is a product of exactly five Sqrt factors, exactly eight Log factors, optional polynomial factors, and optional bounded factors.

## Mathematics

The `log⁸(k)` factor is sub-polynomial — contributing 0 to the effective polynomial degree. Using the ×2 integer trick:

```
effective_x2 = sqrt1_deg_x2 + … + sqrt5_deg_x2 + 2·poly_deg
```

Converges when `2·den_deg > effective_x2` or denominator diverges non-polynomially.

## Changes

### Python (v2.37.0)
- Added `_five_sqrt_eight_log_poly_effective_x2` helper
- Added Phase 100 dispatch block
- 3 new unit tests (295 total, 92% coverage)

### TypeScript (v2.37.0)
- Added `fiveSqrtEightLogPolyEffectiveDeg` helper
- Added Phase 100 dispatch block
- 3 new tests (206 total)

### Rust (v2.37.0)
- Added `five_sqrt_eight_log_poly_effective_x2` helper
- Added Phase 100 dispatch block
- 3 new tests (189 total)

## Eight-Log family: COMPLETE ✅

| Phase | Pattern | Status |
|-------|---------|--------|
| 95 | Zero-Sqrt × Eight-Log | ✅ |
| 96 | One-Sqrt × Eight-Log | ✅ |
| 97 | Two-Sqrt × Eight-Log | ✅ |
| 98 | Three-Sqrt × Eight-Log | ✅ |
| 99 | Four-Sqrt × Eight-Log | ✅ |
| **100** | **Five-Sqrt × Eight-Log** | **✅ this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)