### PR TITLE
feat(cas-summation): Phases 155-160 — Eighteen-Log family (Python + TypeScript + Rust)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 2.97.0 — 2026-05-27
+
+### Added
+
+- **Phase 160 — Five-Sqrt × Eighteen-Log × polynomial** (`_five_sqrt_eighteen_log_poly_effective_x2`):
+  Completes the Eighteen-Log family (Phases 155–160).
+  `effective_x2 = sqrt1+…+sqrt5_deg_x2 + 2·poly_deg`.
+
+## 2.96.0 — 2026-05-27
+
+### Added
+
+- **Phase 159 — Four-Sqrt × Eighteen-Log × polynomial** (`_four_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+…+sqrt4_deg_x2 + 2·poly_deg`.
+
+## 2.95.0 — 2026-05-27
+
+### Added
+
+- **Phase 158 — Three-Sqrt × Eighteen-Log × polynomial** (`_three_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2+sqrt3_deg_x2 + 2·poly_deg`.
+
+## 2.94.0 — 2026-05-27
+
+### Added
+
+- **Phase 157 — Two-Sqrt × Eighteen-Log × polynomial** (`_two_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2_deg_x2 + 2·poly_deg`.
+
+## 2.93.0 — 2026-05-27
+
+### Added
+
+- **Phase 156 — One-Sqrt × Eighteen-Log × polynomial** (`_one_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+
+## 2.92.0 — 2026-05-27
+
+### Added
+
+- **Phase 155 — Eighteen-Log × polynomial** (`_eighteen_log_poly_effective_x2`):
+  `effective_x2 = 2·poly_deg`. No Sqrt factors; log(k)^18 grows sub-polynomially.
+
 ## 2.91.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.91.0"
+version = "2.97.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1463,6 +1463,62 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 160: ``Mul(Sqrt(P1)×5, Log(h1)×18, polynomial..., bounded...)`` numerator.
+    # Five Sqrt + eighteen Log factors; log^18 sub-polynomial → effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg.
+    # Closes when ``2·den_deg > effective_x2`` or non-polynomial diverging denominator.
+    s5l18p_x2 = _five_sqrt_eighteen_log_poly_effective_x2(num, k)
+    if s5l18p_x2 is not None:
+        den_deg_s5l18 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l18 is not None:
+            if 2 * den_deg_s5l18 > s5l18p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 159: ``Mul(Sqrt(P1)×4, Log(h1)×18, polynomial..., bounded...)`` numerator.
+    s4l18p_x2 = _four_sqrt_eighteen_log_poly_effective_x2(num, k)
+    if s4l18p_x2 is not None:
+        den_deg_s4l18 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l18 is not None:
+            if 2 * den_deg_s4l18 > s4l18p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 158: ``Mul(Sqrt(P1)×3, Log(h1)×18, polynomial..., bounded...)`` numerator.
+    s3l18p_x2 = _three_sqrt_eighteen_log_poly_effective_x2(num, k)
+    if s3l18p_x2 is not None:
+        den_deg_s3l18 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l18 is not None:
+            if 2 * den_deg_s3l18 > s3l18p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 157: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1)×18, polynomial..., bounded...)`` numerator.
+    s2l18p_x2 = _two_sqrt_eighteen_log_poly_effective_x2(num, k)
+    if s2l18p_x2 is not None:
+        den_deg_s2l18 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l18 is not None:
+            if 2 * den_deg_s2l18 > s2l18p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 156: ``Mul(Sqrt(P), Log(h1)×18, polynomial..., bounded...)`` numerator.
+    s1l18p_x2 = _one_sqrt_eighteen_log_poly_effective_x2(num, k)
+    if s1l18p_x2 is not None:
+        den_deg_s1l18 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l18 is not None:
+            if 2 * den_deg_s1l18 > s1l18p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 155: ``Mul(Log(h1)×18, polynomial..., bounded...)`` numerator.
+    sl18p_x2 = _eighteen_log_poly_effective_x2(num, k)
+    if sl18p_x2 is not None:
+        den_deg_sl18 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl18 is not None:
+            if 2 * den_deg_sl18 > sl18p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 154: ``Mul(Sqrt(P1)×5, Log(h1)×17, polynomial..., bounded...)`` numerator.
     # Five Sqrt + seventeen Log factors; log^17 sub-polynomial → effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg.
     # Closes when ``2·den_deg > effective_x2`` or non-polynomial diverging denominator.
@@ -6647,6 +6703,213 @@ def _five_sqrt_seventeen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 17:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly eighteen**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 155 — Eighteen-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)^18 · k^m``.  ``log^18(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick (no Sqrt factors present):
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    Sqrt factors are explicitly refused so that this function does not
+    shadow the Sqrt-bearing phases (Phase 156 onward).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 18:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 18:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator.
+    effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 18:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 18:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator.
+    effective_x2 = sqrt1 + sqrt2 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 18:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 18:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator.
+    effective_x2 = sqrt1 + sqrt2 + sqrt3 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 18:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 18:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator.
+    effective_x2 = sqrt1 + sqrt2 + sqrt3 + sqrt4 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 18:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 18:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator.
+    effective_x2 = sqrt1+sqrt2+sqrt3+sqrt4+sqrt5 + 2·poly_deg.
+    Completes the Eighteen-Log family (Phases 155-160).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 18:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 18:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -10520,3 +10520,641 @@ class TestPhase154FiveSqrtSeventeenLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase155EighteenLogPoly:
+    """Phase 155 — Eighteen-Log x polynomial numerator (zero Sqrt)."""
+
+    def test_log18_over_k2_closes(self):
+        """log(k)^18/k^2: eff_x2=0; 2*2=4 > 0 -> closes."""
+        from symbolic_ir import SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log18_times_k_over_k2_closes(self):
+        """log(k)^18*k/k^2: eff_x2=2; 2*2=4 > 2 -> closes."""
+        from symbolic_ir import SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log18_times_k_over_k_refused(self):
+        """log(k)^18*k/k: eff_x2=2; 2*1=2 not > 2 -> refused."""
+        from symbolic_ir import SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase156OneSqrtEighteenLogPoly:
+    """Phase 156 — One-Sqrt x Eighteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_log18_over_k2_closes(self):
+        """sqrt(k)*log(k)^18/k^2: eff_x2=1; 2*2=4 > 1 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log18_times_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^18*k/k^2: eff_x2=3; 2*2=4 > 3 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log18_times_k_over_k_refused(self):
+        """sqrt(k)*log(k)^18*k/k: eff_x2=3; 2*1=2 not > 3 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase157TwoSqrtEighteenLogPoly:
+    """Phase 157 — Two-Sqrt x Eighteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x2_log18_over_k2_closes(self):
+        """sqrt(k)x2*log(k)^18/k^2: eff_x2=2; 2*2=4 > 2 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x2_log18_times_k_over_k3_closes(self):
+        """sqrt(k)x2*log(k)^18*k/k^3: eff_x2=4; 2*3=6 > 4 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x2_log18_times_k_over_k2_refused(self):
+        """sqrt(k)x2*log(k)^18*k/k^2: eff_x2=4; 2*2=4 not > 4 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase158ThreeSqrtEighteenLogPoly:
+    """Phase 158 — Three-Sqrt x Eighteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x3_log18_over_k2_closes(self):
+        """sqrt(k)x3*log(k)^18/k^2: eff_x2=3; 2*2=4 > 3 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x3_log18_times_k_over_k3_closes(self):
+        """sqrt(k)x3*log(k)^18*k/k^3: eff_x2=5; 2*3=6 > 5 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x3_log18_times_k_over_k2_refused(self):
+        """sqrt(k)x3*log(k)^18*k/k^2: eff_x2=5; 2*2=4 not > 5 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase159FourSqrtEighteenLogPoly:
+    """Phase 159 — Four-Sqrt x Eighteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x4_log18_over_k3_closes(self):
+        """sqrt(k)x4*log(k)^18/k^3: eff_x2=4; 2*3=6 > 4 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x4_log18_times_k_over_k4_closes(self):
+        """sqrt(k)x4*log(k)^18*k/k^4: eff_x2=6; 2*4=8 > 6 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(MUL, (_k, IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))))
+        kp1_4 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x4_log18_times_k_over_k3_refused(self):
+        """sqrt(k)x4*log(k)^18*k/k^3: eff_x2=6; 2*3=6 not > 6 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase160FiveSqrtEighteenLogPoly:
+    """Phase 160 — Five-Sqrt x Eighteen-Log x polynomial numerator (completes Eighteen-Log family)."""
+
+    def test_sqrt_k_x5_log18_over_k3_closes(self):
+        """sqrt(k)x5*log(k)^18/k^3: eff_x2=5; 2*3=6 > 5 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x5_log18_times_k_over_k4_closes(self):
+        """sqrt(k)x5*log(k)^18*k/k^4: eff_x2=7; 2*4=8 > 7 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(MUL, (_k, IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))))
+        kp1_4 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x5_log18_times_k_over_k3_refused(self):
+        """sqrt(k)x5*log(k)^18*k/k^3: eff_x2=7; 2*3=6 not > 7 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 2.97.0 — 2026-05-27
+
+### Added
+
+- **Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator** (`five_sqrt_eighteen_log_poly_effective_x2`):
+  Completes the Eighteen-Log family (Phases 155–160).
+  `effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg`. Closes when `2·den_deg > effective_x2`.
+
+## 2.96.0 — 2026-05-27
+
+### Added
+
+- **Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator** (`four_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+…+sqrt4_deg_x2 + 2·poly_deg`.
+
+## 2.95.0 — 2026-05-27
+
+### Added
+
+- **Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator** (`three_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2+sqrt3_deg_x2 + 2·poly_deg`.
+
+## 2.94.0 — 2026-05-27
+
+### Added
+
+- **Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator** (`two_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2_deg_x2 + 2·poly_deg`.
+
+## 2.93.0 — 2026-05-27
+
+### Added
+
+- **Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator** (`one_sqrt_eighteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+
+## 2.92.0 — 2026-05-27
+
+### Added
+
+- **Phase 155 — Eighteen-Log × polynomial numerator** (`eighteen_log_poly_effective_x2`):
+  `effective_x2 = 2·poly_deg`. No Sqrt factors; log(k)^18 grows sub-polynomially.
+
 ## 2.91.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.91.0"
+version = "2.97.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -3870,6 +3870,184 @@ fn five_sqrt_seventeen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Optio
     Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
 }
 
+/// Phase 155 — Eighteen-Log × polynomial numerator.
+///
+/// Effective growth: `log(k)¹⁸ · k^m`. `log¹⁸(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+/// Sqrt factors are explicitly refused so this does not shadow Phase 156 onward.
+fn eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 18 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 18 { return None; }
+    Some(2 * poly_deg)
+}
+
+/// Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · log(k)¹⁸ · k^m`. `log¹⁸(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = a + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn one_sqrt_eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg_x2 = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 18 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let s = sqrt_deg_x2?;
+    if log_count != 18 { return None; }
+    Some(s + 2 * poly_deg)
+}
+
+/// Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)¹⁸ · k^m`. `log¹⁸(k)` is sub-polynomial.
+/// Using the ×2 integer trick: `effective_x2 = a + b + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn two_sqrt_eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 2 { return None; }
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 18 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 2 || log_count != 18 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
+/// Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · log(k)¹⁸ · k^m`. `log¹⁸(k)` is sub-polynomial.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn three_sqrt_eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 3 { return None; }
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 18 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 3 || log_count != 18 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
+/// Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · log(k)¹⁸ · k^m`.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + d + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn four_sqrt_eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 4 { return None; }
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 18 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 4 || log_count != 18 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
+/// Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator.
+/// Completes the Eighteen-Log family (Phases 155-160).
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · sqrt(k^e) · log(k)¹⁸ · k^m`.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + d + e + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn five_sqrt_eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 5 { return None; }
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 18 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 5 || log_count != 18 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
 /// Phase 96 — One-Sqrt × Eight-Log × polynomial numerator.
 ///
 /// Effective growth: `sqrt(k^a) · log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial (`o(k^ε)`),
@@ -4722,6 +4900,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 160: Mul(Sqrt(P1)×5, Log(diverging)×18, polynomial..., bounded...) numerator.
+    if let Some(s5l18_x2) = five_sqrt_eighteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l18) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l18 > s5l18_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 159: Mul(Sqrt(P1)×4, Log(diverging)×18, polynomial..., bounded...) numerator.
+    if let Some(s4l18_x2) = four_sqrt_eighteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l18) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l18 > s4l18_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 158: Mul(Sqrt(P1)×3, Log(diverging)×18, polynomial..., bounded...) numerator.
+    if let Some(s3l18_x2) = three_sqrt_eighteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l18) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l18 > s3l18_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 157: Mul(Sqrt(P1), Sqrt(P2), Log(diverging)×18, polynomial..., bounded...) numerator.
+    if let Some(s2l18_x2) = two_sqrt_eighteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l18) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l18 > s2l18_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 156: Mul(Sqrt(P), Log(diverging)×18, polynomial..., bounded...) numerator.
+    if let Some(s1l18_x2) = one_sqrt_eighteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l18) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l18 > s1l18_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 155: Mul(Log(diverging)×18, polynomial..., bounded...) numerator.
+    if let Some(sl18_x2) = eighteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl18) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl18 > sl18_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 154: Mul(Sqrt(P1)×5, Log(diverging)×17, polynomial..., bounded...) numerator.
     if let Some(s5l17_x2) = five_sqrt_seventeen_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -9414,3 +9414,611 @@ fn phase154_sqrt_k_x5_log17_k_times_k_over_k3_refused() {
     let out = evaluate_sum(f154c, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 155 — Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase155_log18_k_over_k2_closes() {
+    // log(k)^18 / k²: effective_x2=0; 2·2=4 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k155a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_155a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f155a = apply(sym(SUB), vec![g_k155a, g_kp1_155a]);
+    let out = evaluate_sum(f155a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase155_log18_k_times_k_over_k2_closes() {
+    // log(k)^18·k / k²: effective_x2=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k155b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_155b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f155b = apply(sym(SUB), vec![g_k155b, g_kp1_155b]);
+    let out = evaluate_sum(f155b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase155_log18_k_times_k_over_k_refused() {
+    // log(k)^18·k / k: effective_x2=2; 2·1=2 not > 2 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k155c = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1_155c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f155c = apply(sym(SUB), vec![g_k155c, g_kp1_155c]);
+    let out = evaluate_sum(f155c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase156_sqrt_k_log18_k_over_k2_closes() {
+    // √k·log(k)^18 / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k156a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_156a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f156a = apply(sym(SUB), vec![g_k156a, g_kp1_156a]);
+    let out = evaluate_sum(f156a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase156_sqrt_k_log18_k_times_k_over_k2_closes() {
+    // √k·log(k)^18·k / k²: effective_x2=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k156b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_156b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f156b = apply(sym(SUB), vec![g_k156b, g_kp1_156b]);
+    let out = evaluate_sum(f156b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase156_sqrt_k_log18_k_times_k_over_k_refused() {
+    // √k·log(k)^18·k / k: effective_x2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k156c = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1_156c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f156c = apply(sym(SUB), vec![g_k156c, g_kp1_156c]);
+    let out = evaluate_sum(f156c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase157_sqrt_k_x2_log18_k_over_k2_closes() {
+    // √k²·log(k)^18 / k²: effective_x2=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k157a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_157a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f157a = apply(sym(SUB), vec![g_k157a, g_kp1_157a]);
+    let out = evaluate_sum(f157a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase157_sqrt_k_x2_log18_k_times_k_over_k3_closes() {
+    // √k²·log(k)^18·k / k³: effective_x2=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k157b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_157b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f157b = apply(sym(SUB), vec![g_k157b, g_kp1_157b]);
+    let out = evaluate_sum(f157b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase157_sqrt_k_x2_log18_k_times_k_over_k2_refused() {
+    // √k²·log(k)^18·k / k²: effective_x2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k157c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_157c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f157c = apply(sym(SUB), vec![g_k157c, g_kp1_157c]);
+    let out = evaluate_sum(f157c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase158_sqrt_k_x3_log18_k_over_k2_closes() {
+    // √k³·log(k)^18 / k²: effective_x2=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k158a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_158a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f158a = apply(sym(SUB), vec![g_k158a, g_kp1_158a]);
+    let out = evaluate_sum(f158a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase158_sqrt_k_x3_log18_k_times_k_over_k3_closes() {
+    // √k³·log(k)^18·k / k³: effective_x2=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k158b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_158b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f158b = apply(sym(SUB), vec![g_k158b, g_kp1_158b]);
+    let out = evaluate_sum(f158b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase158_sqrt_k_x3_log18_k_times_k_over_k2_refused() {
+    // √k³·log(k)^18·k / k²: effective_x2=5; 2·2=4 not > 5 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k158c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_158c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f158c = apply(sym(SUB), vec![g_k158c, g_kp1_158c]);
+    let out = evaluate_sum(f158c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase159_sqrt_k_x4_log18_k_over_k3_closes() {
+    // √k⁴·log(k)^18 / k³: effective_x2=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k159a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_159a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f159a = apply(sym(SUB), vec![g_k159a, g_kp1_159a]);
+    let out = evaluate_sum(f159a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase159_sqrt_k_x4_log18_k_times_k_over_k4_closes() {
+    // √k⁴·log(k)^18·k / k⁴: effective_x2=6; 2·4=8 > 6 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k4 = apply(sym("Pow"), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym("Pow"), vec![kp1.clone(), int(4)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k159b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_159b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f159b = apply(sym(SUB), vec![g_k159b, g_kp1_159b]);
+    let out = evaluate_sum(f159b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase159_sqrt_k_x4_log18_k_times_k_over_k3_refused() {
+    // √k⁴·log(k)^18·k / k³: effective_x2=6; 2·3=6 not > 6 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3s = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3s = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k159c = apply(sym(DIV), vec![num_k, k3s]);
+    let g_kp1_159c = apply(sym(DIV), vec![num_kp1, kp1_3s]);
+    let f159c = apply(sym(SUB), vec![g_k159c, g_kp1_159c]);
+    let out = evaluate_sum(f159c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase160_sqrt_k_x5_log18_k_over_k3_closes() {
+    // √k⁵·log(k)^18 / k³: effective_x2=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k160a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_160a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f160a = apply(sym(SUB), vec![g_k160a, g_kp1_160a]);
+    let out = evaluate_sum(f160a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase160_sqrt_k_x5_log18_k_times_k_over_k4_closes() {
+    // √k⁵·log(k)^18·k / k⁴: effective_x2=7; 2·4=8 > 7 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k4 = apply(sym("Pow"), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym("Pow"), vec![kp1.clone(), int(4)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k160b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_160b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f160b = apply(sym(SUB), vec![g_k160b, g_kp1_160b]);
+    let out = evaluate_sum(f160b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase160_sqrt_k_x5_log18_k_times_k_over_k3_refused() {
+    // √k⁵·log(k)^18·k / k³: effective_x2=7; 2·3=6 not > 7 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3s = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3s = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k160c = apply(sym(DIV), vec![num_k, k3s]);
+    let g_kp1_160c = apply(sym(DIV), vec![num_kp1, kp1_3s]);
+    let f160c = apply(sym(SUB), vec![g_k160c, g_kp1_160c]);
+    let out = evaluate_sum(f160c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 2.97.0 — 2026-05-27
+
+### Added
+
+- **Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator** (`fiveSqrtEighteenLogPolyEffectiveDeg`):
+  Completes the Eighteen-Log family (Phases 155–160).
+  `effectiveDeg = sqrtHalfDeg1+…+sqrtHalfDeg5 + polyDeg`.
+
+## 2.96.0 — 2026-05-27
+
+### Added
+
+- **Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator** (`fourSqrtEighteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg1+…+sqrtHalfDeg4 + polyDeg`.
+
+## 2.95.0 — 2026-05-27
+
+### Added
+
+- **Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator** (`threeSqrtEighteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg1+sqrtHalfDeg2+sqrtHalfDeg3 + polyDeg`.
+
+## 2.94.0 — 2026-05-27
+
+### Added
+
+- **Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator** (`twoSqrtEighteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg1+sqrtHalfDeg2 + polyDeg`.
+
+## 2.93.0 — 2026-05-27
+
+### Added
+
+- **Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator** (`oneSqrtEighteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg + polyDeg`.
+
+## 2.92.0 — 2026-05-27
+
+### Added
+
+- **Phase 155 — Eighteen-Log × polynomial numerator** (`eighteenLogPolyEffectiveDeg`):
+  `effectiveDeg = polyDeg`. No Sqrt factors; log(k)^18 grows sub-polynomially.
+
 ## 2.91.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.91.0",
+  "version": "2.97.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -2968,6 +2968,145 @@ function fiveSqrtSeventeenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number |
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+function eighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 155 — Eighteen-Log × polynomial numerator.
+  // log^18(k) is sub-polynomial; effective degree = polyDeg. No Sqrt factors allowed.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // no Sqrts allowed
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 18) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 18) return undefined;
+  return polyDeg;
+}
+
+function oneSqrtEighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDeg + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 18) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 18) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+function twoSqrtEighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 18) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 18) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+function threeSqrtEighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 18) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 18) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+function fourSqrtEighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + … + sqrtHalfDegs[3] + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 18) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 18) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+function fiveSqrtEighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + … + sqrtHalfDegs[4] + polyDeg.
+  // Completes the Eighteen-Log family (Phases 155-160).
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 18) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 18) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 function tenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
   if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
   let logCount = 0;
@@ -4178,6 +4317,78 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 160: Mul(Sqrt(P1)×5, Log(h1)×18, polynomial..., bounded...) numerator.
+  // Five Sqrt + eighteen Log factors; log¹⁸ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > fiveSqrtEighteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s5l18Deg = fiveSqrtEighteenLogPolyEffectiveDeg(num, k);
+  if (s5l18Deg !== undefined) {
+    const denDegS5l18 = polynomialDegreeInK(den, k);
+    if (denDegS5l18 !== undefined) {
+      if (denDegS5l18 > s5l18Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 159: Mul(Sqrt(P1)×4, Log(h1)×18, polynomial..., bounded...) numerator.
+  // Four Sqrt + eighteen Log factors; log¹⁸ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > fourSqrtEighteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s4l18Deg = fourSqrtEighteenLogPolyEffectiveDeg(num, k);
+  if (s4l18Deg !== undefined) {
+    const denDegS4l18 = polynomialDegreeInK(den, k);
+    if (denDegS4l18 !== undefined) {
+      if (denDegS4l18 > s4l18Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 158: Mul(Sqrt(P1)×3, Log(h1)×18, polynomial..., bounded...) numerator.
+  // Three Sqrt + eighteen Log factors; log¹⁸ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > threeSqrtEighteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s3l18Deg = threeSqrtEighteenLogPolyEffectiveDeg(num, k);
+  if (s3l18Deg !== undefined) {
+    const denDegS3l18 = polynomialDegreeInK(den, k);
+    if (denDegS3l18 !== undefined) {
+      if (denDegS3l18 > s3l18Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 157: Mul(Sqrt(P1), Sqrt(P2), Log(h1)×18, polynomial..., bounded...) numerator.
+  // Two Sqrt + eighteen Log factors; log¹⁸ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > twoSqrtEighteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s2l18Deg = twoSqrtEighteenLogPolyEffectiveDeg(num, k);
+  if (s2l18Deg !== undefined) {
+    const denDegS2l18 = polynomialDegreeInK(den, k);
+    if (denDegS2l18 !== undefined) {
+      if (denDegS2l18 > s2l18Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 156: Mul(Sqrt(P), Log(h1)×18, polynomial..., bounded...) numerator.
+  // One Sqrt + eighteen Log factors; log¹⁸ sub-polynomial → effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtEighteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l18Deg = oneSqrtEighteenLogPolyEffectiveDeg(num, k);
+  if (s1l18Deg !== undefined) {
+    const denDegS1l18 = polynomialDegreeInK(den, k);
+    if (denDegS1l18 !== undefined) {
+      if (denDegS1l18 > s1l18Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 155: Mul(Log(h1)×18, polynomial..., bounded...) numerator.
+  // Zero Sqrt + eighteen Log factors; log¹⁸ sub-polynomial → effective degree = polyDeg.
+  // Closes when denDeg > eighteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const sl18Deg = eighteenLogPolyEffectiveDeg(num, k);
+  if (sl18Deg !== undefined) {
+    const denDegSl18 = polynomialDegreeInK(den, k);
+    if (denDegSl18 !== undefined) {
+      if (denDegSl18 > sl18Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -12947,3 +12947,1079 @@ describe("Phase 154: FiveSqrt × SeventeenLog × poly numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 155 — Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 155: EighteenLog × poly numerator", () => {
+  it("log(k)^18/k^2 closes (eff=0, denDeg=2 > 0)", () => {
+    const k155a = sym("k");
+    const kp1_155a = { kind: "apply" as const, head: ADD, args: [k155a, int(1)] };
+    const k2_155a = { kind: "apply" as const, head: POW, args: [k155a, int(2)] };
+    const kp12_155a = { kind: "apply" as const, head: POW, args: [kp1_155a, int(2)] };
+    const numK_155a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+      { kind: "apply" as const, head: LOG, args: [k155a] },
+    ]};
+    const numKp1_155a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155a] },
+    ]};
+    const gK155a = { kind: "apply" as const, head: DIV, args: [numK_155a, k2_155a] };
+    const gKp1_155a = { kind: "apply" as const, head: DIV, args: [numKp1_155a, kp12_155a] };
+    const f155a = { kind: "apply" as const, head: SUB, args: [gK155a, gKp1_155a] };
+    const result = evaluateSum(f155a, k155a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^18*k/k^2 closes (eff=1, denDeg=2 > 1)", () => {
+    const k155b = sym("k");
+    const kp1_155b = { kind: "apply" as const, head: ADD, args: [k155b, int(1)] };
+    const k2_155b = { kind: "apply" as const, head: POW, args: [k155b, int(2)] };
+    const kp12_155b = { kind: "apply" as const, head: POW, args: [kp1_155b, int(2)] };
+    const numK_155b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      { kind: "apply" as const, head: LOG, args: [k155b] },
+      k155b,
+    ]};
+    const numKp1_155b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155b] },
+      kp1_155b,
+    ]};
+    const gK155b = { kind: "apply" as const, head: DIV, args: [numK_155b, k2_155b] };
+    const gKp1_155b = { kind: "apply" as const, head: DIV, args: [numKp1_155b, kp12_155b] };
+    const f155b = { kind: "apply" as const, head: SUB, args: [gK155b, gKp1_155b] };
+    const result = evaluateSum(f155b, k155b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^18*k/k refused (eff=1, denDeg=1 not > 1)", () => {
+    const k155c = sym("k");
+    const kp1_155c = { kind: "apply" as const, head: ADD, args: [k155c, int(1)] };
+    const numK_155c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      { kind: "apply" as const, head: LOG, args: [k155c] },
+      k155c,
+    ]};
+    const numKp1_155c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_155c] },
+      kp1_155c,
+    ]};
+    const gK155c = { kind: "apply" as const, head: DIV, args: [numK_155c, k155c] };
+    const gKp1_155c = { kind: "apply" as const, head: DIV, args: [numKp1_155c, kp1_155c] };
+    const f155c = { kind: "apply" as const, head: SUB, args: [gK155c, gKp1_155c] };
+    const result = evaluateSum(f155c, k155c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 156 — One-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 156: OneSqrt × EighteenLog × poly numerator", () => {
+  it("sqrt(k)*log(k)^18/k^2 closes (eff=0.5, denDeg=2 > 0.5)", () => {
+    const k156a = sym("k");
+    const kp1_156a = { kind: "apply" as const, head: ADD, args: [k156a, int(1)] };
+    const k2_156a = { kind: "apply" as const, head: POW, args: [k156a, int(2)] };
+    const kp12_156a = { kind: "apply" as const, head: POW, args: [kp1_156a, int(2)] };
+    const numK_156a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+      { kind: "apply" as const, head: LOG, args: [k156a] },
+    ]};
+    const numKp1_156a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156a] },
+    ]};
+    const gK156a = { kind: "apply" as const, head: DIV, args: [numK_156a, k2_156a] };
+    const gKp1_156a = { kind: "apply" as const, head: DIV, args: [numKp1_156a, kp12_156a] };
+    const f156a = { kind: "apply" as const, head: SUB, args: [gK156a, gKp1_156a] };
+    const result = evaluateSum(f156a, k156a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)*log(k)^18*k/k^2 closes (eff=1.5, denDeg=2 > 1.5)", () => {
+    const k156b = sym("k");
+    const kp1_156b = { kind: "apply" as const, head: ADD, args: [k156b, int(1)] };
+    const k2_156b = { kind: "apply" as const, head: POW, args: [k156b, int(2)] };
+    const kp12_156b = { kind: "apply" as const, head: POW, args: [kp1_156b, int(2)] };
+    const numK_156b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      { kind: "apply" as const, head: LOG, args: [k156b] },
+      k156b,
+    ]};
+    const numKp1_156b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156b] },
+      kp1_156b,
+    ]};
+    const gK156b = { kind: "apply" as const, head: DIV, args: [numK_156b, k2_156b] };
+    const gKp1_156b = { kind: "apply" as const, head: DIV, args: [numKp1_156b, kp12_156b] };
+    const f156b = { kind: "apply" as const, head: SUB, args: [gK156b, gKp1_156b] };
+    const result = evaluateSum(f156b, k156b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)*log(k)^18*k/k refused (eff=1.5, denDeg=1 not > 1.5)", () => {
+    const k156c = sym("k");
+    const kp1_156c = { kind: "apply" as const, head: ADD, args: [k156c, int(1)] };
+    const numK_156c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      { kind: "apply" as const, head: LOG, args: [k156c] },
+      k156c,
+    ]};
+    const numKp1_156c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_156c] },
+      kp1_156c,
+    ]};
+    const gK156c = { kind: "apply" as const, head: DIV, args: [numK_156c, k156c] };
+    const gKp1_156c = { kind: "apply" as const, head: DIV, args: [numKp1_156c, kp1_156c] };
+    const f156c = { kind: "apply" as const, head: SUB, args: [gK156c, gKp1_156c] };
+    const result = evaluateSum(f156c, k156c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 157 — Two-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 157: TwoSqrt × EighteenLog × poly numerator", () => {
+  it("sqrt(k)^2*log(k)^18/k^2 closes (eff=1, denDeg=2 > 1)", () => {
+    const k157a = sym("k");
+    const kp1_157a = { kind: "apply" as const, head: ADD, args: [k157a, int(1)] };
+    const k2_157a = { kind: "apply" as const, head: POW, args: [k157a, int(2)] };
+    const kp12_157a = { kind: "apply" as const, head: POW, args: [kp1_157a, int(2)] };
+    const numK_157a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k157a] },
+      { kind: "apply" as const, head: SQRT, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+      { kind: "apply" as const, head: LOG, args: [k157a] },
+    ]};
+    const numKp1_157a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_157a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157a] },
+    ]};
+    const gK157a = { kind: "apply" as const, head: DIV, args: [numK_157a, k2_157a] };
+    const gKp1_157a = { kind: "apply" as const, head: DIV, args: [numKp1_157a, kp12_157a] };
+    const f157a = { kind: "apply" as const, head: SUB, args: [gK157a, gKp1_157a] };
+    const result = evaluateSum(f157a, k157a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^2*log(k)^18*k/k^3 closes (eff=2, denDeg=3 > 2)", () => {
+    const k157b = sym("k");
+    const kp1_157b = { kind: "apply" as const, head: ADD, args: [k157b, int(1)] };
+    const k3_157b = { kind: "apply" as const, head: POW, args: [k157b, int(3)] };
+    const kp13_157b = { kind: "apply" as const, head: POW, args: [kp1_157b, int(3)] };
+    const numK_157b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k157b] },
+      { kind: "apply" as const, head: SQRT, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      { kind: "apply" as const, head: LOG, args: [k157b] },
+      k157b,
+    ]};
+    const numKp1_157b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_157b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157b] },
+      kp1_157b,
+    ]};
+    const gK157b = { kind: "apply" as const, head: DIV, args: [numK_157b, k3_157b] };
+    const gKp1_157b = { kind: "apply" as const, head: DIV, args: [numKp1_157b, kp13_157b] };
+    const f157b = { kind: "apply" as const, head: SUB, args: [gK157b, gKp1_157b] };
+    const result = evaluateSum(f157b, k157b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^2*log(k)^18*k/k^2 refused (eff=2, denDeg=2 not > 2)", () => {
+    const k157c = sym("k");
+    const kp1_157c = { kind: "apply" as const, head: ADD, args: [k157c, int(1)] };
+    const k2_157c = { kind: "apply" as const, head: POW, args: [k157c, int(2)] };
+    const kp12_157c = { kind: "apply" as const, head: POW, args: [kp1_157c, int(2)] };
+    const numK_157c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k157c] },
+      { kind: "apply" as const, head: SQRT, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      { kind: "apply" as const, head: LOG, args: [k157c] },
+      k157c,
+    ]};
+    const numKp1_157c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_157c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_157c] },
+      kp1_157c,
+    ]};
+    const gK157c = { kind: "apply" as const, head: DIV, args: [numK_157c, k2_157c] };
+    const gKp1_157c = { kind: "apply" as const, head: DIV, args: [numKp1_157c, kp12_157c] };
+    const f157c = { kind: "apply" as const, head: SUB, args: [gK157c, gKp1_157c] };
+    const result = evaluateSum(f157c, k157c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 158 — Three-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 158: ThreeSqrt × EighteenLog × poly numerator", () => {
+  it("sqrt(k)^3*log(k)^18/k^2 closes (eff=1.5, denDeg=2 > 1.5)", () => {
+    const k158a = sym("k");
+    const kp1_158a = { kind: "apply" as const, head: ADD, args: [k158a, int(1)] };
+    const k2_158a = { kind: "apply" as const, head: POW, args: [k158a, int(2)] };
+    const kp12_158a = { kind: "apply" as const, head: POW, args: [kp1_158a, int(2)] };
+    const numK_158a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k158a] },
+      { kind: "apply" as const, head: SQRT, args: [k158a] },
+      { kind: "apply" as const, head: SQRT, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+      { kind: "apply" as const, head: LOG, args: [k158a] },
+    ]};
+    const numKp1_158a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_158a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_158a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158a] },
+    ]};
+    const gK158a = { kind: "apply" as const, head: DIV, args: [numK_158a, k2_158a] };
+    const gKp1_158a = { kind: "apply" as const, head: DIV, args: [numKp1_158a, kp12_158a] };
+    const f158a = { kind: "apply" as const, head: SUB, args: [gK158a, gKp1_158a] };
+    const result = evaluateSum(f158a, k158a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^3*log(k)^18*k/k^3 closes (eff=2.5, denDeg=3 > 2.5)", () => {
+    const k158b = sym("k");
+    const kp1_158b = { kind: "apply" as const, head: ADD, args: [k158b, int(1)] };
+    const k3_158b = { kind: "apply" as const, head: POW, args: [k158b, int(3)] };
+    const kp13_158b = { kind: "apply" as const, head: POW, args: [kp1_158b, int(3)] };
+    const numK_158b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k158b] },
+      { kind: "apply" as const, head: SQRT, args: [k158b] },
+      { kind: "apply" as const, head: SQRT, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      { kind: "apply" as const, head: LOG, args: [k158b] },
+      k158b,
+    ]};
+    const numKp1_158b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_158b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_158b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158b] },
+      kp1_158b,
+    ]};
+    const gK158b = { kind: "apply" as const, head: DIV, args: [numK_158b, k3_158b] };
+    const gKp1_158b = { kind: "apply" as const, head: DIV, args: [numKp1_158b, kp13_158b] };
+    const f158b = { kind: "apply" as const, head: SUB, args: [gK158b, gKp1_158b] };
+    const result = evaluateSum(f158b, k158b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^3*log(k)^18*k/k^2 refused (eff=2.5, denDeg=2 not > 2.5)", () => {
+    const k158c = sym("k");
+    const kp1_158c = { kind: "apply" as const, head: ADD, args: [k158c, int(1)] };
+    const k2_158c = { kind: "apply" as const, head: POW, args: [k158c, int(2)] };
+    const kp12_158c = { kind: "apply" as const, head: POW, args: [kp1_158c, int(2)] };
+    const numK_158c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k158c] },
+      { kind: "apply" as const, head: SQRT, args: [k158c] },
+      { kind: "apply" as const, head: SQRT, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      { kind: "apply" as const, head: LOG, args: [k158c] },
+      k158c,
+    ]};
+    const numKp1_158c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_158c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_158c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_158c] },
+      kp1_158c,
+    ]};
+    const gK158c = { kind: "apply" as const, head: DIV, args: [numK_158c, k2_158c] };
+    const gKp1_158c = { kind: "apply" as const, head: DIV, args: [numKp1_158c, kp12_158c] };
+    const f158c = { kind: "apply" as const, head: SUB, args: [gK158c, gKp1_158c] };
+    const result = evaluateSum(f158c, k158c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 159 — Four-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 159: FourSqrt × EighteenLog × poly numerator", () => {
+  it("sqrt(k)^4*log(k)^18/k^3 closes (eff=2, denDeg=3 > 2)", () => {
+    const k159a = sym("k");
+    const kp1_159a = { kind: "apply" as const, head: ADD, args: [k159a, int(1)] };
+    const k3_159a = { kind: "apply" as const, head: POW, args: [k159a, int(3)] };
+    const kp13_159a = { kind: "apply" as const, head: POW, args: [kp1_159a, int(3)] };
+    const numK_159a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k159a] },
+      { kind: "apply" as const, head: SQRT, args: [k159a] },
+      { kind: "apply" as const, head: SQRT, args: [k159a] },
+      { kind: "apply" as const, head: SQRT, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+      { kind: "apply" as const, head: LOG, args: [k159a] },
+    ]};
+    const numKp1_159a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_159a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159a] },
+    ]};
+    const gK159a = { kind: "apply" as const, head: DIV, args: [numK_159a, k3_159a] };
+    const gKp1_159a = { kind: "apply" as const, head: DIV, args: [numKp1_159a, kp13_159a] };
+    const f159a = { kind: "apply" as const, head: SUB, args: [gK159a, gKp1_159a] };
+    const result = evaluateSum(f159a, k159a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^4*log(k)^18*k/k^4 closes (eff=3, denDeg=4 > 3)", () => {
+    const k159b = sym("k");
+    const kp1_159b = { kind: "apply" as const, head: ADD, args: [k159b, int(1)] };
+    const k4_159b = { kind: "apply" as const, head: POW, args: [k159b, int(4)] };
+    const kp14_159b = { kind: "apply" as const, head: POW, args: [kp1_159b, int(4)] };
+    const numK_159b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k159b] },
+      { kind: "apply" as const, head: SQRT, args: [k159b] },
+      { kind: "apply" as const, head: SQRT, args: [k159b] },
+      { kind: "apply" as const, head: SQRT, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      { kind: "apply" as const, head: LOG, args: [k159b] },
+      k159b,
+    ]};
+    const numKp1_159b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_159b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159b] },
+      kp1_159b,
+    ]};
+    const gK159b = { kind: "apply" as const, head: DIV, args: [numK_159b, k4_159b] };
+    const gKp1_159b = { kind: "apply" as const, head: DIV, args: [numKp1_159b, kp14_159b] };
+    const f159b = { kind: "apply" as const, head: SUB, args: [gK159b, gKp1_159b] };
+    const result = evaluateSum(f159b, k159b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^4*log(k)^18*k/k^3 refused (eff=3, denDeg=3 not > 3)", () => {
+    const k159c = sym("k");
+    const kp1_159c = { kind: "apply" as const, head: ADD, args: [k159c, int(1)] };
+    const k3_159c = { kind: "apply" as const, head: POW, args: [k159c, int(3)] };
+    const kp13_159c = { kind: "apply" as const, head: POW, args: [kp1_159c, int(3)] };
+    const numK_159c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k159c] },
+      { kind: "apply" as const, head: SQRT, args: [k159c] },
+      { kind: "apply" as const, head: SQRT, args: [k159c] },
+      { kind: "apply" as const, head: SQRT, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      { kind: "apply" as const, head: LOG, args: [k159c] },
+      k159c,
+    ]};
+    const numKp1_159c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_159c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_159c] },
+      kp1_159c,
+    ]};
+    const gK159c = { kind: "apply" as const, head: DIV, args: [numK_159c, k3_159c] };
+    const gKp1_159c = { kind: "apply" as const, head: DIV, args: [numKp1_159c, kp13_159c] };
+    const f159c = { kind: "apply" as const, head: SUB, args: [gK159c, gKp1_159c] };
+    const result = evaluateSum(f159c, k159c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 160 — Five-Sqrt × Eighteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 160: FiveSqrt × EighteenLog × poly numerator", () => {
+  it("sqrt(k)^5*log(k)^18/k^3 closes (eff=2.5, denDeg=3 > 2.5)", () => {
+    const k160a = sym("k");
+    const kp1_160a = { kind: "apply" as const, head: ADD, args: [k160a, int(1)] };
+    const k3_160a = { kind: "apply" as const, head: POW, args: [k160a, int(3)] };
+    const kp13_160a = { kind: "apply" as const, head: POW, args: [kp1_160a, int(3)] };
+    const numK_160a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k160a] },
+      { kind: "apply" as const, head: SQRT, args: [k160a] },
+      { kind: "apply" as const, head: SQRT, args: [k160a] },
+      { kind: "apply" as const, head: SQRT, args: [k160a] },
+      { kind: "apply" as const, head: SQRT, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+      { kind: "apply" as const, head: LOG, args: [k160a] },
+    ]};
+    const numKp1_160a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_160a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160a] },
+    ]};
+    const gK160a = { kind: "apply" as const, head: DIV, args: [numK_160a, k3_160a] };
+    const gKp1_160a = { kind: "apply" as const, head: DIV, args: [numKp1_160a, kp13_160a] };
+    const f160a = { kind: "apply" as const, head: SUB, args: [gK160a, gKp1_160a] };
+    const result = evaluateSum(f160a, k160a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^5*log(k)^18*k/k^4 closes (eff=3.5, denDeg=4 > 3.5)", () => {
+    const k160b = sym("k");
+    const kp1_160b = { kind: "apply" as const, head: ADD, args: [k160b, int(1)] };
+    const k4_160b = { kind: "apply" as const, head: POW, args: [k160b, int(4)] };
+    const kp14_160b = { kind: "apply" as const, head: POW, args: [kp1_160b, int(4)] };
+    const numK_160b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k160b] },
+      { kind: "apply" as const, head: SQRT, args: [k160b] },
+      { kind: "apply" as const, head: SQRT, args: [k160b] },
+      { kind: "apply" as const, head: SQRT, args: [k160b] },
+      { kind: "apply" as const, head: SQRT, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      { kind: "apply" as const, head: LOG, args: [k160b] },
+      k160b,
+    ]};
+    const numKp1_160b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_160b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160b] },
+      kp1_160b,
+    ]};
+    const gK160b = { kind: "apply" as const, head: DIV, args: [numK_160b, k4_160b] };
+    const gKp1_160b = { kind: "apply" as const, head: DIV, args: [numKp1_160b, kp14_160b] };
+    const f160b = { kind: "apply" as const, head: SUB, args: [gK160b, gKp1_160b] };
+    const result = evaluateSum(f160b, k160b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)^5*log(k)^18*k/k^3 refused (eff=3.5, denDeg=3 not > 3.5)", () => {
+    const k160c = sym("k");
+    const kp1_160c = { kind: "apply" as const, head: ADD, args: [k160c, int(1)] };
+    const k3_160c = { kind: "apply" as const, head: POW, args: [k160c, int(3)] };
+    const kp13_160c = { kind: "apply" as const, head: POW, args: [kp1_160c, int(3)] };
+    const numK_160c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k160c] },
+      { kind: "apply" as const, head: SQRT, args: [k160c] },
+      { kind: "apply" as const, head: SQRT, args: [k160c] },
+      { kind: "apply" as const, head: SQRT, args: [k160c] },
+      { kind: "apply" as const, head: SQRT, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      { kind: "apply" as const, head: LOG, args: [k160c] },
+      k160c,
+    ]};
+    const numKp1_160c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_160c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_160c] },
+      kp1_160c,
+    ]};
+    const gK160c = { kind: "apply" as const, head: DIV, args: [numK_160c, k3_160c] };
+    const gKp1_160c = { kind: "apply" as const, head: DIV, args: [numKp1_160c, kp13_160c] };
+    const f160c = { kind: "apply" as const, head: SUB, args: [gK160c, gKp1_160c] };
+    const result = evaluateSum(f160c, k160c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Eighteen-Log family (Phases 155–160) of the cas-summation convergence recognizer across Python, TypeScript, and Rust.

## Phases added

| Phase | Pattern | Helper |
|-------|---------|--------|
| 155 | Zero-Sqrt × Eighteen-Log × polynomial | `_eighteen_log_poly_effective_x2` |
| 156 | One-Sqrt × Eighteen-Log × polynomial | `_one_sqrt_eighteen_log_poly_effective_x2` |
| 157 | Two-Sqrt × Eighteen-Log × polynomial | `_two_sqrt_eighteen_log_poly_effective_x2` |
| 158 | Three-Sqrt × Eighteen-Log × polynomial | `_three_sqrt_eighteen_log_poly_effective_x2` |
| 159 | Four-Sqrt × Eighteen-Log × polynomial | `_four_sqrt_eighteen_log_poly_effective_x2` |
| 160 | Five-Sqrt × Eighteen-Log × polynomial | `_five_sqrt_eighteen_log_poly_effective_x2` |

## Key invariants

- `log(k)^18` is sub-polynomial (`o(k^ε)`) → contributes 0 to effective degree
- `effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg` (Python/Rust)
- `effectiveDeg = sum(sqrtHalfDegs) + polyDeg` (TypeScript)
- Convergence: `2·den_deg > effective_x2`
- Dispatch order: 160 → 155 (descending), inserted before Phase 154 block
- Sqrt factors explicitly refused in Phase 155 to avoid shadowing Phase 156+

## Test counts

- Python: 18 new tests (TestPhase155–160), 433 total, 89.87% coverage
- TypeScript: 18 new tests, 386 total
- Rust: 18 new tests, all passing

## Version

v2.91.0 → v2.97.0 (one minor bump per phase)

Stacks on #4497

🤖 Generated with [Claude Code](https://claude.com/claude-code)