### PR TITLE
feat(cas-summation): Phases 161-166 — Nineteen-Log family (Python + TypeScript + Rust)

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 2.103.0 — 2026-05-27
+
+### Added
+
+- **Phase 166 — Five-Sqrt × Nineteen-Log × polynomial** (`_five_sqrt_nineteen_log_poly_effective_x2`):
+  Completes the Nineteen-Log family (Phases 161–166).
+  `effective_x2 = sqrt1+…+sqrt5_deg_x2 + 2·poly_deg`.
+
+## 2.102.0 — 2026-05-27
+
+### Added
+
+- **Phase 165 — Four-Sqrt × Nineteen-Log × polynomial** (`_four_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2+sqrt3+sqrt4_deg_x2 + 2·poly_deg`.
+
+## 2.101.0 — 2026-05-27
+
+### Added
+
+- **Phase 164 — Three-Sqrt × Nineteen-Log × polynomial** (`_three_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2+sqrt3_deg_x2 + 2·poly_deg`.
+
+## 2.100.0 — 2026-05-27
+
+### Added
+
+- **Phase 163 — Two-Sqrt × Nineteen-Log × polynomial** (`_two_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2_deg_x2 + 2·poly_deg`.
+
+## 2.99.0 — 2026-05-27
+
+### Added
+
+- **Phase 162 — One-Sqrt × Nineteen-Log × polynomial** (`_one_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+
+## 2.98.0 — 2026-05-27
+
+### Added
+
+- **Phase 161 — Nineteen-Log × polynomial** (`_nineteen_log_poly_effective_x2`):
+  Opens the Nineteen-Log family (Phases 161–166).
+  `effective_x2 = 2·poly_deg`; no Sqrt factors permitted.
+
 ## 2.97.0 — 2026-05-27
 
 ### Added

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.97.0"
+version = "2.103.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -1463,6 +1463,62 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
                 return True
         elif _h_diverges_at_infinity(den, k):
             return True
+    # Phase 166: ``Mul(Sqrt(P1)×5, Log(h1)×19, polynomial..., bounded...)`` numerator.
+    # Five Sqrt + nineteen Log factors; log^19 sub-polynomial → effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg.
+    # Closes when ``2·den_deg > effective_x2`` or non-polynomial diverging denominator.
+    s5l19p_x2 = _five_sqrt_nineteen_log_poly_effective_x2(num, k)
+    if s5l19p_x2 is not None:
+        den_deg_s5l19 = _polynomial_degree_in_k(den, k)
+        if den_deg_s5l19 is not None:
+            if 2 * den_deg_s5l19 > s5l19p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 165: ``Mul(Sqrt(P1)×4, Log(h1)×19, polynomial..., bounded...)`` numerator.
+    s4l19p_x2 = _four_sqrt_nineteen_log_poly_effective_x2(num, k)
+    if s4l19p_x2 is not None:
+        den_deg_s4l19 = _polynomial_degree_in_k(den, k)
+        if den_deg_s4l19 is not None:
+            if 2 * den_deg_s4l19 > s4l19p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 164: ``Mul(Sqrt(P1)×3, Log(h1)×19, polynomial..., bounded...)`` numerator.
+    s3l19p_x2 = _three_sqrt_nineteen_log_poly_effective_x2(num, k)
+    if s3l19p_x2 is not None:
+        den_deg_s3l19 = _polynomial_degree_in_k(den, k)
+        if den_deg_s3l19 is not None:
+            if 2 * den_deg_s3l19 > s3l19p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 163: ``Mul(Sqrt(P1), Sqrt(P2), Log(h1)×19, polynomial..., bounded...)`` numerator.
+    s2l19p_x2 = _two_sqrt_nineteen_log_poly_effective_x2(num, k)
+    if s2l19p_x2 is not None:
+        den_deg_s2l19 = _polynomial_degree_in_k(den, k)
+        if den_deg_s2l19 is not None:
+            if 2 * den_deg_s2l19 > s2l19p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 162: ``Mul(Sqrt(P), Log(h1)×19, polynomial..., bounded...)`` numerator.
+    s1l19p_x2 = _one_sqrt_nineteen_log_poly_effective_x2(num, k)
+    if s1l19p_x2 is not None:
+        den_deg_s1l19 = _polynomial_degree_in_k(den, k)
+        if den_deg_s1l19 is not None:
+            if 2 * den_deg_s1l19 > s1l19p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
+    # Phase 161: ``Mul(Log(h1)×19, polynomial..., bounded...)`` numerator.
+    sl19p_x2 = _nineteen_log_poly_effective_x2(num, k)
+    if sl19p_x2 is not None:
+        den_deg_sl19 = _polynomial_degree_in_k(den, k)
+        if den_deg_sl19 is not None:
+            if 2 * den_deg_sl19 > sl19p_x2:
+                return True
+        elif _h_diverges_at_infinity(den, k):
+            return True
     # Phase 160: ``Mul(Sqrt(P1)×5, Log(h1)×18, polynomial..., bounded...)`` numerator.
     # Five Sqrt + eighteen Log factors; log^18 sub-polynomial → effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg.
     # Closes when ``2·den_deg > effective_x2`` or non-polynomial diverging denominator.
@@ -6910,6 +6966,213 @@ def _five_sqrt_eighteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int 
             continue
         return None
     if len(sqrt_degs_x2) != 5 or log_count != 18:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _nineteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Return ``2·poly_deg`` when ``node`` is a ``Mul`` with **exactly nineteen**
+    ``Log(diverging-in-k)`` factors, any polynomial factors, and any bounded
+    factors; ``None`` otherwise.
+
+    Phase 161 — Nineteen-Log × polynomial numerator.
+
+    Effective growth:
+    ``log(k)^19 · k^m``.  ``log^19(k)`` is sub-polynomial (``o(k^ε)``),
+    contributing 0 to the effective polynomial degree.
+    Using the ×2 integer trick (no Sqrt factors present):
+    ``effective_x2 = 2·m``.
+    Caller checks ``2·den_deg > effective_x2``.
+
+    Sqrt factors are explicitly refused so that this function does not
+    shadow the Sqrt-bearing phases (Phase 162 onward).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        if _sqrt_effective_half_degree_x2(arg, k) is not None:
+            return None
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 19:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if log_count != 19:
+        return None
+    return 2 * poly_deg_sum
+
+
+def _one_sqrt_nineteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator.
+    effective_x2 = sqrt_deg_x2 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_deg_x2: int | None = None
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if sqrt_deg_x2 is not None:
+                return None
+            sqrt_deg_x2 = deg_x2
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 19:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if sqrt_deg_x2 is None or log_count != 19:
+        return None
+    return sqrt_deg_x2 + 2 * poly_deg_sum
+
+
+def _two_sqrt_nineteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator.
+    effective_x2 = sqrt1 + sqrt2 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 2:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 19:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 2 or log_count != 19:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _three_sqrt_nineteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator.
+    effective_x2 = sqrt1 + sqrt2 + sqrt3 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 3:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 19:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 3 or log_count != 19:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _four_sqrt_nineteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator.
+    effective_x2 = sqrt1 + sqrt2 + sqrt3 + sqrt4 + 2·poly_deg.
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 4:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 19:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 4 or log_count != 19:
+        return None
+    return sum(sqrt_degs_x2) + 2 * poly_deg_sum
+
+
+def _five_sqrt_nineteen_log_poly_effective_x2(node: IRNode, k: IRSymbol) -> int | None:
+    """Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator.
+    effective_x2 = sqrt1+sqrt2+sqrt3+sqrt4+sqrt5 + 2·poly_deg.
+    Completes the Nineteen-Log family (Phases 161-166).
+    """
+    if not isinstance(node, IRApply) or node.head != MUL:
+        return None
+    sqrt_degs_x2: list[int] = []
+    log_count: int = 0
+    poly_deg_sum: int = 0
+    for arg in node.args:
+        deg_x2 = _sqrt_effective_half_degree_x2(arg, k)
+        if deg_x2 is not None:
+            if len(sqrt_degs_x2) >= 5:
+                return None
+            sqrt_degs_x2.append(deg_x2)
+            continue
+        if _is_log_of_diverging_in_k(arg, k):
+            log_count += 1
+            if log_count > 19:
+                return None
+            continue
+        deg = _polynomial_degree_in_k(arg, k)
+        if deg is not None:
+            poly_deg_sum += deg
+            continue
+        if _is_bounded_in_k(arg, k):
+            continue
+        return None
+    if len(sqrt_degs_x2) != 5 or log_count != 19:
         return None
     return sum(sqrt_degs_x2) + 2 * poly_deg_sum
 

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -11158,3 +11158,671 @@ class TestPhase160FiveSqrtEighteenLogPoly:
         f = IRApply(SUB, (g_k, g_kp1))
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase161NineteenLogPoly:
+    """Phase 161 — Nineteen-Log x polynomial numerator (zero Sqrt)."""
+
+    def test_log19_over_k2_closes(self):
+        """log(k)^19/k^2: eff_x2=0; 2*2=4 > 0 -> closes."""
+        from symbolic_ir import SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log19_times_k_over_k2_closes(self):
+        """log(k)^19*k/k^2: eff_x2=2; 2*2=4 > 2 -> closes."""
+        from symbolic_ir import SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_log19_times_k_over_k_refused(self):
+        """log(k)^19*k/k: eff_x2=2; 2*1=2 not > 2 -> refused."""
+        from symbolic_ir import SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase162OneSqrtNineteenLogPoly:
+    """Phase 162 — One-Sqrt x Nineteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_log19_over_k2_closes(self):
+        """sqrt(k)*log(k)^19/k^2: eff_x2=1; 2*2=4 > 1 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log19_times_k_over_k2_closes(self):
+        """sqrt(k)*log(k)^19*k/k^2: eff_x2=3; 2*2=4 > 3 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_log19_times_k_over_k_refused(self):
+        """sqrt(k)*log(k)^19*k/k: eff_x2=3; 2*1=2 not > 3 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, _k))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase163TwoSqrtNineteenLogPoly:
+    """Phase 163 — Two-Sqrt x Nineteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x2_log19_over_k2_closes(self):
+        """sqrt(k)x2*log(k)^19/k^2: eff_x2=2; 2*2=4 > 2 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x2_log19_times_k_over_k3_closes(self):
+        """sqrt(k)x2*log(k)^19*k/k^3: eff_x2=4; 2*3=6 > 4 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x2_log19_times_k_over_k2_refused(self):
+        """sqrt(k)x2*log(k)^19*k/k^2: eff_x2=4; 2*2=4 not > 4 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase164ThreeSqrtNineteenLogPoly:
+    """Phase 164 — Three-Sqrt x Nineteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x3_log19_over_k2_closes(self):
+        """sqrt(k)x3*log(k)^19/k^2: eff_x2=3; 2*2=4 > 3 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x3_log19_times_k_over_k3_closes(self):
+        """sqrt(k)x3*log(k)^19*k/k^3: eff_x2=5; 2*3=6 > 5 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x3_log19_times_k_over_k2_refused(self):
+        """sqrt(k)x3*log(k)^19*k/k^2: eff_x2=5; 2*2=4 not > 5 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k2 = IRApply(MUL, (_k, _k))
+        kp1_2 = IRApply(MUL, (kp1, kp1))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k2))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_2))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase165FourSqrtNineteenLogPoly:
+    """Phase 165 — Four-Sqrt x Nineteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x4_log19_over_k3_closes(self):
+        """sqrt(k)x4*log(k)^19/k^3: eff_x2=4; 2*3=6 > 4 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x4_log19_times_k_over_k4_closes(self):
+        """sqrt(k)x4*log(k)^19*k/k^4: eff_x2=6; 2*4=8 > 6 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x4_log19_times_k_over_k3_refused(self):
+        """sqrt(k)x4*log(k)^19*k/k^3: eff_x2=6; 2*3=6 not > 6 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM
+
+
+class TestPhase166FiveSqrtNineteenLogPoly:
+    """Phase 166 — Five-Sqrt x Nineteen-Log x polynomial numerator."""
+
+    def test_sqrt_k_x5_log19_over_k4_closes(self):
+        """sqrt(k)x5*log(k)^19/k^4: eff_x2=5; 2*4=8 > 5 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,))))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,))))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x5_log19_times_k_over_k4_closes(self):
+        """sqrt(k)x5*log(k)^19*k/k^4: eff_x2=7; 2*4=8 > 7 -> closes."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k4 = IRApply(POW, (_k, IRInteger(4)))
+        kp1_4 = IRApply(POW, (kp1, IRInteger(4)))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k4))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_4))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert not (isinstance(result, IRApply) and result.head == SUM)
+
+    def test_sqrt_k_x5_log19_times_k_over_k3_refused(self):
+        """sqrt(k)x5*log(k)^19*k/k^3: eff_x2=7; 2*3=6 not > 7 -> refused."""
+        from symbolic_ir import SQRT, SUB
+        kp1 = IRApply(ADD, (_k, IRInteger(1)))
+        k3 = IRApply(MUL, (_k, IRApply(MUL, (_k, _k))))
+        kp1_3 = IRApply(MUL, (kp1, IRApply(MUL, (kp1, kp1))))
+        num_k = IRApply(MUL, (IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)), IRApply(SQRT, (_k,)),
+                               IRApply(SQRT, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)), IRApply(LOG, (_k,)),
+                               IRApply(LOG, (_k,)),
+                               _k))
+        num_kp1 = IRApply(MUL, (IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)), IRApply(SQRT, (kp1,)),
+                                 IRApply(SQRT, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)), IRApply(LOG, (kp1,)),
+                                 IRApply(LOG, (kp1,)),
+                                 kp1))
+        g_k = IRApply(DIV, (num_k, k3))
+        g_kp1 = IRApply(DIV, (num_kp1, kp1_3))
+        f = IRApply(SUB, (g_k, g_kp1))
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+        assert isinstance(result, IRApply) and result.head == SUM

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 2.103.0 — 2026-05-27
+
+### Added
+
+- **Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator** (`five_sqrt_nineteen_log_poly_effective_x2`):
+  Completes the Nineteen-Log family (Phases 161–166).
+  `effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg`. Closes when `2·den_deg > effective_x2`.
+
+## 2.102.0 — 2026-05-27
+
+### Added
+
+- **Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator** (`four_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2+sqrt3+sqrt4_deg_x2 + 2·poly_deg`.
+
+## 2.101.0 — 2026-05-27
+
+### Added
+
+- **Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator** (`three_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2+sqrt3_deg_x2 + 2·poly_deg`.
+
+## 2.100.0 — 2026-05-27
+
+### Added
+
+- **Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator** (`two_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt1+sqrt2_deg_x2 + 2·poly_deg`.
+
+## 2.99.0 — 2026-05-27
+
+### Added
+
+- **Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator** (`one_sqrt_nineteen_log_poly_effective_x2`):
+  `effective_x2 = sqrt_deg_x2 + 2·poly_deg`.
+
+## 2.98.0 — 2026-05-27
+
+### Added
+
+- **Phase 161 — Nineteen-Log × polynomial numerator** (`nineteen_log_poly_effective_x2`):
+  Opens the Nineteen-Log family (Phases 161–166).
+  `effective_x2 = 2·poly_deg`. Closes when `2·den_deg > effective_x2`.
+
 ## 2.97.0 — 2026-05-27
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.97.0"
+version = "2.103.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -4048,6 +4048,184 @@ fn five_sqrt_eighteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option
     Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
 }
 
+/// Phase 161 — Nineteen-Log × polynomial numerator.
+/// Opens the Nineteen-Log family (Phases 161-166).
+///
+/// Effective growth: `log(k)¹⁹ · k^m`. `log¹⁹(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn nineteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if sqrt_effective_half_degree_x2(arg, k).is_some() { return None; }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 19 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if log_count != 19 { return None; }
+    Some(2 * poly_deg)
+}
+
+/// Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · log(k)¹⁹ · k^m`. `log¹⁹(k)` is sub-polynomial (`o(k^ε)`),
+/// contributing 0. Using the ×2 integer trick: `effective_x2 = a + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn one_sqrt_nineteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_deg_x2: Option<i64> = None;
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_deg_x2.is_some() { return None; } // second Sqrt — refuse
+            sqrt_deg_x2 = Some(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 19 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    let s = sqrt_deg_x2?;
+    if log_count != 19 { return None; }
+    Some(s + 2 * poly_deg)
+}
+
+/// Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · log(k)¹⁹ · k^m`. `log¹⁹(k)` is sub-polynomial.
+/// Using the ×2 integer trick: `effective_x2 = a + b + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn two_sqrt_nineteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 2 { return None; } // third Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 19 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 2 || log_count != 19 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
+/// Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · log(k)¹⁹ · k^m`.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn three_sqrt_nineteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 3 { return None; } // fourth Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 19 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 3 || log_count != 19 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
+/// Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator.
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · log(k)¹⁹ · k^m`.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + d + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn four_sqrt_nineteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 4 { return None; } // fifth Sqrt — refuse
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 19 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 4 || log_count != 19 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
+/// Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator.
+/// Completes the Nineteen-Log family (Phases 161-166).
+///
+/// Effective growth: `sqrt(k^a) · sqrt(k^b) · sqrt(k^c) · sqrt(k^d) · sqrt(k^e) · log(k)¹⁹ · k^m`.
+/// Using the ×2 integer trick: `effective_x2 = a + b + c + d + e + 2·m`.
+/// Caller checks `2·den_deg > effective_x2`.
+fn five_sqrt_nineteen_log_poly_effective_x2(node: &IRNode, k: &IRNode) -> Option<i64> {
+    let apply_node = match node { IRNode::Apply(a) => a, _ => return None };
+    if !head_is(&apply_node.head, MUL) { return None; }
+    let mut sqrt_degs_x2: Vec<i64> = Vec::new();
+    let mut log_count: usize = 0;
+    let mut poly_deg: i64 = 0;
+    for arg in &apply_node.args {
+        if let Some(d) = sqrt_effective_half_degree_x2(arg, k) {
+            if sqrt_degs_x2.len() >= 5 { return None; }
+            sqrt_degs_x2.push(d);
+            continue;
+        }
+        if is_log_of_diverging_in_k(arg, k) {
+            log_count += 1;
+            if log_count > 19 { return None; }
+            continue;
+        }
+        if let Some(deg) = polynomial_degree_in_k(arg, k) { poly_deg += deg; continue; }
+        if is_bounded_in_k(arg, k) { continue; }
+        return None;
+    }
+    if sqrt_degs_x2.len() != 5 || log_count != 19 { return None; }
+    Some(sqrt_degs_x2.iter().sum::<i64>() + 2 * poly_deg)
+}
+
 /// Phase 96 — One-Sqrt × Eight-Log × polynomial numerator.
 ///
 /// Effective growth: `sqrt(k^a) · log(k)⁸ · k^m`. `log⁸(k)` is sub-polynomial (`o(k^ε)`),
@@ -4900,6 +5078,42 @@ fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
         } else if h_diverges_at_infinity(den, k) {
             return true;
         }
+    }
+    // Phase 166: Mul(Sqrt(P1)×5, Log(diverging)×19, polynomial..., bounded...) numerator.
+    if let Some(s5l19_x2) = five_sqrt_nineteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s5l19) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s5l19 > s5l19_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 165: Mul(Sqrt(P1)×4, Log(diverging)×19, polynomial..., bounded...) numerator.
+    if let Some(s4l19_x2) = four_sqrt_nineteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s4l19) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s4l19 > s4l19_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 164: Mul(Sqrt(P1)×3, Log(diverging)×19, polynomial..., bounded...) numerator.
+    if let Some(s3l19_x2) = three_sqrt_nineteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s3l19) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s3l19 > s3l19_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 163: Mul(Sqrt(P1), Sqrt(P2), Log(diverging)×19, polynomial..., bounded...) numerator.
+    if let Some(s2l19_x2) = two_sqrt_nineteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s2l19) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s2l19 > s2l19_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 162: Mul(Sqrt(P), Log(diverging)×19, polynomial..., bounded...) numerator.
+    if let Some(s1l19_x2) = one_sqrt_nineteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_s1l19) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_s1l19 > s1l19_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
+    }
+    // Phase 161: Mul(Log(diverging)×19, polynomial..., bounded...) numerator.
+    if let Some(sl19_x2) = nineteen_log_poly_effective_x2(num, k) {
+        if let Some(den_deg_sl19) = polynomial_degree_in_k(den, k) {
+            if 2 * den_deg_sl19 > sl19_x2 { return true; }
+        } else if h_diverges_at_infinity(den, k) { return true; }
     }
     // Phase 160: Mul(Sqrt(P1)×5, Log(diverging)×18, polynomial..., bounded...) numerator.
     if let Some(s5l18_x2) = five_sqrt_eighteen_log_poly_effective_x2(num, k) {

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -10022,3 +10022,611 @@ fn phase160_sqrt_k_x5_log18_k_times_k_over_k3_refused() {
     let out = evaluate_sum(f160c, k, int(1), sym("%inf"), eval);
     assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
 }
+
+// ---------------------------------------------------------------------------
+// Phase 161 — Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase161_log19_k_over_k2_closes() {
+    // log(k)^19 / k²: effective_x2=0; 2·2=4 > 0 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k161a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_161a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f161a = apply(sym(SUB), vec![g_k161a, g_kp1_161a]);
+    let out = evaluate_sum(f161a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase161_log19_k_times_k_over_k2_closes() {
+    // log(k)^19·k / k²: effective_x2=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k161b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_161b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f161b = apply(sym(SUB), vec![g_k161b, g_kp1_161b]);
+    let out = evaluate_sum(f161b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase161_log19_k_times_k_over_k_refused() {
+    // log(k)^19·k / k: effective_x2=2; 2·1=2 not > 2 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k161c = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1_161c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f161c = apply(sym(SUB), vec![g_k161c, g_kp1_161c]);
+    let out = evaluate_sum(f161c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase162_sqrt_k_log19_k_over_k2_closes() {
+    // √k·log(k)^19 / k²: effective_x2=1; 2·2=4 > 1 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k162a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_162a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f162a = apply(sym(SUB), vec![g_k162a, g_kp1_162a]);
+    let out = evaluate_sum(f162a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase162_sqrt_k_log19_k_times_k_over_k2_closes() {
+    // √k·log(k)^19·k / k²: effective_x2=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k162b = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_162b = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f162b = apply(sym(SUB), vec![g_k162b, g_kp1_162b]);
+    let out = evaluate_sum(f162b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase162_sqrt_k_log19_k_times_k_over_k_refused() {
+    // √k·log(k)^19·k / k: effective_x2=3; 2·1=2 not > 3 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k162c = apply(sym(DIV), vec![num_k, k.clone()]);
+    let g_kp1_162c = apply(sym(DIV), vec![num_kp1, kp1.clone()]);
+    let f162c = apply(sym(SUB), vec![g_k162c, g_kp1_162c]);
+    let out = evaluate_sum(f162c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase163_sqrt_k_x2_log19_k_over_k2_closes() {
+    // √k²·log(k)^19 / k²: effective_x2=2; 2·2=4 > 2 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k163a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_163a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f163a = apply(sym(SUB), vec![g_k163a, g_kp1_163a]);
+    let out = evaluate_sum(f163a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase163_sqrt_k_x2_log19_k_times_k_over_k3_closes() {
+    // √k²·log(k)^19·k / k³: effective_x2=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k163b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_163b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f163b = apply(sym(SUB), vec![g_k163b, g_kp1_163b]);
+    let out = evaluate_sum(f163b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase163_sqrt_k_x2_log19_k_times_k_over_k2_refused() {
+    // √k²·log(k)^19·k / k²: effective_x2=4; 2·2=4 not > 4 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k163c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_163c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f163c = apply(sym(SUB), vec![g_k163c, g_kp1_163c]);
+    let out = evaluate_sum(f163c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase164_sqrt_k_x3_log19_k_over_k2_closes() {
+    // √k³·log(k)^19 / k²: effective_x2=3; 2·2=4 > 3 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k164a = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_164a = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f164a = apply(sym(SUB), vec![g_k164a, g_kp1_164a]);
+    let out = evaluate_sum(f164a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase164_sqrt_k_x3_log19_k_times_k_over_k3_closes() {
+    // √k³·log(k)^19·k / k³: effective_x2=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k164b = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_164b = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f164b = apply(sym(SUB), vec![g_k164b, g_kp1_164b]);
+    let out = evaluate_sum(f164b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase164_sqrt_k_x3_log19_k_times_k_over_k2_refused() {
+    // √k³·log(k)^19·k / k²: effective_x2=5; 2·2=4 not > 5 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k2 = apply(sym("Pow"), vec![k.clone(), int(2)]);
+    let kp1_2 = apply(sym("Pow"), vec![kp1.clone(), int(2)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k164c = apply(sym(DIV), vec![num_k, k2]);
+    let g_kp1_164c = apply(sym(DIV), vec![num_kp1, kp1_2]);
+    let f164c = apply(sym(SUB), vec![g_k164c, g_kp1_164c]);
+    let out = evaluate_sum(f164c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase165_sqrt_k_x4_log19_k_over_k3_closes() {
+    // √k⁴·log(k)^19 / k³: effective_x2=4; 2·3=6 > 4 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k165a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_165a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f165a = apply(sym(SUB), vec![g_k165a, g_kp1_165a]);
+    let out = evaluate_sum(f165a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase165_sqrt_k_x4_log19_k_times_k_over_k4_closes() {
+    // √k⁴·log(k)^19·k / k⁴: effective_x2=6; 2·4=8 > 6 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k4 = apply(sym("Pow"), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym("Pow"), vec![kp1.clone(), int(4)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k165b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_165b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f165b = apply(sym(SUB), vec![g_k165b, g_kp1_165b]);
+    let out = evaluate_sum(f165b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase165_sqrt_k_x4_log19_k_times_k_over_k3_refused() {
+    // √k⁴·log(k)^19·k / k³: effective_x2=6; 2·3=6 not > 6 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k165c = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_165c = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f165c = apply(sym(SUB), vec![g_k165c, g_kp1_165c]);
+    let out = evaluate_sum(f165c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase166_sqrt_k_x5_log19_k_over_k3_closes() {
+    // √k⁵·log(k)^19 / k³: effective_x2=5; 2·3=6 > 5 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3 = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3 = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+    ]);
+    let g_k166a = apply(sym(DIV), vec![num_k, k3]);
+    let g_kp1_166a = apply(sym(DIV), vec![num_kp1, kp1_3]);
+    let f166a = apply(sym(SUB), vec![g_k166a, g_kp1_166a]);
+    let out = evaluate_sum(f166a, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase166_sqrt_k_x5_log19_k_times_k_over_k4_closes() {
+    // √k⁵·log(k)^19·k / k⁴: effective_x2=7; 2·4=8 > 7 → closes.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k4 = apply(sym("Pow"), vec![k.clone(), int(4)]);
+    let kp1_4 = apply(sym("Pow"), vec![kp1.clone(), int(4)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k166b = apply(sym(DIV), vec![num_k, k4]);
+    let g_kp1_166b = apply(sym(DIV), vec![num_kp1, kp1_4]);
+    let f166b = apply(sym(SUB), vec![g_k166b, g_kp1_166b]);
+    let out = evaluate_sum(f166b, k, int(1), sym("%inf"), eval);
+    assert!(!matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}
+
+#[test]
+fn phase166_sqrt_k_x5_log19_k_times_k_over_k3_refused() {
+    // √k⁵·log(k)^19·k / k³: effective_x2=7; 2·3=6 not > 7 → refused.
+    let k = sym("k");
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let k3s = apply(sym("Pow"), vec![k.clone(), int(3)]);
+    let kp1_3s = apply(sym("Pow"), vec![kp1.clone(), int(3)]);
+    let sqrt_k = apply(sym("Sqrt"), vec![k.clone()]);
+    let sqrt_kp1 = apply(sym("Sqrt"), vec![kp1.clone()]);
+    let log_k = apply(sym(LOG), vec![k.clone()]);
+    let log_kp1 = apply(sym(LOG), vec![kp1.clone()]);
+    let num_k = apply(sym(MUL), vec![
+        sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k.clone(), sqrt_k,
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(), log_k.clone(),
+        log_k.clone(), log_k.clone(), log_k.clone(), log_k,
+        k.clone(),
+    ]);
+    let num_kp1 = apply(sym(MUL), vec![
+        sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1.clone(), sqrt_kp1,
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1.clone(),
+        log_kp1.clone(), log_kp1.clone(), log_kp1.clone(), log_kp1,
+        kp1.clone(),
+    ]);
+    let g_k166c = apply(sym(DIV), vec![num_k, k3s]);
+    let g_kp1_166c = apply(sym(DIV), vec![num_kp1, kp1_3s]);
+    let f166c = apply(sym(SUB), vec![g_k166c, g_kp1_166c]);
+    let out = evaluate_sum(f166c, k, int(1), sym("%inf"), eval);
+    assert!(matches!(&out, IRNode::Apply(node) if node.head == sym(SUM)));
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 2.103.0 — 2026-05-27
+
+### Added
+
+- **Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator** (`fiveSqrtNineteenLogPolyEffectiveDeg`):
+  Completes the Nineteen-Log family (Phases 161–166).
+  `effectiveDeg = sqrtHalfDeg1+…+sqrtHalfDeg5 + polyDeg`.
+
+## 2.102.0 — 2026-05-27
+
+### Added
+
+- **Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator** (`fourSqrtNineteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg1+sqrtHalfDeg2+sqrtHalfDeg3+sqrtHalfDeg4 + polyDeg`.
+
+## 2.101.0 — 2026-05-27
+
+### Added
+
+- **Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator** (`threeSqrtNineteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg1+sqrtHalfDeg2+sqrtHalfDeg3 + polyDeg`.
+
+## 2.100.0 — 2026-05-27
+
+### Added
+
+- **Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator** (`twoSqrtNineteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg1+sqrtHalfDeg2 + polyDeg`.
+
+## 2.99.0 — 2026-05-27
+
+### Added
+
+- **Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator** (`oneSqrtNineteenLogPolyEffectiveDeg`):
+  `effectiveDeg = sqrtHalfDeg + polyDeg`.
+
+## 2.98.0 — 2026-05-27
+
+### Added
+
+- **Phase 161 — Nineteen-Log × polynomial numerator** (`nineteenLogPolyEffectiveDeg`):
+  Opens the Nineteen-Log family (Phases 161–166).
+  `effectiveDeg = polyDeg`; no Sqrt factors permitted.
+
 ## 2.97.0 — 2026-05-27
 
 ### Added

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.97.0",
+  "version": "2.103.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -3107,6 +3107,145 @@ function fiveSqrtEighteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | 
   return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
 }
 
+function nineteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 161 — Nineteen-Log × polynomial numerator.
+  // log^19(k) is sub-polynomial; effective degree = polyDeg. No Sqrt factors allowed.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    if (sqrtEffectiveHalfDegree(arg, k) !== undefined) return undefined; // no Sqrts allowed
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 19) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (logCount !== 19) return undefined;
+  return polyDeg;
+}
+
+function oneSqrtNineteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDeg + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  let sqrtHalfDeg: number | undefined;
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDeg !== undefined) return undefined;
+      sqrtHalfDeg = hd;
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 19) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDeg === undefined || logCount !== 19) return undefined;
+  return sqrtHalfDeg + polyDeg;
+}
+
+function twoSqrtNineteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 2) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 19) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 2 || logCount !== 19) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + polyDeg;
+}
+
+function threeSqrtNineteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 3) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 19) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 3 || logCount !== 19) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + polyDeg;
+}
+
+function fourSqrtNineteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + … + sqrtHalfDegs[3] + polyDeg.
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 4) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 19) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 4 || logCount !== 19) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + polyDeg;
+}
+
+function fiveSqrtNineteenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
+  // Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator.
+  // effective degree = sqrtHalfDegs[0] + … + sqrtHalfDegs[4] + polyDeg.
+  // Completes the Nineteen-Log family (Phases 161-166).
+  if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
+  const sqrtHalfDegs: number[] = [];
+  let logCount = 0;
+  let polyDeg = 0;
+  for (const arg of node.args) {
+    const hd = sqrtEffectiveHalfDegree(arg, k);
+    if (hd !== undefined) {
+      if (sqrtHalfDegs.length >= 5) return undefined;
+      sqrtHalfDegs.push(hd);
+      continue;
+    }
+    if (isLogOfDivergingInK(arg, k)) { logCount++; if (logCount > 19) return undefined; continue; }
+    const deg = polynomialDegreeInK(arg, k);
+    if (deg !== undefined) { polyDeg += deg; continue; }
+    if (isBoundedInK(arg, k)) continue;
+    return undefined;
+  }
+  if (sqrtHalfDegs.length !== 5 || logCount !== 19) return undefined;
+  return sqrtHalfDegs[0] + sqrtHalfDegs[1] + sqrtHalfDegs[2] + sqrtHalfDegs[3] + sqrtHalfDegs[4] + polyDeg;
+}
+
 function tenLogPolyEffectiveDeg(node: IRNode, k: IRNode): number | undefined {
   if (node.kind !== "apply" || !equals(node.head, MUL)) return undefined;
   let logCount = 0;
@@ -4317,6 +4456,78 @@ function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
     const denDegS2l8 = polynomialDegreeInK(den, k);
     if (denDegS2l8 !== undefined) {
       if (denDegS2l8 > s2l8Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 166: Mul(Sqrt(P1)×5, Log(h1)×19, polynomial..., bounded...) numerator.
+  // Five Sqrt + nineteen Log factors; log¹⁹ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > fiveSqrtNineteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s5l19Deg = fiveSqrtNineteenLogPolyEffectiveDeg(num, k);
+  if (s5l19Deg !== undefined) {
+    const denDegS5l19 = polynomialDegreeInK(den, k);
+    if (denDegS5l19 !== undefined) {
+      if (denDegS5l19 > s5l19Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 165: Mul(Sqrt(P1)×4, Log(h1)×19, polynomial..., bounded...) numerator.
+  // Four Sqrt + nineteen Log factors; log¹⁹ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > fourSqrtNineteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s4l19Deg = fourSqrtNineteenLogPolyEffectiveDeg(num, k);
+  if (s4l19Deg !== undefined) {
+    const denDegS4l19 = polynomialDegreeInK(den, k);
+    if (denDegS4l19 !== undefined) {
+      if (denDegS4l19 > s4l19Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 164: Mul(Sqrt(P1)×3, Log(h1)×19, polynomial..., bounded...) numerator.
+  // Three Sqrt + nineteen Log factors; log¹⁹ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > threeSqrtNineteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s3l19Deg = threeSqrtNineteenLogPolyEffectiveDeg(num, k);
+  if (s3l19Deg !== undefined) {
+    const denDegS3l19 = polynomialDegreeInK(den, k);
+    if (denDegS3l19 !== undefined) {
+      if (denDegS3l19 > s3l19Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 163: Mul(Sqrt(P1), Sqrt(P2), Log(h1)×19, polynomial..., bounded...) numerator.
+  // Two Sqrt + nineteen Log factors; log¹⁹ sub-polynomial → effective degree = sum(sqrtHalfDegs) + polyDeg.
+  // Closes when denDeg > twoSqrtNineteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s2l19Deg = twoSqrtNineteenLogPolyEffectiveDeg(num, k);
+  if (s2l19Deg !== undefined) {
+    const denDegS2l19 = polynomialDegreeInK(den, k);
+    if (denDegS2l19 !== undefined) {
+      if (denDegS2l19 > s2l19Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 162: Mul(Sqrt(P), Log(h1)×19, polynomial..., bounded...) numerator.
+  // One Sqrt + nineteen Log factors; log¹⁹ sub-polynomial → effective degree = sqrtHalfDeg + polyDeg.
+  // Closes when denDeg > oneSqrtNineteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const s1l19Deg = oneSqrtNineteenLogPolyEffectiveDeg(num, k);
+  if (s1l19Deg !== undefined) {
+    const denDegS1l19 = polynomialDegreeInK(den, k);
+    if (denDegS1l19 !== undefined) {
+      if (denDegS1l19 > s1l19Deg) return true;
+    } else if (hDivergesAtInfinity(den, k)) {
+      return true;
+    }
+  }
+  // Phase 161: Mul(Log(h1)×19, polynomial..., bounded...) numerator.
+  // Zero Sqrt + nineteen Log factors; log¹⁹ sub-polynomial → effective degree = polyDeg.
+  // Closes when denDeg > nineteenLogPolyEffectiveDeg or non-polynomial diverging denom.
+  const sl19Deg = nineteenLogPolyEffectiveDeg(num, k);
+  if (sl19Deg !== undefined) {
+    const denDegSl19 = polynomialDegreeInK(den, k);
+    if (denDegSl19 !== undefined) {
+      if (denDegSl19 > sl19Deg) return true;
     } else if (hDivergesAtInfinity(den, k)) {
       return true;
     }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -14023,3 +14023,1109 @@ describe("Phase 160: FiveSqrt × EighteenLog × poly numerator", () => {
     expect(result).toMatchObject({ kind: "apply", head: SUM });
   });
 });
+
+// Phase 161 — Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 161: NineteenLog × poly numerator", () => {
+  it("log(k)^19/k^2 closes (eff=0, denDeg=2 > 0)", () => {
+    const k161a = sym("k");
+    const kp1_161a = { kind: "apply" as const, head: ADD, args: [k161a, int(1)] };
+    const k2_161a = { kind: "apply" as const, head: POW, args: [k161a, int(2)] };
+    const kp12_161a = { kind: "apply" as const, head: POW, args: [kp1_161a, int(2)] };
+    const numK_161a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+      { kind: "apply" as const, head: LOG, args: [k161a] },
+    ]};
+    const numKp1_161a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161a] },
+    ]};
+    const gK161a = { kind: "apply" as const, head: DIV, args: [numK_161a, k2_161a] };
+    const gKp1_161a = { kind: "apply" as const, head: DIV, args: [numKp1_161a, kp12_161a] };
+    const f161a = { kind: "apply" as const, head: SUB, args: [gK161a, gKp1_161a] };
+    const result = evaluateSum(f161a, k161a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^19*k/k^2 closes (eff=1, denDeg=2 > 1)", () => {
+    const k161b = sym("k");
+    const kp1_161b = { kind: "apply" as const, head: ADD, args: [k161b, int(1)] };
+    const k2_161b = { kind: "apply" as const, head: POW, args: [k161b, int(2)] };
+    const kp12_161b = { kind: "apply" as const, head: POW, args: [kp1_161b, int(2)] };
+    const numK_161b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      { kind: "apply" as const, head: LOG, args: [k161b] },
+      k161b,
+    ]};
+    const numKp1_161b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161b] },
+      kp1_161b,
+    ]};
+    const gK161b = { kind: "apply" as const, head: DIV, args: [numK_161b, k2_161b] };
+    const gKp1_161b = { kind: "apply" as const, head: DIV, args: [numKp1_161b, kp12_161b] };
+    const f161b = { kind: "apply" as const, head: SUB, args: [gK161b, gKp1_161b] };
+    const result = evaluateSum(f161b, k161b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("log(k)^19*k/k^1 refused (eff=1, denDeg=1 not > 1)", () => {
+    const k161c = sym("k");
+    const kp1_161c = { kind: "apply" as const, head: ADD, args: [k161c, int(1)] };
+    const numK_161c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      { kind: "apply" as const, head: LOG, args: [k161c] },
+      k161c,
+    ]};
+    const numKp1_161c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_161c] },
+      kp1_161c,
+    ]};
+    const gK161c = { kind: "apply" as const, head: DIV, args: [numK_161c, k161c] };
+    const gKp1_161c = { kind: "apply" as const, head: DIV, args: [numKp1_161c, kp1_161c] };
+    const f161c = { kind: "apply" as const, head: SUB, args: [gK161c, gKp1_161c] };
+    const result = evaluateSum(f161c, k161c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// Phase 162 — One-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 162: OneSqrt × NineteenLog × poly numerator", () => {
+  it("sqrt(k)*log(k)^19/k^2 closes (eff=0.5, denDeg=2 > 0.5)", () => {
+    const k162a = sym("k");
+    const kp1_162a = { kind: "apply" as const, head: ADD, args: [k162a, int(1)] };
+    const k2_162a = { kind: "apply" as const, head: POW, args: [k162a, int(2)] };
+    const kp12_162a = { kind: "apply" as const, head: POW, args: [kp1_162a, int(2)] };
+    const numK_162a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+      { kind: "apply" as const, head: LOG, args: [k162a] },
+    ]};
+    const numKp1_162a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162a] },
+    ]};
+    const gK162a = { kind: "apply" as const, head: DIV, args: [numK_162a, k2_162a] };
+    const gKp1_162a = { kind: "apply" as const, head: DIV, args: [numKp1_162a, kp12_162a] };
+    const f162a = { kind: "apply" as const, head: SUB, args: [gK162a, gKp1_162a] };
+    const result = evaluateSum(f162a, k162a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)*log(k)^19*k/k^2 closes (eff=1.5, denDeg=2 > 1.5)", () => {
+    const k162b = sym("k");
+    const kp1_162b = { kind: "apply" as const, head: ADD, args: [k162b, int(1)] };
+    const k2_162b = { kind: "apply" as const, head: POW, args: [k162b, int(2)] };
+    const kp12_162b = { kind: "apply" as const, head: POW, args: [kp1_162b, int(2)] };
+    const numK_162b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      { kind: "apply" as const, head: LOG, args: [k162b] },
+      k162b,
+    ]};
+    const numKp1_162b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162b] },
+      kp1_162b,
+    ]};
+    const gK162b = { kind: "apply" as const, head: DIV, args: [numK_162b, k2_162b] };
+    const gKp1_162b = { kind: "apply" as const, head: DIV, args: [numKp1_162b, kp12_162b] };
+    const f162b = { kind: "apply" as const, head: SUB, args: [gK162b, gKp1_162b] };
+    const result = evaluateSum(f162b, k162b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)*log(k)^19*k/k^1 refused (eff=1.5, denDeg=1 not > 1.5)", () => {
+    const k162c = sym("k");
+    const kp1_162c = { kind: "apply" as const, head: ADD, args: [k162c, int(1)] };
+    const numK_162c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      { kind: "apply" as const, head: LOG, args: [k162c] },
+      k162c,
+    ]};
+    const numKp1_162c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_162c] },
+      kp1_162c,
+    ]};
+    const gK162c = { kind: "apply" as const, head: DIV, args: [numK_162c, k162c] };
+    const gKp1_162c = { kind: "apply" as const, head: DIV, args: [numKp1_162c, kp1_162c] };
+    const f162c = { kind: "apply" as const, head: SUB, args: [gK162c, gKp1_162c] };
+    const result = evaluateSum(f162c, k162c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// Phase 163 — Two-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 163: TwoSqrt × NineteenLog × poly numerator", () => {
+  it("sqrt(k)x2*log(k)^19/k^2 closes (eff=1, denDeg=2 > 1)", () => {
+    const k163a = sym("k");
+    const kp1_163a = { kind: "apply" as const, head: ADD, args: [k163a, int(1)] };
+    const k2_163a = { kind: "apply" as const, head: POW, args: [k163a, int(2)] };
+    const kp12_163a = { kind: "apply" as const, head: POW, args: [kp1_163a, int(2)] };
+    const numK_163a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k163a] },
+      { kind: "apply" as const, head: SQRT, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+      { kind: "apply" as const, head: LOG, args: [k163a] },
+    ]};
+    const numKp1_163a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_163a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163a] },
+    ]};
+    const gK163a = { kind: "apply" as const, head: DIV, args: [numK_163a, k2_163a] };
+    const gKp1_163a = { kind: "apply" as const, head: DIV, args: [numKp1_163a, kp12_163a] };
+    const f163a = { kind: "apply" as const, head: SUB, args: [gK163a, gKp1_163a] };
+    const result = evaluateSum(f163a, k163a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x2*log(k)^19*k/k^3 closes (eff=2, denDeg=3 > 2)", () => {
+    const k163b = sym("k");
+    const kp1_163b = { kind: "apply" as const, head: ADD, args: [k163b, int(1)] };
+    const k3_163b = { kind: "apply" as const, head: POW, args: [k163b, int(3)] };
+    const kp13_163b = { kind: "apply" as const, head: POW, args: [kp1_163b, int(3)] };
+    const numK_163b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k163b] },
+      { kind: "apply" as const, head: SQRT, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      { kind: "apply" as const, head: LOG, args: [k163b] },
+      k163b,
+    ]};
+    const numKp1_163b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_163b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163b] },
+      kp1_163b,
+    ]};
+    const gK163b = { kind: "apply" as const, head: DIV, args: [numK_163b, k3_163b] };
+    const gKp1_163b = { kind: "apply" as const, head: DIV, args: [numKp1_163b, kp13_163b] };
+    const f163b = { kind: "apply" as const, head: SUB, args: [gK163b, gKp1_163b] };
+    const result = evaluateSum(f163b, k163b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x2*log(k)^19*k/k^2 refused (eff=2, denDeg=2 not > 2)", () => {
+    const k163c = sym("k");
+    const kp1_163c = { kind: "apply" as const, head: ADD, args: [k163c, int(1)] };
+    const k2_163c = { kind: "apply" as const, head: POW, args: [k163c, int(2)] };
+    const kp12_163c = { kind: "apply" as const, head: POW, args: [kp1_163c, int(2)] };
+    const numK_163c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k163c] },
+      { kind: "apply" as const, head: SQRT, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      { kind: "apply" as const, head: LOG, args: [k163c] },
+      k163c,
+    ]};
+    const numKp1_163c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_163c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_163c] },
+      kp1_163c,
+    ]};
+    const gK163c = { kind: "apply" as const, head: DIV, args: [numK_163c, k2_163c] };
+    const gKp1_163c = { kind: "apply" as const, head: DIV, args: [numKp1_163c, kp12_163c] };
+    const f163c = { kind: "apply" as const, head: SUB, args: [gK163c, gKp1_163c] };
+    const result = evaluateSum(f163c, k163c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// Phase 164 — Three-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 164: ThreeSqrt × NineteenLog × poly numerator", () => {
+  it("sqrt(k)x3*log(k)^19/k^2 closes (eff=1.5, denDeg=2 > 1.5)", () => {
+    const k164a = sym("k");
+    const kp1_164a = { kind: "apply" as const, head: ADD, args: [k164a, int(1)] };
+    const k2_164a = { kind: "apply" as const, head: POW, args: [k164a, int(2)] };
+    const kp12_164a = { kind: "apply" as const, head: POW, args: [kp1_164a, int(2)] };
+    const numK_164a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k164a] },
+      { kind: "apply" as const, head: SQRT, args: [k164a] },
+      { kind: "apply" as const, head: SQRT, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+      { kind: "apply" as const, head: LOG, args: [k164a] },
+    ]};
+    const numKp1_164a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_164a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_164a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164a] },
+    ]};
+    const gK164a = { kind: "apply" as const, head: DIV, args: [numK_164a, k2_164a] };
+    const gKp1_164a = { kind: "apply" as const, head: DIV, args: [numKp1_164a, kp12_164a] };
+    const f164a = { kind: "apply" as const, head: SUB, args: [gK164a, gKp1_164a] };
+    const result = evaluateSum(f164a, k164a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x3*log(k)^19*k/k^3 closes (eff=2.5, denDeg=3 > 2.5)", () => {
+    const k164b = sym("k");
+    const kp1_164b = { kind: "apply" as const, head: ADD, args: [k164b, int(1)] };
+    const k3_164b = { kind: "apply" as const, head: POW, args: [k164b, int(3)] };
+    const kp13_164b = { kind: "apply" as const, head: POW, args: [kp1_164b, int(3)] };
+    const numK_164b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k164b] },
+      { kind: "apply" as const, head: SQRT, args: [k164b] },
+      { kind: "apply" as const, head: SQRT, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      { kind: "apply" as const, head: LOG, args: [k164b] },
+      k164b,
+    ]};
+    const numKp1_164b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_164b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_164b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164b] },
+      kp1_164b,
+    ]};
+    const gK164b = { kind: "apply" as const, head: DIV, args: [numK_164b, k3_164b] };
+    const gKp1_164b = { kind: "apply" as const, head: DIV, args: [numKp1_164b, kp13_164b] };
+    const f164b = { kind: "apply" as const, head: SUB, args: [gK164b, gKp1_164b] };
+    const result = evaluateSum(f164b, k164b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x3*log(k)^19*k/k^2 refused (eff=2.5, denDeg=2 not > 2.5)", () => {
+    const k164c = sym("k");
+    const kp1_164c = { kind: "apply" as const, head: ADD, args: [k164c, int(1)] };
+    const k2_164c = { kind: "apply" as const, head: POW, args: [k164c, int(2)] };
+    const kp12_164c = { kind: "apply" as const, head: POW, args: [kp1_164c, int(2)] };
+    const numK_164c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k164c] },
+      { kind: "apply" as const, head: SQRT, args: [k164c] },
+      { kind: "apply" as const, head: SQRT, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      { kind: "apply" as const, head: LOG, args: [k164c] },
+      k164c,
+    ]};
+    const numKp1_164c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_164c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_164c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_164c] },
+      kp1_164c,
+    ]};
+    const gK164c = { kind: "apply" as const, head: DIV, args: [numK_164c, k2_164c] };
+    const gKp1_164c = { kind: "apply" as const, head: DIV, args: [numKp1_164c, kp12_164c] };
+    const f164c = { kind: "apply" as const, head: SUB, args: [gK164c, gKp1_164c] };
+    const result = evaluateSum(f164c, k164c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// Phase 165 — Four-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 165: FourSqrt × NineteenLog × poly numerator", () => {
+  it("sqrt(k)x4*log(k)^19/k^3 closes (eff=2, denDeg=3 > 2)", () => {
+    const k165a = sym("k");
+    const kp1_165a = { kind: "apply" as const, head: ADD, args: [k165a, int(1)] };
+    const k3_165a = { kind: "apply" as const, head: POW, args: [k165a, int(3)] };
+    const kp13_165a = { kind: "apply" as const, head: POW, args: [kp1_165a, int(3)] };
+    const numK_165a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k165a] },
+      { kind: "apply" as const, head: SQRT, args: [k165a] },
+      { kind: "apply" as const, head: SQRT, args: [k165a] },
+      { kind: "apply" as const, head: SQRT, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+      { kind: "apply" as const, head: LOG, args: [k165a] },
+    ]};
+    const numKp1_165a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_165a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165a] },
+    ]};
+    const gK165a = { kind: "apply" as const, head: DIV, args: [numK_165a, k3_165a] };
+    const gKp1_165a = { kind: "apply" as const, head: DIV, args: [numKp1_165a, kp13_165a] };
+    const f165a = { kind: "apply" as const, head: SUB, args: [gK165a, gKp1_165a] };
+    const result = evaluateSum(f165a, k165a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x4*log(k)^19*k/k^4 closes (eff=3, denDeg=4 > 3)", () => {
+    const k165b = sym("k");
+    const kp1_165b = { kind: "apply" as const, head: ADD, args: [k165b, int(1)] };
+    const k4_165b = { kind: "apply" as const, head: POW, args: [k165b, int(4)] };
+    const kp14_165b = { kind: "apply" as const, head: POW, args: [kp1_165b, int(4)] };
+    const numK_165b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k165b] },
+      { kind: "apply" as const, head: SQRT, args: [k165b] },
+      { kind: "apply" as const, head: SQRT, args: [k165b] },
+      { kind: "apply" as const, head: SQRT, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      { kind: "apply" as const, head: LOG, args: [k165b] },
+      k165b,
+    ]};
+    const numKp1_165b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_165b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165b] },
+      kp1_165b,
+    ]};
+    const gK165b = { kind: "apply" as const, head: DIV, args: [numK_165b, k4_165b] };
+    const gKp1_165b = { kind: "apply" as const, head: DIV, args: [numKp1_165b, kp14_165b] };
+    const f165b = { kind: "apply" as const, head: SUB, args: [gK165b, gKp1_165b] };
+    const result = evaluateSum(f165b, k165b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x4*log(k)^19*k/k^3 refused (eff=3, denDeg=3 not > 3)", () => {
+    const k165c = sym("k");
+    const kp1_165c = { kind: "apply" as const, head: ADD, args: [k165c, int(1)] };
+    const k3_165c = { kind: "apply" as const, head: POW, args: [k165c, int(3)] };
+    const kp13_165c = { kind: "apply" as const, head: POW, args: [kp1_165c, int(3)] };
+    const numK_165c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k165c] },
+      { kind: "apply" as const, head: SQRT, args: [k165c] },
+      { kind: "apply" as const, head: SQRT, args: [k165c] },
+      { kind: "apply" as const, head: SQRT, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      { kind: "apply" as const, head: LOG, args: [k165c] },
+      k165c,
+    ]};
+    const numKp1_165c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_165c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_165c] },
+      kp1_165c,
+    ]};
+    const gK165c = { kind: "apply" as const, head: DIV, args: [numK_165c, k3_165c] };
+    const gKp1_165c = { kind: "apply" as const, head: DIV, args: [numKp1_165c, kp13_165c] };
+    const f165c = { kind: "apply" as const, head: SUB, args: [gK165c, gKp1_165c] };
+    const result = evaluateSum(f165c, k165c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});
+
+// Phase 166 — Five-Sqrt × Nineteen-Log × polynomial numerator
+// ---------------------------------------------------------------------------
+describe("Phase 166: FiveSqrt × NineteenLog × poly numerator", () => {
+  it("sqrt(k)x5*log(k)^19/k^4 closes (eff=2.5, denDeg=4 > 2.5)", () => {
+    const k166a = sym("k");
+    const kp1_166a = { kind: "apply" as const, head: ADD, args: [k166a, int(1)] };
+    const k4_166a = { kind: "apply" as const, head: POW, args: [k166a, int(4)] };
+    const kp14_166a = { kind: "apply" as const, head: POW, args: [kp1_166a, int(4)] };
+    const numK_166a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k166a] },
+      { kind: "apply" as const, head: SQRT, args: [k166a] },
+      { kind: "apply" as const, head: SQRT, args: [k166a] },
+      { kind: "apply" as const, head: SQRT, args: [k166a] },
+      { kind: "apply" as const, head: SQRT, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+      { kind: "apply" as const, head: LOG, args: [k166a] },
+    ]};
+    const numKp1_166a = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_166a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166a] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166a] },
+    ]};
+    const gK166a = { kind: "apply" as const, head: DIV, args: [numK_166a, k4_166a] };
+    const gKp1_166a = { kind: "apply" as const, head: DIV, args: [numKp1_166a, kp14_166a] };
+    const f166a = { kind: "apply" as const, head: SUB, args: [gK166a, gKp1_166a] };
+    const result = evaluateSum(f166a, k166a, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x5*log(k)^19*k/k^4 closes (eff=3.5, denDeg=4 > 3.5)", () => {
+    const k166b = sym("k");
+    const kp1_166b = { kind: "apply" as const, head: ADD, args: [k166b, int(1)] };
+    const k4_166b = { kind: "apply" as const, head: POW, args: [k166b, int(4)] };
+    const kp14_166b = { kind: "apply" as const, head: POW, args: [kp1_166b, int(4)] };
+    const numK_166b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k166b] },
+      { kind: "apply" as const, head: SQRT, args: [k166b] },
+      { kind: "apply" as const, head: SQRT, args: [k166b] },
+      { kind: "apply" as const, head: SQRT, args: [k166b] },
+      { kind: "apply" as const, head: SQRT, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      { kind: "apply" as const, head: LOG, args: [k166b] },
+      k166b,
+    ]};
+    const numKp1_166b = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_166b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166b] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166b] },
+      kp1_166b,
+    ]};
+    const gK166b = { kind: "apply" as const, head: DIV, args: [numK_166b, k4_166b] };
+    const gKp1_166b = { kind: "apply" as const, head: DIV, args: [numKp1_166b, kp14_166b] };
+    const f166b = { kind: "apply" as const, head: SUB, args: [gK166b, gKp1_166b] };
+    const result = evaluateSum(f166b, k166b, int(1), sym("%inf"), evalNode);
+    expect(result).not.toMatchObject({ kind: "apply", head: SUM });
+  });
+
+  it("sqrt(k)x5*log(k)^19*k/k^3 refused (eff=3.5, denDeg=3 not > 3.5)", () => {
+    const k166c = sym("k");
+    const kp1_166c = { kind: "apply" as const, head: ADD, args: [k166c, int(1)] };
+    const k3_166c = { kind: "apply" as const, head: POW, args: [k166c, int(3)] };
+    const kp13_166c = { kind: "apply" as const, head: POW, args: [kp1_166c, int(3)] };
+    const numK_166c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [k166c] },
+      { kind: "apply" as const, head: SQRT, args: [k166c] },
+      { kind: "apply" as const, head: SQRT, args: [k166c] },
+      { kind: "apply" as const, head: SQRT, args: [k166c] },
+      { kind: "apply" as const, head: SQRT, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      { kind: "apply" as const, head: LOG, args: [k166c] },
+      k166c,
+    ]};
+    const numKp1_166c = { kind: "apply" as const, head: MUL, args: [
+      { kind: "apply" as const, head: SQRT, args: [kp1_166c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166c] },
+      { kind: "apply" as const, head: SQRT, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      { kind: "apply" as const, head: LOG, args: [kp1_166c] },
+      kp1_166c,
+    ]};
+    const gK166c = { kind: "apply" as const, head: DIV, args: [numK_166c, k3_166c] };
+    const gKp1_166c = { kind: "apply" as const, head: DIV, args: [numKp1_166c, kp13_166c] };
+    const f166c = { kind: "apply" as const, head: SUB, args: [gK166c, gKp1_166c] };
+    const result = evaluateSum(f166c, k166c, int(1), sym("%inf"), evalNode);
+    expect(result).toMatchObject({ kind: "apply", head: SUM });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the complete **Nineteen-Log family** (Phases 161–166) to the `cas-summation` convergence recognizer across Python, TypeScript, and Rust.

## Phases Added

| Phase | Description | Version |
|-------|-------------|---------|
| 161 | 0-sqrt × 19-log × polynomial | 2.98.0 |
| 162 | 1-sqrt × 19-log × polynomial | 2.99.0 |
| 163 | 2-sqrt × 19-log × polynomial | 2.100.0 |
| 164 | 3-sqrt × 19-log × polynomial | 2.101.0 |
| 165 | 4-sqrt × 19-log × polynomial | 2.102.0 |
| 166 | 5-sqrt × 19-log × polynomial | 2.103.0 |

## Algorithm

Recognizes convergent telescoping sums ∑[g(k) − g(k+1)] where the numerator contains exactly 19 log factors × M sqrt factors × polynomial. Uses the ×2 integer trick: `effective_x2 = sum(sqrt_degs_x2) + 2·poly_deg`; convergent when `2·den_deg > effective_x2`.

Dispatch inserted before Phase 160 (Eighteen-Log) in descending phase order.

## Tests

- Python: 451 tests (+18), 89.93% coverage
- TypeScript: 404 tests (+18)
- Rust: 387 integration tests (+18)

## Stack

Stacked on `feat/phase155-eighteen-log-poly` (#4498).

🤖 Generated with [Claude Code](https://claude.com/claude-code)